### PR TITLE
add travis file for building on travis-ci.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 doc/html/
+build/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  - sudo apt-get update -q
+
+install:
+  - sudo apt-get install -qy cmake flex bison libblas-dev liblapack-dev
+      libcfitsio3-dev wcslib-dev libfftw3-dev gfortran libncurses5-dev
+      libreadline6-dev libhdf5-serial-dev python-all-dev
+
+
+before_script:
+  - mkdir build
+  - cd build
+  - wget ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar
+  - tar zxvf WSRT_Measures.ztar
+  - cmake ..
+      -DUSE_FFTW3=ON
+      -DBUILD_TESTING=ON
+      -DUSE_OPENMP=OFF
+      -DUSE_HDF5=ON
+      -DBUILD_PYTHON=ON
+      -DDATA_DIR=.
+
+script:
+  - make
+  - make test
+  - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_install:
 install:
   - sudo apt-get install -qy cmake flex bison libblas-dev liblapack-dev
       libcfitsio3-dev wcslib-dev libfftw3-dev gfortran libncurses5-dev
-      libreadline6-dev libhdf5-serial-dev python-all-dev
+      libreadline6-dev libhdf5-serial-dev python-all-dev libboost-dev
+      libboost-python-dev
 
 
 before_script:


### PR DESCRIPTION
This adds a travis file which is used by travis-ci.org to build CASACORE on various platforms and compilers and then runs the test suite. This is done for every branch and every pull request (PR). This is a *very* useful feature to make sure the code base works on various compilers and platforms, and also makes sure a PR doesn't break anything (assuming there is good test coverage).