### PR TITLE
only parallelize quicksort when there is significant work to do

### DIFF
--- a/casa/Utilities/GenSort.tcc
+++ b/casa/Utilities/GenSort.tcc
@@ -77,8 +77,11 @@ void GenSort<T>::quickSortAsc (T* data, Int nr, Bool multiThread)
     swap (*sf, data[nr-1]);
     i = sf-data;
     if (multiThread) {
+        /* TODO only uses 2 threads of the group, should use tasks
+         * only parallelize when work time ~ barrier spin time (3ms)
+         * otherwise oversubscription kills performance */
 #ifdef _OPENMP
-#pragma omp parallel for
+#pragma omp parallel for if (nr > 50000)
 #endif
       for (int thr=0; thr<2; ++thr) {
         if (thr==0) quickSortAsc (data, i);             // sort left part
@@ -755,8 +758,11 @@ void GenSortIndirect<T>::quickSortAsc (uInt* inx, const T* data, Int nr,
     swapInx (*sf, inx[nr-1]);
     Int n = sf-inx;
     if (multiThread) {
+        /* TODO only uses 2 threads of the group, should use tasks
+         * only parallelize when work time ~ barrier spin time (3ms)
+         * otherwise oversubscription kills performance */
 #ifdef _OPENMP
-#pragma omp parallel for
+#pragma omp parallel for if (nr > 50000)
 #endif
       for (int thr=0; thr<2; ++thr) {
         if (thr==0) quickSortAsc (inx, data, n);


### PR DESCRIPTION
gnu openmp will always start a full group of threads regardless of loop
iteration count. So e.g. on a 16 core machine two threads are working
and the rest will wait in the barrier which is a spinlock with approx
3ms spin time.
When the machine is oversubscribed this causes massive slowdowns as the
threads holding the logs need to be scheduled before the parallel block
can end.

To avoid this issue only attempt parallization when there is enough work
to do for the two threads. Alternatively one could also limit the number
of threads to min(2, OMP_NUM_THREADS) or implement more efficient omp task
based parallization which has much smaller spincounts in the
barriers.