### PR TITLE
Add support for python3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# next release
+
+changes since 2.0.3
+
+- Add experimental Python3 support. Read the README for instructions
+- Changed behavior from 2.0.3: Use PYTHON2_* configuration options to set
+  your python2 interpreter.
+
 # 2.0.3
 
 ## General

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,13 @@ enable_language (Fortran)
 
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-# By default build the Python bindings
+# By default build only Python2 bindings
 option (BUILD_PYTHON "Build the python bindings" YES)
+option (BUILD_PYTHON3 "Build the python3 bindings" NO)
+
 # By default build shared libraries
 option (ENABLE_SHARED "Build shared libraries" YES)
+
 option (ENABLE_RPATH "Include rpath in executables and shared libraries" YES)
 
 # By default do not use HDF5, FFTW3, threads
@@ -231,12 +234,15 @@ if (NOT ${MODULE} STREQUAL "casa")
         endif (NOT ${MODULE} STREQUAL "measures")
     endif (NOT ${MODULE} STREQUAL "tables")
 endif (NOT ${MODULE} STREQUAL "casa")
+
 if (BUILD_PYTHON)
     set (_modules ${_modules} python)
-    find_package(Boost REQUIRED COMPONENTS python)
-    find_package(Python REQUIRED)
-    find_package (NUMPY REQUIRED)
 endif (BUILD_PYTHON)
+
+if (BUILD_PYTHON3)
+    set (_modules ${_modules} python3)
+endif (BUILD_PYTHON3)
+
 
 # Determine which external packages to use.
 include (CTest)
@@ -409,14 +415,25 @@ message (STATUS "SOFA library? ......... = ${SOFA_LIBRARIES}")
 message (STATUS "CFitsio library? ...... = ${CFITSIO_LIBRARIES}")
 message (STATUS "HDF5 library? ......... = ${HDF5_hdf5_LIBRARY}")
 message (STATUS "FFTW3 library? ........ = ${FFTW3_LIBRARIES}")
+
 message (STATUS "BUILD_PYTHON .......... = ${BUILD_PYTHON}")
+message (STATUS "BUILD_PYTHON3 .......... = ${BUILD_PYTHON3}")
+
 if (BUILD_PYTHON)
-    message (STATUS "PYTHON library? ....... = ${PYTHON_LIBRARIES}")
-    message (STATUS "NUMPY include? ........ = ${NUMPY_INCLUDE_DIRS}")
-    message (STATUS "Boost library? ........ = ${Boost_LIBRARIES}")
-    message (STATUS "Boost includes? ....... = ${Boost_INCLUDE_DIRS}")
+    message (STATUS "PYTHON2_EXECUTABLE ......... = ${PYTHON2_EXECUTABLE}")
+    message (STATUS "PYTHON2_LIBRARIES........... = ${PYTHON2_LIBRARIES}")
+    message (STATUS "PYTHON2_NUMPY_INCLUDE_DIRS . = ${PYTHON2_NUMPY_INCLUDE_DIRS}")
+    message (STATUS "PYTHON2_Boost_LIBRARIES .... = ${PYTHON2_Boost_LIBRARIES}")
+    message (STATUS "PYTHON2_Boost_INCLUDE_DIRS . = ${PYTHON2_Boost_INCLUDE_DIRS}")
 endif (BUILD_PYTHON)
 
+if (BUILD_PYTHON3)
+    message (STATUS "PYTHON3_EXECUTABLE ......... = ${PYTHON3_EXECUTABLE}")
+    message (STATUS "PYTHON3_LIBRARIES .......... = ${PYTHON3_LIBRARIES}")
+    message (STATUS "PYTHON3_NUMPY_INCLUDE_DIRS . = ${PYTHON3_NUMPY_INCLUDE_DIRS}")
+    message (STATUS "PYTHON3_Boost_LIBRARIES .... = ${PYTHON3_Boost_LIBRARIES}")
+    message (STATUS "PYTHON3_Boost_INCLUDE_DIRS . = ${PYTHON3_Boost_INCLUDE_DIRS}")
+endif (BUILD_PYTHON3)
 
 # List of build variables and defaults.
 #  BUILD_PYTHON                  NO

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ On Debian / Ubuntu you can install these with:
  ``` 
 $ sudo apt-get install build-essential cmake gfortran g++ libncurses5-dev \
     libreadline-dev flex bison libblas-dev liblapacke-dev libcfitsio3-dev \
-    wcslib-dev
+    wcslib-dev 
 ```
 
 and the optional libraries:
 ```
 $ sudo apt-get install libhdf5-serial-dev libfftw3-dev python-numpy \
-    libboost-python-dev
+    libboost-python-dev libpython3.4-dev libpython2.7-dev
 ```
 
 
@@ -79,6 +79,29 @@ $ cmake -DUSE_FFTW3=ON -DDATA_DIR=/usr/share/casacore/data -DUSE_OPENMP=ON \
 
 The `DATA_DIR` should point to the location where you extracted the measures
 data.
+
+We have expirmental support for Python3 now. You can build python3 support using
+`-DBUILD_PYTHON3=on`. Note that CMake may have problems detecting the correct
+python3 libraries and headers, so probably you need to set them manually. For
+example:
+```
+-DPYTHON3_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.4m.so
+-DPYTHON3_INCLUDE_DIR=/usr/include/python3.4
+```
+
+To configure Python2 specific settings use:
+```
+PYTHON2_EXECUTABLE
+PYTHON2_LIBRARY
+PYTHON2_INCLUDE_DIR
+```
+
+To configure Python3 specific settings use:
+```
+PYTHON3_EXECUTABLE
+PYTHON3_LIBRARY
+PYTHON3_INCLUDE_DIR
+```
 
 If you run into problems with boost libraries, try setting `-DBoost_NO_BOOST_CMAKE=True`. This will be necessary if you have the libraries from NRAO casa in your PATH or LD_LIBRARY_PATH.
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,60 @@
-#
-# casacore python bindings
-#
-include_directories (${Boost_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
+message(STATUS "Looking for python2 specific environment...")
+
+# tempororarly set variables used by findpython
+if (PYTHON2_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${PYTHON2_EXECUTABLE} CACHE FILEPATH "")
+endif()
+
+if (PYTHON2_LIBRARY)
+    set(PYTHON_LIBRARY ${PYTHON2_LIBRARY} CACHE FILEPATH "")
+endif()
+
+if (PYTHON2_INCLUDE_DIR)
+set(PYTHON_INCLUDE_DIR ${PYTHON2_INCLUDE_DIR} CACHE FILEPATH "")
+endif()
+
+if (PYTHON2_FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs)
+    set(FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs ${PYTHON2_FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs} CACHE FILEPATH "")
+endif()
+
+# Detect the python properties
+set(Python_FIND_VERSION 2)
+set(PythonInterp_FIND_VERSION_MAJOR 2)
+find_package(Python REQUIRED)
+if (PYTHONINTERP_FOUND)
+    find_package(Boost REQUIRED COMPONENTS python)
+    find_package (NUMPY REQUIRED)
+
+    # copy the variables to their final destination
+    set(PYTHON2_EXECUTABLE ${PYTHON_EXECUTABLE} CACHE FILEPATH "Path to Python2 interpreter")
+    set(PYTHON2_LIBRARY ${PYTHON_LIBRARY} CACHE PATH "Python2 library")
+    set(PYTHON2_INCLUDE_DIR ${PYTHON_INCLUDE_DIR} CACHE PATH "Python2 include folder")
+    set(PYTHON2_FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs ${FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs} CACHE STRING "")
+
+    set(PYTHON2_LIBRARIES ${PYTHON_LIBRARIES} PARENT_SCOPE)
+    set(PYTHON2_NUMPY_INCLUDE_DIRS ${NUMPY_INCLUDE_DIRS} PARENT_SCOPE)
+    set(PYTHON2_Boost_LIBRARIES ${Boost_LIBRARIES} PARENT_SCOPE)
+    set(PYTHON2_Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} PARENT_SCOPE)
+    set(PYTHON2_Boost_PYTHON_LIBRARY_RELEASE ${Boost_PYTHON_LIBRARY_RELEASE} PARENT_SCOPE)
+    set(PYTHON2_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS} PARENT_SCOPE)
+
+    # to access the variables here we also need to set them in the local scope
+    set(PYTHON2_LIBRARIES ${PYTHON_LIBRARIES} )
+    set(PYTHON2_NUMPY_INCLUDE_DIRS ${NUMPY_INCLUDE_DIRS} )
+    set(PYTHON2_Boost_LIBRARIES ${Boost_LIBRARIES} )
+    set(PYTHON2_Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} )
+    set(PYTHON2_Boost_PYTHON_LIBRARY_RELEASE ${Boost_PYTHON_LIBRARY_RELEASE} )
+    set(PYTHON2_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS} )
+
+    # Remove cached variable to not confuse user
+    unset(PYTHON_EXECUTABLE CACHE)
+    unset(PYTHON_LIBRARY CACHE)
+    unset(PYTHON_INCLUDE_DIR CACHE)
+    unset(FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs CACHE)
+endif(PYTHONINTERP_FOUND)
+
+
+include_directories (${PYTHON2_Boost_INCLUDE_DIRS} ${PYTHON2_NUMPY_INCLUDE_DIRS} ${PYTHON2_INCLUDE_DIRS})
 
 add_library (casa_python
 Converters/PycArray.cc
@@ -13,7 +66,7 @@ Converters/PycRecord.cc
 Converters/PycValueHolder.cc
 )
 
-target_link_libraries (casa_python casa_casa ${Boost_PYTHON_LIBRARY_RELEASE} ${PYTHON_LIBRARIES})
+target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_PYTHON_LIBRARY_RELEASE} ${PYTHON2_LIBRARIES})
 
 install (TARGETS casa_python
 RUNTIME DESTINATION bin

--- a/python/Converters/PycArrayComCC.h
+++ b/python/Converters/PycArrayComCC.h
@@ -25,6 +25,10 @@
 //#
 //# $Id: PycArrayComCC.h,v 1.3 2006/11/20 23:58:17 gvandiep Exp $
 
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+#endif
+
 
   Bool PycArrayCheck (PyObject* obj_ptr)
   {
@@ -243,7 +247,11 @@
   {
     PyObject** dst = static_cast<PyObject**>(to);
     for (uInt i=0; i<nr; i++) {
+#ifdef IS_PY3K
+      dst[i] = PyUnicode_FromString(from[i].chars());
+#else
       dst[i] = PyString_FromString(from[i].chars());
+#endif
     }
   }
   void ArrayCopy<String>::fromPy (String* to, const void* from, uInt nr)

--- a/python/Converters/PycImport.cc
+++ b/python/Converters/PycImport.cc
@@ -28,6 +28,10 @@
 #include <casacore/python/Converters/PycImport.h>
 #include <casacore/casa/OS/Path.h>
 
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+#endif
+
 namespace casacore { namespace python {
 
     boost::python::object PycImport (const String& moduleName,
@@ -44,7 +48,12 @@ namespace casacore { namespace python {
         string workingDir = Path(".").absoluteName();
         char path[] = "path";      // warning if "path" is used below
         PyObject* sysPath = PySys_GetObject(path);
-        PyList_Insert (sysPath, 0, PyString_FromString(workingDir.c_str()));
+#ifdef IS_PY3K
+        PyList_Insert (sysPath, 0, PyUnicode_FromString(workingDir.c_str()));
+#else
+          PyList_Insert (sysPath, 0, PyString_FromString(workingDir.c_str()));
+#endif
+
         // First import main.
         boost::python::object mainModule = boost::python::import
           ("__main__");

--- a/python/Converters/PycValueHolder.cc
+++ b/python/Converters/PycValueHolder.cc
@@ -32,6 +32,10 @@
 #include <casacore/casa/Exceptions/Error.h>
 #include <boost/python/object.hpp>
 
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+#endif
+
 namespace casacore { namespace python {
 
   boost::python::object casa_value_to_python::makeobject
@@ -94,11 +98,19 @@ namespace casacore { namespace python {
   void* casa_value_from_python::convertible(PyObject* obj_ptr)
   {
     if (! (PyBool_Check(obj_ptr)
-	   || PyInt_Check(obj_ptr)
+#ifdef IS_PY3K
+	   || PyLong_Check(obj_ptr)
+#else
+       || PyInt_Check(obj_ptr)
+#endif
 	   || PyLong_Check(obj_ptr)
 	   || PyFloat_Check(obj_ptr)
 	   || PyComplex_Check(obj_ptr)
-	   || PyString_Check(obj_ptr)
+#ifdef IS_PY3K
+	   || PyUnicode_Check(obj_ptr)
+#else
+       || PyString_Check(obj_ptr)
+#endif
 	   || PyDict_Check(obj_ptr)
 	   || PyList_Check(obj_ptr)
 	   || PyTuple_Check(obj_ptr)
@@ -144,7 +156,11 @@ namespace casacore { namespace python {
       return casa_array_from_python::makeScalar (obj_ptr);
     } else if (PyBool_Check(obj_ptr)) {
       return ValueHolder(extract<bool>(obj_ptr)());
+#ifdef IS_PY3K
+    } else if (PyLong_Check(obj_ptr)) {
+#else
     } else if (PyInt_Check(obj_ptr)) {
+#endif
       return ValueHolder(extract<int>(obj_ptr)());
     } else if (PyLong_Check(obj_ptr)) {
       return ValueHolder(extract<Int64>(obj_ptr)());
@@ -152,7 +168,11 @@ namespace casacore { namespace python {
       return ValueHolder(extract<double>(obj_ptr)());
     } else if (PyComplex_Check(obj_ptr)) {
       return ValueHolder(extract<std::complex<double> >(obj_ptr)());
+#ifdef IS_PY3K
+    } else if (PyUnicode_Check(obj_ptr)) {
+#else
     } else if (PyString_Check(obj_ptr)) {
+#endif
       return ValueHolder(String(extract<std::string>(obj_ptr)()));
     } else if (PyDict_Check(obj_ptr)) {
       dict d = extract<dict>(obj_ptr)();
@@ -228,7 +248,12 @@ namespace casacore { namespace python {
         dt = PycArrayScalarType (py_elem_obj.ptr());
       } else if (PyBool_Check (py_elem_obj.ptr())) {
 	dt = TpBool;
+#ifdef IS_PY3K
+      } else if (PyLong_Check (py_elem_obj.ptr())) {
+#else
       } else if (PyInt_Check (py_elem_obj.ptr())) {
+#endif
+
 	dt = TpInt;
       } else if (PyLong_Check (py_elem_obj.ptr())) {
 	dt = TpInt64;
@@ -236,7 +261,11 @@ namespace casacore { namespace python {
 	dt = TpDouble;
       } else if (PyComplex_Check (py_elem_obj.ptr())) {
 	dt = TpDComplex;
+#ifdef IS_PY3K
+      } else if (PyUnicode_Check (py_elem_obj.ptr())) {
+#else
       } else if (PyString_Check (py_elem_obj.ptr())) {
+#endif
 	dt = TpString;
       } else {
         throw AipsError ("PycValueHolder: unknown python data type");

--- a/python3/CMakeLists.txt
+++ b/python3/CMakeLists.txt
@@ -1,0 +1,100 @@
+message(STATUS "Looking for python3 specific environment...")
+
+# tempororarly set variables used by findpython
+if (PYTHON3_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${PYTHON3_EXECUTABLE} CACHE FILEPATH "")
+endif()
+
+if (PYTHON3_LIBRARY)
+    set(PYTHON_LIBRARY ${PYTHON3_LIBRARY} CACHE FILEPATH "")
+endif()
+
+if (PYTHON3_INCLUDE_DIR)
+set(PYTHON_INCLUDE_DIR ${PYTHON3_INCLUDE_DIR} CACHE FILEPATH "")
+endif()
+
+if (PYTHON3_FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs)
+    set(FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs ${PYTHON3_FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs} CACHE FILEPATH "")
+endif()
+
+# Detect the python properties
+set(Python_FIND_VERSION 3)
+set(PythonInterp_FIND_VERSION_MAJOR 3)
+find_package(Python REQUIRED)
+if (PYTHONINTERP_FOUND)
+    # NOTE: the name of the python3 version of boost is probably Debian/Ubuntu specific
+    find_package(Boost REQUIRED COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+    find_package (NUMPY REQUIRED)
+
+    # copy the variables to their final destination
+    set(PYTHON3_EXECUTABLE ${PYTHON_EXECUTABLE} CACHE FILEPATH "Path to Python3 interpreter")
+    set(PYTHON3_LIBRARY ${PYTHON_LIBRARY} CACHE PATH "Python3 library")
+    set(PYTHON3_INCLUDE_DIR ${PYTHON_INCLUDE_DIR} CACHE PATH "Python3 include folder")
+    set(PYTHON3_FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs ${FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs} CACHE STRING "")
+
+    set(PYTHON3_LIBRARIES ${PYTHON_LIBRARIES} PARENT_SCOPE)
+    set(PYTHON3_NUMPY_INCLUDE_DIRS ${NUMPY_INCLUDE_DIRS} PARENT_SCOPE)
+    set(PYTHON3_Boost_LIBRARIES ${Boost_LIBRARIES} PARENT_SCOPE)
+    set(PYTHON3_Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} PARENT_SCOPE)
+    set(PYTHON3_Boost_PYTHON_LIBRARY_RELEASE ${Boost_PYTHON_LIBRARY_RELEASE} PARENT_SCOPE)
+    set(PYTHON3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS} PARENT_SCOPE)
+
+    # to access the variables here we also need to set them in the local scope
+    set(PYTHON3_LIBRARIES ${PYTHON_LIBRARIES} )
+    set(PYTHON3_NUMPY_INCLUDE_DIRS ${NUMPY_INCLUDE_DIRS} )
+    set(PYTHON3_Boost_LIBRARIES ${Boost_LIBRARIES} )
+    set(PYTHON3_Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} )
+    set(PYTHON3_Boost_PYTHON_LIBRARY_RELEASE ${Boost_PYTHON_LIBRARY_RELEASE} )
+    set(PYTHON3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS} )
+
+    # Remove cached variable to not confuse user
+    unset(PYTHON_EXECUTABLE CACHE)
+    unset(PYTHON_LIBRARY CACHE)
+    unset(PYTHON_INCLUDE_DIR CACHE)
+    unset(FIND_PACKAGE_MESSAGE_DETAILS_PythonLibs CACHE)
+endif(PYTHONINTERP_FOUND)
+
+
+
+include_directories (${PYTHON3_Boost_INCLUDE_DIRS} ${PYTHON3_NUMPY_INCLUDE_DIRS} ${PYTHON3_INCLUDE_DIRS})
+
+add_library (casa_python3
+../python/Converters/PycArray.cc
+../python/Converters/PycArrayNP.cc
+../python/Converters/PycBasicData.cc
+../python/Converters/PycExcp.cc
+../python/Converters/PycImport.cc
+../python/Converters/PycRecord.cc
+../python/Converters/PycValueHolder.cc
+)
+
+target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_PYTHON_LIBRARY_RELEASE} ${PYTHON3_LIBRARIES})
+
+install (TARGETS casa_python3
+RUNTIME DESTINATION bin
+LIBRARY DESTINATION lib${LIB_SUFFIX}
+ARCHIVE DESTINATION lib${LIB_SUFFIX}
+LIBRARY PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+# don't install headers if python2 cmake logic already installs it
+if (NOT BUILD_PYTHON)
+    install (FILES
+    ../python/Converters/PycArray.h
+    ../python/Converters/PycArrayComCC.h
+    ../python/Converters/PycArrayComH.h
+    ../python/Converters/PycArrayNP.h
+    ../python/Converters/PycBasicData.h
+    ../python/Converters/PycExcp.h
+    ../python/Converters/PycRecord.h
+    ../python/Converters/PycValueHolder.h
+    ../python/Converters/PycArray.tcc
+    DESTINATION include/casacore/python/Converters
+    )
+
+    install (FILES
+    ../python/Converters.h
+    DESTINATION include/casacore/python
+    )
+endif (NOT BUILD_PYTHON)
+


### PR DESCRIPTION
Adds support for Python3. Not enabling travis build, since it requires a recompilation of boost with python3 which just takes ages.

