### PR TITLE
remove warnings with cmake 3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(casacore)
 
 cmake_minimum_required (VERSION 2.6.0)
 
+# fixes warnings on cmake 3.x+ For now we want the old behavior to be backwards compatible
+if (POLICY CMP0048)
+    cmake_policy (SET CMP0048 OLD)
+endif()
+
 set(PROJECT_VERSION_MAJOR 2)
 set(PROJECT_VERSION_MINOR 0)
 set(PROJECT_VERSION_PATCH 1)
@@ -91,18 +96,18 @@ endif (NOT CMAKE_CXX_FLAGS)
 if (NOT CMAKE_BUILD_TYPE)
     # Use debug mode if building in dbg or debug directory.
     get_filename_component(_cmpvar ${CMAKE_BINARY_DIR} NAME)
-    if("_cmpvar" STREQUAL "dbg" OR "_cmpvar" STREQUAL "debug")
+    if(_cmpvar STREQUAL "dbg" OR _cmpvar STREQUAL "debug")
         set (CMAKE_BUILD_TYPE Debug)
     else()
-        if("_cmpvar" STREQUAL "cov")
+        if(_cmpvar STREQUAL "cov")
             set (CMAKE_BUILD_TYPE Debug)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 --coverage")
             set(CMAKE_LD_FLAGS "${CMAKE_LD_FLAGS} --coverage")
         else()
             set (CMAKE_BUILD_TYPE Release)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG")
-        endif("_cmpvar" STREQUAL "cov")
-    endif("_cmpvar" STREQUAL "dbg" OR "_cmpvar" STREQUAL "debug")
+        endif(_cmpvar STREQUAL "cov")
+    endif(_cmpvar STREQUAL "dbg" OR _cmpvar STREQUAL "debug")
 endif (NOT CMAKE_BUILD_TYPE)
 
 # Detect if the compiler supports C++11 if we want to use it.


### PR DESCRIPTION
When using cmake 3.x you get warnings, see below. Since this is science we want to be compatible with every obsolete, outdated, old fashion, antiquated and engrained cmake version imaginable, so I think best solution is to keep the 'old behavior'.

first warning:
```
CMake Warning (dev) at measures/fortran/sofa/CMakeLists.txt:5 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
```
second warning:
```
Warning:Policy CMP0054 is not set: Only interpret if() arguments as variables or keywords
when unquoted.  Run "cmake --help-policy CMP0054" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.
Quoted variables like "_cmpvar" will no longer be dereferenced when the policy is se
 to NEW.  Since the policy is not set the OLD behavior will be used.
```