### PR TITLE
Cube Tile Reuse

### DIFF
--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -107,7 +107,6 @@ TSMCube::TSMCube (TiledStMan* stman, TSMFile* file,
                   Int64 fileOffset,
                   Bool useDerived)
 : cachedTile_p (0),
-  cachedTileLength_p (0),
   stmanPtr_p     (stman),
   useDerived_p   (useDerived),
   values_p       (values),
@@ -141,7 +140,6 @@ TSMCube::TSMCube (TiledStMan* stman, TSMFile* file,
 TSMCube::TSMCube (TiledStMan* stman, AipsIO& ios,
                   Bool useDerived)
 : cachedTile_p (0),
-  cachedTileLength_p (0),
   stmanPtr_p     (stman),
   useDerived_p   (useDerived),
   filePtr_p      (0),
@@ -694,7 +692,7 @@ char* TSMCube::readTile (const char* external)
 {
     char* local = 0;
 
-    if (cachedTile_p != 0 && cachedTileLength_p == localTileLength_p){
+    if (cachedTile_p != 0){
         local = cachedTile_p;
         cachedTile_p = 0;
     } else {
@@ -719,7 +717,6 @@ void TSMCube::deleteCallBack (void* owner, char* buffer)
     TSMCube * tsmCube = ((TSMCube*)owner);
     if (tsmCube->cachedTile_p == 0){
         tsmCube->cachedTile_p = buffer;
-        tsmCube->cachedTileLength_p = tsmCube->localTileLength_p;
     } else {
         delete [] buffer;
     }

--- a/tables/DataMan/TSMCube.h
+++ b/tables/DataMan/TSMCube.h
@@ -351,7 +351,6 @@ protected:
     //# Declare member variables.
 
     char * cachedTile_p; // optimization to hold one tile chunk
-    uInt cachedTileLength_p;
 
     // Pointer to the parent storage manager.
     TiledStMan*     stmanPtr_p;

--- a/tables/DataMan/TSMCube.h
+++ b/tables/DataMan/TSMCube.h
@@ -23,7 +23,7 @@
 //#                        520 Edgemont Road
 //#                        Charlottesville, VA 22903-2475 USA
 //#
-//# $Id$
+//# $Id: TSMCube.h 21521 2014-12-10 08:06:42Z gervandiepen $
 
 #ifndef TABLES_TSMCUBE_H
 #define TABLES_TSMCUBE_H
@@ -349,6 +349,10 @@ private:
 
 protected:
     //# Declare member variables.
+
+    char * cachedTile_p; // optimization to hold one tile chunk
+    uInt cachedTileLength_p;
+
     // Pointer to the parent storage manager.
     TiledStMan*     stmanPtr_p;
     // Is the class used directly or only by a derived class only?


### PR DESCRIPTION
Previously whenver the TSMCube cube object needed to evict a tile from
cache and add a new one it would write the target tile, if needed, and
then deallocate it; then a new tile was allocated and filled.  This
mod caches a tile whenver it is deallocated and allows the allocation
logic to use that cached tile rather than allocated a brand new one.
This approach reduces the amount of allocation which can become
significant when tiles are large (and they are likely to get larger in
HPC applications).

Ran the various tests named tTiled* using valgrind and fixed the one
potential error that was introduced.  Valgrind reports the writing of
unitialized storage but these errors predate this mod.