### PR TITLE
Adding CMAKE_INSTALL_NAME_DIR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if (ENABLE_SHARED)
     option (BUILD_SHARED_LIBS "" YES)
     if (ENABLE_RPATH)
         # Set RPATH to use for installed targets; append linker search path
+        set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" )
         set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
         set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     endif (ENABLE_RPATH)


### PR DESCRIPTION
I added CMAKE_INSTALL_NAME_DIR in CMakeLists.txt as this is needed for OS X builds of CASA.