### PR TITLE
Compatibility with cmake <2.8.3

### DIFF
--- a/cmake/FindCFITSIO.cmake
+++ b/cmake/FindCFITSIO.cmake
@@ -55,10 +55,15 @@ if(NOT CFITSIO_FOUND)
   find_library(M_LIBRARY m)
   mark_as_advanced(CFITSIO_INCLUDE_DIR CFITSIO_LIBRARY M_LIBRARY)
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(CFITSIO
-    REQUIRED_VARS CFITSIO_LIBRARY M_LIBRARY CFITSIO_INCLUDE_DIR
-    VERSION_VAR CFITSIO_VERSION_STRING)
+  if(CMAKE_VERSION VERSION_LESS "2.8.3")
+    find_package_handle_standard_args(CFITSIO DEFAULT_MSG
+      CFITSIO_LIBRARY M_LIBRARY CFITSIO_INCLUDE_DIR)
+  else ()
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(CFITSIO
+      REQUIRED_VARS CFITSIO_LIBRARY M_LIBRARY CFITSIO_INCLUDE_DIR
+      VERSION_VAR CFITSIO_VERSION_STRING)
+  endif ()
 
   set(CFITSIO_INCLUDE_DIRS ${CFITSIO_INCLUDE_DIR})
   set(CFITSIO_LIBRARIES ${CFITSIO_LIBRARY} ${M_LIBRARY})

--- a/cmake/FindWCSLIB.cmake
+++ b/cmake/FindWCSLIB.cmake
@@ -52,10 +52,15 @@ if(NOT WCSLIB_FOUND)
   find_library(M_LIBRARY m)
   mark_as_advanced(WCSLIB_INCLUDE_DIR WCSLIB_LIBRARY M_LIBRARY)
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(WCSLIB
-    REQUIRED_VARS WCSLIB_LIBRARY M_LIBRARY WCSLIB_INCLUDE_DIR
-    VERSION_VAR WCSLIB_VERSION_STRING)
+  if(CMAKE_VERSION VERSION_LESS "2.8.3")
+    find_package_handle_standard_args(WCSLIB DEFAULT_MSG
+      WCSLIB_LIBRARY M_LIBRARY WCSLIB_INCLUDE_DIR)
+  else ()
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(WCSLIB
+      REQUIRED_VARS WCSLIB_LIBRARY M_LIBRARY WCSLIB_INCLUDE_DIR
+      VERSION_VAR WCSLIB_VERSION_STRING)
+  endif ()
 
   set(WCSLIB_INCLUDE_DIRS ${WCSLIB_INCLUDE_DIR})
   set(WCSLIB_LIBRARIES ${WCSLIB_LIBRARY} ${M_LIBRARY})


### PR DESCRIPTION
Fix issue #147, where CMake's `find_package_handle_standard_args` behaves differently before cmake 2.8.3. 

If you have such an old cmake, then the wcslib and cfitsio versions will not be checked (which was the behavior before 9bbb01c)