### PR TITLE
Install Allocator.h needed by public Block.h

### DIFF
--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -309,6 +309,7 @@ DESTINATION include/casacore/casa/BasicSL
 )
 
 install (FILES
+Containers/Allocator.h
 Containers/Block.h
 Containers/BlockIO.h
 Containers/BlockIO.tcc


### PR DESCRIPTION
The file was introduced in gh-132 but it was forgotten to install it.