### PR TITLE
Added missing Containers/Allocator.h

### DIFF
--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -309,6 +309,7 @@ DESTINATION include/casacore/casa/BasicSL
 )
 
 install (FILES
+Containers/Allocator.h
 Containers/Block.h
 Containers/BlockIO.h
 Containers/BlockIO.tcc


### PR DESCRIPTION
CMakeLists.txt was missing Allocator.h, which caused CASA Code configuration to fail.