### PR TITLE
OSX 10.9 clang fix

### DIFF
--- a/casa/BasicSL/Complex.h
+++ b/casa/BasicSL/Complex.h
@@ -344,7 +344,7 @@ Complex erfc(const Complex &in);
 namespace std { 
   inline float  conj(float  x) { return x; }
   inline double conj(double x) { return x; }
-#if !(defined(AIPS_CXX11) || (defined(__APPLE_CC__) && __APPLE_CC__ > 5621))
+#if !(defined(AIPS_CXX11) || (defined(__APPLE_CC__) && __APPLE_CC__ >= 5621))
   inline float  real(float  x) { return x; }
   inline double real(double x) { return x; }
   inline float  imag(float   ) { return 0; }

--- a/casa/Quanta/QMath.h
+++ b/casa/Quanta/QMath.h
@@ -229,7 +229,7 @@ Quantum<Qtype> max(const Quantum<Qtype> &left, const Quantum<Qtype> &other);
 // <group name="foreign">
 Int ceil(const Int &val);
 Int floor(const Int &val);
-#if !(defined(AIPS_CXX11) || (defined(__APPLE_CC__) && __APPLE_CC__ > 5621))
+#if !(defined(AIPS_CXX11) || (defined(__APPLE_CC__) && __APPLE_CC__ >= 5621))
 Float real(const Float &val);
 Double real(const Double &val);
 #endif

--- a/casa/Utilities/CountedPtr.h
+++ b/casa/Utilities/CountedPtr.h
@@ -30,7 +30,7 @@
 
 #include <casacore/casa/aips.h>
 
-#if (defined(AIPS_CXX11) || (defined(__APPLE_CC__) && __APPLE_CC__ > 5621))
+#if (defined(AIPS_CXX11) || (defined(__APPLE_CC__) && __APPLE_CC__ >= 5621))
 #include <memory>
 #define SHARED_PTR std::shared_ptr
 #define DYNAMIC_POINTER_CAST std::dynamic_pointer_cast


### PR DESCRIPTION
Mavericks (10.9) clang:

Apple LLVM version 6.1.0 (clang-602.0.49) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.3.0
Thread model: posix

This needs to be included in the __APPLE_CC__ version detection.