### PR TITLE
allow build with gcc 5

### DIFF
--- a/casa/aipsdef.h
+++ b/casa/aipsdef.h
@@ -93,14 +93,14 @@ namespace std {};
 #else
 #define WHATEVER_SUN_TYPEDEF(X)
 #define WHATEVER_TYPENAME typename
-#if defined(AIPS_CRAY_PGI) || defined(AIPS_GCC4)
+#if defined(AIPS_CRAY_PGI) || defined(AIPS_GCC)
 #define WHATEVER_SUN_EXCEPTSPEC(X) throw(X)
 #else
 #define WHATEVER_SUN_EXCEPTSPEC(X)
 #endif
 #endif
 
-#if defined(AIPS_USE_NEW_SGI) || defined(AIPS_GCC3) || defined(AIPS_GCC4) || defined(AIPS_CRAY_PGI)
+#if defined(AIPS_USE_NEW_SGI) || defined(AIPS_GCC) || defined(AIPS_CRAY_PGI)
 #if defined(WHATEVER_VECTOR_FORWARD_DEC)
 #undef WHATEVER_VECTOR_FORWARD_DEC
 #endif

--- a/casa/aipsenv.h
+++ b/casa/aipsenv.h
@@ -45,6 +45,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #define AIPS_GCC
 #endif
 
+/* ONLY USE IF CODE WILL _NOT_ WORK WITH NEWER VERSIONS */
 #if defined(AIPS_GCC2)
 #undef AIPS_GCC2
 #endif
@@ -52,6 +53,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #define AIPS_GCC2
 #endif
 
+/* ONLY USE IF CODE WILL _NOT_ WORK WITH NEWER VERSIONS */
 #if defined(AIPS_GCC295)
 #undef AIPS_GCC295
 #endif
@@ -59,6 +61,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #define AIPS_GCC295
 #endif
 
+/* ONLY USE IF CODE WILL _NOT_ WORK WITH NEWER VERSIONS */
 #if defined(AIPS_GCC3)
 #undef AIPS_GCC3
 #endif
@@ -66,6 +69,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #define AIPS_GCC3
 #endif
 
+/* ONLY USE IF CODE WILL _NOT_ WORK WITH NEWER VERSIONS */
 #if defined(AIPS_GCC4)
 #undef AIPS_GCC4
 #endif

--- a/casa/math.h
+++ b/casa/math.h
@@ -55,7 +55,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     using std::abs;
 } //# NAMESPACE CASACORE - END
 # endif
-# if !(defined(AIPS_KAICC) || defined(AIPS_GCC3) || defined(AIPS_GCC4) || defined(AIPS_INTELCC) || defined(AIPS_DARWIN) || defined(AIPS_CRAY_PGI))
+# if !(defined(AIPS_KAICC) || defined(AIPS_GCC) || defined(AIPS_INTELCC) || defined(AIPS_DARWIN) || defined(AIPS_CRAY_PGI))
 #  define NEEDS_POWFLOATFLOAT
 # endif
 #endif

--- a/ms/MeasurementSets/MSTable.tcc
+++ b/ms/MeasurementSets/MSTable.tcc
@@ -35,7 +35,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# These statics cannot be compiled with egcs 1.0.3a.
-#if !defined(__GNUG__) || (defined(__GNUG__) && (__GNUG__ == 2) && (__GNUC_MINOR__ >= 91)) || defined(AIPS_GCC3) || defined(AIPS_GCC4)
+#if !defined(__GNUG__) || (defined(__GNUG__) && (__GNUG__ == 2) && (__GNUC_MINOR__ >= 91)) || defined(AIPS_GCC)
 template <class ColEnum, class KeyEnum> 
 SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::columnMap_p("");
 template <class ColEnum, class KeyEnum> 


### PR DESCRIPTION
Changed versioned gcc checks that are destined to break to generic
unversioned ones.
May break some builds with gcc2 but that should not exist anymore in any
useful environment.