### PR TITLE
Travis: add Gitter webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,11 @@ script:
   - make -j4 
   - make test
   - sudo make install
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/a21dbde2d416245fd698
+    on_success: always  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: false     # default: false


### PR DESCRIPTION
With this webhook, reports of the travis builds are published to the casacore gitter channel. Gitter is a sort of 'developer chat room', you can visit at https://gitter.im/casacore/casacore