### PR TITLE
add better c++11 macro

### DIFF
--- a/casa/aipsenv.h
+++ b/casa/aipsenv.h
@@ -32,8 +32,8 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-// Set if compiler supports C++11.
-#if __cplusplus == 201103L
+// Set if compiler supports C++11 or newer
+#if __cplusplus >= 201103L
 #define AIPS_CXX11
 #endif
 


### PR DESCRIPTION
AIPS_HAVE_CXX11 denotes c++11 support or newer. This is usually better
because c++ standards are usually souce level backward compatible so a
minimum version check is more future proof.