### PR TITLE
Use travis container based setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,29 @@ compiler:
   - clang
   - gcc
 
+sudo: false
+
 install:
   - ./travis-deps.sh
 
+addons:
+  apt:
+    packages:
+    - cmake
+    - flex
+    - bison
+    - libblas-dev
+    - liblapack-dev
+    - libcfitsio3-dev
+    - wcslib-dev
+    - libfftw3-dev
+    - gfortran
+    - libncurses5-dev
+    - libreadline6-dev
+    - libhdf5-serial-dev
+    - libboost-dev
+    - libboost-python-dev
+    - python-numpy
 
 before_script:
   - wget http://www.iausofa.org/2015_0209_F/sofa_f-20150209_a.tar.gz -O /tmp/sofa.tgz
@@ -28,11 +48,12 @@ before_script:
       -DBUILD_PYTHON=ON
       -DDATA_DIR=$PWD
       -DSOFA_ROOT_DIR=$HOME
+      -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/installed
 
 script:
   - make -j4 
   - make test
-  - sudo make install
+  - make install
 
 notifications:
   webhooks:

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -3,14 +3,8 @@
 set -e
 set -x
 
-if [ "$TRAVIS_OS_NAME" = linux ]; then
-    sudo apt-get update -q
-    sudo apt-get install -qy cmake flex bison libblas-dev liblapack-dev \
-            libcfitsio3-dev wcslib-dev libfftw3-dev gfortran libncurses5-dev \
-            libreadline6-dev libhdf5-serial-dev python-all-dev libboost-dev \
-            libboost-python-dev python-numpy
-
-elif [ "$TRAVIS_OS_NAME" = osx ]; then
+if [ "$TRAVIS_OS_NAME" = osx ]; then
+    brew update >/dev/null
     brew tap homebrew/science
-    brew install cmake cfitsio wcslib fftw hdf5 boost-python readline 
+    brew install cfitsio wcslib fftw hdf5 boost-python
 fi


### PR DESCRIPTION
Running travis in a container supposedly makes it quicker. However, you cannot be root in a container. So the test now installs into a user directory instead of using `sudo make install` which installed into `/usr/local` or something.

The OSX build does not use containers, but this build ignores the flag `sudo: false` in `.travis.yml` (thank Travis support for helping out).