### PR TITLE
fix cmake output message on missing c++11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (CXX11 OR CASA_BUILD)
       if (CASA_BUILD)
         message(FATAL_ERROR "CASA_BUILD requires a c++11 compatible compiler")
       endif()
-      option(CXX11 "" NO)
+      set(CXX11 OFF)
     endif()
 endif()
 


### PR DESCRIPTION
non CASA_BUILD setup still printed c++11 support enabled when the
compiler check failed.