### PR TITLE
optimize byteswap implementation

### DIFF
--- a/casa/OS/CanonicalConversion.h
+++ b/casa/OS/CanonicalConversion.h
@@ -31,6 +31,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/OS/Conversion.h>
+#include <cstring>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -440,21 +441,61 @@ private:
 };
 
 
+#if defined( __i386__ ) || defined(i386) || defined(_M_IX86) || \
+    defined(__x86_64__) || defined(__amd64__) || defined(__x86_64) || \
+    defined(_M_AMD64)
+#define CASACORE_HAVE_UNALIGNED_ACCESS
+#endif
+
 
 inline void CanonicalConversion::reverse2 (void* to, const void* from)
 {
+#ifdef CASACORE_HAVE_UNALIGNED_ACCESS
+    unsigned short x = *(unsigned short*)from;
+    *(unsigned short*)to = ((x & 0xffu) << 8) | (x >> 8);
+#else
     ((char*)to)[0] = ((const char*)from)[1];
     ((char*)to)[1] = ((const char*)from)[0];
+#endif
 }
+
 inline void CanonicalConversion::reverse4 (void* to, const void* from)
 {
+#ifdef CASACORE_HAVE_UNALIGNED_ACCESS
+    unsigned int x = *(unsigned int*)from;
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
+    *(unsigned int*)to = __builtin_bswap32(x);
+#else
+    /* also recognized as bswap by clang and gcc >= 4.5 */
+    *(unsigned int*)to = ((x & 0xffu) << 24) | ((x & 0xff00u) << 8) |
+                         ((x & 0xff0000u) >> 8) | (x >> 24);
+#endif
+
+#else
     ((char*)to)[0] = ((const char*)from)[3];
     ((char*)to)[1] = ((const char*)from)[2];
     ((char*)to)[2] = ((const char*)from)[1];
     ((char*)to)[3] = ((const char*)from)[0];
+#endif
 }
+
 inline void CanonicalConversion::reverse8 (void* to, const void* from)
 {
+#ifdef CASACORE_HAVE_UNALIGNED_ACCESS
+    uInt64 x = *(uInt64*)from;
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
+    *(uInt64*)to = __builtin_bswap64(x);
+#else
+    *(uInt64*)to = ((x & 0xffULL) << 56) |
+                   ((x & 0xff00ULL) << 40) |
+                   ((x & 0xff0000ULL) << 24) |
+                   ((x & 0xff000000ULL) << 8) |
+                   ((x & 0xff00000000ULL) >> 8) |
+                   ((x & 0xff0000000000ULL) >> 24) |
+                   ((x & 0xff000000000000ULL) >> 40) |
+                   ( x >> 56);
+#endif
+#else
     ((char*)to)[0] = ((const char*)from)[7];
     ((char*)to)[1] = ((const char*)from)[6];
     ((char*)to)[2] = ((const char*)from)[5];
@@ -463,30 +504,27 @@ inline void CanonicalConversion::reverse8 (void* to, const void* from)
     ((char*)to)[5] = ((const char*)from)[2];
     ((char*)to)[6] = ((const char*)from)[1];
     ((char*)to)[7] = ((const char*)from)[0];
+#endif
 }
 
 inline void CanonicalConversion::move2 (void* to, const void* from)
 {
-    ((char*)to)[0] = ((const char*)from)[0];
-    ((char*)to)[1] = ((const char*)from)[1];
+    memcpy(to, from, 2);
 }
+
 inline void CanonicalConversion::move4 (void* to, const void* from)
 {
-    ((char*)to)[0] = ((const char*)from)[0];
-    ((char*)to)[1] = ((const char*)from)[1];
-    ((char*)to)[2] = ((const char*)from)[2];
-    ((char*)to)[3] = ((const char*)from)[3];
+    memcpy(to, from, 4);
 }
+
 inline void CanonicalConversion::move8 (void* to, const void* from)
 {
-    ((char*)to)[0] = ((const char*)from)[0];
-    ((char*)to)[1] = ((const char*)from)[1];
-    ((char*)to)[2] = ((const char*)from)[2];
-    ((char*)to)[3] = ((const char*)from)[3];
-    ((char*)to)[4] = ((const char*)from)[4];
-    ((char*)to)[5] = ((const char*)from)[5];
-    ((char*)to)[6] = ((const char*)from)[6];
-    ((char*)to)[7] = ((const char*)from)[7];
+    if (sizeof(to) < 8) {
+        memmove(to, from, 8);
+    }
+    else {
+        memcpy(to, from, 8);
+    }
 }
 
 

--- a/casa/OS/LECanonicalConversion.h
+++ b/casa/OS/LECanonicalConversion.h
@@ -31,6 +31,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/OS/Conversion.h>
+#include <cstring>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -437,21 +438,61 @@ private:
 };
 
 
+#if defined( __i386__ ) || defined(i386) || defined(_M_IX86) || \
+    defined(__x86_64__) || defined(__amd64__) || defined(__x86_64) || \
+    defined(_M_AMD64)
+#define CASACORE_HAVE_UNALIGNED_ACCESS
+#endif
+
 
 inline void LECanonicalConversion::reverse2 (void* to, const void* from)
 {
+#ifdef CASACORE_HAVE_UNALIGNED_ACCESS
+    unsigned short x = *(unsigned short*)from;
+    *(unsigned short*)to = ((x & 0xffu) << 8) | (x >> 8);
+#else
     ((char*)to)[0] = ((const char*)from)[1];
     ((char*)to)[1] = ((const char*)from)[0];
+#endif
 }
+
 inline void LECanonicalConversion::reverse4 (void* to, const void* from)
 {
+#ifdef CASACORE_HAVE_UNALIGNED_ACCESS
+    unsigned int x = *(unsigned int*)from;
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
+    *(unsigned int*)to = __builtin_bswap32(x);
+#else
+    /* also recognized as bswap by clang and gcc >= 4.5 */
+    *(unsigned int*)to = ((x & 0xffu) << 24) | ((x & 0xff00u) << 8) |
+                         ((x & 0xff0000u) >> 8) | (x >> 24);
+#endif
+
+#else
     ((char*)to)[0] = ((const char*)from)[3];
     ((char*)to)[1] = ((const char*)from)[2];
     ((char*)to)[2] = ((const char*)from)[1];
     ((char*)to)[3] = ((const char*)from)[0];
+#endif
 }
+
 inline void LECanonicalConversion::reverse8 (void* to, const void* from)
 {
+#ifdef CASACORE_HAVE_UNALIGNED_ACCESS
+    uInt64 x = *(uInt64*)from;
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
+    *(uInt64*)to = __builtin_bswap64(x);
+#else
+    *(uInt64*)to = ((x & 0xffULL) << 56) |
+                   ((x & 0xff00ULL) << 40) |
+                   ((x & 0xff0000ULL) << 24) |
+                   ((x & 0xff000000ULL) << 8) |
+                   ((x & 0xff00000000ULL) >> 8) |
+                   ((x & 0xff0000000000ULL) >> 24) |
+                   ((x & 0xff000000000000ULL) >> 40) |
+                   ( x >> 56);
+#endif
+#else
     ((char*)to)[0] = ((const char*)from)[7];
     ((char*)to)[1] = ((const char*)from)[6];
     ((char*)to)[2] = ((const char*)from)[5];
@@ -460,30 +501,27 @@ inline void LECanonicalConversion::reverse8 (void* to, const void* from)
     ((char*)to)[5] = ((const char*)from)[2];
     ((char*)to)[6] = ((const char*)from)[1];
     ((char*)to)[7] = ((const char*)from)[0];
+#endif
 }
 
 inline void LECanonicalConversion::move2 (void* to, const void* from)
 {
-    ((char*)to)[0] = ((const char*)from)[0];
-    ((char*)to)[1] = ((const char*)from)[1];
+    memcpy(to, from, 2);
 }
+
 inline void LECanonicalConversion::move4 (void* to, const void* from)
 {
-    ((char*)to)[0] = ((const char*)from)[0];
-    ((char*)to)[1] = ((const char*)from)[1];
-    ((char*)to)[2] = ((const char*)from)[2];
-    ((char*)to)[3] = ((const char*)from)[3];
+    memcpy(to, from, 4);
 }
+
 inline void LECanonicalConversion::move8 (void* to, const void* from)
 {
-    ((char*)to)[0] = ((const char*)from)[0];
-    ((char*)to)[1] = ((const char*)from)[1];
-    ((char*)to)[2] = ((const char*)from)[2];
-    ((char*)to)[3] = ((const char*)from)[3];
-    ((char*)to)[4] = ((const char*)from)[4];
-    ((char*)to)[5] = ((const char*)from)[5];
-    ((char*)to)[6] = ((const char*)from)[6];
-    ((char*)to)[7] = ((const char*)from)[7];
+    if (sizeof(to) < 8) {
+        memmove(to, from, 8);
+    }
+    else {
+        memcpy(to, from, 8);
+    }
 }
 
 


### PR DESCRIPTION
Most architectures have dedicated byteswap instructions but the code is
written so the compiler does not detect the swap.
Use intrinsics or use more compiler friendly code to archive better code
generation.