### PR TITLE
make initialization behavior of array::resize without ArrayInitPolicy parameter inconsistent.

### DIFF
--- a/casa/Arrays/Array.h
+++ b/casa/Arrays/Array.h
@@ -507,8 +507,8 @@ public:
     // be called first.
     // <group>
     virtual void resize();
-    virtual void resize(const IPosition &newShape, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
-    //virtual void resize(const IPosition &newShape, Bool copyValues, ArrayInitPolicy initPolicy);
+    virtual void resize(const IPosition &newShape, Bool copyValues=False);
+    virtual void resize(const IPosition &newShape, Bool copyValues, ArrayInitPolicy policy);
     // </group>
 
     // Access a single element of the array. This is relatively
@@ -886,6 +886,9 @@ private:
     // otherwise BulkAllocator for the current allocator is returned.
     Allocator_private::BulkAllocator<T> *nonNewDelAllocator() const;
 protected:
+    static ArrayInitPolicy defaultArrayInitPolicy() {
+        return Block<T>::init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT;
+    }
     // pre/post processing hook of takeStorage() for subclasses.
     virtual void preTakeStorage(const IPosition &) {}
     virtual void postTakeStorage() {}

--- a/casa/Arrays/Array.tcc
+++ b/casa/Arrays/Array.tcc
@@ -748,6 +748,10 @@ template<class T> void Array<T>::resize()
 {
     resize (IPosition());
 }
+template<class T> void Array<T>::resize(const IPosition &len, Bool copyValues)
+{
+    resize(len, copyValues, defaultArrayInitPolicy());
+}
 template<class T> void Array<T>::resize(const IPosition &len, Bool copyValues, ArrayInitPolicy policy)
 {
     DebugAssert(ok(), ArrayError);

--- a/casa/Arrays/ArrayBase.cc
+++ b/casa/Arrays/ArrayBase.cc
@@ -690,6 +690,10 @@ CountedPtr<ArrayBase> ArrayBase::makeArray() const
 {
   throw ArrayError ("ArrayBase::makeArray cannot be used");
 }
+void ArrayBase::resize(const IPosition&, Bool)
+{
+  throw ArrayError ("ArrayBase::resize cannot be used");
+}
 void ArrayBase::resize(const IPosition&, Bool, ArrayInitPolicy)
 {
   throw ArrayError ("ArrayBase::resize cannot be used");

--- a/casa/Arrays/ArrayBase.h
+++ b/casa/Arrays/ArrayBase.h
@@ -144,7 +144,11 @@ public:
 
   // Resize the array and optionally copy the values.
   // <br>The default implementation in ArrayBase throws an exception.
-  virtual void resize(const IPosition &newShape, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
+  virtual void resize(const IPosition &newShape, Bool copyValues=False);
+
+  // Resize the array and optionally copy the values.
+  // <br>The default implementation in ArrayBase throws an exception.
+  virtual void resize(const IPosition &newShape, Bool copyValues, ArrayInitPolicy policy);
 
   // Create an ArrayIterator object of the correct type.
   // This is implemented in the derived Array classes.

--- a/casa/Arrays/Cube.h
+++ b/casa/Arrays/Cube.h
@@ -134,9 +134,13 @@ public:
     // Resize to the given shape.
     // Resize without argument is equal to resize(0,0,0).
     // <group>
-    void resize(size_t nx, size_t ny, size_t nz, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
+    using Array<T>::resize;
+    void resize(size_t nx, size_t ny, size_t nz, Bool copyValues=False) {
+        Cube<T>::resize(nx, ny, nz, copyValues, Array<T>::defaultArrayInitPolicy());
+    }
+    void resize(size_t nx, size_t ny, size_t nz, Bool copyValues, ArrayInitPolicy policy);
     virtual void resize();
-    virtual void resize(const IPosition &newShape, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
+    virtual void resize(const IPosition &newShape, Bool copyValues, ArrayInitPolicy policy);
     // </group>
 
     // Copy the values from other to this cube. If this cube has zero

--- a/casa/Arrays/Matrix.h
+++ b/casa/Arrays/Matrix.h
@@ -150,9 +150,13 @@ public:
     // Resize to the given shape (must be 2-dimensional).
     // Resize without argument is equal to resize(0,0).
     // <group>
-    void resize(size_t nx, size_t ny, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
+    using Array<T>::resize;
+    void resize(size_t nx, size_t ny, Bool copyValues=False) {
+        Matrix<T>::resize(nx, ny, copyValues, Array<T>::defaultArrayInitPolicy());
+    }
+    void resize(size_t nx, size_t ny, Bool copyValues, ArrayInitPolicy policy);
     virtual void resize();
-    virtual void resize(const IPosition &newShape, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
+    virtual void resize(const IPosition &newShape, Bool copyValues, ArrayInitPolicy policy);
     // </group>
 
     // Copy the values from other to this Matrix. If this matrix has zero

--- a/casa/Arrays/Vector.h
+++ b/casa/Arrays/Vector.h
@@ -167,10 +167,13 @@ public:
     //# be hidden).
     // Resize without argument is equal to resize(0, False).
     // <group>
-    void resize(size_t len, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT)
+    using Array<T>::resize;
+    void resize(size_t len, Bool copyValues=False)
+      { Vector<T>::resize(len, copyValues, Array<T>::defaultArrayInitPolicy()); }
+    void resize(size_t len, Bool copyValues, ArrayInitPolicy policy)
       { if (len != this->nelements()) resize (IPosition(1,len), copyValues, policy); }
-    virtual void resize(const IPosition &len, Bool copyValues=False, ArrayInitPolicy policy = ArrayInitPolicy::INIT);
     virtual void resize();
+    virtual void resize(const IPosition &len, Bool copyValues, ArrayInitPolicy policy);
     // </group>
 
     // Assign to this Vector. If this Vector is zero-length, then resize

--- a/casa/Arrays/test/tArray.cc
+++ b/casa/Arrays/test/tArray.cc
@@ -1062,6 +1062,7 @@ void newCubeTest()
         Cube<Int> c(shape, values, COPY, DefaultAllocator<Int>::value);
         delete[] values;
         c.resize(IPosition(3, 2, 3, 2), False, ArrayInitPolicy::NO_INIT);
+        c.resize(2, 4, 4, False, ArrayInitPolicy::NO_INIT);
     }
 }
 
@@ -1079,6 +1080,7 @@ void newMatrixTest()
         Matrix<Int> c(shape, values, COPY, DefaultAllocator<Int>::value);
         delete[] values;
         c.resize(IPosition(2, 2, 3), False, ArrayInitPolicy::NO_INIT);
+        c.resize(4, 4, False, ArrayInitPolicy::NO_INIT);
     }
 }
 
@@ -1096,6 +1098,7 @@ void newVectorTest()
         Vector<Int> c(shape, values, COPY, DefaultAllocator<Int>::value);
         delete[] values;
         c.resize(IPosition(1, 3), False, ArrayInitPolicy::NO_INIT);
+        c.resize(4, False, ArrayInitPolicy::NO_INIT);
     }
 }
 

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -752,12 +752,12 @@ public:
       return allocator_p;
   }
 
-  // end of friend
-
   static bool init_anyway() {
      return !(Block_internal_IsFundamental<T>::value
          || Block_internal_IsPointer<T>::value);
    }
+
+  // end of friend
 
   void init(ArrayInitPolicy initPolicy) {
     set_capacity(get_size());


### PR DESCRIPTION
To improve the performance of resize without ArrayInitPolicy parameter, the behavior of the resize becomes inconsistent.
