### PR TITLE
Removed validation from removeColumn for same reasons as for renameColumn

### DIFF
--- a/ms/MeasurementSets/MSTable.h
+++ b/ms/MeasurementSets/MSTable.h
@@ -219,24 +219,18 @@ public:
     // </group>
 
     // Remove a column from a table
-    // An exception is thrown if this invalidates the table
+    // No exception is thrown if this invalidates the table
+    // in order to permit more complex operations with invalid
+    // intermediate states
     void removeColumn(const String & columnName)
     {
 	Table::removeColumn(columnName);
-	if (!this->validate()) {
-          throw(AipsError("removeColumn " + columnName +
-                          " -> invalid MeasurementSet"));
-	}
     }
 
     // Remove columns from a table
-    // An exception is thrown if this invalidates the table
     void removeColumn(const Vector<String>& columnNames)
     {
 	Table::removeColumn(columnNames);
-	if (!this->validate()) {
-          throw(AipsError("removeColumn(s) -> invalid MeasurementSet"));
-	}
     }
 
     // Rename a column


### PR DESCRIPTION
The validation call inside removeColumn is counterproductive for the same reasons
as it was in renameColumn. Working on modifications of a table setup may have invalid
intermediate states. The validation has to be called explicitly by the programmer at
the right moment.
