### PR TITLE
Add explicit template instantiation to reduce build time and library sizes

### DIFF
--- a/casa/Arrays/Array.h
+++ b/casa/Arrays/Array.h
@@ -922,7 +922,26 @@ protected:
                    begin_p + size_t(length_p(ndim()-1)) * steps_p(ndim()-1))); }
 };
 
+
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Array<Bool>;
+  extern template class Array<Char>;
+  extern template class Array<Short>;
+  extern template class Array<uShort>;
+  extern template class Array<Int>;
+  extern template class Array<uInt>;
+  extern template class Array<Int64>;
+  extern template class Array<Float>;
+  extern template class Array<Double>;
+  extern template class Array<Complex>;
+  extern template class Array<DComplex>;
+  extern template class Array<String>;
+#endif
+
 }//#End casa namespace
+
+
 #ifndef CASACORE_NO_AUTO_TEMPLATES
 #include <casacore/casa/Arrays/Array.tcc>
 #endif //# CASACORE_NO_AUTO_TEMPLATES

--- a/casa/Arrays/Array_tmpl.cc
+++ b/casa/Arrays/Array_tmpl.cc
@@ -1,0 +1,49 @@
+//# Array_tmpl.cc: Explicit Array template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Array.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/casa/Arrays/Array.h>
+#include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/Arrays/MaskedArray.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class Array<Bool>;
+  template class Array<Char>;
+  template class Array<Short>;
+  template class Array<uShort>;
+  template class Array<Int>;
+  template class Array<uInt>;
+  template class Array<Int64>;
+  template class Array<Float>;
+  template class Array<Double>;
+  template class Array<Complex>;
+  template class Array<DComplex>;
+  template class Array<String>;
+}
+#endif

--- a/casa/Arrays/Vector.h
+++ b/casa/Arrays/Vector.h
@@ -312,7 +312,25 @@ private:
     void initVector(const Block<T> &, Int64 nr);      // copy semantics
 };
 
+
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Vector<Bool>;
+  extern template class Vector<Char>;
+  extern template class Vector<Short>;
+  extern template class Vector<uShort>;
+  extern template class Vector<Int>;
+  extern template class Vector<uInt>;
+  extern template class Vector<Int64>;
+  extern template class Vector<Float>;
+  extern template class Vector<Double>;
+  extern template class Vector<Complex>;
+  extern template class Vector<DComplex>;
+  extern template class Vector<String>;
+#endif
+
 } //#End namespace casacore
+
 
 #ifndef CASACORE_NO_AUTO_TEMPLATES
 #include <casacore/casa/Arrays/Vector.tcc>

--- a/casa/Arrays/Vector_tmpl.cc
+++ b/casa/Arrays/Vector_tmpl.cc
@@ -1,0 +1,47 @@
+//# Vector_tmpl.cc: Explicit Vector template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Vector.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/casa/Arrays/Vector.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class Vector<Bool>;
+  template class Vector<Char>;
+  template class Vector<Short>;
+  template class Vector<uShort>;
+  template class Vector<Int>;
+  template class Vector<uInt>;
+  template class Vector<Int64>;
+  template class Vector<Float>;
+  template class Vector<Double>;
+  template class Vector<Complex>;
+  template class Vector<DComplex>;
+  template class Vector<String>;
+}
+#endif

--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -15,6 +15,7 @@ Arrays/ArrayPosIter.cc
 Arrays/ArrayUtil2.cc
 Arrays/Array2.cc
 Arrays/Array2Math.cc
+Arrays/Array_tmpl.cc
 Arrays/AxesMapping.cc
 Arrays/AxesSpecifier.cc
 Arrays/ExtendSpecifier.cc
@@ -24,6 +25,7 @@ Arrays/MaskArrMath2.cc
 Arrays/Matrix2Math.cc
 Arrays/Slice.cc
 Arrays/Slicer.cc
+Arrays/Vector_tmpl.cc
 BasicMath/Math.cc
 BasicMath/Primes.cc
 BasicMath/Random.cc
@@ -35,6 +37,7 @@ BasicSL/STLMath.cc
 BasicSL/String.cc
 Containers/Allocator.cc
 Containers/Block.cc
+Containers/Block_tmpl.cc
 Containers/HashMap2.cc
 Containers/IterError.cc
 Containers/List2.cc

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -893,6 +893,24 @@ public:
  };
 
 
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Block<Bool>;
+  extern template class Block<Char>;
+  extern template class Block<Short>;
+  extern template class Block<uShort>;
+  extern template class Block<Int>;
+  extern template class Block<uInt>;
+  extern template class Block<Int64>;
+  extern template class Block<Float>;
+  extern template class Block<Double>;
+  extern template class Block<Complex>;
+  extern template class Block<DComplex>;
+  extern template class Block<String>;
+  extern template class Block<void*>;
+#endif
+
+
 } //# NAMESPACE CASACORE - END
 
 #endif

--- a/casa/Containers/Block_tmpl.cc
+++ b/casa/Containers/Block_tmpl.cc
@@ -1,0 +1,48 @@
+//# Block_tmpl.cc: Explicit Block template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Block.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/casa/Containers/Block.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class Block<Bool>;
+  template class Block<Char>;
+  template class Block<Short>;
+  template class Block<uShort>;
+  template class Block<Int>;
+  template class Block<uInt>;
+  template class Block<Int64>;
+  template class Block<Float>;
+  template class Block<Double>;
+  template class Block<Complex>;
+  template class Block<DComplex>;
+  template class Block<String>;
+  template class Block<void*>;
+}
+#endif

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -2199,7 +2199,7 @@ void MSFitsInput::fillFieldTable(BinaryTable& bt, Int nField) {
     	restfreq.getColumn(restFreq_p);
         // purposeful assignment of throwImmediately
         // because it appears that the sense of rows and columns are reversed here
-        Int nrestfreqs = restFreq_p.nrow();
+        uInt nrestfreqs = restFreq_p.nrow();
         throwImmediately = nrestfreqs != noif;
         ThrowIf(
     			throwImmediately,

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -18,6 +18,8 @@ endforeach (src)
 include_directories (${CMAKE_CURRENT_BINARY_DIR})
 
 add_library (casa_tables
+Tables/ArrayColumn_tmpl.cc
+Tables/ArrColDesc_tmpl.cc
 Tables/BaseColDesc.cc
 Tables/BaseColumn.cc
 Tables/BaseTabIter.cc
@@ -41,6 +43,8 @@ Tables/RefColumn.cc
 Tables/RefRows.cc
 Tables/RefTable.cc
 Tables/RowCopier.cc
+Tables/ScaColDesc_tmpl.cc
+Tables/ScalarColumn_tmpl.cc
 Tables/ScaRecordColData.cc
 Tables/ScaRecordColDesc.cc
 Tables/SetupNewTab.cc

--- a/tables/Tables/ArrColDesc.h
+++ b/tables/Tables/ArrColDesc.h
@@ -280,6 +280,21 @@ protected:
 };
 
 
+//# Explicitly instantiate these templates in ArrColDesc_tmpl.cc
+#ifdef AIPS_CXX11
+  extern template class ArrayColumnDesc<Bool>;
+  extern template class ArrayColumnDesc<Char>;
+  extern template class ArrayColumnDesc<Short>;
+  extern template class ArrayColumnDesc<uShort>;
+  extern template class ArrayColumnDesc<Int>;
+  extern template class ArrayColumnDesc<uInt>;
+  extern template class ArrayColumnDesc<Float>;
+  extern template class ArrayColumnDesc<Double>;
+  extern template class ArrayColumnDesc<Complex>;
+  extern template class ArrayColumnDesc<DComplex>;
+  extern template class ArrayColumnDesc<String>;
+#endif
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/tables/Tables/ArrColDesc_tmpl.cc
+++ b/tables/Tables/ArrColDesc_tmpl.cc
@@ -1,0 +1,46 @@
+//# ArrColDesc_tmpl.cc: Explicit ArrayColumnDesc template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Vector.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/tables/Tables/ArrColDesc.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class ArrayColumnDesc<Bool>;
+  template class ArrayColumnDesc<Char>;
+  template class ArrayColumnDesc<Short>;
+  template class ArrayColumnDesc<uShort>;
+  template class ArrayColumnDesc<Int>;
+  template class ArrayColumnDesc<uInt>;
+  template class ArrayColumnDesc<Float>;
+  template class ArrayColumnDesc<Double>;
+  template class ArrayColumnDesc<Complex>;
+  template class ArrayColumnDesc<DComplex>;
+  template class ArrayColumnDesc<String>;
+}
+#endif

--- a/tables/Tables/ArrayColumn.h
+++ b/tables/Tables/ArrayColumn.h
@@ -613,6 +613,22 @@ private:
 };
 
 
+//# Explicitly instantiate these templates in ArrayColumn_tmpl.cc
+#ifdef AIPS_CXX11
+  extern template class ArrayColumn<Bool>;
+  extern template class ArrayColumn<Char>;
+  extern template class ArrayColumn<Short>;
+  extern template class ArrayColumn<uShort>;
+  extern template class ArrayColumn<Int>;
+  extern template class ArrayColumn<uInt>;
+  extern template class ArrayColumn<Float>;
+  extern template class ArrayColumn<Double>;
+  extern template class ArrayColumn<Complex>;
+  extern template class ArrayColumn<DComplex>;
+  extern template class ArrayColumn<String>;
+#endif
+
+
 } //# NAMESPACE CASACORE - END
 
 

--- a/tables/Tables/ArrayColumn_tmpl.cc
+++ b/tables/Tables/ArrayColumn_tmpl.cc
@@ -1,0 +1,46 @@
+//# ArrayColumn_tmpl.cc: Explicit ArrayColumn template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Vector.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/tables/Tables/ArrayColumn.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class ArrayColumn<Bool>;
+  template class ArrayColumn<Char>;
+  template class ArrayColumn<Short>;
+  template class ArrayColumn<uShort>;
+  template class ArrayColumn<Int>;
+  template class ArrayColumn<uInt>;
+  template class ArrayColumn<Float>;
+  template class ArrayColumn<Double>;
+  template class ArrayColumn<Complex>;
+  template class ArrayColumn<DComplex>;
+  template class ArrayColumn<String>;
+}
+#endif

--- a/tables/Tables/ScaColDesc.h
+++ b/tables/Tables/ScaColDesc.h
@@ -245,6 +245,21 @@ private:
 };
 
 
+//# Explicitly instantiate these templates in ScaColDesc_tmpl.cc
+#ifdef AIPS_CXX11
+  extern template class ScalarColumnDesc<Bool>;
+  extern template class ScalarColumnDesc<Char>;
+  extern template class ScalarColumnDesc<Short>;
+  extern template class ScalarColumnDesc<uShort>;
+  extern template class ScalarColumnDesc<Int>;
+  extern template class ScalarColumnDesc<uInt>;
+  extern template class ScalarColumnDesc<Float>;
+  extern template class ScalarColumnDesc<Double>;
+  extern template class ScalarColumnDesc<Complex>;
+  extern template class ScalarColumnDesc<DComplex>;
+  extern template class ScalarColumnDesc<String>;
+#endif
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/tables/Tables/ScaColDesc_tmpl.cc
+++ b/tables/Tables/ScaColDesc_tmpl.cc
@@ -1,0 +1,46 @@
+//# ScaColDesc_tmpl.cc: Explicit ScalarColumnDesc template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Vector.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/tables/Tables/ScaColDesc.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class ScalarColumnDesc<Bool>;
+  template class ScalarColumnDesc<Char>;
+  template class ScalarColumnDesc<Short>;
+  template class ScalarColumnDesc<uShort>;
+  template class ScalarColumnDesc<Int>;
+  template class ScalarColumnDesc<uInt>;
+  template class ScalarColumnDesc<Float>;
+  template class ScalarColumnDesc<Double>;
+  template class ScalarColumnDesc<Complex>;
+  template class ScalarColumnDesc<DComplex>;
+  template class ScalarColumnDesc<String>;
+}
+#endif

--- a/tables/Tables/ScalarColumn.h
+++ b/tables/Tables/ScalarColumn.h
@@ -263,11 +263,28 @@ protected:
 };
 
 
-//# Make old name ROScalarColumn still available.
-#define ROScalarColumn ScalarColumn
+//# Explicitly instantiate these templates in ScalarColumn_tmpl.cc
+#ifdef AIPS_CXX11
+  extern template class ScalarColumn<Bool>;
+  extern template class ScalarColumn<Char>;
+  extern template class ScalarColumn<Short>;
+  extern template class ScalarColumn<uShort>;
+  extern template class ScalarColumn<Int>;
+  extern template class ScalarColumn<uInt>;
+  extern template class ScalarColumn<Float>;
+  extern template class ScalarColumn<Double>;
+  extern template class ScalarColumn<Complex>;
+  extern template class ScalarColumn<DComplex>;
+  extern template class ScalarColumn<String>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END
+
+
+//# Make old name ROScalarColumn still available.
+#define ROScalarColumn ScalarColumn
+
 
 #ifndef CASACORE_NO_AUTO_TEMPLATES
 #include <casacore/tables/Tables/ScalarColumn.tcc>

--- a/tables/Tables/ScalarColumn_tmpl.cc
+++ b/tables/Tables/ScalarColumn_tmpl.cc
@@ -1,0 +1,46 @@
+//# ScalarColumn_tmpl.cc: Explicit ScalarColumn template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Vector.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/tables/Tables/ScalarColumn.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class ScalarColumn<Bool>;
+  template class ScalarColumn<Char>;
+  template class ScalarColumn<Short>;
+  template class ScalarColumn<uShort>;
+  template class ScalarColumn<Int>;
+  template class ScalarColumn<uInt>;
+  template class ScalarColumn<Float>;
+  template class ScalarColumn<Double>;
+  template class ScalarColumn<Complex>;
+  template class ScalarColumn<DComplex>;
+  template class ScalarColumn<String>;
+}
+#endif


### PR DESCRIPTION
The explicit instantiation of often used template types reduces the build time and library sizes considerably.