### PR TITLE
CAS-7523, store the true sideband value for getNetSideBands()

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -4089,9 +4089,8 @@ vector<MSMetaData::SpwProperties>  MSMetaData::_getSpwInfo2(
 		tmp.resize(0);
 		cwCol.get(i, tmp);
 		spwInfo[i].chanwidths = QVD(tmp, *cwUnits.begin());
-		// coded this way in ValueMapping
-		spwInfo[i].netsideband = nss[i] == 2 ? 1 : -1;
-		spwInfo[i].nchans = tmp.size();
+		spwInfo[i].netsideband = nss[i];
+        spwInfo[i].nchans = tmp.size();
 		uInt nchan = spwInfo[i].nchans;
 		QVD halfWidths = (spwInfo[i].chanwidths)/2.0;
 		Quantity lowFreq = (spwInfo[i].chanfreqs - halfWidths).min();

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -1994,6 +1994,18 @@ void testIt(MSMetaData& md) {
             }
         }
         {
+            cout << "*** test getNetSidebands()" << endl;
+            vector<Int> netsb = md.getNetSidebands();
+            Int expec[] = {
+                3, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2,
+                2, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+            };
+            uInt n = netsb.size();
+            for(uInt i=0; i<n; ++i) {
+                AlwaysAssert(netsb[i] == expec[i], AipsError);
+            }
+        }
+        {
 			cout << "*** cache size " << md.getCache() << endl;
 		}
 	}


### PR DESCRIPTION
This is a small change to fulfill Ger's request that the actual net sideband values be stored an returned, rather than using Todd Hunter's algorithm which causes -1 or 1 to be stored and returned, no matter what the actual values might be.