### PR TITLE
CAS-7770, added getRefDir() for ephemeris sources

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -1003,6 +1003,20 @@ MDirection MSMetaData::phaseDirFromFieldIDAndTime(const uInt fieldID,  const MEp
 	return msfc.phaseDirMeas(fieldID, inSeconds);
 } 
 
+MDirection MSMetaData::getReferenceDirection(
+    const uInt fieldID,  const MEpoch& ep
+) const {
+    _hasFieldID(fieldID);
+    ROMSFieldColumns msfc(_ms->field());
+    if(! msfc.needInterTime(fieldID)) {
+        return msfc.referenceDirMeas(fieldID, 0.0);
+    }
+    MEpoch::Types msType = MEpoch::castType(msfc.timeMeas()(fieldID).getRef().getType());
+    Unit sec("s");
+    Double inSeconds = MEpoch::Convert(ep, msType)().get(sec).getValue();
+    return msfc.referenceDirMeas(fieldID, inSeconds);
+}
+
 void MSMetaData::_getFieldsAndSpwMaps(
 	std::map<Int, std::set<uInt> >& fieldToSpwMap,
 	vector<std::set<Int> >& spwToFieldMap

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -288,6 +288,14 @@ public:
 	//if that is attached to that field id
 	MDirection phaseDirFromFieldIDAndTime(const uInt fieldID,  
 					      const MEpoch& ep=MEpoch(Quantity(0.0, Unit("s")))) const ;
+
+    // Get the reference direction for a given field ID and epoch interpolate
+    // polynomial if it is the field ID is such or use ephemerides table
+    // if that is attached to that field ID
+    MDirection getReferenceDirection(
+        const uInt fieldID,
+        const MEpoch& ep=MEpoch(Quantity(0.0, Unit("s")))
+    ) const;
 	
 	// get the field IDs for the specified field name. Case insensitive.
 	std::set<Int> getFieldIDsForField(const String& field) const;

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -1994,6 +1994,42 @@ void testIt(MSMetaData& md) {
             }
         }
         {
+            cout << "*** test getReferenceDirection()" << endl;
+            uInt nfields = md.nFields();
+            for (uInt i=0; i<nfields; ++i) {
+                MDirection dir = md.getReferenceDirection(i);
+                Vector<Double> angle = dir.getAngle().getValue();
+                switch(i) {
+                case 0:
+                    AlwaysAssert(near(angle[0], -2.8964345, 1e-6), AipsError);
+                    AlwaysAssert(near(angle[1], -0.10104256, 1e-6), AipsError);
+                    break;
+                case 1:
+                    AlwaysAssert(near(angle[0], -2.71545722, 1e-6), AipsError);
+                    AlwaysAssert(near(angle[1], -0.22613985, 1e-6), AipsError);
+                    break;
+                case 2:
+                    AlwaysAssert(near(angle[0], -2.72554329, 1e-6), AipsError);
+                    AlwaysAssert(near(angle[1], -0.1219181, 1e-6), AipsError);
+                    break;
+                case 3:
+                    AlwaysAssert(near(angle[0], -1.98190197, 1e-6), AipsError);
+                    AlwaysAssert(near(angle[1], -0.44437211, 1e-6), AipsError);
+                    break;
+                case 4:
+                    AlwaysAssert(near(angle[0], -2.04411602, 1e-6), AipsError);
+                    AlwaysAssert(near(angle[1], -0.32533384, 1e-6), AipsError);
+                    break;
+                case 5:
+                    AlwaysAssert(near(angle[0], -1.94537525, 1e-6), AipsError);
+                    AlwaysAssert(near(angle[1], -0.27584353, 1e-6), AipsError);
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        {
 			cout << "*** cache size " << md.getCache() << endl;
 		}
 	}


### PR DESCRIPTION
added getReferenceDirection() which returns reference direction for both non-ephemeris and ephemeris (if optional epoch is provided). 