### PR TITLE
CAS-7837 account for case of no intents, so segfault doesn't occur

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3690,6 +3690,11 @@ void MSMetaData::_getFieldsAndIntentsMaps(
 	std::map<String, std::set<Int> >& intentToFieldsMap
 ) {
 	// This method is responsible for setting _intentToFieldIDMap and _fieldToIntentsMap
+    if (getIntents().empty()) {
+        fieldToIntentsMap = vector<std::set<String> >(nFields());
+        intentToFieldsMap.clear();
+        return;
+    }
 	if (! _intentToFieldIDMap.empty() && ! _fieldToIntentsMap.empty()) {
 		fieldToIntentsMap = _fieldToIntentsMap;
 		intentToFieldsMap = _intentToFieldIDMap;

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -655,6 +655,9 @@ private:
 
 	CountedPtr<QVD > _getExposureTimes();
 
+    // If there are no intents, then fieldToIntentsMap will be of length
+    // nFields() and all of its entries will be the empty set, and
+    // intentToFieldsMap will be empty
 	void _getFieldsAndIntentsMaps(
 		vector<std::set<String> >& fieldToIntentsMap,
 		std::map<String, std::set<Int> >& intentToFieldsMap


### PR DESCRIPTION
In the case of the MS having no intents, a segfault would occur in _getFieldsAndIntentsMaps(). This submissions fixes that by returning immediately if that condition is met.