### PR TITLE
SPW parser error handling improvements

### DIFF
--- a/ms/CMakeLists.txt
+++ b/ms/CMakeLists.txt
@@ -106,6 +106,7 @@ MSSel/MSSpwGram.cc
 MSSel/MSSpwIndex.cc
 MSSel/MSSpWindowIndex.cc
 MSSel/MSSpwParse.cc
+MSSel/MSSSpwErrorHandler.cc
 MSSel/MSStateGram.cc
 MSSel/MSStateIndex.cc
 MSSel/MSStateParse.cc
@@ -272,6 +273,7 @@ MSSel/MSSpwGram.h
 MSSel/MSSpwIndex.h
 MSSel/MSSpWindowIndex.h
 MSSel/MSSpwParse.h
+MSSel/MSSSpwErrorHandler.h
 MSSel/MSStateGram.h
 MSSel/MSStateIndex.h
 MSSel/MSStateParse.h

--- a/ms/MSSel/MSSSpwErrorHandler.cc
+++ b/ms/MSSel/MSSSpwErrorHandler.cc
@@ -1,0 +1,62 @@
+//# MSSSpwErrorHandler.cc: Error handler for the SPW parser
+//# Copyright (C) 1994,1995,1996,1997,2000
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/ms/MSSel/MSSSpwErrorHandler.h>
+#include <casacore/ms/MSSel/MSSelectionError.h>
+#include <casacore/casa/Arrays/Vector.h>
+#include <vector>
+
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+  String MSSSpwErrorHandler::constructMessage()
+  {
+    ostringstream Mesg;
+    if (messageList.size() > 0)
+      {
+	Mesg << messageList[0];
+	if (tokenList.size() > 0)
+	  for (uInt i=0;i<tokenList.size();i++) Mesg << tokenList[i] << " ";
+	else
+	  for (uInt i=1;i<messageList.size(); i++) Mesg << endl << messageList[i];
+      }
+    String casaMesg(Mesg.str());
+    return casaMesg;
+  }
+
+  void MSSSpwErrorHandler::handleError(MSSelectionError&  mssErrorType) 
+  {
+    if (messageList.size() > 0)
+      {
+	String mesg(constructMessage());
+	mssErrorType.addMessage(mesg);
+	LogIO logIO;
+	logIO << mssErrorType.getMesg() << LogIO::WARN << LogIO::POST;
+      }
+  }
+
+} //# NAMESPACE CASACORE - END
+

--- a/ms/MSSel/MSSSpwErrorHandler.h
+++ b/ms/MSSel/MSSSpwErrorHandler.h
@@ -1,0 +1,73 @@
+//# MSSpwErrorHandler.h: Error handler class for SPW parser
+//# Copyright (C) 1994,1995,1996,1997,1999,2000
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#ifndef MS_MSSPWERRORHANDLER_H
+#define MS_MSSPWERRORHANDLER_H
+
+//# Includes
+#include <casacore/casa/aips.h>
+#include <casacore/casa/Logging/LogIO.h>
+#include <casacore/casa/Exceptions/Error.h>
+#include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
+#include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
+#include <vector>
+using namespace std;
+
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+  //# This header file defines the error handler class for the
+  //# SPW parser in MSSelection module
+
+
+  // <summary>
+  // </summary>
+  // <use visibility=export>
+  // <reviewed reviewer="UNKNOWN" date="" tests="">
+  // </reviewed>
+
+  // <synopsis> 
+  //
+  // Specialization of the MSSelectionErrorHandler for SPW parser.
+  // The constructMessage() and handleError() methods are specialized
+  // here.
+  //
+  //</synopsis>
+  
+  class MSSSpwErrorHandler: public MSSelectionErrorHandler 
+  {
+  public:
+    // The default constructor generates the message "Table error".
+    MSSSpwErrorHandler():MSSelectionErrorHandler() {};
+    virtual ~MSSSpwErrorHandler () {};
+    
+    String constructMessage();
+    void handleError(MSSelectionError& mssErrorType) ;
+  };
+} //# NAMESPACE CASACORE - END
+
+
+#endif

--- a/ms/MSSel/MSSelection.cc
+++ b/ms/MSSel/MSSelection.cc
@@ -52,11 +52,13 @@
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/casa/iostream.h>
 #include <casacore/ms/MSSel/MSSelectionError.h>
+#include <casacore/ms/MSSel/MSSSpwErrorHandler.h>
 #include <casacore/ms/MSSel/MSSelectionTools.h>
 #include <casacore/ms/MSSel/MSSelectableTable.h>
 #include <casacore/ms/MSSel/MSSelectableMainColumn.h>
 #include <casacore/ms/MSSel/MSAntennaParse.h>
 #include <casacore/ms/MSSel/MSStateParse.h>
+#include <casacore/ms/MSSel/MSSpwParse.h>
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Utilities/GenSort.h>
@@ -366,14 +368,32 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
   void MSSelection::deleteErrorHandlers()
   {
+    // if (MSAntennaParse::thisMSAErrorHandler!=NULL)
+    //   {
+    // 	delete MSAntennaParse::thisMSAErrorHandler;
+    // 	MSAntennaParse::thisMSAErrorHandler=NULL;
+    //   }
+    // if (MSStateParse::thisMSSErrorHandler!=NULL)
+    //   {
+    // 	delete MSStateParse::thisMSSErrorHandler;
+    // 	MSStateParse::thisMSSErrorHandler=NULL;
+    //   }
+    // if (MSSpwParse::thisMSSpwErrorHandler!=NULL)
+    //   {
+    // 	delete MSSpwParse::thisMSSpwErrorHandler;
+    // 	MSSpwParse::thisMSSpwErrorHandler=NULL;
+    //   }
+
     if (mssErrHandler_p != NULL) 
       {
-	delete mssErrHandler_p;
-	mssErrHandler_p=MSAntennaParse::thisMSAErrorHandler=NULL;
-	mssErrHandler_p=MSStateParse::thisMSSErrorHandler=NULL;
+    	delete mssErrHandler_p;
+    	mssErrHandler_p=MSAntennaParse::thisMSAErrorHandler=NULL;
+    	mssErrHandler_p=MSStateParse::thisMSSErrorHandler=NULL;
+    	mssErrHandler_p=MSSpwParse::thisMSSpwErrorHandler=NULL;
       }
-    mssErrHandler_p=MSAntennaParse::thisMSAErrorHandler=NULL;
-    mssErrHandler_p=MSStateParse::thisMSSErrorHandler=NULL;
+    // mssErrHandler_p=MSAntennaParse::thisMSAErrorHandler=NULL;
+    // mssErrHandler_p=MSStateParse::thisMSSErrorHandler=NULL;
+    // mssErrHandler_p=MSSpwParse::thisMSSpwErrorHandler=NULL;
     //    mssErrHandler_p=NULL;
   }
   
@@ -436,28 +456,34 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	      setErrorHandler(ANTENNA_EXPR, mssErrHandler_p);
 	    }
 	  else
-	    {
-	      //mssErrHandler_p = MSAntennaParse::thisMSAErrorHandler;
-	      MSAntennaParse::thisMSAErrorHandler->reset();
-	      //	mssErrHandler_p->reset();
-	    }
+	    MSAntennaParse::thisMSAErrorHandler->reset();
 	  break;
 	}
       case STATE_EXPR:
 	{
 	  if (MSStateParse::thisMSSErrorHandler == NULL)
 	    {
-	      if (mssErrHandler_p == NULL) mssErrHandler_p = new MSSelectionErrorHandler();
-	      setErrorHandler(STATE_EXPR, mssErrHandler_p);
+	      //if (mssErrHandler_p == NULL) mssErrHandler_p = new MSSelectionErrorHandler();
+	      MSSelectionErrorHandler *tt = new MSSelectionErrorHandler();
+	      setErrorHandler(STATE_EXPR, tt);
 	    }
 	  else
-	    {
-	      //mssErrHandler_p = MSAntennaParse::thisMSAErrorHandler;
-	      MSStateParse::thisMSSErrorHandler->reset();
-	      //	mssErrHandler_p->reset();
-	    }
+	    MSStateParse::thisMSSErrorHandler->reset();
 	  break;
 	}
+      case SPW_EXPR:
+	{
+	  if (MSSpwParse::thisMSSpwErrorHandler == NULL)
+	    {
+	      // if (mssErrHandler_p == NULL) mssErrHandler_p = new MSSSpwErrorHandler();
+	      MSSSpwErrorHandler *tt = new MSSSpwErrorHandler();
+	      setErrorHandler(SPW_EXPR, tt, True /*overRide*/);
+	    }
+	  else
+	    MSSpwParse::thisMSSpwErrorHandler->reset();
+	  break;
+	}
+	
       default:  
 	throw(MSSelectionError(String("Wrong MSExprType in MSSelection::initErrorHandler()")));
 	break;
@@ -489,6 +515,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     
     initErrorHandler(ANTENNA_EXPR);
     initErrorHandler(STATE_EXPR);
+    initErrorHandler(SPW_EXPR);
 
     try
       {
@@ -717,6 +744,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    MSStateParse::thisMSSErrorHandler = mssEH;
 	  break;
 	}
+      case SPW_EXPR:
+	{
+	  if (overRide)
+	    MSSpwParse::thisMSSpwErrorHandler = mssEH;
+	  else if (MSSpwParse::thisMSSpwErrorHandler == NULL)
+	    MSSpwParse::thisMSSpwErrorHandler = mssEH;
+	  break;
+	}
       default: throw(MSSelectionError(String("Wrong MSExprType in MSSelection::setErrorHandler()")));
       };
   }
@@ -734,6 +769,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       {
 	MSSelectionStateParseError msStateException(String(""));
 	MSStateParse::thisMSSErrorHandler->handleError(msStateException);
+      }
+
+    if (MSSpwParse::thisMSSpwErrorHandler->nMessages() > 0)
+      {
+	MSSelectionSpwParseError msSpwException(String(""));
+	MSSpwParse::thisMSSpwErrorHandler->handleError(msSpwException);
       }
   }
 

--- a/ms/MSSel/MSSpwParse.cc
+++ b/ms/MSSel/MSSpwParse.cc
@@ -31,6 +31,7 @@
 #include <casacore/ms/MSSel/MSSelectionError.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Logging/LogIO.h>
+#include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
@@ -40,6 +41,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   Vector<Int> MSSpwParse::ddidList;
   Matrix<Int> MSSpwParse::chanList; 
   TableExprNode MSSpwParse::columnAsTEN_p;
+  MSSelectionErrorHandler* MSSpwParse::thisMSSpwErrorHandler = 0;
   //# Constructor
   //
   //------------------------------------------------------------------

--- a/ms/MSSel/MSSpwParse.h
+++ b/ms/MSSel/MSSpwParse.h
@@ -32,6 +32,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/ms/MSSel/MSParse.h>
 #include <casacore/casa/Arrays/Matrix.h>
+#include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -115,11 +116,12 @@ public:
   // Get table expression node object.
   static const TableExprNode* node();
   static MSSpwParse* thisMSSParser;
+  static MSSelectionErrorHandler* thisMSSpwErrorHandler;
   static Vector<Int> selectedDDIDs() {return ddidList;}
   static Vector<Int> selectedIDs() {return idList;}
   static Matrix<Int> selectedChanIDs() {return chanList;}
   static void reset() {idList.resize(0);chanList.resize(0,0);ddidList.resize(0);};
-  static void cleanup() {if (node_p) delete node_p;node_p=0x0;};
+  static void cleanup() {if (node_p) delete node_p;node_p=0x0; if (thisMSSpwErrorHandler) delete thisMSSpwErrorHandler; thisMSSpwErrorHandler=0x0;}
 
   MSSpectralWindow& subTable() {return spwSubTable_p;}
 private:

--- a/ms/MSSel/MSStateParse.h
+++ b/ms/MSSel/MSStateParse.h
@@ -101,7 +101,7 @@ public:
   static MSSelectionErrorHandler* thisMSSErrorHandler;
   static Vector<Int> selectedIDs() {return idList;};
   static void reset(){idList.resize(0);};
-  static void cleanup() {if (node_p) delete node_p;node_p=0x0;}
+  static void cleanup() {if (node_p) delete node_p;node_p=0x0;if (thisMSSErrorHandler) delete thisMSSErrorHandler;thisMSSErrorHandler=0x0;}
 private:
   static TableExprNode* node_p;
   const String colName;


### PR DESCRIPTION
Handling of errors in SPW parser is via an error handler now. This
brings uniform error reporting and allows changing the error reporting
behaviour programmatically by the clients.

Instead of throwing an exception for no-match for some components of
the expression, the error is now reported as a warning.  If no
components were matched, an exception is thrown.

Added new class MSSSpwErrorHandler.