### PR TITLE
CAS-7637 add getRestFrequencies() and getTransitions() to MSMetaData

### DIFF
--- a/ms/MSOper/MSKeys.cc
+++ b/ms/MSOper/MSKeys.cc
@@ -137,6 +137,16 @@ std::set<ScanKey> scanKeys(
 	return scanKeys;
 }
 
+Bool operator<(const SourceKey& lhs, const SourceKey& rhs) {
+    if (lhs.id < rhs.id) {
+        return True;
+    }
+    else if (lhs.id == rhs.id && lhs.spw < rhs.spw) {
+        return True;
+    }
+    return False;
+}
+
 
 }
 

--- a/ms/MSOper/MSKeys.h
+++ b/ms/MSOper/MSKeys.h
@@ -97,6 +97,16 @@ Bool operator<(const ArrayKey& lhs, const ArrayKey& rhs);
 // construct scan keys given a set of scan numbers and an ArrayKey
 std::set<ScanKey> scanKeys(const std::set<Int>& scans, const ArrayKey& arrayKey);
 
+// represents primary key in the SOURCE table
+struct SourceKey {
+    // SOURCE_ID column
+    uInt id;
+    uInt spw;
+};
+
+// define operator<() so it can be used as a key in std::map
+Bool operator<(const SourceKey& lhs, const SourceKey& rhs);
+
 }
 
 #endif

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -180,30 +180,25 @@ void MSMetaData::_getStateToIntentsMap(
 }
 
 vector<std::pair<Quantity, Quantity> > MSMetaData::getProperMotions() const {
-	// this method is repsonsible for setting _properMotions
+	// this method is responsible for setting _properMotions
 	if (! _properMotions.empty()) {
 		return _properMotions;
 	}
 	String colName = MSSource::columnName(MSSource::PROPER_MOTION);
-	ROArrayColumn<Double> col(_ms->source(), colName);
-	const TableRecord& keywords = col.keywordSet();
-	vector<String> u = keywords.asArrayString("QuantumUnits").tovector();
-	std::pair<String, String> units = u.size() == 1
-		? std::pair<String, String>(u[0], u[0])
-		: std::pair<String, String>(u[0], u[1]);
-	uInt nrow = col.nrow();
+	ArrayQuantColumn<Double> col(_ms->source(), colName);
+	uInt nrow = _ms->source().nrow();
 	vector<std::pair<Quantity, Quantity> > myvec(nrow);
+	Vector<Quantity> av(2);
 	for (uInt i=0; i<nrow; ++i) {
-		Vector<Double> fs = col.get(i);
-		myvec[i].first = Quantity(fs[0], units.first);
-		myvec[i].second = Quantity(fs[1], units.second);
+	    col.get(i, av, False);
+	    myvec[i].first = av[0];
+	    myvec[i].second = av[1];
 	}
 	if (_cacheUpdated(sizeof(myvec))) {
 		_properMotions = myvec;
 	}
 	return myvec;
 }
-
 
 std::set<Int> MSMetaData::getScanNumbers(Int obsID, Int arrayID) const {
 	ArrayKey arrayKey;
@@ -242,8 +237,8 @@ uInt MSMetaData::nRows(CorrelationType cType) {
 		return nRows();
 	}
 	uInt nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -268,8 +263,8 @@ uInt MSMetaData::nRows(
 	subScanKey.fieldID = fieldID;
 	_checkSubScan(subScanKey);
 	uInt nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
     _getRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -290,8 +285,8 @@ uInt MSMetaData::nRows(
 uInt MSMetaData::nRows(CorrelationType cType, uInt fieldID) const {
 	_checkField(fieldID);
 	uInt nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -310,8 +305,8 @@ uInt MSMetaData::nRows(CorrelationType cType, uInt fieldID) const {
 
 Double MSMetaData::nUnflaggedRows() const {
 	Double nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getUnflaggedRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -324,8 +319,8 @@ Double MSMetaData::nUnflaggedRows(CorrelationType cType) const {
 		return nUnflaggedRows();
 	}
 	Double nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getUnflaggedRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -350,8 +345,8 @@ Double MSMetaData::nUnflaggedRows(
 	subScanKey.fieldID = fieldID;
 	_checkSubScan(subScanKey);
 	Double nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getUnflaggedRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -371,8 +366,8 @@ Double MSMetaData::nUnflaggedRows(
 
 Double MSMetaData::nUnflaggedRows(CorrelationType cType, Int fieldID) const {
 	Double nACRows, nXCRows;
-	CountedPtr<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	CountedPtr<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	SHARED_PTR<std::map<SubScanKey, Double> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<Double> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getUnflaggedRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -411,12 +406,12 @@ void MSMetaData::_getRowStats(
 		(*subScanToNXCRowsMap)[*subIter] = 0;
 		++subIter;
 	}
-	CountedPtr<Vector<Int> > ant1, ant2;
+	SHARED_PTR<Vector<Int> > ant1, ant2;
 	_getAntennas(ant1, ant2);
-	CountedPtr<Vector<Int> > scans = _getScans();
-	CountedPtr<Vector<Int> > fieldIDs = _getFieldIDs();
-	CountedPtr<Vector<Int> > obsIDs = _getObservationIDs();
-	CountedPtr<Vector<Int> > arrIDs = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > fieldIDs = _getFieldIDs();
+	SHARED_PTR<Vector<Int> > obsIDs = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > arrIDs = _getArrayIDs();
 	Vector<Int>::const_iterator aEnd = ant1->end();
 	Vector<Int>::const_iterator a1Iter = ant1->begin();
 	Vector<Int>::const_iterator a2Iter = ant2->begin();
@@ -451,10 +446,10 @@ void MSMetaData::_getRowStats(
 
 void MSMetaData::_getRowStats(
 	uInt& nACRows, uInt& nXCRows,
-	CountedPtr<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
-	CountedPtr<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
-	CountedPtr<vector<uInt> >& fieldToNACRowsMap,
-	CountedPtr<vector<uInt> >& fieldToNXCRowsMap
+	SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
+	SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
+	SHARED_PTR<vector<uInt> >& fieldToNACRowsMap,
+	SHARED_PTR<vector<uInt> >& fieldToNXCRowsMap
 ) const {
 	// this method is responsible for setting _nACRows, _nXCRows, _subScanToNACRowsMap,
 	// _subScanToNXCRowsMap, _fieldToNACRowsMap, _fieldToNXCRowsMap
@@ -475,10 +470,10 @@ void MSMetaData::_getRowStats(
 		myScanToNXCRowsMap, myFieldToNACRowsMap,
 		myFieldToNXCRowsMap
 	);
-	scanToNACRowsMap = myScanToNACRowsMap;
-	scanToNXCRowsMap = myScanToNXCRowsMap;
-	fieldToNACRowsMap = myFieldToNACRowsMap;
-	fieldToNXCRowsMap = myFieldToNXCRowsMap;
+	scanToNACRowsMap.reset(myScanToNACRowsMap);
+	scanToNXCRowsMap.reset(myScanToNXCRowsMap);
+	fieldToNACRowsMap.reset(myFieldToNACRowsMap);
+	fieldToNXCRowsMap.reset(myFieldToNXCRowsMap);
 	uInt size = 2*(
 		sizeof(uInt) + _sizeof(*scanToNACRowsMap)
 		+ _sizeof(*fieldToNACRowsMap)
@@ -494,8 +489,8 @@ void MSMetaData::_getRowStats(
 }
 
 void MSMetaData::_getAntennas(
-	CountedPtr<Vector<Int> >& ant1,
-	CountedPtr<Vector<Int> >& ant2
+	SHARED_PTR<Vector<Int> >& ant1,
+	SHARED_PTR<Vector<Int> >& ant2
 ) const {
 	if (
 		_antenna1 && _antenna1->size() > 0
@@ -520,24 +515,24 @@ void MSMetaData::_getAntennas(
 	}
 }
 
-CountedPtr<Vector<Int> > MSMetaData::_getScans() const {
+SHARED_PTR<Vector<Int> > MSMetaData::_getScans() const {
 	if (_scans && _scans->size() > 0) {
 		return _scans;
 	}
 	String scanColName = MeasurementSet::columnName(MSMainEnums::SCAN_NUMBER);
-	CountedPtr<Vector<Int> > scans(new Vector<Int>(ROScalarColumn<Int>(*_ms, scanColName).getColumn()));
+	SHARED_PTR<Vector<Int> > scans(new Vector<Int>(ROScalarColumn<Int>(*_ms, scanColName).getColumn()));
 	if (_cacheUpdated(sizeof(Int)*scans->size())) {
 		_scans = scans;
 	}
 	return scans;
 }
 
-CountedPtr<Vector<Int> > MSMetaData::_getObservationIDs() const {
+SHARED_PTR<Vector<Int> > MSMetaData::_getObservationIDs() const {
 	if (_observationIDs && _observationIDs->size() > 0) {
 		return _observationIDs;
 	}
 	static const String obsColName = MeasurementSet::columnName(MSMainEnums::OBSERVATION_ID);
-	CountedPtr<Vector<Int> > obsIDs(
+	SHARED_PTR<Vector<Int> > obsIDs(
 		new Vector<Int>(ROScalarColumn<Int>(*_ms, obsColName).getColumn())
     );
 	if (_cacheUpdated(sizeof(Int)*obsIDs->size())) {
@@ -546,12 +541,12 @@ CountedPtr<Vector<Int> > MSMetaData::_getObservationIDs() const {
 	return obsIDs;
 }
 
-CountedPtr<Vector<Int> > MSMetaData::_getArrayIDs() const {
+SHARED_PTR<Vector<Int> > MSMetaData::_getArrayIDs() const {
 	if (_arrayIDs && _arrayIDs->size() > 0) {
 		return _arrayIDs;
 	}
 	static const String arrColName = MeasurementSet::columnName(MSMainEnums::ARRAY_ID);
-	CountedPtr<Vector<Int> > arrIDs(
+	SHARED_PTR<Vector<Int> > arrIDs(
 		new Vector<Int>(ROScalarColumn<Int>(*_ms, arrColName).getColumn())
 	);
 	if (_cacheUpdated(sizeof(Int)*arrIDs->size())) {
@@ -560,12 +555,12 @@ CountedPtr<Vector<Int> > MSMetaData::_getArrayIDs() const {
 	return arrIDs;
 }
 
-CountedPtr<Vector<Int> > MSMetaData::_getFieldIDs() const {
+SHARED_PTR<Vector<Int> > MSMetaData::_getFieldIDs() const {
 	if (_fieldIDs && ! _fieldIDs->empty()) {
 		return _fieldIDs;
 	}
 	String fieldIdColName = MeasurementSet::columnName(MSMainEnums::FIELD_ID);
-	CountedPtr<Vector<Int> > fields(
+	SHARED_PTR<Vector<Int> > fields(
 		new Vector<Int>(ROScalarColumn<Int>(*_ms, fieldIdColName).getColumn())
 	);
 	if (_cacheUpdated(sizeof(Int)*fields->size())) {
@@ -574,12 +569,12 @@ CountedPtr<Vector<Int> > MSMetaData::_getFieldIDs() const {
 	return fields;
 }
 
-CountedPtr<Vector<Int> > MSMetaData::_getStateIDs() const {
+SHARED_PTR<Vector<Int> > MSMetaData::_getStateIDs() const {
 	if (_stateIDs && _stateIDs->size() > 0) {
 		return _stateIDs;
 	}
 	static const String stateColName = MeasurementSet::columnName(MSMainEnums::STATE_ID);
-	CountedPtr<Vector<Int> > states(
+	SHARED_PTR<Vector<Int> > states(
 		new Vector<Int>(ROScalarColumn<Int>(*_ms, stateColName).getColumn())
 	);
     Int maxState = max(*states);
@@ -596,13 +591,13 @@ CountedPtr<Vector<Int> > MSMetaData::_getStateIDs() const {
 	return states;
 }
 
-CountedPtr<Vector<Int> > MSMetaData::_getDataDescIDs() const {
+SHARED_PTR<Vector<Int> > MSMetaData::_getDataDescIDs() const {
 	if (_dataDescIDs && ! _dataDescIDs->empty()) {
 		return _dataDescIDs;
 	}
 	static const String ddColName = MeasurementSet::columnName(MSMainEnums::DATA_DESC_ID);
 	ROScalarColumn<Int> ddCol(*_ms, ddColName);
-	CountedPtr<Vector<Int> > dataDescIDs(
+	SHARED_PTR<Vector<Int> > dataDescIDs(
 		new Vector<Int>(ddCol.getColumn())
 	);
 	if (_cacheUpdated(sizeof(Int)*dataDescIDs->size())) {
@@ -1028,8 +1023,8 @@ void MSMetaData::_getFieldsAndSpwMaps(
 		spwToFieldMap = _spwToFieldIDsMap;
 		return;
 	}
-	CountedPtr<Vector<Int> > allDDIDs = _getDataDescIDs();
-	CountedPtr<Vector<Int> > allFieldIDs = _getFieldIDs();
+	SHARED_PTR<Vector<Int> > allDDIDs = _getDataDescIDs();
+	SHARED_PTR<Vector<Int> > allFieldIDs = _getFieldIDs();
 	Vector<Int>::const_iterator endDDID = allDDIDs->end();
 	Vector<Int>::const_iterator curField = allFieldIDs->begin();
 	fieldToSpwMap.clear();
@@ -1449,10 +1444,10 @@ vector<std::map<Int, Quantity> > MSMetaData::getFirstExposureTimeMap() {
 		return _firstExposureTimeMap;
 	}
 	uInt nDataDescIDs = nDataDescriptions();
-	CountedPtr<Vector<Int> > scans = _getScans();
-	CountedPtr<Vector<Int> > dataDescIDs = _getDataDescIDs();
-	CountedPtr<Vector<Double> > times = _getTimes();
-	CountedPtr<QVD > exposureTimes = _getExposureTimes();
+	SHARED_PTR<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > dataDescIDs = _getDataDescIDs();
+	SHARED_PTR<Vector<Double> > times = _getTimes();
+	SHARED_PTR<QVD > exposureTimes = _getExposureTimes();
 	vector<std::map<Int, Quantity> > firstExposureTimeMap(nDataDescIDs);
 	vector<std::map<Int, Double> > tmap(nDataDescIDs);
 	Vector<Int>::const_iterator siter = scans->begin();
@@ -1524,10 +1519,10 @@ std::set<SubScanKey> MSMetaData::_getSubScanKeys() const {
 		return _subscans;
 	}
 	std::set<SubScanKey> mysubscans;
-	CountedPtr<Vector<Int> > scans = _getScans();
-	CountedPtr<Vector<Int> > fields = _getFieldIDs();
-	CountedPtr<Vector<Int> > arrays = _getArrayIDs();
-	CountedPtr<Vector<Int> > obs = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > fields = _getFieldIDs();
+	SHARED_PTR<Vector<Int> > arrays = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > obs = _getObservationIDs();
 	Vector<Int>::const_iterator scanIter = scans->begin();
 	Vector<Int>::const_iterator scanEnd = scans->end();
 	Vector<Int>::const_iterator fIter = fields->begin();
@@ -1934,7 +1929,7 @@ std::set<Int> MSMetaData::getScansForTimes(
 	arrayKey.obsID = obsID;
 	arrayKey.arrayID = arrayID;
 	std::set<ScanKey> uniqueScans = getScanKeys(arrayKey);
-	CountedPtr<std::map<ScanKey, std::set<Double> > > scanToTimesMap = _getScanToTimesMap();
+	SHARED_PTR<std::map<ScanKey, std::set<Double> > > scanToTimesMap = _getScanToTimesMap();
 	Double minTime = center - tol;
 	Double maxTime = center + tol;
 	std::set<Int> scans;
@@ -1950,20 +1945,20 @@ std::set<Int> MSMetaData::getScansForTimes(
 	return scans;
 }
 
-CountedPtr<std::map<ScanKey, std::set<Double> > > MSMetaData::_getScanToTimesMap() const {
+SHARED_PTR<std::map<ScanKey, std::set<Double> > > MSMetaData::_getScanToTimesMap() const {
 	if (_scanToTimesMap && ! _scanToTimesMap->empty()) {
 		return _scanToTimesMap;
 	}
-	CountedPtr<Vector<Int> > scans = _getScans();
-	CountedPtr<Vector<Int> > obsIDs = _getObservationIDs();
-	CountedPtr<Vector<Int> > arrayIDs = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > obsIDs = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > arrayIDs = _getArrayIDs();
 	Vector<Int>::const_iterator curScan = scans->begin();
 	Vector<Int>::const_iterator lastScan = scans->end();
-	CountedPtr<Vector<Double> > times = _getTimes();
+	SHARED_PTR<Vector<Double> > times = _getTimes();
 	Vector<Double>::const_iterator curTime = times->begin();
 	Vector<Int>::const_iterator curObs = obsIDs->begin();
 	Vector<Int>::const_iterator curArray = arrayIDs->begin();
-	CountedPtr<std::map<ScanKey, std::set<Double> > > scanToTimesMap(
+	SHARED_PTR<std::map<ScanKey, std::set<Double> > > scanToTimesMap(
 		new std::map<ScanKey, std::set<Double> >()
 	);
 	ScanKey scanKey;
@@ -1983,12 +1978,12 @@ CountedPtr<std::map<ScanKey, std::set<Double> > > MSMetaData::_getScanToTimesMap
 	return scanToTimesMap;
 }
 
-CountedPtr<Vector<Double> > MSMetaData::_getTimes() const {
+SHARED_PTR<Vector<Double> > MSMetaData::_getTimes() const {
 	if (_times && ! _times->empty()) {
 		return _times;
 	}
 	String timeColName = MeasurementSet::columnName(MSMainEnums::TIME);
-	CountedPtr<Vector<Double> > times(
+	SHARED_PTR<Vector<Double> > times(
 		new Vector<Double>(	 ScalarColumn<Double>(*_ms, timeColName).getColumn())
 	);
 	if (_cacheUpdated(sizeof(Double)*times->size())) {
@@ -1997,14 +1992,14 @@ CountedPtr<Vector<Double> > MSMetaData::_getTimes() const {
 	return times;
 }
 
-CountedPtr<QVD > MSMetaData::_getExposureTimes() {
+SHARED_PTR<QVD > MSMetaData::_getExposureTimes() {
 	if (_exposures && ! _exposures->getValue().empty()) {
 		return _exposures;
 	}
 	String colName = MeasurementSet::columnName(MSMainEnums::EXPOSURE);
 	ScalarColumn<Double> exposure (*_ms, colName);
 	String unit = *exposure.keywordSet().asArrayString("QuantumUnits").begin();
-	CountedPtr<QVD > ex(
+	SHARED_PTR<QVD > ex(
 		new QVD(exposure.getColumn(), unit)
 	);
 	if (_cacheUpdated((20 + sizeof(Double))*ex->getValue().size())) {
@@ -2013,12 +2008,12 @@ CountedPtr<QVD > MSMetaData::_getExposureTimes() {
 	return ex;
 }
 
-CountedPtr<ArrayColumn<Bool> > MSMetaData::_getFlags() const {
+SHARED_PTR<ArrayColumn<Bool> > MSMetaData::_getFlags() const {
 	if (_flagsColumn && _flagsColumn->nrow() > 0) {
 		return _flagsColumn;
 	}
 	String flagColName = MeasurementSet::columnName(MSMainEnums::FLAG);
-	CountedPtr<ArrayColumn<Bool> > flagsColumn(
+	SHARED_PTR<ArrayColumn<Bool> > flagsColumn(
 		new ArrayColumn<Bool>(*_ms, flagColName)
 	);
 	uInt mysize = 0;
@@ -2036,11 +2031,11 @@ std::set<Double> MSMetaData::getTimesForScans(
 ) const {
 	std::set<Double> times;
 	if (scans.empty()) {
-		CountedPtr<Vector<Double> > allTimes = _getTimes();
+		SHARED_PTR<Vector<Double> > allTimes = _getTimes();
 		times.insert(allTimes->begin(), allTimes->end());
 		return times;
 	}
-	CountedPtr<std::map<ScanKey, std::set<Double> > > scanToTimesMap = _getScanToTimesMap();
+	SHARED_PTR<std::map<ScanKey, std::set<Double> > > scanToTimesMap = _getScanToTimesMap();
 	// std::set<Int> scanNumbers = getScanNumbers();
 	std::set<ScanKey>::const_iterator scan = scans.begin();
 	std::set<ScanKey>::const_iterator end = scans.end();
@@ -2105,17 +2100,17 @@ void MSMetaData::_getTimesAndInvervals(
 	scanToTimeRangeMap.clear();
 	scanSpwToAverageIntervalMap.clear();
 	scanSpwToTimesMap.clear();
-	CountedPtr<Vector<Int> > obsIDs = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > obsIDs = _getObservationIDs();
 	Vector<Int>::const_iterator oIter = obsIDs->begin();
-	CountedPtr<Vector<Int> > arrayIDs = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > arrayIDs = _getArrayIDs();
 	Vector<Int>::const_iterator aIter = arrayIDs->begin();
-	CountedPtr<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > scans = _getScans();
 	Vector<Int>::const_iterator sIter = scans->begin();
 	Vector<Int>::const_iterator sEnd = scans->end();
 
-	CountedPtr<Vector<Int> > dataDescIDs = _getDataDescIDs();
+	SHARED_PTR<Vector<Int> > dataDescIDs = _getDataDescIDs();
 	Vector<Int>::const_iterator dIter = dataDescIDs->begin();
-	CountedPtr<Vector<Double> > times = _getTimes();
+	SHARED_PTR<Vector<Double> > times = _getTimes();
 
 	Vector<Double>::const_iterator  tIter = times->begin();
 	String intervalColName = MeasurementSet::columnName(MSMainEnums::INTERVAL);
@@ -2499,7 +2494,7 @@ Record MSMetaData::getSummary() const {
 		++oCount;
 	}
 	summary.define("nrows", nRows());
-	CountedPtr<Vector<Double> > times = _getTimes();
+	SHARED_PTR<Vector<Double> > times = _getTimes();
 	summary.define("begin time", min(*times));
 	summary.define("end time", max(*times));
 	return summary;
@@ -2605,8 +2600,8 @@ std::map<String, std::set<Double> > MSMetaData::_getIntentsToTimesMap() const {
 	if (uniqueIntents.empty()) {
 		return mymap;
 	}
-	CountedPtr<Vector<Int> > stateIDs = _getStateIDs();
-	CountedPtr<Vector<Double> > times = _getTimes();
+	SHARED_PTR<Vector<Int> > stateIDs = _getStateIDs();
+	SHARED_PTR<Vector<Double> > times = _getTimes();
 	Vector<Int>::const_iterator state = stateIDs->begin();
 	Vector<Double>::const_iterator time = times->begin();
 	Vector<Int>::const_iterator end = stateIDs->end();
@@ -2731,8 +2726,8 @@ vector<std::set<Int> > MSMetaData::_getObservationIDToArrayIDsMap() const {
 	if (! _obsToArraysMap.empty()) {
 		return _obsToArraysMap;
 	}
-	CountedPtr<Vector<Int> > obsIDs = _getObservationIDs();
-	CountedPtr<Vector<Int> > arrayIDs = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > obsIDs = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > arrayIDs = _getArrayIDs();
 	Vector<Int>::const_iterator oIter = obsIDs->begin();
 	Vector<Int>::const_iterator oEnd = obsIDs->end();
 	Vector<Int>::const_iterator aIter = arrayIDs->begin();
@@ -2768,25 +2763,95 @@ vector<MDirection> MSMetaData::getSourceDirections() const {
 		return _sourceDirs;
 	}
 	String colName = MSSource::columnName(MSSource::DIRECTION);
-	ROArrayColumn<Double> col(_ms->source(), colName);
-	const TableRecord& keywords = col.keywordSet();
-	vector<String> u = keywords.asArrayString("QuantumUnits").tovector();
-	std::pair<String, String> units(u[0], u[1]);
-	MDirection::Types frame;
-	String frameString = keywords.asRecord("MEASINFO").asString("Ref");
-	ThrowIf(
-		! MDirection::getType(
-			frame,  frameString
-		), "Unknown direction reference frame " + frameString
-	);
-	vector<MDirection> myvec = _getDirections(
-		col, units,
-		vector<MDirection::Types>(col.nrow(), frame)
-	);
+	ScalarMeasColumn<MDirection> col(_ms->source(), colName);
+	uInt nrows = _ms->source().nrow();
+	vector<MDirection> myvec(nrows);
+	MDirection direction;
+	for (uInt i=0; i<nrows; ++i) {
+	    col.get(i, direction);
+	    myvec[i] = direction;
+	}
 	if (_cacheUpdated(sizeof(myvec))) {
 		_sourceDirs = myvec;
 	}
 	return myvec;
+}
+
+map<SourceKey, MSMetaData::SourceProperties> MSMetaData::_getSourceInfo() const {
+    // this method is responsible for setting _sourceInfo
+    if (! _sourceInfo.empty()) {
+        return _sourceInfo;
+    }
+    String colName = MSSource::columnName(MSSource::SOURCE_ID);
+    ROScalarColumn<Int> id(_ms->source(), colName);
+    colName = MSSource::columnName(MSSource::SPECTRAL_WINDOW_ID);
+    ROScalarColumn<Int> spw(_ms->source(), colName);
+    colName = MSSource::columnName(MSSource::NAME);
+    ROScalarColumn<String> name(_ms->source(), colName);
+    colName = MSSource::columnName(MSSource::REST_FREQUENCY);
+    ArrayMeasColumn<MFrequency> restfreq(_ms->source(), colName);
+    colName = MSSource::columnName(MSSource::TRANSITION);
+    ROArrayColumn<String> transition(_ms->source(), colName);
+    map<SourceKey, SourceProperties> mymap;
+    uInt nrows = _ms->source().nrow();
+    Vector<MFrequency> rf;
+    SourceKey key;
+    SourceProperties props;
+    static const Unit emptyUnit;
+    static const Unit hz("Hz");
+    for (uInt i=0; i<nrows; ++i) {
+        key.id = id(i);
+        key.spw = spw(i);
+        props.name = name(i);
+        if (restfreq.isDefined(i)) {
+            restfreq.get(i, rf);
+            props.restfreq.reset(new vector<MFrequency>(rf.tovector()));
+        }
+        else {
+            props.restfreq.reset();
+        }
+        if (transition.isDefined(i)) {
+            props.transition.reset(new vector<String>(transition(i).tovector()));
+        }
+        else {
+            props.transition.reset();
+        }
+        mymap[key] = props;
+    }
+    ThrowIf(
+        mymap.size() < nrows,
+        "Too few source keys found, there are duplicate SOURCE table keys"
+    );
+    // this is a reasonable approximation for now
+    uInt mysize = nrows*(2*sizeof(uInt) + sizeof(Double) + 30);
+    if (_cacheUpdated(mysize)) {
+        _sourceInfo = mymap;
+    }
+    return mymap;
+}
+
+map<SourceKey, SHARED_PTR<vector<MFrequency> > > MSMetaData::getRestFrequencies() const {
+    map<SourceKey, SourceProperties> mymap = _getSourceInfo();
+    map<SourceKey, SHARED_PTR<vector<MFrequency> > > ret;
+    map<SourceKey, SourceProperties>::const_iterator iter = mymap.begin();
+    map<SourceKey, SourceProperties>::const_iterator end = mymap.end();
+    while (iter != end) {
+        ret[iter->first] = iter->second.restfreq;
+        ++iter;
+    }
+    return ret;
+}
+
+map<SourceKey, SHARED_PTR<vector<String> > > MSMetaData::getTransitions() const {
+    map<SourceKey, SourceProperties> mymap = _getSourceInfo();
+    map<SourceKey, SHARED_PTR<vector<String> > > ret;
+    map<SourceKey, SourceProperties>::const_iterator iter = mymap.begin();
+    map<SourceKey, SourceProperties>::const_iterator end = mymap.end();
+    while (iter != end) {
+        ret[iter->first] = iter->second.transition;
+        ++iter;
+    }
+    return ret;
 }
 
 vector<String> MSMetaData::getSourceNames() const {
@@ -2865,8 +2930,8 @@ std::set<Int> MSMetaData::getFieldsForTimes(
 	_checkTolerance(tol);
 	Double minTime = center - tol;
 	Double maxTime = center + tol;
-	CountedPtr<std::map<Int, std::set<Double> > > fieldToTimesMap;
-	CountedPtr<std::map<Double, std::set<Int> > > timeToFieldsMap;
+	SHARED_PTR<std::map<Int, std::set<Double> > > fieldToTimesMap;
+	SHARED_PTR<std::map<Double, std::set<Int> > > timeToFieldsMap;
 	_getFieldsAndTimesMaps(
 		fieldToTimesMap, timeToFieldsMap
 	);
@@ -2898,8 +2963,8 @@ void MSMetaData::_checkTolerance(const Double tol) {
 }
 
 void MSMetaData::_getFieldsAndTimesMaps(
-		CountedPtr<std::map<Int, std::set<Double> > >& fieldToTimesMap,
-		CountedPtr<std::map<Double, std::set<Int> > >& timeToFieldsMap
+		SHARED_PTR<std::map<Int, std::set<Double> > >& fieldToTimesMap,
+		SHARED_PTR<std::map<Double, std::set<Int> > >& timeToFieldsMap
 ) {
 	// This method is responsible for setting _fieldToTimesMap and _timeToFieldMap
 	if (
@@ -2912,8 +2977,8 @@ void MSMetaData::_getFieldsAndTimesMaps(
 	}
 	fieldToTimesMap.reset(new std::map<Int, std::set<Double> >());
 	timeToFieldsMap.reset(new std::map<Double, std::set<Int> >());
-	CountedPtr<Vector<Int> > allFields = _getFieldIDs();
-	CountedPtr<Vector<Double> > allTimes = this->_getTimes();
+	SHARED_PTR<Vector<Int> > allFields = _getFieldIDs();
+	SHARED_PTR<Vector<Double> > allTimes = this->_getTimes();
 	Vector<Int>::const_iterator lastField = allFields->end();
 	Vector<Double>::const_iterator curTime = allTimes->begin();
 	for (
@@ -2935,8 +3000,8 @@ std::set<Double> MSMetaData::getTimesForField(const Int fieldID) {
 	if (! _hasFieldID(fieldID)) {
 		return std::set<Double>();
 	}
-	CountedPtr<std::map<Int, std::set<Double> > > fieldToTimesMap;
-	CountedPtr<std::map<Double, std::set<Int> > > timeToFieldsMap;
+	SHARED_PTR<std::map<Int, std::set<Double> > > fieldToTimesMap;
+	SHARED_PTR<std::map<Double, std::set<Int> > > timeToFieldsMap;
 	_getFieldsAndTimesMaps(
 		fieldToTimesMap, timeToFieldsMap
 	);
@@ -3065,22 +3130,6 @@ vector<MDirection> MSMetaData::getPhaseDirs() const {
 	}
 	if (_cacheUpdated(_sizeof(myDirs))) {
 		_phaseDirs = myDirs;
-	}
-	return myDirs;
-}
-
-vector<MDirection> MSMetaData::_getDirections(
-	const ROArrayColumn<Double>& col,
-	const pair<String, String>& units,
-	const vector<MDirection::Types>& refFrames
-) {
-	uInt n = col.nrow();
-	vector<MDirection> myDirs(n);
-	for (uInt i=0; i<n; ++i) {
-		vector<Double> longlat = col.get(i).tovector();
-		Quantity longitude(longlat[0], units.first);
-		Quantity latitude(longlat[1], units.second);
-		myDirs[i] = MDirection(longitude, latitude, refFrames[i]);
 	}
 	return myDirs;
 }
@@ -3218,7 +3267,7 @@ Matrix<Bool> MSMetaData::getUniqueBaselines() {
 	if (! _uniqueBaselines.empty()) {
 		return _uniqueBaselines;
 	}
-	CountedPtr<Vector<Int> > ant1, ant2;
+	SHARED_PTR<Vector<Int> > ant1, ant2;
 	_getAntennas(ant1, ant2);
 
 	Vector<Int>::const_iterator a1Iter = ant1->begin();
@@ -3303,14 +3352,14 @@ std::map<SubScanKey, MSMetaData::SubScanProperties> MSMetaData::_getSubScanPrope
 	if (! _subScanProperties.empty()) {
 		return _subScanProperties;
 	}
-	CountedPtr<Vector<Int> > scans = _getScans();
-	CountedPtr<Vector<Int> > fields = _getFieldIDs();
-	CountedPtr<Vector<Int> > ddIDs = _getDataDescIDs();
-	CountedPtr<Vector<Int> > states = _getStateIDs();
-	CountedPtr<Vector<Double> > times = _getTimes();
-	CountedPtr<Vector<Int> > arrays = _getArrayIDs();
-	CountedPtr<Vector<Int> > observations = _getObservationIDs();
-	CountedPtr<Vector<Int> > ant1, ant2;
+	SHARED_PTR<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > fields = _getFieldIDs();
+	SHARED_PTR<Vector<Int> > ddIDs = _getDataDescIDs();
+	SHARED_PTR<Vector<Int> > states = _getStateIDs();
+	SHARED_PTR<Vector<Double> > times = _getTimes();
+	SHARED_PTR<Vector<Int> > arrays = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > observations = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > ant1, ant2;
 	_getAntennas(ant1, ant2);
 	Vector<Int>::const_iterator scanIter = scans->begin();
 	Vector<Int>::const_iterator scanEnd = scans->end();
@@ -3417,10 +3466,10 @@ std::map<Double, Double> MSMetaData::_getTimeToTotalBWMap(
 
 void MSMetaData::_getUnflaggedRowStats(
 	Double& nACRows, Double& nXCRows,
-	CountedPtr<std::map<SubScanKey, Double> >& subScanNACRows,
-	CountedPtr<std::map<SubScanKey, Double> >& subScanNXCRows,
-	CountedPtr<vector<Double> >& fieldNACRows,
-	CountedPtr<vector<Double> >& fieldNXCRows
+	SHARED_PTR<std::map<SubScanKey, Double> >& subScanNACRows,
+	SHARED_PTR<std::map<SubScanKey, Double> >& subScanNXCRows,
+	SHARED_PTR<vector<Double> >& fieldNACRows,
+	SHARED_PTR<vector<Double> >& fieldNXCRows
 ) const {
 	// This method is responsible for setting _nUnflaggedACRows, _nUnflaggedXCRows,
 	// _unflaggedFieldNACRows, _unflaggedFieldNXCRows, _unflaggedScanNACRows,
@@ -3480,13 +3529,13 @@ void MSMetaData::_getUnflaggedRowStats(
 		(*subScanNXCRows)[*iter] = 0;
 		++iter;
 	}
-	CountedPtr<Vector<Int> > ant1, ant2;
+	SHARED_PTR<Vector<Int> > ant1, ant2;
 	_getAntennas(ant1, ant2);
-	CountedPtr<Vector<Int> > dataDescIDs = _getDataDescIDs();
-	CountedPtr<Vector<Int> > scans = _getScans();
-	CountedPtr<Vector<Int> > fieldIDs = _getFieldIDs();
-	CountedPtr<Vector<Int> > obsIDs = _getObservationIDs();
-	CountedPtr<Vector<Int> > arrIDs = _getArrayIDs();
+	SHARED_PTR<Vector<Int> > dataDescIDs = _getDataDescIDs();
+	SHARED_PTR<Vector<Int> > scans = _getScans();
+	SHARED_PTR<Vector<Int> > fieldIDs = _getFieldIDs();
+	SHARED_PTR<Vector<Int> > obsIDs = _getObservationIDs();
+	SHARED_PTR<Vector<Int> > arrIDs = _getArrayIDs();
 	Vector<Int>::const_iterator aEnd = ant1->end();
 	Vector<Int>::const_iterator a1Iter = ant1->begin();
 	Vector<Int>::const_iterator a2Iter = ant2->begin();
@@ -3501,7 +3550,7 @@ void MSMetaData::_getUnflaggedRowStats(
     vector<uInt> dataDescIDToSpwMap = getDataDescIDToSpwMap();
 	std::set<uInt> a, b, c, d, e;
 	vector<SpwProperties> spwInfo = _getSpwInfo(a, b, c, d, e);
-	CountedPtr<ArrayColumn<Bool> > flags = _getFlags();
+	SHARED_PTR<ArrayColumn<Bool> > flags = _getFlags();
 	while (a1Iter != aEnd) {
 		uInt spw = dataDescIDToSpwMap[*dIter];
 		SpwProperties spwProp = spwInfo[spw];
@@ -3613,10 +3662,10 @@ void MSMetaData::_getSpwsAndIntentsMaps(
 		_intentToSpwsMap = intentToSpwsMap;
 		return;
 	}
-	CountedPtr<Vector<Int> > dataDescIDs = _getDataDescIDs();
+	SHARED_PTR<Vector<Int> > dataDescIDs = _getDataDescIDs();
 	Vector<Int>::const_iterator curDDID = dataDescIDs->begin();
 	Vector<Int>::const_iterator endDDID = dataDescIDs->end();
-	CountedPtr<Vector<Int> > states = _getStateIDs();
+	SHARED_PTR<Vector<Int> > states = _getStateIDs();
 	Vector<Int>::const_iterator curState = states->begin();
 	vector<uInt> dataDescToSpwMap = getDataDescIDToSpwMap();
 	while (curDDID!=endDDID) {
@@ -3658,8 +3707,8 @@ void MSMetaData::_getFieldsAndStatesMaps(
 		stateToFieldsMap = _stateToFieldsMap;
 		return;
 	}
-	CountedPtr<Vector<Int> > allStates = _getStateIDs();
-	CountedPtr<Vector<Int> > allFields = _getFieldIDs();
+	SHARED_PTR<Vector<Int> > allStates = _getStateIDs();
+	SHARED_PTR<Vector<Int> > allFields = _getFieldIDs();
 	Vector<Int>::const_iterator endState = allStates->end();
 	Vector<Int>::const_iterator curField = allFields->begin();
 	fieldToStatesMap.clear();
@@ -3827,7 +3876,7 @@ std::pair<MDirection, MDirection> MSMetaData::getPointingDirection(
 		row >= this->nRows(),
 		"Row number exceeds number of rows in the MS"
 	);
-	CountedPtr<Vector<Int> > ant1, ant2;
+	SHARED_PTR<Vector<Int> > ant1, ant2;
 	_getAntennas(ant1, ant2);
 	antenna1 = (*ant1)[row];
 	antenna2 = (*ant2)[row];
@@ -4069,7 +4118,7 @@ Bool MSMetaData::_hasFieldID(const Int fieldID) const {
 
 std::set<Int> MSMetaData::getUniqueFiedIDs() const {
 	if (_uniqueFieldIDs.empty()) {
-		CountedPtr<Vector<Int> > allFieldIDs = _getFieldIDs();
+		SHARED_PTR<Vector<Int> > allFieldIDs = _getFieldIDs();
 		_uniqueFieldIDs.insert(allFieldIDs->begin(), allFieldIDs->end());
 	}
 	return _uniqueFieldIDs;
@@ -4086,7 +4135,7 @@ Bool MSMetaData::_hasStateID(const Int stateID) const {
 		+ ") in this MS's STATE table"
 	);
 	if (_uniqueStateIDs.empty()) {
-		CountedPtr<Vector<Int> > allStateIDs = _getStateIDs();
+		SHARED_PTR<Vector<Int> > allStateIDs = _getStateIDs();
 		_uniqueStateIDs.insert(allStateIDs->begin(), allStateIDs->end());
 	}
 	return _uniqueStateIDs.find(stateID) != _uniqueStateIDs.end();

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -42,6 +42,7 @@ namespace casacore {
 template <class T> class ArrayColumn;
 struct ArrayKey;
 struct ScanKey;
+struct SourceKey;
 struct SubScanKey;
 
 // <summary>
@@ -201,12 +202,18 @@ public:
 	// get the set of field names corresponding to the specified spectral window.
 	std::set<String> getFieldNamesForSpw(const uInt spw);
 
+	// get rest frequencies from the SOURCE table
+	map<SourceKey, SHARED_PTR<vector<MFrequency> > > getRestFrequencies() const;
 
 	// get the set of spectral windows for the specified scan.
 	std::set<uInt> getSpwsForScan(const ScanKey& scan) const;
 
 	// get the set of scan numbers for the specified spectral window.
 	std::set<Int> getScansForSpw(uInt spw, Int obsID, Int arrayID) const;
+
+	// get the transitions from the SOURCE table. If there are no transitions
+	// for a particular key, the shared ptr contains the null ptr.
+    map<SourceKey, SHARED_PTR<vector<String> > > getTransitions() const;
 
 	// get the number of antennas in the ANTENNA table
 	uInt nAntennas() const;
@@ -453,8 +460,6 @@ public:
 
 	vector<MFrequency> getRefFreqs() const;
 
-
-
 	vector<uInt> nChans() const;
 
 	uInt nPol();
@@ -524,6 +529,13 @@ private:
 		std::map<Double, TimeStampProperties> timeProps;
 	};
 
+	// represents non-primary key data for a SOURCE table row
+	struct SourceProperties {
+	    String name;
+	    SHARED_PTR<vector<MFrequency> > restfreq;
+	    SHARED_PTR<vector<String> > transition;
+	};
+
 	// The general pattern is that a mutable gets set only once, on demand, when its
 	// setter is called for the first time. If this pattern is broken, defective behavior
 	// will occur.
@@ -555,12 +567,12 @@ private:
 	mutable std::set<String> _uniqueIntents;
 	mutable std::set<Int>  _uniqueFieldIDs, _uniqueStateIDs;
 	mutable std::set<uInt> _avgSpw, _tdmSpw, _fdmSpw, _wvrSpw, _sqldSpw;
-	mutable CountedPtr<Vector<Int> > _antenna1, _antenna2, _scans, _fieldIDs,
+	mutable SHARED_PTR<Vector<Int> > _antenna1, _antenna2, _scans, _fieldIDs,
 		_stateIDs, _dataDescIDs, _observationIDs, _arrayIDs;
-	mutable CountedPtr<std::map<SubScanKey, uInt> > _subScanToNACRowsMap, _subScanToNXCRowsMap;
-	//mutable CountedPtr<std::map<Int, uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
+	mutable SHARED_PTR<std::map<SubScanKey, uInt> > _subScanToNACRowsMap, _subScanToNXCRowsMap;
+	//mutable SHARED_PTR<std::map<Int, uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
 
-	mutable CountedPtr<vector<uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
+	mutable SHARED_PTR<vector<uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
  	mutable std::map<ScanKey, std::set<String> > _scanToIntentsMap;
 	mutable vector<std::set<String> > _stateToIntentsMap, _spwToIntentsMap, _fieldToIntentsMap;
 	mutable vector<SpwProperties> _spwInfo;
@@ -573,14 +585,14 @@ private:
 	mutable vector<vector<Int> > _corrTypes;
 	mutable vector<Array<Int> >_corrProds;
 
-	mutable CountedPtr<Vector<Double> > _times;
-	CountedPtr<QVD > _exposures;
-	mutable CountedPtr<std::map<ScanKey, std::set<Double> > > _scanToTimesMap;
+	mutable SHARED_PTR<Vector<Double> > _times;
+	SHARED_PTR<QVD > _exposures;
+	mutable SHARED_PTR<std::map<ScanKey, std::set<Double> > > _scanToTimesMap;
 	std::map<String, std::set<uInt> > _intentToSpwsMap;
 	mutable std::map<String, std::set<Double> > _intentToTimesMap;
 
-	CountedPtr<std::map<Int, std::set<Double> > > _fieldToTimesMap;
-	CountedPtr<std::map<Double, std::set<Int> > > _timeToFieldsMap;
+	SHARED_PTR<std::map<Int, std::set<Double> > > _fieldToTimesMap;
+	SHARED_PTR<std::map<Double, std::set<Int> > > _timeToFieldsMap;
 
 	mutable vector<MPosition> _observatoryPositions, _antennaPositions;
 	mutable vector<QVD > _antennaOffsets;
@@ -588,12 +600,11 @@ private:
 	Matrix<Bool> _uniqueBaselines;
 	Quantity _exposureTime;
 	mutable Double _nUnflaggedACRows, _nUnflaggedXCRows;
-	mutable CountedPtr<vector<Double> > _unflaggedFieldNACRows, _unflaggedFieldNXCRows;
-	mutable CountedPtr<std::map<SubScanKey, Double> > _unflaggedSubScanNACRows, _unflaggedSubScanNXCRows;
-	// mutable CountedPtr<AOSFMapD> _unflaggedScanNACRows, _unflaggedScanNXCRows;
+	mutable SHARED_PTR<vector<Double> > _unflaggedFieldNACRows, _unflaggedFieldNXCRows;
+	mutable SHARED_PTR<std::map<SubScanKey, Double> > _unflaggedSubScanNACRows, _unflaggedSubScanNXCRows;
 	const String _taqlTableName;
 	const vector<const Table*> _taqlTempTable;
-	mutable CountedPtr<ArrayColumn<Bool> > _flagsColumn;
+	mutable SHARED_PTR<ArrayColumn<Bool> > _flagsColumn;
 
 	mutable Bool _spwInfoStored;
 	vector<std::map<Int, Quantity> > _firstExposureTimeMap;
@@ -609,6 +620,8 @@ private:
 	mutable vector<MDirection> _phaseDirs, _sourceDirs;
 
 	mutable vector<std::pair<Quantity, Quantity> > _properMotions;
+
+	mutable map<SourceKey, SourceProperties> _sourceInfo;
 
 	// disallow copy constructor and = operator
 	MSMetaData(const MSMetaData&);
@@ -667,20 +680,14 @@ private:
 	vector<MPosition> _getAntennaPositions() const;
 
 	void _getAntennas(
-		CountedPtr<Vector<Int> >& ant1,
-		CountedPtr<Vector<Int> >& ant2
+		SHARED_PTR<Vector<Int> >& ant1,
+		SHARED_PTR<Vector<Int> >& ant2
 	) const;
-	CountedPtr<Vector<Int> > _getArrayIDs() const;
+	SHARED_PTR<Vector<Int> > _getArrayIDs() const;
 
-	CountedPtr<Vector<Int> > _getDataDescIDs() const;
+	SHARED_PTR<Vector<Int> > _getDataDescIDs() const;
 
-	static vector<MDirection> _getDirections(
-		const ROArrayColumn<Double>& col,
-		const pair<String, String>& units,
-		const vector<MDirection::Types>& refFrames
-	);
-
-	CountedPtr<QVD > _getExposureTimes();
+	SHARED_PTR<QVD > _getExposureTimes();
 
     // If there are no intents, then fieldToIntentsMap will be of length
     // nFields() and all of its entries will be the empty set, and
@@ -706,27 +713,27 @@ private:
 	);
 
 	void _getFieldsAndTimesMaps(
-		CountedPtr<std::map<Int, std::set<Double> > >& fieldToTimesMap,
-		CountedPtr<std::map<Double, std::set<Int> > >& timesToFieldMap
+		SHARED_PTR<std::map<Int, std::set<Double> > >& fieldToTimesMap,
+		SHARED_PTR<std::map<Double, std::set<Int> > >& timesToFieldMap
 	);
 
-	CountedPtr<Vector<Int> > _getFieldIDs() const;
+	SHARED_PTR<Vector<Int> > _getFieldIDs() const;
 
-	CountedPtr<ArrayColumn<Bool> > _getFlags() const;
+	SHARED_PTR<ArrayColumn<Bool> > _getFlags() const;
 
 	std::map<String, std::set<Double> > _getIntentsToTimesMap() const;
 
-	CountedPtr<Vector<Int> > _getObservationIDs() const;
+	SHARED_PTR<Vector<Int> > _getObservationIDs() const;
 
-	CountedPtr<Vector<Int> > _getScans() const;
+	SHARED_PTR<Vector<Int> > _getScans() const;
 
 	vector<std::set<String> > _getSpwToIntentsMap();
 
-	CountedPtr<Vector<Int> > _getStateIDs() const;
+	SHARED_PTR<Vector<Int> > _getStateIDs() const;
 
-	CountedPtr<Vector<Double> > _getTimes() const;
+	SHARED_PTR<Vector<Double> > _getTimes() const;
 
-	//CountedPtr<std::map<Double, TimeStampProperties> > _getTimeStampProperties() const;
+	//SHARED_PTR<std::map<Double, TimeStampProperties> > _getTimeStampProperties() const;
 
 	Bool _hasIntent(const String& intent) const;
 
@@ -759,10 +766,10 @@ private:
 
 	void _getRowStats(
 		uInt& nACRows, uInt& nXCRows,
-		CountedPtr<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
-		CountedPtr<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
-		CountedPtr<vector<uInt> >& fieldToNACRowsMap,
-		CountedPtr<vector<uInt> >& fieldToNXCRowsMap
+		SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
+		SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
+		SHARED_PTR<vector<uInt> >& fieldToNACRowsMap,
+		SHARED_PTR<vector<uInt> >& fieldToNXCRowsMap
 	) const;
 
 	// get all ScanKeys in the dataset
@@ -797,7 +804,9 @@ private:
 
 	std::map<ScanKey, std::set<SubScanKey> > _getScanToSubScansMap() const;
 
-	CountedPtr<std::map<ScanKey, std::set<Double> > > _getScanToTimesMap() const;
+	SHARED_PTR<std::map<ScanKey, std::set<Double> > > _getScanToTimesMap() const;
+
+	map<SourceKey, SourceProperties> _getSourceInfo() const;
 
 	vector<SpwProperties> _getSpwInfo(
 		std::set<uInt>& avgSpw, std::set<uInt>& tdmSpw,
@@ -838,10 +847,10 @@ private:
 
 	void _getUnflaggedRowStats(
 		Double& nACRows, Double& nXCRows,
-		CountedPtr<std::map<SubScanKey, Double> >& subScanToNACRowsMap,
-		CountedPtr<std::map<SubScanKey, Double> >& subScanToNXCRowsMap,
-		CountedPtr<vector<Double> >& fieldToNACRowsMap,
-		CountedPtr<vector<Double> >& fieldToNXCRowsMap
+		SHARED_PTR<std::map<SubScanKey, Double> >& subScanToNACRowsMap,
+		SHARED_PTR<std::map<SubScanKey, Double> >& subScanToNXCRowsMap,
+		SHARED_PTR<vector<Double> >& fieldToNACRowsMap,
+		SHARED_PTR<vector<Double> >& fieldToNXCRowsMap
 	) const;
 
 	void _getUnflaggedRowStats(

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -1214,7 +1214,6 @@ void testIt(MSMetaData& md) {
 		}
 		{
 			cout << "*** test getUniqueBaselines() and nBaselines()" << endl;
-			cout << md.getUniqueBaselines() << endl;
 			AlwaysAssert(md.nBaselines() == 21, AipsError);
 		}
 		{
@@ -1295,7 +1294,6 @@ void testIt(MSMetaData& md) {
 					default:
 						throw AipsError();
 					}
-					cout << "number " << iter->first << endl;
 					AlwaysAssert(iter->second == expec, AipsError);
 				}
 			}
@@ -1345,7 +1343,6 @@ void testIt(MSMetaData& md) {
 		{
 			cout << "*** test getCenterFreqs()" << endl;
 			vector<Quantity> centers = md.getCenterFreqs();
-			cout << "centers " << centers << endl;
 			Double mine[] = {
 				187550000000.0,	214250000000.0,
 				214234375000.0,	216250000000.0,
@@ -1531,9 +1528,7 @@ void testIt(MSMetaData& md) {
 				vector<MFrequency> rf = md.getRefFreqs();
 				for (uInt i=0; i<n; ++i) {
 					AlwaysAssert(rf[i].getRefString() == "TOPO", AipsError);
-                    cout << "*** unit " << rf[i].getUnit().getName() << endl;
                     AlwaysAssert(rf[i].getUnit() == Unit("Hz"), AipsError);
-					cout << std::setprecision(20) << "got " << rf[i].get("Hz").getValue() << " exp " << expec[i] << endl;
 					AlwaysAssert(near(rf[i].get("Hz").getValue(), expec[i], 1e-8), AipsError);
 				}
 			}
@@ -1798,7 +1793,7 @@ void testIt(MSMetaData& md) {
 			}
 		}
 		{
-			cout << "test getSpwToTimesForScan()" << endl;
+			cout << "*** test getSpwToTimesForScan()" << endl;
 			ScanKey scan;
 			scan.obsID = 0;
 			scan.arrayID = 0;
@@ -2108,6 +2103,40 @@ void testIt(MSMetaData& md) {
             vector<QVector<Double> > ebwv = md.getChanResolutions(True);
             AlwaysAssert(near(ebwv[9].getValue()[0], 20.23684342, 1e-8), AipsError);
             AlwaysAssert(ebwv[9].getUnit() == "km/s", AipsError);
+        }
+        {
+            cout << "test getRestFrequencies()" << endl;
+            map<SourceKey, SHARED_PTR<vector<MFrequency> > > rfs = md.getRestFrequencies();
+            map<SourceKey, SHARED_PTR<vector<MFrequency> > >::const_iterator iter = rfs.begin();
+            map<SourceKey, SHARED_PTR<vector<MFrequency> > >::const_iterator end = rfs.end();
+            while (iter != end) {
+                if (iter->second ) {
+                    AlwaysAssert(
+                        iter->first.id == 0 && iter->first.spw == 34, AipsError
+                    );
+                    AlwaysAssert(iter->second->size() == 2, AipsError);
+                    AlwaysAssert((*iter->second)[0].get("Hz").getValue() == 1e10, AipsError);
+                    AlwaysAssert((*iter->second)[1].get("Hz").getValue() == 2e10, AipsError);
+                }
+                ++iter;
+            }
+        }
+        {
+            cout << "test getTransitions()" << endl;
+            map<SourceKey, SHARED_PTR<vector<String> > > rfs = md.getTransitions();
+            map<SourceKey, SHARED_PTR<vector<String> > >::const_iterator iter = rfs.begin();
+            map<SourceKey, SHARED_PTR<vector<String> > >::const_iterator end = rfs.end();
+            while (iter != end) {
+                if (iter->second ) {
+                    AlwaysAssert(
+                        iter->first.id == 0 && iter->first.spw == 34, AipsError
+                    );
+                    AlwaysAssert(iter->second->size() == 2, AipsError);
+                    AlwaysAssert((*iter->second)[0] == "myline", AipsError);
+                    AlwaysAssert((*iter->second)[1] == "yourline", AipsError);
+                }
+                ++iter;
+            }
         }
         {
 			cout << "*** cache size " << md.getCache() << endl;


### PR DESCRIPTION
added SourceKey struct to MSKeys

added getRestFrequencies() and getTransitions() to MSMetaData along with private method for retrieving and storing data from SOURCE table.

Replaced CountedPtr with SHARED_PTR in MSMetaData, since that's what we are moving toward.

Replaced a couple of instances of "brute force" code with uses to Measures columns.