### PR TITLE
Build python bindings by default (not for CASA build)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,9 @@ enable_language (Fortran)
 
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+# By default build the Python bindings
+option (BUILD_PYTHON "Build the python bindings" YES)
 # By default build shared libraries
-option (BUILD_PYTHON "Build the python bindings" NO)
 option (ENABLE_SHARED "Build shared libraries" YES)
 option (ENABLE_RPATH "Include rpath in executables and shared libraries" YES)
 


### PR DESCRIPTION
This was triggered by #238. Building the python libraries does not have a disadvantage except for compilation time. Of course it can be manually disabled, and is disabled by default if CASA_BUILD=True.