### PR TITLE
Special treatment for SFL projection when reference values are set.

### DIFF
--- a/coordinates/Coordinates/DirectionCoordinate.cc
+++ b/coordinates/Coordinates/DirectionCoordinate.cc
@@ -604,6 +604,7 @@ Bool DirectionCoordinate::setReferencePixel(const Vector<Double> &refPix)
     //cout << "refPix[0]=" << refPix[0]
     //     << " refPix[1]=" << refPix[1]
     //     << endl;
+
     wcs_p.crpix[0] = refPix[0];
     wcs_p.crpix[1] = refPix[1];
     set_wcs(wcs_p);
@@ -639,6 +640,7 @@ Bool DirectionCoordinate::setIncrement(const Vector<Double> &inc)
 //
     Vector<Double> tmp(inc.copy());
     fromCurrent(tmp);
+
     wcs_p.cdelt[0] = tmp[0];  
     wcs_p.cdelt[1] = tmp[1];
     set_wcs(wcs_p);
@@ -656,6 +658,16 @@ Bool DirectionCoordinate::setReferenceValue(const Vector<Double> &refval)
 //
     Vector<Double> tmp(refval.copy());
     fromCurrent(tmp);
+//
+    // special treatment for SFL projection (see Calabretta & Greisen 2002)
+    if(projection_p.type() == Projection::SFL){
+      if (wcs_p.cdelt[1] != 0. && (!wcs_p.altlin&4 || wcs_p.crota[1]==0.) ){
+	// Force reference point to lat = 0 if CROTA is not set or is zero
+        // to avoid "wcsset_error: Ill-conditioned coordinate transformation parameters"
+	wcs_p.crpix[1] -= tmp[1]/wcs_p.cdelt[1];
+	tmp[1] = 0.;
+      }
+    }
 //
     wcs_p.crval[0] = tmp[0];
     wcs_p.crval[1] = tmp[1];

--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -590,6 +590,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		   << "The SIP convention for representing distortion in FITS headers\n  is not part of FITS standard v3.0"
 		   << " and not yet supported by CASA.\n  Header\n  "<< header[i] << "\n  was interpreted as\n  " << tmp << LogIO::POST;
 	    } else {
+	        if(header[i].contains("-GLS")){
+	  	    os << LogIO::WARN << "Note: The GLS projection is deprecated. Use SFL instead." << LogIO::POST;
+	        }
 		all = all.append(header(i));
 	    }
 	    delete [] tmp;

--- a/coordinates/Coordinates/Projection.cc
+++ b/coordinates/Coordinates/Projection.cc
@@ -304,15 +304,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    throw(AipsError("Projection::validate() - there are missing"
 			    "obligatory parameters"));
 	}
- 	else if (requiredSize < actualSize && verbose){ 
-	  if(name(which_p)=="SFL" and actualSize==3){
-	    cerr << "Note: The GLS projection is deprecated. Use SFL instead." << endl;
-	  }
-	  else{
-	    cerr << "Projection::validate() - " << actualSize << " projection parameters provided, at most "
-		 << requiredSize << " expected. Will try to continue ..."
-		 << endl;
-	  }
+ 	else if (requiredSize < actualSize && verbose){
+	    if(!(name(which_p)=="SFL" and actualSize==3)){
+	        cerr << "Projection::validate() - " << actualSize << " projection parameters provided, at most "
+		     << requiredSize << " expected. Will try to continue ..."
+		     << endl;
+	    }
  	}
 	else if (actualSize < requiredSize){ // take care of default values 
 	    parameters_p.resize(requiredSize);


### PR DESCRIPTION
The LON ref val must be forced to zero.
Also improved warning messaging for GLS projection conversion to SFL.
Related CASA ticket: CAS-7759 .