### PR TITLE
Statistics framework enhancements

### DIFF
--- a/lattices/LatticeMath/LatticeStatistics.h
+++ b/lattices/LatticeMath/LatticeStatistics.h
@@ -45,6 +45,7 @@
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/scimath/Mathematics/FitToHalfStatisticsData.h>
 #include <casacore/scimath/Mathematics/StatisticsData.h>
+#include <casacore/scimath/Mathematics/StatisticsAlgorithm.h>
 #include <vector>
 #include <list>
 
@@ -54,9 +55,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 template <class T> class MaskedLattice;
 template <class T> class TempLattice;
 class IPosition;
-
-template <class AccumType, class T, class U> class StatisticsAlgorithm;
-template <class AccumType, class T, class U> class ClassicalStatistics;
 
 #include <casacore/casa/iosstrfwd.h>
 

--- a/scimath/Mathematics/ChauvenetCriterionStatistics.h
+++ b/scimath/Mathematics/ChauvenetCriterionStatistics.h
@@ -44,8 +44,9 @@ namespace casacore {
 // Alternatively, one can specify a z score which indicates the number of standard deviations
 // beyond which to discard points. In this case, no iterating is done.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class ChauvenetCriterionStatistics
-	: public ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator> {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool*, class WeightsIterator=DataIterator>
+class ChauvenetCriterionStatistics
+	: public ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> {
 public:
 
 	// If <src>zscore</src> is not negative, use that value to discard outliers beyond
@@ -59,8 +60,8 @@ public:
 	virtual ~ChauvenetCriterionStatistics();
 
 	// copy semantics
-	ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>& operator=(
-		const ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>& other
+	ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
+		const ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 	);
 
 	// get the algorithm that this object uses for computing stats

--- a/scimath/Mathematics/ChauvenetCriterionStatistics.tcc
+++ b/scimath/Mathematics/ChauvenetCriterionStatistics.tcc
@@ -35,39 +35,39 @@
 
 namespace casacore {
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::ChauvenetCriterionStatistics(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::ChauvenetCriterionStatistics(
 	Double zscore, Int maxIterations
 )
-  : ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>(),
+  : ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>(),
     _zscore(zscore), _maxIterations(maxIterations), _rangeIsSet(False), _niter(0) {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::~ChauvenetCriterionStatistics() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::~ChauvenetCriterionStatistics() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>&
-ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::operator=(
-	const ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>& other
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>&
+ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(
+	const ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 ) {
     if (this == &other) {
         return *this;
     }
-    ClassicalStatistics<AccumType, InputIterator, MaskIterator>::operator=(other);
+    ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(other);
     _zscore = other._zscore;
     _maxIterations = other._maxIterations;
     _niter = other._niter;
     return *this;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::reset() {
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::reset();
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset() {
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset();
 	_rangeIsSet = False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::setCalculateAsAdded(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::setCalculateAsAdded(
 	Bool c
 ) {
 	ThrowIf(
@@ -76,8 +76,8 @@ void ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::setCa
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::_setRange() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ChauvenetCriterionStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_setRange() {
 	if (_rangeIsSet) {
 		return;
 	}
@@ -86,7 +86,7 @@ void ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::_setR
 	StatsData<AccumType> sd;
 	while (_niter <= maxI) {
 		if (_niter == 0) {
-			ClassicalStatistics<AccumType, InputIterator, MaskIterator> cs(*this);
+			ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> cs(*this);
 			sd = cs.getStatistics();
 		}
 		else {
@@ -99,7 +99,7 @@ void ChauvenetCriterionStatistics<AccumType, InputIterator, MaskIterator>::_setR
 		CountedPtr<std::pair<AccumType, AccumType> > range = new std::pair<AccumType, AccumType>(
 			sd.mean - zScore*sd.stddev, sd.mean + zScore*sd.stddev
 		);
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_setRange(range);
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_setRange(range);
 		// _rangeIsSet is set here to prevent infinite recursion on next loop iteration
 		_rangeIsSet = True;
 		prevNpts = (uInt64)sd.npts;

--- a/scimath/Mathematics/ClassicalStatistics.h
+++ b/scimath/Mathematics/ClassicalStatistics.h
@@ -54,20 +54,21 @@ namespace casacore {
 // don't understand, that impacted performance significantly. So I'm using the current
 // architecture, which I know is a bit a maintenance nightmare.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class ClassicalStatistics
-	: public StatisticsAlgorithm<AccumType, InputIterator, MaskIterator> {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool*, class WeightsIterator=DataIterator> 
+class ClassicalStatistics
+	: public StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator> {
 public:
 
 	ClassicalStatistics();
 
 	// copy semantics
-	ClassicalStatistics(const ClassicalStatistics<AccumType, InputIterator, MaskIterator>& cs);
+	ClassicalStatistics(const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& cs);
 
 	virtual ~ClassicalStatistics();
 
 	// copy semantics
-	ClassicalStatistics<AccumType, InputIterator, MaskIterator>& operator=(
-		const ClassicalStatistics<AccumType, InputIterator, MaskIterator>& other
+	ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
+		const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 	);
 
 	// get the algorithm that this object uses for computing stats
@@ -177,7 +178,7 @@ public:
 	virtual void setCalculateAsAdded(Bool c);
 
 	// An exception will be thrown if setCalculateAsAdded(True) has been called.
-	void setDataProvider(StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider);
+	void setDataProvider(StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider);
 
 	void setStatsToCalculate(std::set<StatisticsData::STATS>& stats);
 
@@ -190,50 +191,50 @@ protected:
 	// so that derived classes may override it.
 	inline virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude
 	) const;
 
 	virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _accumNpts(
 			uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	) const;
 	// </group>
@@ -267,7 +268,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 		const vector<AccumType>& maxLimit
 	) const;
@@ -275,7 +276,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -283,7 +284,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -291,7 +292,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -300,7 +301,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const ;
@@ -308,7 +309,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -316,7 +317,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -325,7 +326,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -344,50 +345,50 @@ protected:
 	// <group>
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	) const;
 	// </group>
@@ -396,51 +397,51 @@ protected:
 	// populate an unsorted array with valid data.
 	// no weights, no mask, no ranges
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	// ranges
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride
 	) const;
 
 	// mask and ranges
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// weights
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride
 	) const;
 
 	// weights and ranges
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// weights and mask
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	// weights, mask, ranges
 	virtual void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
@@ -453,19 +454,19 @@ protected:
 	// the method will return with no further processing.
 	// no weights, no mask, no ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -473,7 +474,7 @@ protected:
 
 	// mask and ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -481,30 +482,30 @@ protected:
 
 	// weights
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights and ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights and mask
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights, mask, ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -514,56 +515,56 @@ protected:
 	// <group>
 	// no weights, no mask, no ranges
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, uInt maxElements
 	) const;
 
 	// ranges
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		uInt maxElements
 	) const;
 
 	// mask
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride, uInt maxElements
 	) const;
 
 	// mask and ranges
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude, uInt maxElements
 	) const;
 
 	// weights
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		uInt maxElements
 	) const;
 
 	// weights and ranges
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude, uInt maxElements
 	) const;
 
 	// weights and mask
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride, uInt maxElements
 	) const;
 
 	// weights, mask, ranges
 	virtual Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		uInt maxElements
@@ -575,14 +576,14 @@ protected:
 	virtual void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	);
 
 	// no weights, no mask
 	virtual void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 
 	);
@@ -590,7 +591,7 @@ protected:
 	virtual void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 
 	);
@@ -598,7 +599,7 @@ protected:
 	virtual void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);
@@ -609,28 +610,28 @@ protected:
 	virtual void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	);
 
 	virtual void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	);
 
 	virtual void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	virtual void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);
@@ -643,18 +644,19 @@ private:
 	Bool _calculateAsAdded, _doMaxMin, _doMedAbsDevMed, _mustAccumulate;
 
 	// mutables, used to mitigate repeated code
-	mutable typename vector<InputIterator>::const_iterator _dend, _diter;
+	mutable typename vector<DataIterator>::const_iterator _dend, _diter;
 	mutable vector<Int64>::const_iterator _citer;
 	mutable vector<uInt>::const_iterator _dsiter;
 	mutable std::map<uInt, MaskIterator> _masks;
 	mutable uInt _maskStride;
-	mutable std::map<uInt, InputIterator> _weights;
+	mutable std::map<uInt, WeightsIterator> _weights;
 	mutable std::map<uInt, DataRanges> _ranges;
 	mutable std::map<uInt, Bool> _isIncludeRanges;
 	mutable Bool _hasMask, _hasRanges, _hasWeights, _myIsInclude;
 	mutable DataRanges _myRanges;
 	mutable MaskIterator _myMask;
-	mutable InputIterator _myData, _myWeights;
+	mutable DataIterator _myData;
+	mutable WeightsIterator _myWeights;
 	mutable uInt _dataCount, _myStride;
 	mutable uInt64 _myCount;
 

--- a/scimath/Mathematics/ClassicalStatistics.tcc
+++ b/scimath/Mathematics/ClassicalStatistics.tcc
@@ -37,36 +37,36 @@
 namespace casacore {
 
 // min > max indicates that these quantities have not be calculated
-template <class AccumType, class InputIterator, class MaskIterator>
-ClassicalStatistics<AccumType, InputIterator, MaskIterator>::ClassicalStatistics()
-	: StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>(),
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::ClassicalStatistics()
+	: StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>(),
 	  _statsData(initializeStatsData<AccumType>()),
 	  _idataset(0), _calculateAsAdded(False), _doMaxMin(True),
 	  _doMedAbsDevMed(False), _mustAccumulate(False) {
 	reset();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ClassicalStatistics<AccumType, InputIterator, MaskIterator>::~ClassicalStatistics() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::~ClassicalStatistics() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ClassicalStatistics<AccumType, InputIterator, MaskIterator>::ClassicalStatistics(
-    const ClassicalStatistics<AccumType, InputIterator, MaskIterator>& cs
-) : StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>(cs),
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::ClassicalStatistics(
+    const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& cs
+) : StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>(cs),
 	_statsData(cs._statsData),
     _idataset(cs._idataset),_calculateAsAdded(cs._calculateAsAdded),
     _doMaxMin(cs._doMaxMin), _doMedAbsDevMed(cs._doMedAbsDevMed), _mustAccumulate(cs._mustAccumulate) {
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ClassicalStatistics<AccumType, InputIterator, MaskIterator>&
-ClassicalStatistics<AccumType, InputIterator, MaskIterator>::operator=(
-	const ClassicalStatistics<AccumType, InputIterator, MaskIterator>& other
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>&
+ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(
+	const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 ) {
     if (this == &other) {
         return *this;
     }
-    StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::operator=(other);
+    StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(other);
     _statsData = copy(_statsData);
     _idataset = other._idataset;
     _calculateAsAdded = other._calculateAsAdded;
@@ -76,8 +76,8 @@ ClassicalStatistics<AccumType, InputIterator, MaskIterator>::operator=(
     return *this;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedian(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedian(
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes,
 	Bool persistSortedArray
@@ -104,8 +104,8 @@ AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 	return *_getStatsData().median;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::set<uInt64> ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_medianIndices(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::set<uInt64> ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_medianIndices(
 	CountedPtr<uInt64> knownNpts
 ) {
 	std::set<uInt64> indices;
@@ -120,8 +120,8 @@ std::set<uInt64> ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_m
 	return indices;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedianAbsDevMed(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAbsDevMed(
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes,
 	Bool persistSortedArray
@@ -156,8 +156,8 @@ AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 }
 
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedianAndQuantiles(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAndQuantiles(
 	std::map<Double, AccumType>& quantiles, const std::set<Double>& fractions,
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes,
@@ -207,8 +207,8 @@ AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 	return *_getStatsData().median;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMinMax(
 	AccumType& mymin, AccumType& mymax
 ) {
 	if ( _getStatsData().min.null() || _getStatsData().max.null()) {
@@ -227,8 +227,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(
 	mymax = *_getStatsData().max;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-uInt64 ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getNPts() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+uInt64 ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNPts() {
 	if (_getStatsData().npts == 0) {
 		ThrowIf(
 			_calculateAsAdded,
@@ -241,8 +241,8 @@ uInt64 ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getNPts() {
 	return (uInt64)_getStatsData().npts;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::map<Double, AccumType> ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getQuantiles(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::map<Double, AccumType> ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getQuantiles(
 	const std::set<Double>& fractions, CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes,
 	Bool persistSortedArray
@@ -291,13 +291,13 @@ std::map<Double, AccumType> ClassicalStatistics<AccumType, InputIterator, MaskIt
 	return quantileToValue;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::reset() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset() {
 	_clearData();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::setCalculateAsAdded(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::setCalculateAsAdded(
 	Bool c
 ) {
 	ThrowIf (
@@ -313,9 +313,9 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::setCalculateAs
 	_calculateAsAdded = c;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::setDataProvider(
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::setDataProvider(
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 ) {
 	ThrowIf(
 		_calculateAsAdded,
@@ -323,11 +323,11 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::setDataProvide
 		"in which case it is nonsensical to use a data provider. Please call "
 		"setCalculateAsAdded(False), and then set the data provider"
 	);
-	StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setDataProvider(dataProvider);
+	StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setDataProvider(dataProvider);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::setStatsToCalculate(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::setStatsToCalculate(
 	std::set<StatisticsData::STATS>& stats
 ) {
 	ThrowIf(
@@ -338,36 +338,36 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::setStatsToCalc
 	_doMaxMin = stats.empty()
 		|| stats.find(StatisticsData::MAX) != stats.end()
 		|| stats.find(StatisticsData::MIN) != stats.end();
-	StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setStatsToCalculate(stats);
+	StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setStatsToCalculate(stats);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_addData() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_addData() {
 	this->_setSortedArray(vector<AccumType>());
 	_getStatsData().median = NULL;
 	_mustAccumulate = True;
 	if (_calculateAsAdded) {
 		_getStatistics();
-		StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_clearData();
+		StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearData();
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_clearData() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearData() {
 	_clearStats();
-	StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_clearData();
+	StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearData();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_clearStats() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearStats() {
 	_statsData = initializeStatsData<AccumType>();
     _idataset = 0;
 	_doMedAbsDevMed = False;
 	_mustAccumulate = True;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::pair<Int64, Int64> ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getStatisticIndex(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::pair<Int64, Int64> ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getStatisticIndex(
 	StatisticsData::STATS stat
 ) {
 	ThrowIf(
@@ -410,8 +410,8 @@ std::pair<Int64, Int64> ClassicalStatistics<AccumType, InputIterator, MaskIterat
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_getStatistic(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistic(
 	StatisticsData::STATS stat
 ) {
 	AccumType value;
@@ -426,15 +426,15 @@ AccumType ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_getStati
 	return value;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatsData<AccumType> ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_getStatistics() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatsData<AccumType> ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistics() {
 	if (! _mustAccumulate) {
 		return _getStatsData();
 	}
 	_initIterators();
 	_getStatsData().masked = False;
 	_getStatsData().weighted = False;
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	while (True) {
 		_initLoopVars();
@@ -543,21 +543,21 @@ StatsData<AccumType> ClassicalStatistics<AccumType, InputIterator, MaskIterator>
 	return copy(_getStatsData());
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& /*dataBegin*/, Int64 nr, uInt /*dataStride*/
+	const DataIterator& /*dataBegin*/, Int64 nr, uInt /*dataStride*/
 ) const {
 	npts += nr;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -570,19 +570,19 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
 		) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -590,20 +590,20 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
 		if (*mask) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -617,40 +617,40 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
 		) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		if (*weight > 0) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -664,21 +664,21 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
 		) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -693,20 +693,20 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
 		) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -714,14 +714,14 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
 		if (*mask && *weight > 0) {
 			++npts;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumulate(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumulate(
 	AccumType& mymin, AccumType& mymax, Int64& minpos, Int64& maxpos, const AccumType& datum, Int64 count
 ) {
 	if (_doMaxMin) {
@@ -738,8 +738,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumulate(
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumulate(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumulate(
 	AccumType& mymin, AccumType& mymax, Int64& minpos, Int64& maxpos,
     const AccumType& datum, const AccumType& weight, Int64 count
 ) {
@@ -758,8 +758,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumulate(
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-vector<vector<uInt64> > ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_binCounts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+vector<vector<uInt64> > ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_binCounts(
 	vector<CountedPtr<AccumType> >& sameVal,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc
 ) {
@@ -803,7 +803,7 @@ vector<vector<uInt64> > ClassicalStatistics<AccumType, InputIterator, MaskIterat
 		++iDesc;
 	}
 	_initIterators();
-    StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+    StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	while (True) {
 		_initLoopVars();
@@ -892,13 +892,13 @@ vector<vector<uInt64> > ClassicalStatistics<AccumType, InputIterator, MaskIterat
 	return bins;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_createDataArray(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_createDataArray(
 	vector<AccumType>& ary
 ) {
 	//cout << __func__ << endl;
 	_initIterators();
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	while (True) {
 		_initLoopVars();
@@ -978,8 +978,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_createDataArr
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_createDataArrays(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_createDataArrays(
 	vector<vector<AccumType> >& arys, const vector<std::pair<AccumType, AccumType> > &includeLimits,
 	uInt maxCount
 ) {
@@ -1008,7 +1008,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_createDataArr
 		++iLimits;
 	}
 	_initIterators();
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	uInt currentCount = 0;
 	while (True) {
@@ -1096,8 +1096,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_createDataArr
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-vector<std::map<uInt64, AccumType> > ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_dataFromMultipleBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+vector<std::map<uInt64, AccumType> > ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_dataFromMultipleBins(
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, uInt maxArraySize,
 	const vector<std::set<uInt64> >& dataIndices
 ) {
@@ -1221,8 +1221,8 @@ vector<std::map<uInt64, AccumType> > ClassicalStatistics<AccumType, InputIterato
 	return ret;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-vector<std::map<uInt64, AccumType> > ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_dataFromSingleBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+vector<std::map<uInt64, AccumType> > ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_dataFromSingleBins(
 	const vector<uInt64>& binNpts, uInt maxArraySize, const vector<std::pair<AccumType, AccumType> >& binLimits,
 	const vector<std::set<uInt64> >& dataIndices
 ) {
@@ -1312,8 +1312,8 @@ vector<std::map<uInt64, AccumType> > ClassicalStatistics<AccumType, InputIterato
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_convertToAbsDevMedArray(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_convertToAbsDevMedArray(
 	vector<AccumType>& myArray, AccumType median
 ) {
 	typename vector<AccumType>::iterator iter = myArray.begin();
@@ -1324,13 +1324,13 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_convertToAbsD
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_doMinMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_doMinMax(
 	AccumType& datamin, AccumType& datamax
 ) {
 	//cout << __func__ << endl;
     _initIterators();
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	CountedPtr<AccumType> mymax;
 	CountedPtr<AccumType> mymin;
@@ -1417,11 +1417,11 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_doMinMax(
 	datamax = *mymax;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Int64 ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_doNpts() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Int64 ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_doNpts() {
 	//cout << __func__ << endl;
 	_initIterators();
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	uInt64 npts = 0;
 	while (True) {
@@ -1541,11 +1541,11 @@ Int64 ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_doNpts() {
 		} \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 ) const {
 	vector<vector<uInt64> >::iterator bCounts = binCounts.begin();
@@ -1559,22 +1559,22 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		 _findBinCode
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 ) const {
@@ -1589,7 +1589,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1602,17 +1602,17 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 		) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 ) const {
@@ -1627,7 +1627,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1635,17 +1635,17 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 		if (*mask) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -1661,7 +1661,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1675,17 +1675,17 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 		) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 ) const {
@@ -1700,25 +1700,25 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		if (*weight > 0) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 ) const {
@@ -1733,8 +1733,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1748,17 +1748,17 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 		) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -1774,8 +1774,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1790,17 +1790,17 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 		) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 ) const {
@@ -1815,8 +1815,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 	typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 	typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1824,14 +1824,14 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 		if (*mask && *weight > 0) {
 			_findBinCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::map<uInt64, AccumType> ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_indicesToValues(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::map<uInt64, AccumType> ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_indicesToValues(
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt maxArraySize,
 	const std::set<uInt64>& indices, Bool persistSortedArray
@@ -1880,8 +1880,8 @@ std::map<uInt64, AccumType> ClassicalStatistics<AccumType, InputIterator, MaskIt
 	)[0];
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_initIterators() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_initIterators() {
 	ThrowIf(
 		this->_getData().size() == 0 && ! this->_getDataProvider(),
 		"No data sets have been added"
@@ -1891,7 +1891,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_initIterators
 	}
 	else {
 		_dataCount = 0;
-		const vector<InputIterator>& data = this->_getData();
+		const vector<DataIterator>& data = this->_getData();
 		_diter = data.begin();
 		_dend = data.end();
 		const vector<uInt>& dataStrides = this->_getDataStrides();
@@ -1910,9 +1910,9 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_initIterators
 	_hasWeights = False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_initLoopVars() {
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_initLoopVars() {
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	if (dataProvider) {
 		_myData = dataProvider->getData();
@@ -1956,13 +1956,13 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_initLoopVars(
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_isNptsSmallerThan(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_isNptsSmallerThan(
 	vector<AccumType>& unsortedAry, uInt maxArraySize
 ) {
 	//cout << __func__ << endl;
 	_initIterators();
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	Bool limitReached = False;
 	while (True) {
@@ -2055,8 +2055,8 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_isNptsSmaller
 	return True;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_makeBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_makeBins(
 	typename StatisticsUtilities<AccumType>::BinDesc& bins, AccumType minData, AccumType maxData, uInt maxBins, Bool allowPad
 ) {
 
@@ -2089,29 +2089,29 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_makeBins(
 		mymax = new AccumType(*datum); \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		_minMaxCode
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2124,19 +2124,19 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 		) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2144,20 +2144,20 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 		if (*mask) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2171,40 +2171,40 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 		) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		if (*weight > 0) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2218,21 +2218,21 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 		) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2247,20 +2247,20 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 		) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2268,7 +2268,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 		if (*mask && *weight > 0) {
 			_minMaxCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
@@ -2279,28 +2279,28 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
 	AccumType myDatum = _doMedAbsDevMed ? abs((AccumType)*datum - *_statsData.median) : *datum; \
 	ary.push_back(myDatum);
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		_populateArrayCode1
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
 	typename DataRanges::const_iterator endRange = ranges.end();
@@ -2312,39 +2312,39 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
 	MaskIterator mask = maskBegin;
 	while (count < nr) {
 		if (*mask) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
 	MaskIterator mask = maskBegin;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2358,39 +2358,39 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		if (*weight > 0) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2404,19 +2404,19 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2424,20 +2424,20 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		if (*mask && *weight > 0) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2452,7 +2452,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArrayCode1
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
@@ -2485,9 +2485,9 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	}
 
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	typename vector<vector<AccumType> >::iterator bArys = arys.begin();
@@ -2496,19 +2496,19 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		_populateArraysCode
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -2518,7 +2518,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
 	typename DataRanges::const_iterator endRange = ranges.end();
@@ -2530,15 +2530,15 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -2548,22 +2548,22 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
 	MaskIterator mask = maskBegin;
 	while (count < nr) {
 		if (*mask) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -2574,7 +2574,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
 	MaskIterator mask = maskBegin;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2588,16 +2588,16 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	typename vector<vector<AccumType> >::iterator bArys = arys.begin();
@@ -2605,24 +2605,24 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		if (*weight > 0) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -2631,8 +2631,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2646,15 +2646,15 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -2663,8 +2663,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2672,15 +2672,15 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		if (*mask && *weight > 0) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -2690,8 +2690,8 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 	typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2706,27 +2706,27 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray
 		) {
 			_populateArraysCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	uInt maxElements
 ) const {
 	if (ary.size() + nr > maxElements) {
 		return True;
 	}
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		//ary.push_back(_doMedAbsDevMed ? abs((AccumType)*datum - *_median) : *datum);
 		ary.push_back(_doMedAbsDevMed ? abs((AccumType)*datum - *_statsData.median) : *datum);
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
@@ -2741,15 +2741,15 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		return True; \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	uInt maxElements
 ) const {
 	Int64 count = 0;
 	uInt npts = ary.size();
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
 	typename DataRanges::const_iterator endRange = ranges.end();
@@ -2761,21 +2761,21 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	uInt maxElements
 ) const {
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
 	MaskIterator mask = maskBegin;
 	uInt npts = ary.size();
@@ -2783,21 +2783,21 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		if (*mask) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
 	Int64 count = 0;
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
 	MaskIterator mask = maskBegin;
 	uInt npts = ary.size();
@@ -2812,21 +2812,21 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	uInt maxElements
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	uInt npts = ary.size();
@@ -2834,21 +2834,21 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		if (*weight > 0) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2863,21 +2863,21 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, uInt maxElements
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride;
@@ -2886,21 +2886,21 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		if (*mask && *weight > 0) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -2916,19 +2916,19 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestA
 		) {
 			_PopulateTestArrayCode
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 	return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_updateMaxMin(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_updateMaxMin(
 	AccumType mymin, AccumType mymax, Int64 minpos, Int64 maxpos, uInt dataStride,
 	const Int64& currentDataset
 ) {
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	if (maxpos >= 0) {
 		_getStatsData().maxpos.first = currentDataset;
@@ -2948,35 +2948,35 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_updateMaxMin(
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		_accumulate (
 			mymin, mymax, minpos, maxpos, *datum, count
 		);
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 	ngood = nr;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -2992,20 +2992,20 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedSta
 			);
 			++ngood;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -3016,22 +3016,22 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedSta
 			);
 			++ngood;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -3048,14 +3048,14 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedSta
 			);
 			++ngood;
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_valuesFromSortedArray(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_valuesFromSortedArray(
 	std::map<uInt64, AccumType>& values, CountedPtr<uInt64> knownNpts,
 	const std::set<uInt64>& indices, uInt maxArraySize, Bool persistSortedArray
 ) {
@@ -3120,7 +3120,7 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_valuesFromSor
 			}
 		}
 	}
-	values = StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_valuesFromArray(
+	values = StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::_valuesFromArray(
 		myArray, indices
 	);
 	if (! _doMedAbsDevMed) {
@@ -3134,15 +3134,15 @@ Bool ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_valuesFromSor
 	return True;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
@@ -3151,21 +3151,21 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 				mymin, mymax, minpos, maxpos, *datum, *weight, count
 			);
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -3181,22 +3181,22 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 				mymin, mymax, minpos, maxpos, *datum, *weight, count
 			);
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -3213,21 +3213,21 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 				mymin, mymax, minpos, maxpos, *datum, *weight, count
 			);
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -3237,7 +3237,7 @@ void ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 				mymin, mymax, minpos, maxpos, *datum, *weight, count
 			);
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}

--- a/scimath/Mathematics/ConstrainedRangeStatistics.h
+++ b/scimath/Mathematics/ConstrainedRangeStatistics.h
@@ -40,15 +40,16 @@ namespace casacore {
 // Abstract base class for statistics algorithms which are characterized by
 // a range of good values. The range is usually calculated dynamically based on the entire distribution.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class ConstrainedRangeStatistics
-	: public ClassicalStatistics<AccumType, InputIterator, MaskIterator> {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool*, class WeightsIterator=DataIterator>
+class ConstrainedRangeStatistics
+	: public ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> {
 public:
 
 	virtual ~ConstrainedRangeStatistics();
 
 	// copy semantics
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>& operator=(
-		const ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>& other
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
+		const ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 	);
 
 	// <group>
@@ -151,50 +152,50 @@ protected:
 	// so that derived classes may override it.
 	inline void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataStart, Int64 nr, uInt dataStride
+		const DataIterator& dataStart, Int64 nr, uInt dataStride
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataStart, Int64 nr, uInt dataStride,
+		const DataIterator& dataStart, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	) const;
 	// </group>
@@ -202,7 +203,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 		const vector<AccumType>& maxLimit
 	) const;
@@ -210,7 +211,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -218,7 +219,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -226,7 +227,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -235,7 +236,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const ;
@@ -243,7 +244,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -251,7 +252,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -260,7 +261,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -275,50 +276,50 @@ protected:
 	// <group>
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	) const;
 	// </group>
@@ -332,70 +333,70 @@ protected:
 
 	// no weights, no mask, no ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	// ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride
 	) const;
 
 	// mask and ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// weights
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride
 	) const;
 
 	// weights and ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// weights and mask
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	// weights, mask, ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// no weights, no mask, no ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -403,7 +404,7 @@ protected:
 
 	// mask and ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -411,30 +412,30 @@ protected:
 
 	// weights
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights and ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights and mask
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights, mask, ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -444,56 +445,56 @@ protected:
 	// <group>
 	// no weights, no mask, no ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, uInt maxElements
 	) const;
 
 	// ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		uInt maxElements
 	) const;
 
 	// mask
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride, uInt maxElements
 	) const;
 
 	// mask and ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude, uInt maxElements
 	) const;
 
 	// weights
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		uInt maxElements
 	) const;
 
 	// weights and ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude, uInt maxElements
 	) const;
 
 	// weights and mask
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride, uInt maxElements
 	) const;
 
 	// weights, mask, ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		uInt maxElements
@@ -510,28 +511,28 @@ protected:
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	);
 
 	// no weights, no mask
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	);
 
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);
@@ -542,28 +543,28 @@ protected:
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);

--- a/scimath/Mathematics/ConstrainedRangeStatistics.tcc
+++ b/scimath/Mathematics/ConstrainedRangeStatistics.tcc
@@ -36,34 +36,34 @@
 namespace casacore {
 
 // min > max indicates that these quantities have not be calculated
-template <class AccumType, class InputIterator, class MaskIterator>
-ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::ConstrainedRangeStatistics()
-	: ClassicalStatistics<AccumType, InputIterator, MaskIterator>(),
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::ConstrainedRangeStatistics()
+	: ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>(),
 	 _range(), _doMedAbsDevMed(False) /*, _median()*/ /*, _npts(0),
 	  _max(), _min(), _maxpos(-1, -1), _minpos(-1, -1) */ {
 	reset();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::~ConstrainedRangeStatistics() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::~ConstrainedRangeStatistics() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>&
-ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::operator=(
-	const ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>& other
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>&
+ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(
+	const ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 ) {
     if (this == &other) {
         return *this;
     }
-    ClassicalStatistics<AccumType, InputIterator, MaskIterator>::operator=(other);
+    ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(other);
     _range = other._range;
     _doMedAbsDevMed = other._doMedAbsDevMed;
     //_median = other._median.null() ? NULL : new AccumType(*other._median);
     return *this;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getMedian(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedian(
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes,
 	Bool persistSortedArray
@@ -71,7 +71,7 @@ AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::ge
 	if (this->_getStatsData().median.null()) {
 		_setRange();
 		this->_getStatsData().median = new AccumType(
-			ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedian(
+			ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedian(
 				knownNpts, knownMin, knownMax, binningThreshholdSizeBytes, persistSortedArray
 			)
 		);
@@ -79,8 +79,8 @@ AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::ge
 	return *this->_getStatsData().median;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getMedianAbsDevMed(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAbsDevMed(
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes, Bool persistSortedArray
 ) {
@@ -90,96 +90,96 @@ AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::ge
 		this->getMedian();
 	}
 	_doMedAbsDevMed = True;
-	AccumType medabsdevmed = ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedianAbsDevMed(
+	AccumType medabsdevmed = ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAbsDevMed(
 		knownNpts, knownMin, knownMax, binningThreshholdSizeBytes, persistSortedArray
 	);
 	_doMedAbsDevMed = False;
 	return medabsdevmed;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getMedianAndQuantiles(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAndQuantiles(
 	std::map<Double, AccumType>& quantileToValue, const std::set<Double>& quantiles,
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax,
 	uInt binningThreshholdSizeBytes, Bool persistSortedArray
 ) {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMedianAndQuantiles(
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAndQuantiles(
 		quantileToValue, quantiles, knownNpts, knownMin, knownMax,
 		binningThreshholdSizeBytes, persistSortedArray
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMinMax(
 	AccumType& mymin, AccumType& mymax
 ) {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMinMax(
 		mymin, mymax
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-uInt64 ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getNPts() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+uInt64 ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNPts() {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getNPts();
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNPts();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::map<Double, AccumType> ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getQuantiles(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::map<Double, AccumType> ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getQuantiles(
 	const std::set<Double>& quantiles, CountedPtr<uInt64> knownNpts,
 	CountedPtr<AccumType> knownMin, CountedPtr<AccumType> knownMax,
 	uInt binningThreshholdSizeBytes, Bool persistSortedArray
 ) {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getQuantiles(
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getQuantiles(
 		quantiles, knownNpts, knownMin, knownMax, binningThreshholdSizeBytes,
 		persistSortedArray
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::pair<Int64, Int64> ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getStatisticIndex(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::pair<Int64, Int64> ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getStatisticIndex(
 	StatisticsData::STATS stat
 ) {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::getStatisticIndex(stat);
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getStatisticIndex(stat);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::reset() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset() {
 	_range = NULL;
 	_doMedAbsDevMed = False;
 	//_median = NULL;
-	ClassicalStatistics<AccumType, InputIterator, MaskIterator>::reset();
+	ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset();
 }
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (_isInRange(*datum)) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -193,19 +193,19 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumN
 			) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -213,20 +213,20 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumN
 			if (*mask && _isInRange(*datum)) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -241,40 +241,40 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumN
 			) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (_isInRange(*datum) && *weight > 0) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -288,21 +288,21 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumN
 			) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -317,20 +317,20 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumN
 			) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -338,14 +338,14 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumN
 			if (*mask && _isInRange(*datum) && *weight > 0) {
 				++npts;
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_isInRange(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_isInRange(
 	const AccumType& datum
 ) const {
 	return datum >= _range->first && datum <= _range->second;
@@ -386,11 +386,11 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_isInRa
 		} \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
@@ -405,22 +405,22 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			_findBinCodeCR
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
@@ -436,7 +436,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -449,17 +449,17 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 			) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
@@ -475,7 +475,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -483,17 +483,17 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 			if (*mask) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
@@ -510,7 +510,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -524,17 +524,17 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 			) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
@@ -550,25 +550,25 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (*weight > 0) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
@@ -584,8 +584,8 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -599,17 +599,17 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 			) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
@@ -626,8 +626,8 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -642,17 +642,17 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 			) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
@@ -668,8 +668,8 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 		typename vector<typename StatisticsUtilities<AccumType>::BinDesc>::const_iterator eBinDesc = binDesc.end();
 		typename vector<AccumType>::const_iterator bMaxLimit = maxLimit.begin();
 		typename vector<AccumType>::const_iterator iMaxLimit = bMaxLimit;
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -677,24 +677,24 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBi
 			if (*mask && *weight > 0) {
 				_findBinCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_getStatistic(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistic(
 	StatisticsData::STATS stat
 ) {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_getStatistic(stat);
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistic(stat);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatsData<AccumType> ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_getStatistics() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatsData<AccumType> ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistics() {
 	_setRange();
-	return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_getStatistics();
+	return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistics();
 }
 
 #define _minMaxCodeCR \
@@ -713,29 +713,29 @@ StatsData<AccumType> ConstrainedRangeStatistics<AccumType, InputIterator, MaskIt
 		} \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			_minMaxCodeCR
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -748,19 +748,19 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 			) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -768,20 +768,20 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 			if (*mask) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -795,40 +795,40 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 			) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (*weight > 0) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -842,21 +842,21 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 			) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -871,20 +871,20 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 			) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -892,7 +892,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 			if (*mask && *weight > 0) {
 				_minMaxCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
@@ -905,28 +905,28 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax
 		ary.push_back(myDatum); \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			_populateArrayCodeCR1
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
 		typename DataRanges::const_iterator endRange = ranges.end();
@@ -938,39 +938,39 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
 		MaskIterator mask = maskBegin;
 		while (count < nr) {
 			if (*mask) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
 		MaskIterator mask = maskBegin;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -984,39 +984,39 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (*weight > 0) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1030,19 +1030,19 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1050,20 +1050,20 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			if (*mask && *weight > 0) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1078,7 +1078,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArrayCodeCR1
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
@@ -1106,9 +1106,9 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		} \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 		typename vector<vector<AccumType> >::iterator bArys = arys.begin();
@@ -1117,19 +1117,19 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			_populateArraysCodeCR
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -1139,7 +1139,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
 		typename DataRanges::const_iterator endRange = ranges.end();
@@ -1151,15 +1151,15 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -1169,22 +1169,22 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
 		MaskIterator mask = maskBegin;
 		while (count < nr) {
 			if (*mask) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -1195,7 +1195,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
 		MaskIterator mask = maskBegin;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1209,16 +1209,16 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 		typename vector<vector<AccumType> >::iterator bArys = arys.begin();
@@ -1226,24 +1226,24 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (*weight > 0) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -1252,8 +1252,8 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1267,15 +1267,15 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
@@ -1284,8 +1284,8 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1293,15 +1293,15 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			if (*mask && *weight > 0) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -1311,8 +1311,8 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator bIncludeLimits = includeLimits.begin();
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator iIncludeLimits = bIncludeLimits;
 		typename vector<std::pair<AccumType, AccumType> >::const_iterator eIncludeLimits = includeLimits.end();
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1327,7 +1327,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_populateArraysCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
@@ -1343,33 +1343,33 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		} \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	uInt maxElements
 ) const {
 		Int64 count = 0;
 		uInt npts = ary.size();
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			_PopulateTestArrayCodeCR
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	uInt maxElements
 ) const {
 		Int64 count = 0;
 		uInt npts = ary.size();
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
 		typename DataRanges::const_iterator endRange = ranges.end();
@@ -1381,21 +1381,21 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	uInt maxElements
 ) const {
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
 		MaskIterator mask = maskBegin;
 		uInt npts = ary.size();
@@ -1403,21 +1403,21 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			if (*mask) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
 		Int64 count = 0;
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
 		MaskIterator mask = maskBegin;
 		uInt npts = ary.size();
@@ -1432,21 +1432,21 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	uInt maxElements
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		uInt npts = ary.size();
@@ -1454,21 +1454,21 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			if (*weight > 0) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1483,21 +1483,21 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, uInt maxElements
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride;
@@ -1506,21 +1506,21 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			if (*mask && *weight > 0) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 		return False;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1536,7 +1536,7 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 			) {
 				_PopulateTestArrayCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
@@ -1551,31 +1551,31 @@ Bool ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_popula
 		++ngood; \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			_unweightedStatsCodeCR
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1588,20 +1588,20 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweig
 			) {
 				_unweightedStatsCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1609,21 +1609,21 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweig
 		if (*mask) {
 			_unweightedStatsCodeCR
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) {
-		InputIterator datum = dataBegin;
+		DataIterator datum = dataBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1637,7 +1637,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweig
 			) {
 				_unweightedStatsCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, mask, unityStride, dataStride, maskStride
 			);
 		}
@@ -1650,36 +1650,36 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweig
 		this->_accumulate (mymin, mymax, minpos, maxpos, *datum, *weight, count); \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		while (count < nr) {
 			if (*weight > 0) {
 				_weightedStatsCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1;
 		typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -1693,22 +1693,22 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weight
 			) {
 				_weightedStatsCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, unityStride, dataStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1723,21 +1723,21 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weight
 			) {
 				_weightedStatsCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) {
-		InputIterator datum = dataBegin;
-		InputIterator weight = weightsBegin;
+		DataIterator datum = dataBegin;
+		WeightsIterator weight = weightsBegin;
 		MaskIterator mask = maskBegin;
 		Int64 count = 0;
 		Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -1745,7 +1745,7 @@ void ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weight
 			if (*mask && *weight > 0) {
 				_weightedStatsCodeCR
 			}
-			StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+			StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 				datum, count, weight, mask, unityStride, dataStride, maskStride
 			);
 		}

--- a/scimath/Mathematics/FitToHalfStatistics.h
+++ b/scimath/Mathematics/FitToHalfStatistics.h
@@ -43,8 +43,9 @@ namespace casacore {
 // distribution, and the total number of points is exactly twice the number of real
 // data points that are included.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class FitToHalfStatistics
-	: public ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator> {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool *, class WeightsIterator=DataIterator>
+class FitToHalfStatistics
+	: public ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> {
 public:
 
 	const static AccumType TWO;
@@ -59,8 +60,8 @@ public:
 	virtual ~FitToHalfStatistics();
 
 	// copy semantics
-	FitToHalfStatistics<AccumType, InputIterator, MaskIterator>& operator=(
-		const FitToHalfStatistics<AccumType, InputIterator, MaskIterator>& other
+	FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
+		const FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 	);
 
 	// get the algorithm that this object uses for computing stats
@@ -162,28 +163,28 @@ protected:
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	);
 
 	// no weights, no mask
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	);
 
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);
@@ -199,28 +200,28 @@ protected:
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);

--- a/scimath/Mathematics/FitToHalfStatistics.tcc
+++ b/scimath/Mathematics/FitToHalfStatistics.tcc
@@ -35,35 +35,35 @@
 
 namespace casacore {
 
-template <class AccumType, class InputIterator, class MaskIterator>
-const AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::TWO = AccumType(2);
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+const AccumType FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::TWO = AccumType(2);
 
 // min > max indicates that these quantities have not be calculated
-template <class AccumType, class InputIterator, class MaskIterator>
-FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::FitToHalfStatistics(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::FitToHalfStatistics(
 	FitToHalfStatisticsData::CENTER centerType,
 	FitToHalfStatisticsData::USE_DATA useData,
 	AccumType centerValue
 )
-	: ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>(),
+	: ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>(),
 	  _centerType(centerType), _useLower(useData == FitToHalfStatisticsData::LE_CENTER), _centerValue(centerValue),
 	  _statsData(initializeStatsData<AccumType>()), _doMedAbsDevMed(False), _rangeIsSet(False),
 	  _realMax(), _realMin() {
 	reset();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::~FitToHalfStatistics() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::~FitToHalfStatistics() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-FitToHalfStatistics<AccumType, InputIterator, MaskIterator>&
-FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::operator=(
-	const FitToHalfStatistics<AccumType, InputIterator, MaskIterator>& other
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>&
+FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(
+	const FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 ) {
     if (this == &other) {
         return *this;
     }
-    ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::operator=(other);
+    ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(other);
     _centerType = other._centerType;
     _useLower = other._useLower;
     _centerValue = other._centerValue;
@@ -75,8 +75,8 @@ FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::operator=(
     return *this;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedian(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedian(
 	CountedPtr<uInt64> , CountedPtr<AccumType> ,
 	CountedPtr<AccumType> , uInt , Bool
 ) {
@@ -86,8 +86,8 @@ AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 	return *_getStatsData().median;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedianAndQuantiles(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAndQuantiles(
 	std::map<Double, AccumType>& quantileToValue, const std::set<Double>& quantiles,
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax,
@@ -101,8 +101,8 @@ AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 	return getMedian();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedianAbsDevMed(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAbsDevMed(
 	CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
 	CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes, Bool persistSortedArray
 ) {
@@ -114,7 +114,7 @@ AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 		CountedPtr<AccumType> realMin, realMax;
 		//_getRealMinMax(realMin, realMax, knownMin, knownMax);
 		_getStatsData().medAbsDevMed = new AccumType(
-			ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getMedianAbsDevMed(
+			ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMedianAbsDevMed(
 				realNPts, knownMin, knownMax, binningThreshholdSizeBytes, persistSortedArray
 			)
 		);
@@ -122,8 +122,8 @@ AccumType FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMedian
 	return *_getStatsData().medAbsDevMed;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_getRealMinMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getRealMinMax(
 		CountedPtr<AccumType>& realMin, CountedPtr<AccumType>& realMax,
 	CountedPtr<AccumType> knownMin, CountedPtr<AccumType> knownMax
 ) {
@@ -150,13 +150,13 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_getRealMinMax
 }
 
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMinMax(
 	AccumType& mymin, AccumType& mymax
 ) {
 	if ( _getStatsData().min.null() || _getStatsData().max.null()) {
 		// This call returns the min and max of the real portion of the dataset
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(mymin, mymax);
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getMinMax(mymin, mymax);
 		_realMin = new AccumType(mymin);
 		_realMax = new AccumType(mymax);
 		if (_useLower) {
@@ -174,8 +174,8 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getMinMax(
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::map<Double, AccumType> FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getQuantiles(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::map<Double, AccumType> FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getQuantiles(
 	const std::set<Double>& fractions, CountedPtr<uInt64> knownNpts,
 	CountedPtr<AccumType> knownMin, CountedPtr<AccumType> knownMax,
 	uInt binningThreshholdSizeBytes, Bool persistSortedArray
@@ -277,7 +277,7 @@ std::map<Double, AccumType> FitToHalfStatistics<AccumType, InputIterator, MaskIt
 		? new uInt64(getNPts()/2) : new uInt64(*knownNpts/2);
 	CountedPtr<AccumType> realMin, realMax;
 	_getRealMinMax(realMin, realMax, knownMin, knownMax);
-	std::map<Double, AccumType> realPart = ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getQuantiles(
+	std::map<Double, AccumType> realPart = ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getQuantiles(
 		realPortionFractions, realNPts, realMin, realMax, binningThreshholdSizeBytes,
 		persistSortedArray
 	);
@@ -301,22 +301,22 @@ std::map<Double, AccumType> FitToHalfStatistics<AccumType, InputIterator, MaskIt
 	return actual;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-uInt64 FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::getNPts() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+uInt64 FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNPts() {
 	if (_getStatsData().npts == 0) {
 		// guard against subsequent calls multiplying by two
-		_getStatsData().npts = 2*ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::getNPts();
+		_getStatsData().npts = 2*ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNPts();
 	}
 	return (uInt64)_getStatsData().npts;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::reset() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset() {
 	_clearData();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::setCalculateAsAdded(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::setCalculateAsAdded(
 	Bool c
 ) {
 	ThrowIf(
@@ -325,32 +325,32 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::setCalculateAs
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_clearData() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearData() {
 	_doMedAbsDevMed = False;
 	StatsData<AccumType> oldStats = copy(_statsData);
 	_statsData = initializeStatsData<AccumType>();
 	_statsData.mean = oldStats.mean;
 	_statsData.median = oldStats.median.null() ? NULL : new AccumType(*oldStats.median);
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_clearData();
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearData();
 
 }
 
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatsData<AccumType> FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_getStatistics() {
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_getStatistics();
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatsData<AccumType> FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistics() {
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_getStatistics();
 	_getStatsData().sum = _getStatsData().mean * _getStatsData().sumweights;
 	return copy(_getStatsData());
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_setRange() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_setRange() {
 	if (_rangeIsSet) {
 		return;
 	}
 	//this->_setRangeIsBeingSet(True);
-	ClassicalStatistics<AccumType, InputIterator, MaskIterator> cs(*this);
+	ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> cs(*this);
 	if (_centerType == FitToHalfStatisticsData::CMEAN || _centerType == FitToHalfStatisticsData::CMEDIAN) {
 		_centerValue = _centerType == FitToHalfStatisticsData::CMEAN
 			? cs.getStatistic(StatisticsData::MEAN)
@@ -363,7 +363,7 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_setRange() {
 	CountedPtr<std::pair<AccumType, AccumType> > range = _useLower
 		? new std::pair<AccumType, AccumType>(mymin, _centerValue)
 		: new std::pair<AccumType, AccumType>(_centerValue, mymax);
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_setRange(range);
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_setRange(range);
 	_rangeIsSet = True;
 }
 
@@ -377,31 +377,31 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_setRange() {
 		ngood += 2; \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		_unweightedStatsCodeFH
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -414,20 +414,20 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedSta
 		) {
 			_unweightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -435,21 +435,21 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedSta
 		if (*mask) {
 			_unweightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
+	DataIterator datum = dataBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -463,18 +463,18 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_unweightedSta
 		) {
 			_unweightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_updateMaxMin(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_updateMaxMin(
 	AccumType mymin, AccumType mymax, Int64 minpos, Int64 maxpos, uInt dataStride,
 	const Int64& currentDataset
 ) {
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider
 		= this->_getDataProvider();
 	if (maxpos >= 0) {
 		_realMax = new AccumType(mymax);
@@ -516,36 +516,36 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_updateMaxMin(
 		); \
 	}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	while (count < nr) {
 		if (*weight > 0) {
 			_weightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1;
 	typename DataRanges::const_iterator beginRange = ranges.begin();
@@ -559,22 +559,22 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 		) {
 			_weightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, unityStride, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -589,21 +589,21 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 		) {
 			_weightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void FitToHalfStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) {
-	InputIterator datum = dataBegin;
-	InputIterator weight = weightsBegin;
+	DataIterator datum = dataBegin;
+	WeightsIterator weight = weightsBegin;
 	MaskIterator mask = maskBegin;
 	Int64 count = 0;
 	Bool unityStride = dataStride == 1 && maskStride == 1;
@@ -611,7 +611,7 @@ void FitToHalfStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats
 		if (*mask && *weight > 0) {
 			_weightedStatsCodeFH
 		}
-		StatisticsIncrementer<InputIterator, MaskIterator>::increment(
+		StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
 			datum, count, weight, mask, unityStride, dataStride, maskStride
 		);
 	}

--- a/scimath/Mathematics/HingesFencesStatistics.h
+++ b/scimath/Mathematics/HingesFencesStatistics.h
@@ -42,8 +42,9 @@ namespace casacore {
 // of values between Q1 - f*D and Q3 + f*D, inclusive, where D = Q3 - Q1 and Q1 and Q3 are
 // the first and third quartiles, respectively.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class HingesFencesStatistics
-	: public ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator> {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool *, class WeightsIterator=DataIterator>
+class HingesFencesStatistics
+	: public ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> {
 public:
 
 	// If <src>f</src> is negative, the full dataset is used; ie the object has the same
@@ -53,8 +54,8 @@ public:
 	virtual ~HingesFencesStatistics();
 
 	// copy semantics
-	HingesFencesStatistics<AccumType, InputIterator, MaskIterator>& operator=(
-		const HingesFencesStatistics<AccumType, InputIterator, MaskIterator>& other
+	HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
+		const HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 	);
 
 	// get the algorithm that this object uses for computing stats
@@ -79,50 +80,50 @@ protected:
 	// so that derived classes may override it.
 	inline void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataStart, Int64 nr, uInt dataStride
+		const DataIterator& dataStart, Int64 nr, uInt dataStride
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataStart, Int64 nr, uInt dataStride,
+		const DataIterator& dataStart, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _accumNpts(
 		uInt64& npts,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	) const;
 	// </group>
@@ -131,7 +132,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 		const vector<AccumType>& maxLimit
 	) const;
@@ -139,7 +140,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -147,7 +148,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -155,7 +156,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -164,7 +165,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const ;
@@ -172,7 +173,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -180,7 +181,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
@@ -189,7 +190,7 @@ protected:
 	virtual void _findBins(
 		vector<vector<uInt64> >& binCounts,
 		vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc, const vector<AccumType>& maxLimit
 	) const;
@@ -198,50 +199,50 @@ protected:
 	// <group>
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 		Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	virtual void _minMax(
 		CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	) const;
 	// </group>
@@ -255,70 +256,70 @@ protected:
 
 	// no weights, no mask, no ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	) const;
 
 	// ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude
 	) const;
 
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride
 	) const;
 
 	// mask and ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// weights
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride
 	) const;
 
 	// weights and ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// weights and mask
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	) const;
 
 	// weights, mask, ranges
 	void _populateArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	) const;
 
 	// no weights, no mask, no ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -326,7 +327,7 @@ protected:
 
 	// mask and ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -334,30 +335,30 @@ protected:
 
 	// weights
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights and ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights and mask
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 	) const;
 
 	// weights, mask, ranges
 	virtual void _populateArrays(
-		vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
@@ -367,56 +368,56 @@ protected:
 	// <group>
 	// no weights, no mask, no ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, uInt maxElements
 	) const;
 
 	// ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const DataRanges& ranges, Bool isInclude,
 		uInt maxElements
 	) const;
 
 	// mask
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride, uInt maxElements
 	) const;
 
 	// mask and ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude, uInt maxElements
 	) const;
 
 	// weights
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr, uInt dataStride,
 		uInt maxElements
 	) const;
 
 	// weights and ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude, uInt maxElements
 	) const;
 
 	// weights and mask
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin,
-		const InputIterator& weightBegin, Int64 nr,
+		vector<AccumType>& ary, const DataIterator& dataBegin,
+		const WeightsIterator& weightBegin, Int64 nr,
 		uInt dataStride, const MaskIterator& maskBegin,
 		uInt maskStride, uInt maxElements
 	) const;
 
 	// weights, mask, ranges
 	Bool _populateTestArray(
-		vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightBegin,
+		vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude,
 		uInt maxElements
@@ -428,28 +429,28 @@ protected:
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride
 	);
 
 	// no weights, no mask
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const DataRanges& ranges, Bool isInclude
 	);
 
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	void _unweightedStats(
 		uInt64& ngood, AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+		const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 		const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);
@@ -460,28 +461,28 @@ protected:
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightsBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 		Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 	);
 
 	void _weightedStats(
 		AccumType& mymin, AccumType& mymax,
 		Int64& minpos, Int64& maxpos,
-		const InputIterator& dataBegin, const InputIterator& weightBegin,
+		const DataIterator& dataBegin, const WeightsIterator& weightBegin,
 		Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 		const DataRanges& ranges, Bool isInclude
 	);

--- a/scimath/Mathematics/HingesFencesStatistics.tcc
+++ b/scimath/Mathematics/HingesFencesStatistics.tcc
@@ -37,46 +37,46 @@
 namespace casacore {
 
 // min > max indicates that these quantities have not be calculated
-template <class AccumType, class InputIterator, class MaskIterator>
-HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::HingesFencesStatistics(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::HingesFencesStatistics(
 	Double f
 )
-	: ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>(),
+	: ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>(),
 	  _f(f), _rangeIsSet(False), _hasRange(False) {
 	reset();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::~HingesFencesStatistics() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::~HingesFencesStatistics() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-HingesFencesStatistics<AccumType, InputIterator, MaskIterator>&
-HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::operator=(
-	const HingesFencesStatistics<AccumType, InputIterator, MaskIterator>& other
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>&
+HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(
+	const HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 ) {
     if (this == &other) {
         return *this;
     }
-    ClassicalStatistics<AccumType, InputIterator, MaskIterator>::operator=(other);
+    ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator=(other);
     _f = other._f;
     _rangeIsSet = other._rangeIsSet;
     _hasRange = other._hasRange;
     return *this;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::reset() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset() {
 	_rangeIsSet = False;
 	_hasRange = False;
 	//_range = NULL;
 	//_median = NULL;
 	//_doMedAbsDevMed = False;
 	//_settingRange = False;
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::reset();
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::reset();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::setCalculateAsAdded(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::setCalculateAsAdded(
 	Bool c
 ) {
 	ThrowIf(
@@ -85,316 +85,316 @@ void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::setCalculat
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride, maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride, maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride, maskBegin,
 			maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, nr, dataStride, maskBegin,
 			maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin,weightsBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin,weightsBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, weightsBegin, nr,
 			dataStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, weightsBegin, nr,
 			dataStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, weightsBegin, nr,
 			dataStride, maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, weightsBegin, nr,
 			dataStride, maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 	uInt64& npts,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, weightsBegin, nr,
 			dataStride, maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_accumNpts(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_accumNpts(
 			npts, dataBegin, weightsBegin, nr,
 			dataStride, maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin,
 			nr, dataStride, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin,
 			nr, dataStride, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, nr,
 			dataStride, ranges, isInclude, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, nr,
 			dataStride, ranges, isInclude, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, nr,
 			dataStride, maskBegin, maskStride, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, nr,
 			dataStride, maskBegin, maskStride, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+    const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, ranges, isInclude,
 			binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, ranges, isInclude,
 			binDesc, maxLimit
@@ -402,647 +402,647 @@ void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 	vector<vector<uInt64> >& binCounts,
     vector<CountedPtr<AccumType> >& sameVal, vector<Bool>& allSame,
-    const InputIterator& dataBegin, const InputIterator& weightsBegin,
+    const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<typename StatisticsUtilities<AccumType>::BinDesc>& binDesc,
 	const vector<AccumType>& maxLimit
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, binDesc, maxLimit
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_findBins(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_findBins(
 			binCounts, sameVal, allSame, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, binDesc, maxLimit
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride, maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride, maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride,
 			ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride,
 			ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 	CountedPtr<AccumType>& mymin, CountedPtr<AccumType>& mymax,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_minMax(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_minMax(
 			mymin, mymax, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride,
 			ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride,
 			ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride,
 			maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride,
 			maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,
 			nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,
 			nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,	nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArray(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArray(
 			ary, dataBegin, weightsBegin,	nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			ranges, isInclude, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			ranges, isInclude, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			maskBegin, maskStride, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			maskBegin, maskStride, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,
 			nr, dataStride, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,
 			nr, dataStride, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
-	vector<vector<AccumType> >& arys, uInt& currentCount, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
+	vector<vector<AccumType> >& arys, uInt& currentCount, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude,
 	const vector<std::pair<AccumType, AccumType> > &includeLimits, uInt maxCount
 ) const {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,	nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, includeLimits, maxCount
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateArrays(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateArrays(
 			arys, currentCount, dataBegin, weightsBegin,	nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, includeLimits, maxCount
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const DataRanges& ranges, Bool isInclude,
 	uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, ranges, isInclude, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, ranges, isInclude, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, maskBegin, maskStride, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, maskBegin, maskStride, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, Int64 nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, Int64 nr,
 	uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, maskBegin,
 			maskStride, ranges, isInclude, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin,	nr, dataStride, maskBegin,
 			maskStride, ranges, isInclude, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride, ranges, isInclude, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride, ranges, isInclude, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin,
-	const InputIterator& weightsBegin, Int64 nr, uInt dataStride,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin,
+	const WeightsIterator& weightsBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-Bool HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
-	vector<AccumType>& ary, const InputIterator& dataBegin, const InputIterator& weightsBegin,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+Bool HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
+	vector<AccumType>& ary, const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude, uInt maxElements
 ) const {
 	if (_hasRange) {
-		return ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, maxElements
 		);
 	}
 	else {
-		return ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_populateTestArray(
+		return ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_populateTestArray(
 			ary, dataBegin, weightsBegin, nr, dataStride,
 			maskBegin, maskStride, ranges, isInclude, maxElements
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_setRange() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_setRange() {
 	if (_rangeIsSet) {
 		return;
 	}
@@ -1054,179 +1054,179 @@ void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_setRange()
 	std::set<Double> quantiles;
 	quantiles.insert(0.25);
 	quantiles.insert(0.75);
-	ClassicalStatistics<AccumType, InputIterator, MaskIterator> cs(*this);
+	ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator> cs(*this);
 	std::map<Double, AccumType> quartiles = cs.getQuantiles(quantiles);
-	//ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_clearStats();
+	//ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearStats();
 	AccumType iqr = quartiles[0.75] - quartiles[0.25];
 	CountedPtr<std::pair<AccumType, AccumType> > range = new std::pair<AccumType, AccumType>(
 		quartiles[0.25] - _f*iqr, quartiles[0.75] + _f*iqr
 	);
-	ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_setRange(range);
+	ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_setRange(range);
 	_rangeIsSet = True;
 	_hasRange = True;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos, dataBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos, dataBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos,
 			dataBegin, nr, dataStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos,
 			dataBegin, nr, dataStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos,
 			dataBegin, nr, dataStride, maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos,
 			dataBegin, nr, dataStride, maskBegin, maskStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 	uInt64& ngood, AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, Int64 nr, uInt dataStride,
+	const DataIterator& dataBegin, Int64 nr, uInt dataStride,
 	const MaskIterator& maskBegin, uInt maskStride, const DataRanges& ranges,
 	Bool isInclude
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos, dataBegin, nr,
 			dataStride, maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_unweightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_unweightedStats(
 			ngood, mymin, mymax, minpos, maxpos, dataBegin, nr,
 			dataStride, maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin,
 			weightsBegin, nr, dataStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin,
 			weightsBegin, nr, dataStride
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const DataRanges& ranges, Bool isInclude
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin, weightsBegin,
 			nr, dataStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride,
 	const DataRanges& ranges, Bool isInclude
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, ranges, isInclude
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride, ranges, isInclude
 		);
 	}
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void HingesFencesStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void HingesFencesStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 	AccumType& mymin, AccumType& mymax,
 	Int64& minpos, Int64& maxpos,
-	const InputIterator& dataBegin, const InputIterator& weightsBegin,
+	const DataIterator& dataBegin, const WeightsIterator& weightsBegin,
 	Int64 nr, uInt dataStride, const MaskIterator& maskBegin, uInt maskStride
 ) {
 	if (_hasRange) {
-		ConstrainedRangeStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ConstrainedRangeStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride
 		);
 	}
 	else {
-		ClassicalStatistics<AccumType, InputIterator, MaskIterator>::_weightedStats(
+		ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>::_weightedStats(
 			mymin, mymax, minpos, maxpos, dataBegin, weightsBegin,
 			nr, dataStride, maskBegin, maskStride
 		);

--- a/scimath/Mathematics/StatisticsAlgorithm.h
+++ b/scimath/Mathematics/StatisticsAlgorithm.h
@@ -97,7 +97,8 @@ namespace casacore {
 // has a weight of zero is not considered a member of the dataset for the pruposes of
 // quantile calculations.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class StatisticsAlgorithm {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool *, class WeightsIterator=DataIterator>
+class StatisticsAlgorithm {
 
 public:
 
@@ -119,48 +120,48 @@ public:
 	// considered bad (excluded) if <src>isInclude</src> is False.
 
 	virtual void addData(
-		const InputIterator& first, uInt nr, uInt dataStride=1,
+		const DataIterator& first, uInt nr, uInt dataStride=1,
 		Bool nrAccountsForStride=False
 	);
 
 	virtual void addData(
-		const InputIterator& first, uInt nr,
+		const DataIterator& first, uInt nr,
 		const DataRanges& dataRanges, Bool isInclude=True, uInt dataStride=1,
 		Bool nrAccountsForStride=False
 	);
 
 	virtual void addData(
-		const InputIterator& first, const MaskIterator& maskFirst,
+		const DataIterator& first, const MaskIterator& maskFirst,
 		uInt nr, uInt dataStride=1, Bool nrAccountsForStride=False, uInt maskStride=1
 	);
 
 	virtual void addData(
-		const InputIterator& first, const MaskIterator& maskFirst,
+		const DataIterator& first, const MaskIterator& maskFirst,
 		uInt nr, const DataRanges& dataRanges,
 		Bool isInclude=True, uInt dataStride=1, Bool nrAccountsForStride=False,
 		uInt maskStride=1
 	);
 
 	virtual void addData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		uInt nr, uInt dataStride=1, Bool nrAccountsForStride=False
 	);
 
 	virtual void addData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		uInt nr, const DataRanges& dataRanges,
 		Bool isInclude=True, uInt dataStride=1, Bool nrAccountsForStride=False
 	);
 
 	virtual void addData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		const MaskIterator& maskFirst, uInt nr, uInt dataStride=1,
 		Bool nrAccountsForStride=False,
 		uInt maskStride=1
 	);
 
 	virtual void addData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		const MaskIterator& maskFirst, uInt nr, const DataRanges& dataRanges,
 		Bool isInclude=True, uInt dataStride=1, Bool nrAccountsForStride=False,
 		uInt maskStride=1
@@ -231,49 +232,49 @@ public:
 	// setdata() clears any current datasets or data provider and then adds the specified data set as
 	// the first dataset in the (possibly new) set of data sets for which statistics are
 	// to be calculated. See addData() for parameter meanings.
-	virtual void setData(const InputIterator& first, uInt nr, uInt dataStride=1, Bool nrAccountsForStride=False);
+	virtual void setData(const DataIterator& first, uInt nr, uInt dataStride=1, Bool nrAccountsForStride=False);
 
 	virtual void setData(
-		const InputIterator& first, uInt nr,
+		const DataIterator& first, uInt nr,
 		const DataRanges& dataRanges, Bool isInclude=True, uInt dataStride=1,
 		Bool nrAccountsForStride=False
 	);
 
 	virtual void setData(
-		const InputIterator& first, const MaskIterator& maskFirst,
+		const DataIterator& first, const MaskIterator& maskFirst,
 		uInt nr, uInt dataStride=1, Bool nrAccountsForStride=False,
 		uInt maskStride=1
 	);
 
 	virtual void setData(
-		const InputIterator& first, const MaskIterator& maskFirst,
+		const DataIterator& first, const MaskIterator& maskFirst,
 		uInt nr, const DataRanges& dataRanges,
 		Bool isInclude=True, uInt dataStride=1, Bool nrAccountsForStride=False,
 		uInt maskStride=1
 	);
 
 	virtual void setData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		uInt nr, uInt dataStride=1,
 		Bool nrAccountsForStride=False
 	);
 
 	virtual void setData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		uInt nr, const DataRanges& dataRanges,
 		Bool isInclude=True, uInt dataStride=1,
 		Bool nrAccountsForStride=False
 	);
 
 	virtual void setData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		const MaskIterator& maskFirst, uInt nr, uInt dataStride=1,
 		Bool nrAccountsForStride=False,
 		uInt maskStride=1
 	);
 
 	virtual void setData(
-		const InputIterator& first, const InputIterator& weightFirst,
+		const DataIterator& first, const WeightsIterator& weightFirst,
 		const MaskIterator& maskFirst, uInt nr, const DataRanges& dataRanges,
 		Bool isInclude=True, uInt dataStride=1, Bool nrAccountsForStride=False,
 		uInt maskStride=1
@@ -283,7 +284,7 @@ public:
 	// instead of settng and adding data "by hand", set the data provider that will provide
 	// all the data sets. Calling this method will clear any other data sets that have
 	// previously been set or added.
-	virtual void setDataProvider(StatsDataProvider<AccumType, InputIterator, MaskIterator> *dataProvider) {
+	virtual void setDataProvider(StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider) {
 		ThrowIf(! dataProvider, "Logic Error: data provider cannot be NULL");
 		_clearData();
 		_dataProvider = dataProvider;
@@ -297,8 +298,8 @@ protected:
 	StatisticsAlgorithm();
 
 	// use copy semantics
-	StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>& operator=(
-		const StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>& other
+	StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
+		const StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 	);
 
 	// Allows derived classes to do things after data is set or added.
@@ -309,9 +310,9 @@ protected:
 
 	const vector<Int64>& _getCounts() const { return _counts; }
 
-	const vector<InputIterator>& _getData() const { return _data; }
+	const vector<DataIterator>& _getData() const { return _data; }
 
-	StatsDataProvider<AccumType, InputIterator, MaskIterator>* _getDataProvider() {
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>* _getDataProvider() {
 		return _dataProvider;
 	}
 
@@ -339,7 +340,7 @@ protected:
 		return _unsupportedStats;
 	}
 
-	const std::map<uInt, InputIterator>& _getWeights() const {
+	const std::map<uInt, WeightsIterator>& _getWeights() const {
 		return _weights;
 	}
 
@@ -360,9 +361,9 @@ protected:
 	void _setSortedArray(const vector<AccumType>& v) { _sortedArray = v; }
 
 private:
-	vector<InputIterator> _data;
+	vector<DataIterator> _data;
 	// maps data to weights
-	std::map<uInt, InputIterator> _weights;
+	std::map<uInt, WeightsIterator> _weights;
 	// maps data to masks
 	std::map<uInt, MaskIterator> _masks;
 	vector<Int64> _counts;
@@ -372,7 +373,7 @@ private:
 	std::map<uInt, DataRanges> _dataRanges;
 	vector<AccumType> _sortedArray;
 	std::set<StatisticsData::STATS> _statsToCalculate, _unsupportedStats;
-	StatsDataProvider<AccumType, InputIterator, MaskIterator> *_dataProvider;
+	StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *_dataProvider;
 
 	void _throwIfDataProviderDefined() const;
 };

--- a/scimath/Mathematics/StatisticsAlgorithm.tcc
+++ b/scimath/Mathematics/StatisticsAlgorithm.tcc
@@ -33,16 +33,16 @@
 
 namespace casacore {
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::StatisticsAlgorithm()
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::StatisticsAlgorithm()
 : _data(), _weights(), _masks(), _counts(), _dataStrides(), _maskStrides(),
   _isIncludeRanges(), _dataRanges(), _sortedArray(), _statsToCalculate(),
   _unsupportedStats(), _dataProvider(NULL) {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>&
-StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::operator= (
-	const StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>& other
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>&
+StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::operator= (
+	const StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
 ) {
 	 if (this == &other) {
 		 return *this;
@@ -63,12 +63,12 @@ StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::operator= (
 	 return *this;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::~StatisticsAlgorithm() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::~StatisticsAlgorithm() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, uInt nr, uInt dataStride, Bool nrAccountsForStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, uInt nr, uInt dataStride, Bool nrAccountsForStride
 ) {
 	_throwIfDataProviderDefined();
 	_data.push_back(first);
@@ -84,9 +84,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	_addData();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, uInt nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, uInt nr,
 	const DataRanges& dataRanges, Bool isInclude, uInt dataStride,
 	Bool nrAccountsForStride
 ) {
@@ -106,9 +106,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	this->addData(first, nr, dataStride, nrAccountsForStride);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, const MaskIterator& maskFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, const MaskIterator& maskFirst,
 	uInt nr, uInt dataStride, Bool nrAccountsForStride, uInt maskStride
 ) {
 	_throwIfDataProviderDefined();
@@ -118,9 +118,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	this->addData(first, nr, dataStride, nrAccountsForStride);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, const MaskIterator& maskFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, const MaskIterator& maskFirst,
 	uInt nr, const DataRanges& dataRanges,
 	Bool isInclude, uInt dataStride, Bool nrAccountsForStride,
 	uInt maskStride
@@ -135,9 +135,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	uInt nr, uInt dataStride, Bool nrAccountsForStride
 ) {
 	_throwIfDataProviderDefined();
@@ -145,9 +145,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	this->addData(first, nr, dataStride, nrAccountsForStride);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	uInt nr, const DataRanges& dataRanges,
 	Bool isInclude, uInt dataStride, Bool nrAccountsForStride
 ) {
@@ -158,9 +158,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	const MaskIterator& maskFirst, uInt nr, uInt dataStride,
 	Bool nrAccountsForStride, uInt maskStride
 ) {
@@ -171,9 +171,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::addData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	const MaskIterator& maskFirst, uInt nr, const DataRanges& dataRanges,
 	Bool isInclude, uInt dataStride, Bool nrAccountsForStride,
 	uInt maskStride
@@ -186,13 +186,13 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::addData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::deleteSortedArray() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::deleteSortedArray() {
 	_sortedArray.clear();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::getQuantile(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::getQuantile(
 	Double quantile, CountedPtr<uInt64> knownNpts,
 	CountedPtr<AccumType> knownMin, CountedPtr<AccumType> knownMax,
 	uInt binningThreshholdSizeBytes, Bool persistSortedArray
@@ -204,8 +204,8 @@ AccumType StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::getQuanti
 	).begin()->second;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-AccumType StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::getStatistic(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+AccumType StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::getStatistic(
 	StatisticsData::STATS stat
 ) {
 	ThrowIf(
@@ -221,22 +221,22 @@ AccumType StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::getStatis
 	return this->_getStatistic(stat);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatsData<AccumType> StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::getStatistics() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatsData<AccumType> StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::getStatistics() {
 	return this->_getStatistics();
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, uInt nr, uInt dataStride, Bool nrAccountsForStride
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, uInt nr, uInt dataStride, Bool nrAccountsForStride
 ) {
 	_clearData();
 	addData(first, nr, dataStride, nrAccountsForStride);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, uInt nr,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, uInt nr,
 	const DataRanges& dataRanges, Bool isInclude, uInt dataStride,
 	Bool nrAccountsForStride
 ) {
@@ -246,9 +246,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, const MaskIterator& maskFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, const MaskIterator& maskFirst,
 	uInt nr, uInt dataStride, Bool nrAccountsForStride, uInt maskStride
 ) {
 	_clearData();
@@ -257,9 +257,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, const MaskIterator& maskFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, const MaskIterator& maskFirst,
 	uInt nr, const DataRanges& dataRanges,
 	Bool isInclude, uInt dataStride, Bool nrAccountsForStride,
 	uInt maskStride
@@ -271,18 +271,18 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	uInt nr, uInt dataStride, Bool nrAccountsForStride
 ) {
 	_clearData();
 	addData(first, weightFirst, nr, dataStride, nrAccountsForStride);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	uInt nr, const DataRanges& dataRanges,
 	Bool isInclude, uInt dataStride, Bool nrAccountsForStride
 ) {
@@ -293,9 +293,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	const MaskIterator& maskFirst, uInt nr, uInt dataStride,
 	Bool nrAccountsForStride, uInt maskStride
 ) {
@@ -306,9 +306,9 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
-	const InputIterator& first, const InputIterator& weightFirst,
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setData(
+	const DataIterator& first, const WeightsIterator& weightFirst,
 	const MaskIterator& maskFirst, uInt nr, const DataRanges& dataRanges,
 	Bool isInclude, uInt dataStride, Bool nrAccountsForStride, uInt maskStride
 ) {
@@ -319,15 +319,15 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setData(
 	);
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::setStatsToCalculate(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::setStatsToCalculate(
 	std::set<StatisticsData::STATS>& stats
 ) {
 	_statsToCalculate = stats;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_clearData() {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::_clearData() {
 	_data.clear();
 	_counts.clear();
 	_masks.clear();
@@ -339,8 +339,8 @@ void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_clearData() {
 	_dataProvider = NULL;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-std::map<uInt64, AccumType> StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_valuesFromArray(
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+std::map<uInt64, AccumType> StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::_valuesFromArray(
 	vector<AccumType>& myArray, const std::set<uInt64>& indices
 ) {
 	//uInt64 largestIdx = *indices.rbegin();
@@ -370,8 +370,8 @@ std::map<uInt64, AccumType> StatisticsAlgorithm<AccumType, InputIterator, MaskIt
 	return indexToValuesMap;
 }
 
-template <class AccumType, class InputIterator, class MaskIterator>
-void StatisticsAlgorithm<AccumType, InputIterator, MaskIterator>::_throwIfDataProviderDefined() const {
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator>::_throwIfDataProviderDefined() const {
 	ThrowIf(
 		_dataProvider,
 		"Logic Error: Cannot add data after a data provider has been set. Call setData() to clear "

--- a/scimath/Mathematics/StatisticsIncrementer.h
+++ b/scimath/Mathematics/StatisticsIncrementer.h
@@ -33,7 +33,8 @@ namespace casacore {
 
 // Utility functions used for incrementing pointers in a data set used by the stats framework.
 
-template <class InputIterator, class MaskIterator=const Bool*>  class StatisticsIncrementer {
+template <class DataIterator, class MaskIterator=const Bool *, class WeightsIterator=DataIterator>
+class StatisticsIncrementer {
 public:
 
 	~StatisticsIncrementer() {}
@@ -42,22 +43,22 @@ public:
 	// <src> loopCount is always incremented by one, independent of the values
 	// of <src>dataStride</src> and <src>maskStride</src>
 	inline static void increment(
-		InputIterator& datum, Int64& loopCount, Bool unityStride, uInt dataStride
+		DataIterator& datum, Int64& loopCount, Bool unityStride, uInt dataStride
 	);
 
 	inline static void increment(
-		InputIterator& datum, Int64& loopCount, InputIterator& weight,
+		DataIterator& datum, Int64& loopCount, WeightsIterator& weight,
 		Bool unityStride, uInt dataStride
 	);
 
 	inline static void increment(
-		InputIterator& datum, Int64& loopCount, MaskIterator& mask,
+		DataIterator& datum, Int64& loopCount, MaskIterator& mask,
 		Bool unityStride, uInt dataStride, uInt maskStride
 	);
 
 	inline static void increment(
-		InputIterator& datum, Int64& loopCount,
-		InputIterator& weight, MaskIterator& mask,
+		DataIterator& datum, Int64& loopCount,
+		WeightsIterator& weight, MaskIterator& mask,
 		Bool unityStride, uInt dataStride, uInt maskStride
 	);
 	// </group>

--- a/scimath/Mathematics/StatisticsIncrementer.tcc
+++ b/scimath/Mathematics/StatisticsIncrementer.tcc
@@ -31,9 +31,9 @@
 
 namespace casacore {
 
-template <class InputIterator, class MaskIterator>
-void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
-	InputIterator& datum, Int64& loopCount, Bool unityStride, uInt dataStride
+template <class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
+	DataIterator& datum, Int64& loopCount, Bool unityStride, uInt dataStride
 ) {
 	if (unityStride) {
 		++datum;
@@ -49,9 +49,9 @@ void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
 	++loopCount;
 }
 
-template <class InputIterator, class MaskIterator>
-void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
-	InputIterator& datum, Int64& loopCount, InputIterator& weight,
+template <class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
+	DataIterator& datum, Int64& loopCount, WeightsIterator& weight,
 	Bool unityStride, uInt dataStride
 ) {
 	if (unityStride) {
@@ -69,9 +69,9 @@ void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
 	++loopCount;
 }
 
-template <class InputIterator, class MaskIterator>
-void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
-	InputIterator& datum, Int64& loopCount, InputIterator& weight,
+template <class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
+	DataIterator& datum, Int64& loopCount, WeightsIterator& weight,
 	MaskIterator& mask, Bool unityStride, uInt dataStride, uInt maskStride
 ) {
 	if (unityStride) {
@@ -105,9 +105,9 @@ void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
 	++loopCount;
 }
 
-template <class InputIterator, class MaskIterator>
-void StatisticsIncrementer<InputIterator, MaskIterator>::increment(
-	InputIterator& datum, Int64& loopCount, MaskIterator& mask,
+template <class DataIterator, class MaskIterator, class WeightsIterator>
+void StatisticsIncrementer<DataIterator, MaskIterator, WeightsIterator>::increment(
+	DataIterator& datum, Int64& loopCount, MaskIterator& mask,
 	Bool unityStride, uInt dataStride, uInt maskStride
 ) {
 	if (unityStride) {

--- a/scimath/Mathematics/StatsDataProvider.h
+++ b/scimath/Mathematics/StatsDataProvider.h
@@ -36,7 +36,8 @@ namespace casacore {
 // Abstract base class which defines interface for providing "datasets" to the statistics framework
 // when nontrivial means of doing so are not sufficient.
 
-template <class AccumType, class InputIterator, class MaskIterator=const Bool*> class StatsDataProvider {
+template <class AccumType, class DataIterator, class MaskIterator=const Bool *, class WeightsIterator=DataIterator>
+class StatsDataProvider {
 public:
 
 	virtual ~StatsDataProvider();
@@ -57,7 +58,7 @@ public:
 	virtual uInt64 getCount() = 0;
 
 	// get the current dataset
-	virtual InputIterator getData() = 0;
+	virtual DataIterator getData() = 0;
 
 	// Get the associated mask of the current dataset. Only called if hasMask() returns True;
 	virtual MaskIterator getMask() = 0;
@@ -72,7 +73,7 @@ public:
 	virtual uInt getStride() = 0;
 
 	// Get the associated weights of the current dataset. Only called if hasWeights() returns True;
-	virtual InputIterator getWeights() = 0;
+	virtual WeightsIterator getWeights() = 0;
 
 	// Does the current data set have an associated mask?
 	virtual Bool hasMask() const = 0;

--- a/scimath/Mathematics/StatsDataProvider.tcc
+++ b/scimath/Mathematics/StatsDataProvider.tcc
@@ -31,11 +31,11 @@
 
 namespace casacore {
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatsDataProvider<AccumType, InputIterator, MaskIterator>::StatsDataProvider() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::StatsDataProvider() {}
 
-template <class AccumType, class InputIterator, class MaskIterator>
-StatsDataProvider<AccumType, InputIterator, MaskIterator>::~StatsDataProvider() {}
+template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
+StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::~StatsDataProvider() {}
 
 }
 

--- a/scimath/Mathematics/test/tChauvenetCriterionStatistics.cc
+++ b/scimath/Mathematics/test/tChauvenetCriterionStatistics.cc
@@ -123,6 +123,14 @@ int main() {
     		AlwaysAssert(sd.npts == 100, AipsError);
     		AlwaysAssert(*sd.max == data[99], AipsError);
     	}
+    	{
+    		// a compile test: change final template parameter to Int*
+    		ChauvenetCriterionStatistics<Double, Double*, Bool*, Int*> cs(-1, -1);
+    		cs.setData(data, 107);
+    		StatsData<Double> sd = cs.getStatistics();
+    		AlwaysAssert(sd.npts == 100, AipsError);
+    		AlwaysAssert(*sd.max == data[99], AipsError);
+    	}
 
     }
 

--- a/scimath/Mathematics/test/tClassicalStatistics.cc
+++ b/scimath/Mathematics/test/tClassicalStatistics.cc
@@ -445,6 +445,40 @@ int main() {
     		AlwaysAssert(near(sd.variance, variance), AipsError);
     	}
     	{
+    		// integer weights
+			ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		cs.setData(v0.begin(), w0.begin(), w0.size());
+    		cs.addData(v1.begin(), w1.begin(), w1.size());
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (529.0 - 82.0*82.0/20.0)/19.0;
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 10, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 2, AipsError);
+    		AlwaysAssert(near(sd.mean, 4.1), AipsError);
+    		AlwaysAssert(*sd.min == 1, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 1, AipsError);
+    		AlwaysAssert(sd.npts == 7, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(529.0/20.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 82.0, AipsError);
+    		AlwaysAssert(sd.sumweights == 20.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 529.0, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    	}
+    	{
     		// weights and ranges
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -485,6 +519,46 @@ int main() {
     		AlwaysAssert(near(sd.variance, variance), AipsError);
     	}
     	{
+    		// integer weights; ranges
+			ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 9;
+    		cs.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (195.25 - 40.5*40.5/11.0)/10.0;
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 8, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, 40.5/11.0), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == 3, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(195.25/11.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 40.5, AipsError);
+    		AlwaysAssert(sd.sumweights == 11.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 195.25, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    	}
+    	{
     		// weights, ranges, and masks
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -494,6 +568,72 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (195.25 - 40.5*40.5/11.0)/10.0;
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 8, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, 40.5/11.0), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == 3, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(195.25/11.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 40.5, AipsError);
+    		AlwaysAssert(sd.sumweights == 11.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 195.25, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    		AlwaysAssert(
+    			cs.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(1, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			cs.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 4),
+    			AipsError
+    		);
+    		AlwaysAssert(cs.getStatistic(
+    			StatisticsData::NPTS) == 3, AipsError
+    		);
+    		AlwaysAssert(cs.getStatistic(
+    			StatisticsData::RMS) == sqrt(195.25/11.0), AipsError
+    		);
+    	}
+    	{
+    		// integer weights; ranges, and masks
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -594,7 +734,50 @@ int main() {
     		AlwaysAssert(sd.sumsq == 195.25, AipsError);
     		AlwaysAssert(near(sd.variance, variance), AipsError);
     	}
-
+    	{
+    		// integer weights; masks
+			ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = False;
+    		m0[2] = False;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = False;
+    		m1[1] = True;
+    		m1[2] = False;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size());
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size());
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (195.25 - 40.5*40.5/11.0)/10.0;
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 8, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, 40.5/11.0), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == 3, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(195.25/11.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 40.5, AipsError);
+    		AlwaysAssert(sd.sumweights == 11.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 195.25, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    	}
     	{
     		// getMinMax(), two datasets
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
@@ -700,6 +883,26 @@ int main() {
     		AlwaysAssert(mymax == 8, AipsError);
     	}
     	{
+		    // getMinMax, integer weights
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+		    vector<Int> w0(v0.size());
+		    w0[0] = 1;
+		    w0[1] = 0;
+		    w0[2] = 3;
+		    w0[3] = 4;
+		    w0[4] = 5;
+		    vector<Int> w1(v1.size());
+		    w1[0] = 1;
+		    w1[1] = 2;
+		    w1[2] = 0;
+		    cs.setData(v0.begin(), w0.begin(), w0.size());
+		    cs.addData(v1.begin(), w1.begin(), w1.size());
+		    Double mymin, mymax;
+		    cs.getMinMax(mymin, mymax);
+		    AlwaysAssert(mymin == 1.5, AipsError);
+		    AlwaysAssert(mymax == 8, AipsError);
+    	}
+	    {
     		// getMinMax(), weights and ranges
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -725,6 +928,32 @@ int main() {
     		AlwaysAssert(mymin == 2.5, AipsError);
     		AlwaysAssert(mymax == 8, AipsError);
     	}
+	    {
+		    // getMinMax(), integer weights, and ranges
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+		    vector<Int> w0(v0.size());
+		    w0[0] = 0;
+		    w0[1] = 2;
+		    w0[2] = 3;
+		    w0[3] = 4;
+		    w0[4] = 5;
+		    vector<Int> w1(v1.size());
+		    w1[0] = 1;
+		    w1[1] = 2;
+		    w1[2] = 3;
+		    vector<std::pair<Double, Double> > r0(1);
+		    r0[0].first = 0.9;
+		    r0[0].second = 1.6;
+		    vector<std::pair<Double, Double> > r1(1);
+		    r1[0].first = 6;
+		    r1[0].second = 9;
+		    cs.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+		    cs.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+		    Double mymin, mymax;
+		    cs.getMinMax(mymin, mymax);
+		    AlwaysAssert(mymin == 2.5, AipsError);
+		    AlwaysAssert(mymax == 8, AipsError);
+	    }
     	{
     		// getMinMax(), weights, ranges, and masks
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
@@ -761,8 +990,42 @@ int main() {
     		AlwaysAssert(mymin == 2.5, AipsError);
     		AlwaysAssert(mymax == 8, AipsError);
     	}
-
-
+    	{
+    		// getMinMax(), integer weights, ranges, and masks
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		Double mymin, mymax;
+    		cs.getMinMax(mymin, mymax);
+    		AlwaysAssert(mymin == 2.5, AipsError);
+    		AlwaysAssert(mymax == 8, AipsError);
+    	}
 
 
     	{
@@ -980,6 +1243,41 @@ int main() {
     		AlwaysAssert(q == 10.0, AipsError);
     	}
     	{
+    		// getQuantile(): integer weights
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		cs.setData(v0.begin(), w0.begin(), w0.size());
+    		cs.addData(v1.begin(), w1.begin(), w1.size());
+    		// 1, 1.5, 2.5, 3, 5, 8, 10
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 1.0, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 1.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 5.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 5.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 10.0, AipsError);
+    	}
+    	{
     		// getQuantile(): ranges and weights
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -989,6 +1287,47 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 9;
+    		cs.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+    		// 2.5, 3, 8
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 8.0, AipsError);
+    	}
+    	{
+    		// getQuantile(): ranges and integer weights
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -1066,6 +1405,51 @@ int main() {
     		AlwaysAssert(q == 8.0, AipsError);
     	}
     	{
+    		// getQuantile(): integer weights and mask
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = False;
+    		m0[2] = False;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = False;
+    		m1[1] = True;
+    		m1[2] = False;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size());
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size());
+    		// 2.5, 3, 8
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 8.0, AipsError);
+    	}
+    	{
     		// getQuantile(): weights, mask, ranges
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -1075,6 +1459,77 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		// 2.5, 3, 8
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		std::set<Double> quantiles;
+    		quantiles.insert(0.1);
+    		quantiles.insert(0.2);
+    		quantiles.insert(0.3);
+    		quantiles.insert(0.4);
+    		quantiles.insert(0.5);
+    		quantiles.insert(0.6);
+    		quantiles.insert(0.7);
+    		quantiles.insert(0.8);
+    		quantiles.insert(0.9);
+    		std::map<Double, Double> qs = cs.getQuantiles(quantiles);
+    		AlwaysAssert(qs[0.1] == 2.5, AipsError);
+    		AlwaysAssert(qs[0.2] == 2.5, AipsError);
+    		AlwaysAssert(qs[0.3] == 2.5, AipsError);
+    		AlwaysAssert(qs[0.4] == 3.0, AipsError);
+    		AlwaysAssert(qs[0.5] == 3.0, AipsError);
+    		AlwaysAssert(qs[0.6] == 3.0, AipsError);
+    		AlwaysAssert(qs[0.7] == 8.0, AipsError);
+    		AlwaysAssert(qs[0.8] == 8.0, AipsError);
+    		AlwaysAssert(qs[0.9] == 8.0, AipsError);
+    	}
+    	{
+    		// getQuantile(): integer weights, mask, ranges
+		    ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -1252,7 +1707,7 @@ int main() {
     		AlwaysAssert(median == -0.5, AipsError);
 
     	}
-    	{
+	    {
     		// getMedian() with mask, but no weights or ranges, using binning
     		ClassicalStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		cs.setData(bigData.begin(), bigMask.begin(), bigData.size());

--- a/scimath/Mathematics/test/tFitToHalfStatistics.cc
+++ b/scimath/Mathematics/test/tFitToHalfStatistics.cc
@@ -740,6 +740,64 @@ int main() {
     		);
     	}
     	{
+    		// integer weights
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+    			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+    		);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		fh.setData(v0.begin(), w0.begin(), w0.size());
+    		fh.addData(v1.begin(), w1.begin(), w1.size());
+    		StatsData<Double> sd = fh.getStatistics();
+    		Double npts = 8;
+    		Double sumofweights = 28;
+    		Double sumsq = 641.44;
+    		Double nvariance =  123.72;
+    		Double mean = 4.3;
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(near(*sd.max, 2*mean - 1), AipsError);
+    		AlwaysAssert(sd.maxpos.first == -1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == -1, AipsError);
+    		AlwaysAssert(near(sd.mean, mean), AipsError);
+    		AlwaysAssert(*sd.min == 1, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 1, AipsError);
+    		AlwaysAssert(sd.npts == npts, AipsError);
+    		AlwaysAssert(near(sd.rms, sqrt(sumsq/sumofweights)), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(nvariance/(sumofweights - 1))), AipsError);
+    		AlwaysAssert(near(sd.sum, mean*sumofweights), AipsError);
+    		AlwaysAssert(near(sd.sumsq, sumsq), AipsError);
+    		AlwaysAssert(near(sd.variance, nvariance/(sumofweights - 1)), AipsError);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(-1, -1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(fh.getStatistic(
+    			StatisticsData::NPTS) == npts, AipsError
+    		);
+    		AlwaysAssert(
+    			near(
+    				fh.getStatistic(StatisticsData::RMS),
+    				sqrt(sumsq/sumofweights)
+    			), AipsError
+    		);
+    	}
+    	{
     		// weights and ranges
     		// 4, 2.5
     		// 8
@@ -753,6 +811,70 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 9;
+    		fh.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+    		fh.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+    		StatsData<Double> sd = fh.getStatistics();
+    		Double npts = 4;
+    		Double sumofweights = 18;
+    		Double sumsq = 154146.0/484.0;
+    		Double nvariance = 11568.0/484.0;
+    		Double mean = 44.5/11.0;
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(near(*sd.max, 2*mean - 2.5), AipsError);
+    		AlwaysAssert(sd.maxpos.first == -1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == -1, AipsError);
+    		AlwaysAssert(near(sd.mean, mean), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == npts, AipsError);
+    		AlwaysAssert(near(sd.rms, sqrt(sumsq/sumofweights)), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(nvariance/(sumofweights - 1))), AipsError);
+    		AlwaysAssert(near(sd.sum, mean*sumofweights), AipsError);
+    		AlwaysAssert(near(sd.sumsq, sumsq), AipsError);
+    		AlwaysAssert(near(sd.variance, nvariance/(sumofweights - 1)), AipsError);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(-1, -1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 4),
+    			AipsError
+    		);
+    		AlwaysAssert(fh.getStatistic(
+    			StatisticsData::NPTS) == npts, AipsError
+    		);
+    		AlwaysAssert(
+    			near(
+    				fh.getStatistic(StatisticsData::RMS),
+    				sqrt(sumsq/sumofweights)
+    			), AipsError
+    		);
+    	}
+    	{
+    		// integer weights and ranges
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+    			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+    		);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -882,6 +1004,80 @@ int main() {
     		);
     	}
     	{
+    		// integer weights; ranges, and masks
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+    			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+    		);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		fh.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		fh.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		StatsData<Double> sd = fh.getStatistics();
+    		Double npts = 4;
+    		Double sumofweights = 18;
+    		Double sumsq = 154146.0/484.0;
+    		Double nvariance = 11568.0/484.0;
+    		Double mean = 44.5/11.0;
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(near(*sd.max, 2*mean - 2.5), AipsError);
+    		AlwaysAssert(sd.maxpos.first == -1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == -1, AipsError);
+    		AlwaysAssert(near(sd.mean, mean), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == npts, AipsError);
+    		AlwaysAssert(near(sd.rms, sqrt(sumsq/sumofweights)), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(nvariance/(sumofweights - 1))), AipsError);
+    		AlwaysAssert(near(sd.sum, mean*sumofweights), AipsError);
+    		AlwaysAssert(near(sd.sumsq, sumsq), AipsError);
+    		AlwaysAssert(near(sd.variance, nvariance/(sumofweights - 1)), AipsError);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(-1, -1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 4),
+    			AipsError
+    		);
+    		AlwaysAssert(fh.getStatistic(
+    			StatisticsData::NPTS) == npts, AipsError
+    		);
+    		AlwaysAssert(
+    			near(
+    				fh.getStatistic(StatisticsData::RMS),
+    				sqrt(sumsq/sumofweights)
+    			), AipsError
+    		);
+    	}
+    	{
     		// weights, masks
     		FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> fh(
     			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
@@ -893,6 +1089,74 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = False;
+    		m0[2] = False;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = False;
+    		m1[1] = True;
+    		m1[2] = False;
+    		fh.setData(v0.begin(), w0.begin(), m0.begin(), v0.size());
+    		fh.addData(v1.begin(), w1.begin(), m1.begin(), v1.size());
+    		StatsData<Double> sd = fh.getStatistics();
+    		Double npts = 4;
+    		Double sumofweights = 18;
+    		Double sumsq = 154146.0/484.0;
+    		Double nvariance = 11568.0/484.0;
+    		Double mean = 44.5/11.0;
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(near(*sd.max, 2*mean - 2.5), AipsError);
+    		AlwaysAssert(sd.maxpos.first == -1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == -1, AipsError);
+    		AlwaysAssert(near(sd.mean, mean), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == npts, AipsError);
+    		AlwaysAssert(near(sd.rms, sqrt(sumsq/sumofweights)), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(nvariance/(sumofweights - 1))), AipsError);
+    		AlwaysAssert(near(sd.sum, mean*sumofweights), AipsError);
+    		AlwaysAssert(near(sd.sumsq, sumsq), AipsError);
+    		AlwaysAssert(near(sd.variance, nvariance/(sumofweights - 1)), AipsError);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(-1, -1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			fh.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 4),
+    			AipsError
+    		);
+    		AlwaysAssert(fh.getStatistic(
+    			StatisticsData::NPTS) == npts, AipsError
+    		);
+    		AlwaysAssert(
+    			near(
+    				fh.getStatistic(StatisticsData::RMS),
+    				sqrt(sumsq/sumofweights)
+    			), AipsError
+    		);
+    	}
+    	{
+    		// integer weights, masks
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+    			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+    		);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -1080,6 +1344,28 @@ int main() {
     		AlwaysAssert(near(mymax, 5.5), AipsError);
     	}
     	{
+		    // getMinMax, integer weights
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+			    FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+			);
+		    vector<Int> w0(v0.size());
+		    w0[0] = 1;
+		    w0[1] = 0;
+		    w0[2] = 3;
+		    w0[3] = 4;
+		    w0[4] = 5;
+		    vector<Int> w1(v1.size());
+		    w1[0] = 1;
+		    w1[1] = 2;
+		    w1[2] = 0;
+		    fh.setData(v0.begin(), w0.begin(), w0.size());
+		    fh.addData(v1.begin(), w1.begin(), w1.size());
+		    Double mymin, mymax;
+		    fh.getMinMax(mymin, mymax);
+		    AlwaysAssert(mymin == 1.5, AipsError);
+		    AlwaysAssert(near(mymax, 5.5), AipsError);
+    	}
+    	{
     		// 4, 2.5
     		// 8
     		// getMinMax(), weights and ranges
@@ -1109,7 +1395,34 @@ int main() {
     		AlwaysAssert(mymin == 2.5, AipsError);
     		AlwaysAssert(near(mymax, 123.0/22.0), AipsError);
     	}
-
+    	{
+		    // getMinMax(), integer weights and ranges
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+    			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+			);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 9;
+    		fh.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+    		fh.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+    		Double mymin, mymax;
+    		fh.getMinMax(mymin, mymax);
+    		AlwaysAssert(mymin == 2.5, AipsError);
+    		AlwaysAssert(near(mymax, 123.0/22.0), AipsError);
+    	}
     	{
     		// getMinMax(), weights, ranges, and masks
     		FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> fh(
@@ -1123,6 +1436,45 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		fh.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		fh.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		Double mymin, mymax;
+    		fh.getMinMax(mymin, mymax);
+    		AlwaysAssert(mymin == 2.5, AipsError);
+    		AlwaysAssert(near(mymax, 123.0/22.0), AipsError);
+    	}
+    	{
+    		// getMinMax(), integer weights, ranges, and masks
+		    FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> fh(
+    			FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+    		);
+
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;

--- a/scimath/Mathematics/test/tHingesFencesStatistics.cc
+++ b/scimath/Mathematics/test/tHingesFencesStatistics.cc
@@ -424,6 +424,40 @@ int main() {
     		AlwaysAssert(near(sd.variance, variance), AipsError);
     	}
     	{
+    		// integer weights
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		cs.setData(v0.begin(), w0.begin(), w0.size());
+    		cs.addData(v1.begin(), w1.begin(), w1.size());
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (529.0 - 82.0*82.0/20.0)/19.0;
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 10, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 2, AipsError);
+    		AlwaysAssert(near(sd.mean, 4.1), AipsError);
+    		AlwaysAssert(*sd.min == 1, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 1, AipsError);
+    		AlwaysAssert(sd.npts == 7, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(529.0/20.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 82.0, AipsError);
+    		AlwaysAssert(sd.sumweights == 20.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 529.0, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    	}
+    	{
     		// weights and ranges
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -433,6 +467,46 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 9;
+    		cs.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (195.25 - 40.5*40.5/11.0)/10.0;
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 8, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, 40.5/11.0), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == 3, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(195.25/11.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 40.5, AipsError);
+    		AlwaysAssert(sd.sumweights == 11.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 195.25, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    	}
+    	{
+    		// integer weights and ranges
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -530,6 +604,72 @@ int main() {
     		);
     	}
     	{
+    		// integer weights, ranges, and masks
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (195.25 - 40.5*40.5/11.0)/10.0;
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 8, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, 40.5/11.0), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == 3, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(195.25/11.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 40.5, AipsError);
+    		AlwaysAssert(sd.sumweights == 11.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 195.25, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    		AlwaysAssert(
+    			cs.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(1, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			cs.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 4),
+    			AipsError
+    		);
+    		AlwaysAssert(cs.getStatistic(
+    			StatisticsData::NPTS) == 3, AipsError
+    		);
+    		AlwaysAssert(cs.getStatistic(
+    			StatisticsData::RMS) == sqrt(195.25/11.0), AipsError
+    		);
+    	}
+    	{
     		// weights, masks
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -539,6 +679,50 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = False;
+    		m0[2] = False;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = False;
+    		m1[1] = True;
+    		m1[2] = False;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size());
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size());
+    		StatsData<Double> sd = cs.getStatistics();
+    		Double variance = (195.25 - 40.5*40.5/11.0)/10.0;
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 8, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, 40.5/11.0), AipsError);
+    		AlwaysAssert(*sd.min == 2.5, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 4, AipsError);
+    		AlwaysAssert(sd.npts == 3, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(195.25/11.0), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(variance)), AipsError);
+    		AlwaysAssert(sd.sum == 40.5, AipsError);
+    		AlwaysAssert(sd.sumweights == 11.0, AipsError);
+    		AlwaysAssert(sd.sumsq == 195.25, AipsError);
+    		AlwaysAssert(near(sd.variance, variance), AipsError);
+    	}
+    	{
+    		// integer weights, masks
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -679,6 +863,26 @@ int main() {
     		AlwaysAssert(mymax == 8, AipsError);
     	}
     	{
+		    // getMinMax, integer weights
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+		    vector<Int> w0(v0.size());
+		    w0[0] = 1;
+		    w0[1] = 0;
+		    w0[2] = 3;
+		    w0[3] = 4;
+		    w0[4] = 5;
+		    vector<Int> w1(v1.size());
+		    w1[0] = 1;
+		    w1[1] = 2;
+		    w1[2] = 0;
+		    cs.setData(v0.begin(), w0.begin(), w0.size());
+		    cs.addData(v1.begin(), w1.begin(), w1.size());
+		    Double mymin, mymax;
+		    cs.getMinMax(mymin, mymax);
+		    AlwaysAssert(mymin == 1.5, AipsError);
+		    AlwaysAssert(mymax == 8, AipsError);
+    	}
+	    {
     		// getMinMax(), weights and ranges
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -704,6 +908,32 @@ int main() {
     		AlwaysAssert(mymin == 2.5, AipsError);
     		AlwaysAssert(mymax == 8, AipsError);
     	}
+	    {
+		    // getMinMax(), integer weights and ranges
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+		    vector<Int> w0(v0.size());
+		    w0[0] = 0;
+		    w0[1] = 2;
+		    w0[2] = 3;
+		    w0[3] = 4;
+		    w0[4] = 5;
+		    vector<Int> w1(v1.size());
+		    w1[0] = 1;
+		    w1[1] = 2;
+		    w1[2] = 3;
+		    vector<std::pair<Double, Double> > r0(1);
+		    r0[0].first = 0.9;
+		    r0[0].second = 1.6;
+		    vector<std::pair<Double, Double> > r1(1);
+		    r1[0].first = 6;
+		    r1[0].second = 9;
+		    cs.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+		    cs.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+		    Double mymin, mymax;
+		    cs.getMinMax(mymin, mymax);
+		    AlwaysAssert(mymin == 2.5, AipsError);
+		    AlwaysAssert(mymax == 8, AipsError);
+	    }
     	{
     		// getMinMax(), weights, ranges, and masks
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
@@ -714,6 +944,42 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		Double mymin, mymax;
+    		cs.getMinMax(mymin, mymax);
+    		AlwaysAssert(mymin == 2.5, AipsError);
+    		AlwaysAssert(mymax == 8, AipsError);
+    	}
+    	{
+    		// getMinMax(), integer weights, ranges, and masks
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -959,6 +1225,41 @@ int main() {
     		AlwaysAssert(q == 10.0, AipsError);
     	}
     	{
+    		// getQuantile(): integer weights
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		cs.setData(v0.begin(), w0.begin(), w0.size());
+    		cs.addData(v1.begin(), w1.begin(), w1.size());
+    		// 1, 1.5, 2.5, 3, 5, 8, 10
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 1.0, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 1.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 5.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 5.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 10.0, AipsError);
+    	}
+    	{
     		// getQuantile(): ranges and weights
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -968,6 +1269,47 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 9;
+    		cs.setData(v0.begin(), w0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), v1.size(), r1, True);
+    		// 2.5, 3, 8
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 8.0, AipsError);
+    	}
+    	{
+    		// getQuantile(): ranges and integer weights
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -1045,6 +1387,51 @@ int main() {
     		AlwaysAssert(q == 8.0, AipsError);
     	}
     	{
+    		// getQuantile(): integer weights and mask
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = False;
+    		m0[2] = False;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = False;
+    		m1[1] = True;
+    		m1[2] = False;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size());
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size());
+    		// 2.5, 3, 8
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 8.0, AipsError);
+    	}
+    	{
     		// getQuantile(): weights, mask, ranges
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> cs;
     		vector<Double> w0(v0.size());
@@ -1054,6 +1441,77 @@ int main() {
     		w0[3] = 4;
     		w0[4] = 5;
     		vector<Double> w1(v1.size());
+    		w1[0] = 1;
+    		w1[1] = 2;
+    		w1[2] = 3;
+    		vector<Bool> m0(v0.size());
+    		m0[0] = True;
+    		m0[1] = True;
+    		m0[2] = True;
+    		m0[3] = True;
+    		m0[4] = True;
+    		vector<Bool> m1(v1.size());
+    		m1[0] = True;
+    		m1[1] = True;
+    		m1[2] = False;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 0.9;
+    		r0[0].second = 1.6;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 6;
+    		r1[0].second = 12;
+    		cs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size(), r0, False);
+    		cs.addData(v1.begin(), w1.begin(), m1.begin(), v1.size(), r1, True);
+    		// 2.5, 3, 8
+    		Double q = cs.getQuantile(0.1);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.2);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.3);
+    		AlwaysAssert(q == 2.5, AipsError);
+    		q = cs.getQuantile(0.4);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.5);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.6);
+    		AlwaysAssert(q == 3.0, AipsError);
+    		q = cs.getQuantile(0.7);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.8);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		q = cs.getQuantile(0.9);
+    		AlwaysAssert(q == 8.0, AipsError);
+    		std::set<Double> quantiles;
+    		quantiles.insert(0.1);
+    		quantiles.insert(0.2);
+    		quantiles.insert(0.3);
+    		quantiles.insert(0.4);
+    		quantiles.insert(0.5);
+    		quantiles.insert(0.6);
+    		quantiles.insert(0.7);
+    		quantiles.insert(0.8);
+    		quantiles.insert(0.9);
+    		std::map<Double, Double> qs = cs.getQuantiles(quantiles);
+    		AlwaysAssert(qs[0.1] == 2.5, AipsError);
+    		AlwaysAssert(qs[0.2] == 2.5, AipsError);
+    		AlwaysAssert(qs[0.3] == 2.5, AipsError);
+    		AlwaysAssert(qs[0.4] == 3.0, AipsError);
+    		AlwaysAssert(qs[0.5] == 3.0, AipsError);
+    		AlwaysAssert(qs[0.6] == 3.0, AipsError);
+    		AlwaysAssert(qs[0.7] == 8.0, AipsError);
+    		AlwaysAssert(qs[0.8] == 8.0, AipsError);
+    		AlwaysAssert(qs[0.9] == 8.0, AipsError);
+    	}
+    	{
+    		// getQuantile(): integer weights, mask, ranges
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> cs;
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		vector<Int> w1(v1.size());
     		w1[0] = 1;
     		w1[1] = 2;
     		w1[2] = 3;
@@ -1763,6 +2221,72 @@ int main() {
     		);
     	}
     	{
+    		// integer weights
+    		// 5, 2, 6, 10, 7, -1
+    		// 15, 11, 6, 20, -3, 14
+
+    		// 2, 6, 10, 7, -1
+    		// 11, 6, 20, -3, 14
+
+    		// 2, 6, 10, 7
+    		// 11, 6
+
+    		// 4 + 18 + 40 + 35 + 22 + 18
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> hfs(0);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3;
+    		w0[3] = 4;
+    		w0[4] = 5;
+    		w0[5] = 1;
+    		w0[6] = 0;
+    		w0[7] = 2;
+    		w0[8] = 3;
+    		w0[9] = 2;
+    		w0[10] = 1;
+    		w0[11] = 2;
+    		hfs.setData(v0.begin(), w0.begin(), v0.size()/2);
+    		hfs.addData(v0.begin() + v0.size()/2, w0.begin() + w0.size()/2, v0.size() - v0.size()/2);
+    		StatsData<Double> sd = hfs.getStatistics();
+    		Double eSum = 137;
+    		Double eSumWeights = 19;
+    		Double eNpts = 6;
+    		Double eSumSq = 1111;
+    		Double eVar = (eSumSq - eSum*eSum/eSumWeights)/(eSumWeights - 1);
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 11, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(sd.mean == eSum/eSumWeights, AipsError);
+    		AlwaysAssert(*sd.min == 2, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 1, AipsError);
+    		AlwaysAssert(sd.npts == eNpts, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(eSumSq/eSumWeights), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(eVar)), AipsError);
+    		AlwaysAssert(sd.sum == eSum, AipsError);
+    		AlwaysAssert(sd.sumsq == eSumSq, AipsError);
+    		AlwaysAssert(near(sd.variance, eVar), AipsError);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(1, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(hfs.getStatistic(
+    			StatisticsData::NPTS) == eNpts, AipsError
+    		);
+    		AlwaysAssert(hfs.getStatistic(
+    			StatisticsData::RMS) == sqrt(eSumSq/eSumWeights), AipsError
+    		);
+    	}
+    	{
     		// weights and ranges
     		// 5, 2, 6, 10, 7, -1
     		// 15, 11, 6, 20, -3, 14
@@ -1778,6 +2302,83 @@ int main() {
 
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> hfs(0);
     		vector<Double> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3; // *6 = 18
+    		w0[3] = 4; // *10 = 40
+    		w0[4] = 5; // *7 = 35
+    		w0[5] = 1;
+    		w0[6] = 0;
+    		w0[7] = 2; // *11 = 22
+    		w0[8] = 3; // *6 = 18
+    		w0[9] = 2;
+    		w0[10] = 1;
+    		w0[11] = 2;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 1;
+    		r0[0].second = 2;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 0;
+    		r1[0].second = 15;
+    		hfs.setData(v0.begin(), w0.begin(), v0.size()/2, r0, False);
+    		hfs.addData(
+    			v0.begin() + v0.size()/2, w0.begin() + w0.size()/2,
+    			v0.size() - v0.size()/2, r1, True
+    		);
+    		StatsData<Double> sd = hfs.getStatistics();
+    		Double eSum = 133;
+    		Double eSumWeights = 17;
+    		Double eNpts = 5;
+    		Double eSumSq = 1103;
+    		Double eVar = (eSumSq - eSum*eSum/eSumWeights)/(eSumWeights - 1);
+    		AlwaysAssert(! sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 11, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(sd.mean == eSum/eSumWeights, AipsError);
+    		AlwaysAssert(*sd.min == 6, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 2, AipsError);
+    		AlwaysAssert(sd.npts == eNpts, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(eSumSq/eSumWeights), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(eVar)), AipsError);
+    		AlwaysAssert(sd.sum == eSum, AipsError);
+    		AlwaysAssert(sd.sumsq == eSumSq, AipsError);
+    		AlwaysAssert(near(sd.variance, eVar), AipsError);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(1, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 2),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatistic(StatisticsData::NPTS) == eNpts, AipsError
+    		);
+    		AlwaysAssert(hfs.getStatistic(
+    			StatisticsData::RMS) == sqrt(eSumSq/eSumWeights), AipsError
+    		);
+    	}
+    	{
+    		// integer weights and ranges
+    		// 5, 2, 6, 10, 7, -1
+    		// 15, 11, 6, 20, -3, 14
+
+    		// 2, 6, 10, 7, -1
+    		// 11, 6, 20, -3, 14
+
+    		// 6, 10, 7, -1
+    		// 11, 6, 14
+
+    		// 6, 10, 7
+    		// 11, 6
+
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> hfs(0);
+    		vector<Int> w0(v0.size());
     		w0[0] = 0;
     		w0[1] = 2;
     		w0[2] = 3; // *6 = 18
@@ -1926,6 +2527,92 @@ int main() {
     		);
     	}
     	{
+    		// integer weights, ranges, and masks
+    		// 5, 2, 6, 10, 7, -1
+    		// 15, 11, 6, 20, -3, 14
+
+    		// 2, 6, 10, 7, -1
+    		// 11, 6, 20, -3, 14
+
+    		// 6, 10, 7, -1
+    		// 11, 6, 14
+
+    		// 6, 10, -1
+    		// 11, 14
+
+    		// 6, 10
+    		// 11
+
+
+
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> hfs(0);
+    		vector<Int> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2;
+    		w0[2] = 3; // *6 = 18
+    		w0[3] = 4; // *10 = 40
+    		w0[4] = 5;
+    		w0[5] = 1;
+    		w0[6] = 0;
+    		w0[7] = 2; // *11 = 22
+    		w0[8] = 3;
+    		w0[9] = 2;
+    		w0[10] = 1;
+    		w0[11] = 2;
+    		vector<std::pair<Double, Double> > r0(1);
+    		r0[0].first = 1;
+    		r0[0].second = 2;
+    		vector<std::pair<Double, Double> > r1(1);
+    		r1[0].first = 0;
+    		r1[0].second = 15;
+    		vector<Bool> m0(v0.size(), True);
+    		m0[4] = False;
+    		m0[8] = False;
+    		hfs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size()/2, r0, False);
+    		hfs.addData(
+    			v0.begin() + v0.size()/2, w0.begin() + w0.size()/2,
+    			m0.begin() + m0.size()/2,
+    			v0.size() - v0.size()/2, r1, True
+    		);
+    		StatsData<Double> sd = hfs.getStatistics();
+    		Double eSum = 80;
+    		Double eSumWeights = 9;
+    		Double eNpts = 3;
+    		Double eSumSq = 750;
+    		Double eVar = (eSumSq - eSum*eSum/eSumWeights)/(eSumWeights - 1);
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 11, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, eSum/eSumWeights), AipsError);
+    		AlwaysAssert(*sd.min == 6, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 2, AipsError);
+    		AlwaysAssert(sd.npts == eNpts, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(eSumSq/eSumWeights), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(eVar)), AipsError);
+    		AlwaysAssert(sd.sum == eSum, AipsError);
+    		AlwaysAssert(sd.sumsq == eSumSq, AipsError);
+    		AlwaysAssert(near(sd.variance, eVar), AipsError);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(1, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 2),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatistic(StatisticsData::NPTS) == eNpts, AipsError
+    		);
+    		AlwaysAssert(hfs.getStatistic(
+    			StatisticsData::RMS) == sqrt(eSumSq/eSumWeights), AipsError
+    		);
+    	}
+    	{
     		// weights, masks
     		// 5, 2, 6, 10, 7, -1
     		// 15, 11, 6, 20, -3, 14
@@ -1941,6 +2628,81 @@ int main() {
 
     		HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> hfs(0);
     		vector<Double> w0(v0.size());
+    		w0[0] = 0;
+    		w0[1] = 2; // *2 = 4
+    		w0[2] = 3; // *6 = 18
+    		w0[3] = 4; // *10 = 40
+    		w0[4] = 5;
+    		w0[5] = 1; // *-1 = -1
+    		w0[6] = 0;
+    		w0[7] = 2; // *11 = 22
+    		w0[8] = 3;
+    		w0[9] = 2;
+    		w0[10] = 1;
+    		w0[11] = 2;
+    		vector<Bool> m0(v0.size(), True);
+    		m0[4] = False;
+    		m0[8] = False;
+    		hfs.setData(v0.begin(), w0.begin(), m0.begin(), v0.size()/2);
+    		hfs.addData(
+    			v0.begin() + v0.size()/2, w0.begin() + w0.size()/2,
+    			m0.begin() + m0.size()/2,
+    			v0.size() - v0.size()/2
+    		);
+    		StatsData<Double> sd = hfs.getStatistics();
+    		Double eSum = 83;
+    		Double eSumWeights = 12;
+    		Double eNpts = 5;
+    		Double eSumSq = 759;
+    		Double eVar = (eSumSq - eSum*eSum/eSumWeights)/(eSumWeights - 1);
+    		AlwaysAssert(sd.masked, AipsError);
+    		AlwaysAssert(sd.weighted, AipsError);
+    		AlwaysAssert(*sd.max == 11, AipsError);
+    		AlwaysAssert(sd.maxpos.first == 1, AipsError);
+    		AlwaysAssert(sd.maxpos.second == 1, AipsError);
+    		AlwaysAssert(near(sd.mean, eSum/eSumWeights), AipsError);
+    		AlwaysAssert(*sd.min == -1, AipsError);
+    		AlwaysAssert(sd.minpos.first == 0, AipsError);
+    		AlwaysAssert(sd.minpos.second == 5, AipsError);
+    		AlwaysAssert(sd.npts == eNpts, AipsError);
+    		AlwaysAssert(sd.rms == sqrt(eSumSq/eSumWeights), AipsError);
+    		AlwaysAssert(near(sd.stddev, sqrt(eVar)), AipsError);
+    		AlwaysAssert(sd.sum == eSum, AipsError);
+    		AlwaysAssert(sd.sumsq == eSumSq, AipsError);
+    		AlwaysAssert(near(sd.variance, eVar), AipsError);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MAX)
+    			== std::pair<Int64 COMMA Int64>(1, 1),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatisticIndex(StatisticsData::MIN)
+    			== std::pair<Int64 COMMA Int64>(0, 5),
+    			AipsError
+    		);
+    		AlwaysAssert(
+    			hfs.getStatistic(StatisticsData::NPTS) == eNpts, AipsError
+    		);
+    		AlwaysAssert(hfs.getStatistic(
+    			StatisticsData::RMS) == sqrt(eSumSq/eSumWeights), AipsError
+    		);
+    	}
+    	{
+    		// integer weights, masks
+    		// 5, 2, 6, 10, 7, -1
+    		// 15, 11, 6, 20, -3, 14
+
+    		// 2, 6, 10, 7, -1
+    		// 11, 6, 20, -3, 14
+
+    		// 2, 6, 10, -1
+    		// 11, 20, -3, 14
+
+    		// 2, 6, 10, -1
+    		// 11
+
+		    HingesFencesStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator, vector<Int>::const_iterator> hfs(0);
+    		vector<Int> w0(v0.size());
     		w0[0] = 0;
     		w0[1] = 2; // *2 = 4
     		w0[2] = 3; // *6 = 18


### PR DESCRIPTION
Upcoming changes to CASA's visstat require that some classes in the new statistics framework support different types for the iterator over data vs the iterator over weights. This branch includes all of the required changes to support that feature, including appropriate unit tests. Note that the changes have been implemented to be backward compatible -- previously existing unit tests are still applicable, and have not been changed.