### PR TITLE
CAS-5996, plug memory leak, close open table upon exception

### DIFF
--- a/images/Images/ImageUtilities2.tcc
+++ b/images/Images/ImageUtilities2.tcc
@@ -257,21 +257,25 @@ template <typename T> void ImageUtilities::openImage(
 	);
 	LatticeBase* lattPtr = ImageOpener::openImage (fileName);
     ThrowIf(
-		lattPtr == 0,
+		! lattPtr,
 		"Image " + fileName + " cannot be opened; its type is unknown"
 	);
     T x = 0;
-    ThrowIf(
-        lattPtr->dataType() != whatType(&x),
-        "Logic Error: " + fileName
-        + " has a different data type than the data type of the requested object"
-    );
+    if (lattPtr->dataType() != whatType(&x)) {
+    	delete lattPtr;
+        ThrowCc(
+        	"Logic Error: " + fileName
+			+ " has a different data type than the data type of the requested object"
+		);
+    }
 	pImage = dynamic_cast<ImageInterface<T> *>(lattPtr);
-	ThrowIf(
-		pImage == 0,
-		"Unrecognized image data type, "
-	    "presently only Float and Complex images are supported"
-	);
+	if (pImage == 0) {
+		delete lattPtr;
+		ThrowCc(
+			"Unrecognized image data type, "
+			"presently only Float and Complex images are supported"
+		);
+	}
 }
 
 template <typename T> void ImageUtilities::openImage(


### PR DESCRIPTION
Upon certain failure modes of opening an image, a memory leak would occur and a table would be left open upon an exception being thrown. This modification fixes that.