### PR TITLE
Added methods to ImageProxy to return objects

### DIFF
--- a/images/Images/ImageProxy.cc
+++ b/images/Images/ImageProxy.cc
@@ -917,6 +917,11 @@ namespace casacore { //# name space casa begins
     return coord;
   }
 
+    const CoordinateSystem& ImageProxy::coordSysObject() const {
+        checkNull();
+        return *itsCoordSys;
+    }
+
   Vector<Double> ImageProxy::toWorld (const Vector<Double>& pixel,
                                       Bool reverseAxes)
   {
@@ -975,7 +980,7 @@ namespace casacore { //# name space casa begins
     return rec;
   }
 
-  ImageInfo ImageProxy::imageInfoObject() const {
+  const ImageInfo& ImageProxy::imageInfoObject() const {
     if (itsImageFloat) {
       return itsImageFloat->imageInfo();
     }

--- a/images/Images/ImageProxy.cc
+++ b/images/Images/ImageProxy.cc
@@ -31,6 +31,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/images/Images/ImageProxy.h>
 #include <casacore/images/Images/ImageInterface.h>
+#include <casacore/images/Images/ImageInfo.h>
 #include <casacore/images/Images/ImageConcat.h>
 #include <casacore/images/Images/ImageFITSConverter.h>
 #include <casacore/images/Images/ImageRegrid.h>
@@ -577,6 +578,11 @@ namespace casacore { //# name space casa begins
     return ostr.str();
   }
 
+  DataType ImageProxy::type() const {
+      checkNull();
+      return itsLattice->dataType();
+  }
+
   String ImageProxy::imageType() const
   {
     // LatticeBase does not have a fileType function or so.
@@ -965,18 +971,26 @@ namespace casacore { //# name space casa begins
   {
     Record rec;
     String error;
+    imageInfoObject().toRecord(error, rec);
+    return rec;
+  }
+
+  ImageInfo ImageProxy::imageInfoObject() const {
     if (itsImageFloat) {
-      itsImageFloat->imageInfo().toRecord (error, rec);
-    } else if (itsImageDouble) {
-      itsImageDouble->imageInfo().toRecord (error, rec);
-    } else if (itsImageComplex) {
-      itsImageComplex->imageInfo().toRecord (error, rec);
-    } else if (itsImageDComplex) {
-      itsImageDComplex->imageInfo().toRecord (error, rec);
-    } else {
+      return itsImageFloat->imageInfo();
+    }
+    else if (itsImageDouble) {
+      return itsImageDouble->imageInfo();
+    }
+    else if (itsImageComplex) {
+      return itsImageComplex->imageInfo();
+    }
+    else if (itsImageDComplex) {
+      return itsImageDComplex->imageInfo();
+    }
+    else {
       throw AipsError ("ImageProxy does not contain an image object");
     }
-    return rec;
   }
 
   Record ImageProxy::miscInfo() const

--- a/images/Images/ImageProxy.h
+++ b/images/Images/ImageProxy.h
@@ -269,6 +269,8 @@ namespace casacore {
     // Get the coordinate system.
     Record coordSys() const;
 
+    const CoordinateSystem& coordSysObject() const;
+
     // Convert a pixel coordinate to world coordinate.
     // if <src>reverseAxes=True</src> the input and output vector will be
     // reversed (as needed for pyrap).
@@ -284,7 +286,7 @@ namespace casacore {
     // Get the image info.
     Record imageInfo() const;
 
-    ImageInfo imageInfoObject() const;
+    const ImageInfo& imageInfoObject() const;
 
     // Get the miscellaneous info.
     Record miscInfo() const;

--- a/images/Images/ImageProxy.h
+++ b/images/Images/ImageProxy.h
@@ -41,6 +41,7 @@
 namespace casacore {
 
   //# Forward Declarations.
+  class ImageInfo;
   template<typename T> class ImageInterface;
   class LatticeExprNode;
   class CoordinateSystem;
@@ -175,6 +176,8 @@ namespace casacore {
     // Get the data type of the image.
     String dataType() const;
 
+    DataType type() const;
+
     // Get the image type (PagedImage, HDF5Image, etc.)
     String imageType() const;
 
@@ -280,6 +283,8 @@ namespace casacore {
 
     // Get the image info.
     Record imageInfo() const;
+
+    ImageInfo imageInfoObject() const;
 
     // Get the miscellaneous info.
     Record miscInfo() const;

--- a/images/Images/test/CMakeLists.txt
+++ b/images/Images/test/CMakeLists.txt
@@ -56,6 +56,7 @@ tImageExpr3Gram
 tImageExprGram
 tImageExprParse_addDir
 tImageInfo
+tImageProxy
 tImageRegrid
 tImageStatistics
 tImageStatistics2

--- a/images/Images/test/tImageProxy.cc
+++ b/images/Images/test/tImageProxy.cc
@@ -38,6 +38,7 @@ int main() {
         ImageInfo ii = proxy.imageInfoObject();
         AlwaysAssert(ii.getBeamSet().hasSingleBeam(), AipsError);
         AlwaysAssert(proxy.type() == TpFloat, AipsError);
+        AlwaysAssert(proxy.coordSysObject().nWorldAxes() == 2, AipsError);
     }
     catch (const AipsError& x) {
         cout << "Caught error " << x.getMesg() << endl;

--- a/images/Images/test/tImageProxy.cc
+++ b/images/Images/test/tImageProxy.cc
@@ -1,0 +1,48 @@
+ //# tImageProxy.cc
+//# Copyright (C) 1998,1999,2000,2002
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//#
+//# $Id$
+
+#include <casacore/images/Images/ImageProxy.h>
+
+#include <casacore/images/Images/ImageInfo.h>
+
+#include <casacore/casa/namespace.h>
+
+int main() {
+    try {
+        ImageProxy proxy("imagetestimage.fits", "", vector<ImageProxy>());
+        ImageInfo ii = proxy.imageInfoObject();
+        AlwaysAssert(ii.getBeamSet().hasSingleBeam(), AipsError);
+        AlwaysAssert(proxy.type() == TpFloat, AipsError);
+    }
+    catch (const AipsError& x) {
+        cout << "Caught error " << x.getMesg() << endl;
+        return 1;
+    } 
+    cout << "OK" << endl;
+    return 0;
+}


### PR DESCRIPTION
Added imageInfoObject() and type() methods to return native casacore objects/types rather than Records/Strings.