### PR TITLE
Fixed a bug in re-using MSSelection object + added more test

### DIFF
--- a/ms/MSSel/MSAntennaParse.h
+++ b/ms/MSSel/MSAntennaParse.h
@@ -174,6 +174,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   public:
     static MSAntennaParse* thisMSAParser;
     static MSSelectionErrorHandler* thisMSAErrorHandler;
+    static void cleanupErrorHandler() {if (thisMSAErrorHandler) delete thisMSAErrorHandler;thisMSAErrorHandler=0x0;}
     std::bitset<HIGHESTLEVEL> complexity;
   private:
     TableExprNode node_p;

--- a/ms/MSSel/MSSelection.cc
+++ b/ms/MSSel/MSSelection.cc
@@ -76,7 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     spwIDs_p(), scanIDs_p(), arrayIDs_p(), ddIDs_p(), observationIDs_p(), baselineIDs_p(),
     selectedTimesList_p(), selectedUVRange_p(),selectedUVUnits_p(),
     selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0)),
-    maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), mssErrHandler_p(NULL), 
+    maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), 
     isMS_p(True), toTENCalled_p(False)
   {
     clear(); // Clear the internals of the MSSelection object
@@ -109,7 +109,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     spwIDs_p(), scanIDs_p(),ddIDs_p(),baselineIDs_p(), selectedTimesList_p(),
     selectedUVRange_p(),selectedUVUnits_p(),selectedPolMap_p(Vector<Int>(0)),
     selectedSetupMap_p(Vector<Vector<Int> >(0)),
-    maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), mssErrHandler_p(NULL), 
+    maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), 
     isMS_p(True), toTENCalled_p(False)
   {
     //
@@ -379,11 +379,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
   void MSSelection::deleteErrorHandlers()
   {
-    // if (mssErrHandler_p != NULL) 
-    //   {
-    // 	delete mssErrHandler_p;
-    // 	mssErrHandler_p=MSAntennaParse::thisMSAErrorHandler=NULL;
-    //   }
     MSAntennaParse::cleanupErrorHandler();
     MSStateParse::cleanupErrorHandler();
     MSSpwParse::cleanupErrorHandler();
@@ -456,12 +451,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	{
 	  if (MSAntennaParse::thisMSAErrorHandler == NULL)
 	    {
-	      //if (mssErrHandler_p == NULL) 
-		{
-		  //mssErrHandler_p = new MSSelectionErrorHandler();
-		  MSSelectionErrorHandler* tt = new MSSelectionErrorHandler();
-		  setErrorHandler(ANTENNA_EXPR, tt, True);//mssErrHandler_p);
-		}
+	      MSSelectionErrorHandler* tt = new MSSelectionErrorHandler();
+	      setErrorHandler(ANTENNA_EXPR, tt, True);
 	    }
 	  else
 	    MSAntennaParse::thisMSAErrorHandler->reset();

--- a/ms/MSSel/MSSelection.h
+++ b/ms/MSSel/MSSelection.h
@@ -583,7 +583,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     OrderedMap<Int, Vector<Int> > selectedPolMap_p;
     OrderedMap<Int, Vector<Vector<Int> > > selectedSetupMap_p;
     Int maxScans_p, maxObs_p, maxArray_p;
-    MSSelectionErrorHandler* mssErrHandler_p;
     Bool isMS_p,toTENCalled_p;
   };
   

--- a/ms/MSSel/test/tMSSelection.out
+++ b/ms/MSSel/test/tMSSelection.out
@@ -1,3 +1,4 @@
+Test:1  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3'
 BE: Baseline Expr=1,2,3
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -33,6 +34,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 276
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:2  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -69,6 +71,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:3  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&*'
 BE: Baseline Expr=1,2,3&*
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -104,6 +107,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 276
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:4  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&&'
 BE: Baseline Expr=1,2,3&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -140,6 +144,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:5  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&&&'
 BE: Baseline Expr=1,2,3&&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -176,6 +181,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:6  ./tMSSelection ms=mssel_test_small.ms baseline='!1,2,3&&&'
 BE: Baseline Expr=!1,2,3&&&
 	BE: Ant1         = [-1, -2, -3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -211,6 +217,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:7  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&4,5,6'
 BE: Baseline Expr=1,2,3&4,5,6
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [4, 5, 6]
@@ -247,6 +254,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:8  ./tMSSelection ms=mssel_test_small.ms baseline='!1,2,3&4,5,6'
 BE: Baseline Expr=!1,2,3&4,5,6
 	BE: Ant1         = [-1, -2, -3]
 	BE: Ant2         = [-4, -5, -6]
@@ -282,6 +290,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:9  ./tMSSelection ms=mssel_test_small.ms baseline='!1,2,3&'
 BE: Baseline Expr=!1,2,3&
 	BE: Ant1         = [-1, -2, -3]
 	BE: Ant2         = [-1, -2, -3]
@@ -317,6 +326,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:10  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&;1,2,3&&'
 BE: Baseline Expr=1,2,3&;1,2,3&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -353,6 +363,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:11  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&;1,2,3&&&'
 BE: Baseline Expr=1,2,3&;1,2,3&&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -389,6 +400,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:12  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&;!1,2,3&&&'
 BE: Baseline Expr=1,2,3&;!1,2,3&&&
 	BE: Ant1         = [1, 2, 3, -1, -2, -3]
 	BE: Ant2         = [1, 2, 3, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -425,6 +437,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:13  ./tMSSelection ms=mssel_test_small.ms baseline='*;!1&2,3,4'
 BE: Baseline Expr=*;!1&2,3,4
 	BE: Ant1         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -1]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -2, -3, -4]
@@ -460,6 +473,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:14  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -495,6 +509,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 460
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:15  ./tMSSelection ms=mssel_test_small.ms baseline='DV*@A1*,DV*@P*,DV*@S*&(DV*)@(P*);!5;!11'
 BE: Baseline Expr=DV*@A1*,DV*@P*,DV*@S*&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 10, 12, 9, 11, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -530,6 +545,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 230
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:16  ./tMSSelection ms=mssel_test_small.ms baseline='DV*@A1*,DV*@P*,DV*@S*;!20;!21'
 BE: Baseline Expr=DV*@A1*,DV*@P*,DV*@S*;!20;!21
 	BE: Ant1         = [5, 6, 7, 8, 10, 12, 9, 11]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -565,6 +581,7 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:17  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -607,6 +624,7 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:18  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*FULL*:85290~86290.305MHz'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -647,6 +665,89 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:18a  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*FULL*:85290~96290.305MHz'
+BE: Baseline Expr=1,2,3&
+	BE: Ant1         = [1, 2, 3]
+	BE: Ant2         = [1, 2, 3]
+	Baselines = 1 1 2 
+	            2 3 3 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=ALMA*FULL*:85290~96290.305MHz
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 0, 32, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62903e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=
+	StE: StateObsMode = []
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=
+	TE: Time         = Axis Lengths: [2, 0] []
+UVE: UVRange Expr=
+	UVE: UVRange      = Axis Lengths: [2, 0] []
+	UVE: UV in meters = []
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=
+	PE: PolMap       = 
+	PE: CorrMap      = 
+
+===========================================================
+DDIDs(Poln)  = []
+DDIDs(SPW)   = [1]
+StateList    = []
+Number of selected rows: 0
+###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:18b  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*FULL*:75290~86290.305MHz'
+BE: Baseline Expr=1,2,3&
+	BE: Ant1         = [1, 2, 3]
+	BE: Ant2         = [1, 2, 3]
+	Baselines = 1 1 2 
+	            2 3 3 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=ALMA*FULL*:75290~86290.305MHz
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 1, 63, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62591e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=
+	StE: StateObsMode = []
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=
+	TE: Time         = Axis Lengths: [2, 0] []
+UVE: UVRange Expr=
+	UVE: UVRange      = Axis Lengths: [2, 0] []
+	UVE: UV in meters = []
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=
+	PE: PolMap       = 
+	PE: CorrMap      = 
+
+===========================================================
+DDIDs(Poln)  = []
+DDIDs(SPW)   = [1]
+StateList    = []
+Number of selected rows: 0
+###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:19  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='ALMA*FULL*:5~10;20~30;50~70'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4]
 	BE: Ant2         = [9, 11]
@@ -690,6 +791,50 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 529
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:19a  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='"ALMA_RB_03#BB_1#SW-01#FULL_RES"'
+BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)
+	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4]
+	BE: Ant2         = [9, 11]
+	Baselines = 5 5 6 6 7 7 8 8 9 10 10 12 12 0 0 1 1 2 2 3 3 4 4 
+	            9 11 9 11 9 11 9 11 11 9 11 9 11 9 11 9 11 9 11 9 11 9 11 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr="ALMA_RB_03#BB_1#SW-01#FULL_RES"
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 0, 63, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62903e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=
+	StE: StateObsMode = []
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=
+	TE: Time         = Axis Lengths: [2, 0] []
+UVE: UVRange Expr=
+	UVE: UVRange      = Axis Lengths: [2, 0] []
+	UVE: UV in meters = []
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=
+	PE: PolMap       = 
+	PE: CorrMap      = 
+
+===========================================================
+DDIDs(Poln)  = []
+DDIDs(SPW)   = [1]
+StateList    = []
+Number of selected rows: 529
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:19b  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='"ALMA_RB_03#BB_1#SW-01#FULL_RE"'
+###AipsError: No Spw ID(s) matched specifications 
+(near char. 0 in string ""ALMA_RB_03#BB_1#SW-01#FULL_RE"")
+Test:20  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -733,6 +878,7 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 230
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:21  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='0~4:5~10;20~30;50~70' field='0'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -788,6 +934,7 @@ DDIDs(SPW)   = [0, 1, 2]
 StateList    = []
 Number of selected rows: 140
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:22  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' field='J16*'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -831,6 +978,7 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 70
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:23  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*PHASE*'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -874,6 +1022,7 @@ DDIDs(SPW)   = [1]
 StateList    = [6, 7]
 Number of selected rows: 160
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:24  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -917,6 +1066,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 30
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:25  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*' time='*+0:0:1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -963,6 +1113,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 10
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:26  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*' time='*+0:0:1' uvdist='>1000m'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1012,6 +1163,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 8
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:27  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*' time='*+0:0:1' uvdist='>1000m:50%'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1061,6 +1213,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:28  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1106,6 +1259,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:29  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1151,12 +1305,16 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:30  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*,*JUNK*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: State Expression: No match found for "*JUNK*"
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:31  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz,x' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: Spw Expression: No match found for "x" 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:32  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: Antenna Expression: No match found for token(s) "x"  
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:33  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*,*JUNK*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1202,6 +1360,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:34  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz,x' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1247,6 +1406,7 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:35  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1291,4 +1451,198 @@ DDIDs(Poln)  = [1, 2]
 DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:36  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='0,100' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
+BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
+	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
+	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
+	Baselines = 5 5 6 6 7 7 8 8 9 10 10 12 12 0 0 1 1 2 2 3 3 4 4 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 
+	            9 11 9 11 9 11 9 11 11 9 11 9 11 9 11 9 11 9 11 9 11 9 11 0 1 2 3 4 5 6 7 8 9 10 11 12 0 1 2 3 4 5 6 7 8 9 10 11 12 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=ALMA*FULL*:85290~86290.305MHz
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 1, 32, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62591e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=0,100
+	StE: StateObsMode = [0]
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=*+0:0:1
+	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09]
+
+UVE: UVRange Expr=>1000m:50%
+	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[500
+ 5.10424e+38]
+
+	UVE: UV in meters = [1]
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=XX,YX
+	PE: PolMap       = (0,[0, 2])
+	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+
+===========================================================
+DDIDs(Poln)  = [1, 2]
+DDIDs(SPW)   = [1]
+StateList    = [0]
+Number of selected rows: 0
+###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:37  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
+BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
+	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
+	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
+	Baselines = 5 5 6 6 7 7 8 8 9 10 10 12 12 0 0 1 1 2 2 3 3 4 4 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 
+	            9 11 9 11 9 11 9 11 11 9 11 9 11 9 11 9 11 9 11 9 11 9 11 0 1 2 3 4 5 6 7 8 9 10 11 12 0 1 2 3 4 5 6 7 8 9 10 11 12 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=0,1,100
+	SE: SPW          = [0, 1]
+	SE: Chan         = Axis Lengths: [2, 4]  (NB: Matrix in Row/Column order)
+[0, 0, 3, 1
+ 1, 0, 63, 1]
+
+	SE: Freq         = Axis Lengths: [2, 4]  (NB: Matrix in Row/Column order)
+[0, 1.8455e+11, 1.9055e+11, 1.875e+09
+ 1, 8.62903e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=*OFF*
+	StE: StateObsMode = [0, 1]
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=*+0:0:1
+	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09]
+
+UVE: UVRange Expr=>1000m:50%
+	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[500
+ 5.10424e+38]
+
+	UVE: UV in meters = [1]
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=XX,YX
+	PE: PolMap       = (0,[0, 2])
+	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+
+===========================================================
+DDIDs(Poln)  = [1, 2]
+DDIDs(SPW)   = [0, 1]
+StateList    = [0, 1]
+Number of selected rows: 9
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:38  ./tMSSelection ms=mssel_test_small.ms baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
+BE: Baseline Expr=0,1,2;500
+	BE: Ant1         = [0, 1, 2]
+	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+	Baselines = 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 
+	            1 2 3 4 5 6 7 8 9 10 11 12 2 3 4 5 6 7 8 9 10 11 12 3 4 5 6 7 8 9 10 11 12 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=ALMA*FULL*:85290~86290.305MHz
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 1, 32, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62591e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=*OFF*
+	StE: StateObsMode = [0, 1]
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=*+0:0:1
+	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09]
+
+UVE: UVRange Expr=>1000m:50%
+	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[500
+ 5.10424e+38]
+
+	UVE: UV in meters = [1]
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=XX,YX
+	PE: PolMap       = (0,[0, 2])
+	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+
+===========================================================
+DDIDs(Poln)  = [1, 2]
+DDIDs(SPW)   = [1]
+StateList    = [0, 1]
+Number of selected rows: 6
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:39  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='0,100' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
+BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
+	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
+	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
+	Baselines = 5 5 6 6 7 7 8 8 9 10 10 12 12 0 0 1 1 2 2 3 3 4 4 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 -11 
+	            9 11 9 11 9 11 9 11 11 9 11 9 11 9 11 9 11 9 11 9 11 9 11 0 1 2 3 4 5 6 7 8 9 10 11 12 0 1 2 3 4 5 6 7 8 9 10 11 12 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=ALMA*FULL*:85290~86290.305MHz
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 1, 32, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62591e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=0,100
+	StE: StateObsMode = [0]
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=*+0:0:1
+	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09]
+
+UVE: UVRange Expr=>1000m:50%
+	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+[500
+ 5.10424e+38]
+
+	UVE: UV in meters = [1]
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=XX,YX
+	PE: PolMap       = (0,[0, 2])
+	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+
+===========================================================
+DDIDs(Poln)  = [1, 2]
+DDIDs(SPW)   = [1]
+StateList    = [0]
+Number of selected rows: 0
+###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:40  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
+###MSSelectionError: Spw Expression: No match found for 100, 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test:41  ./tMSSelection ms=mssel_test_small.ms baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
+###MSSelectionError: No match found for the antenna specificion [ID(s): [500]] 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/ms/MSSel/test/tMSSelection.out
+++ b/ms/MSSel/test/tMSSelection.out
@@ -1,4 +1,3 @@
-Test:1  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3'
 BE: Baseline Expr=1,2,3
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -34,7 +33,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 276
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:2  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -71,7 +69,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:3  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&*'
 BE: Baseline Expr=1,2,3&*
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -107,7 +104,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 276
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:4  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&&'
 BE: Baseline Expr=1,2,3&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -144,7 +140,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:5  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&&&'
 BE: Baseline Expr=1,2,3&&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -181,7 +176,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:6  ./tMSSelection ms=mssel_test_small.ms baseline='!1,2,3&&&'
 BE: Baseline Expr=!1,2,3&&&
 	BE: Ant1         = [-1, -2, -3]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -217,7 +211,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:7  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&4,5,6'
 BE: Baseline Expr=1,2,3&4,5,6
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [4, 5, 6]
@@ -254,7 +247,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:8  ./tMSSelection ms=mssel_test_small.ms baseline='!1,2,3&4,5,6'
 BE: Baseline Expr=!1,2,3&4,5,6
 	BE: Ant1         = [-1, -2, -3]
 	BE: Ant2         = [-4, -5, -6]
@@ -290,7 +282,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:9  ./tMSSelection ms=mssel_test_small.ms baseline='!1,2,3&'
 BE: Baseline Expr=!1,2,3&
 	BE: Ant1         = [-1, -2, -3]
 	BE: Ant2         = [-1, -2, -3]
@@ -326,7 +317,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:10  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&;1,2,3&&'
 BE: Baseline Expr=1,2,3&;1,2,3&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -363,7 +353,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:11  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&;1,2,3&&&'
 BE: Baseline Expr=1,2,3&;1,2,3&&&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -400,7 +389,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:12  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&;!1,2,3&&&'
 BE: Baseline Expr=1,2,3&;!1,2,3&&&
 	BE: Ant1         = [1, 2, 3, -1, -2, -3]
 	BE: Ant2         = [1, 2, 3, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -437,7 +425,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:13  ./tMSSelection ms=mssel_test_small.ms baseline='*;!1&2,3,4'
 BE: Baseline Expr=*;!1&2,3,4
 	BE: Ant1         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -1]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -2, -3, -4]
@@ -473,7 +460,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:14  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -509,7 +495,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 460
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:15  ./tMSSelection ms=mssel_test_small.ms baseline='DV*@A1*,DV*@P*,DV*@S*&(DV*)@(P*);!5;!11'
 BE: Baseline Expr=DV*@A1*,DV*@P*,DV*@S*&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 10, 12, 9, 11, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -545,7 +530,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 230
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:16  ./tMSSelection ms=mssel_test_small.ms baseline='DV*@A1*,DV*@P*,DV*@S*;!20;!21'
 BE: Baseline Expr=DV*@A1*,DV*@P*,DV*@S*;!20;!21
 	BE: Ant1         = [5, 6, 7, 8, 10, 12, 9, 11]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -581,7 +565,6 @@ DDIDs(SPW)   = []
 StateList    = []
 Number of selected rows: 1058
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:17  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -624,7 +607,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:18  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*FULL*:85290~86290.305MHz'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -665,7 +647,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:18a  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*FULL*:85290~96290.305MHz'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -706,7 +687,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:18b  ./tMSSelection ms=mssel_test_small.ms baseline='1,2,3&' spw='ALMA*FULL*:75290~86290.305MHz'
 BE: Baseline Expr=1,2,3&
 	BE: Ant1         = [1, 2, 3]
 	BE: Ant2         = [1, 2, 3]
@@ -747,7 +727,6 @@ StateList    = []
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:19  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='ALMA*FULL*:5~10;20~30;50~70'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4]
 	BE: Ant2         = [9, 11]
@@ -791,7 +770,6 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 529
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:19a  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='"ALMA_RB_03#BB_1#SW-01#FULL_RES"'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4]
 	BE: Ant2         = [9, 11]
@@ -831,10 +809,8 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 529
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:19b  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='"ALMA_RB_03#BB_1#SW-01#FULL_RE"'
 ###AipsError: No Spw ID(s) matched specifications 
 (near char. 0 in string ""ALMA_RB_03#BB_1#SW-01#FULL_RE"")
-Test:20  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -878,7 +854,6 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 230
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:21  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='0~4:5~10;20~30;50~70' field='0'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -934,7 +909,6 @@ DDIDs(SPW)   = [0, 1, 2]
 StateList    = []
 Number of selected rows: 140
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:22  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' field='J16*'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -978,7 +952,6 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 70
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:23  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*PHASE*'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1022,7 +995,6 @@ DDIDs(SPW)   = [1]
 StateList    = [6, 7]
 Number of selected rows: 160
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:24  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1066,7 +1038,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 30
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:25  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*' time='*+0:0:1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1113,7 +1084,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 10
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:26  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*' time='*+0:0:1' uvdist='>1000m'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1163,7 +1133,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 8
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:27  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' stateobsmode='*OFF*' time='*+0:0:1' uvdist='>1000m:50%'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1213,7 +1182,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:28  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1259,7 +1227,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:29  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1305,16 +1272,12 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:30  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*,*JUNK*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: State Expression: No match found for "*JUNK*"
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:31  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz,x' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: Spw Expression: No match found for "x" 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:32  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: Antenna Expression: No match found for token(s) "x"  
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:33  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*,*JUNK*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1360,7 +1323,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:34  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz,x' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1406,7 +1368,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:35  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1452,7 +1413,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:36  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='0,100' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1499,7 +1459,6 @@ StateList    = [0]
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:37  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1547,7 +1506,6 @@ DDIDs(SPW)   = [0, 1]
 StateList    = [0, 1]
 Number of selected rows: 9
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:38  ./tMSSelection ms=mssel_test_small.ms baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'
 BE: Baseline Expr=0,1,2;500
 	BE: Ant1         = [0, 1, 2]
 	BE: Ant2         = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -1593,7 +1551,6 @@ DDIDs(SPW)   = [1]
 StateList    = [0, 1]
 Number of selected rows: 6
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:39  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='0,100' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11
 	BE: Ant1         = [5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, -5, -11]
 	BE: Ant2         = [9, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
@@ -1640,9 +1597,7 @@ StateList    = [0]
 Number of selected rows: 0
 ###MSSelectionError: MSSelectionNullSelection : The selected table has zero rows.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:40  ./tMSSelection ms=mssel_test_small.ms baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: Spw Expression: No match found for 100, 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-Test:41  ./tMSSelection ms=mssel_test_small.ms baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'
 ###MSSelectionError: No match found for the antenna specificion [ID(s): [500]] 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/ms/MSSel/test/tMSSelection.run
+++ b/ms/MSSel/test/tMSSelection.run
@@ -11,7 +11,7 @@
   MS=$CASADEMO"mssel_test_small.ms"
 
   runCmd(){
-      #echo "Test:$1 "$2; 
+      echo "Test:$1 "$2; 
       eval "$2"
       }
 
@@ -46,8 +46,20 @@
   runCmd 16 "$casa_checktool ./tMSSelection ms=$MS baseline='DV*@A1*,DV*@P*,DV*@S*;!20;!21'"
 
   runCmd 17 "$casa_checktool ./tMSSelection ms=$MS baseline='1,2,3&' spw='ALMA*'";
-  runCmd 18 "$casa_checktool ./tMSSelection ms=$MS baseline='1,2,3&' spw='ALMA*FULL*:85290~86290.305MHz'";
-  runCmd 19 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='ALMA*FULL*:5~10;20~30;50~70'";
+  #
+  # Check with physical range spec. in SPW selection
+  #
+  runCmd 18 "$casa_checktool ./tMSSelection ms=$MS baseline='1,2,3&' spw='ALMA*FULL*:85290~86290.305MHz'";  # Spec. within limits
+  runCmd 18a "$casa_checktool ./tMSSelection ms=$MS baseline='1,2,3&' spw='ALMA*FULL*:85290~96290.305MHz'"; # Spec. underflows
+  runCmd 18b "$casa_checktool ./tMSSelection ms=$MS baseline='1,2,3&' spw='ALMA*FULL*:75290~86290.305MHz'"; # Spec. overflows
+
+  # 
+  # Check name spec. in SPW selection
+  # 
+  runCmd 19 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='ALMA*FULL*:5~10;20~30;50~70'"; # Name as pattern
+  runCmd 19a "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='\"ALMA_RB_03#BB_1#SW-01#FULL_RES\"'"; # Name as literal
+  runCmd 19b "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*)' spw='\"ALMA_RB_03#BB_1#SW-01#FULL_RE\"'";  # Name as literal with error
+
   runCmd 20 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70'";
   runCmd 21 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='0~4:5~10;20~30;50~70' field='0'";
   runCmd 22 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' spw='ALMA*FULL*:5~10;20~30;50~70' field='J16*'";
@@ -66,6 +78,14 @@
   runCmd 33 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*,*JUNK*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'";
   runCmd 34 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz,x' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'";
   runCmd 35 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11;x' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'";
+
+  runCmd 36 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='0,100' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'";
+  runCmd 37 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'";
+  runCmd 38 "$casa_checktool ./tMSSelection ms=$MS baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='1'";
+
+  runCmd 39 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='0,100' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'";
+  runCmd 40 "$casa_checktool ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'";
+  runCmd 41 "$casa_checktool ./tMSSelection ms=$MS baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'";
 
   #
   # Remove the test MS and any other cleanup required.

--- a/ms/MSSel/test/tMSSelection.run
+++ b/ms/MSSel/test/tMSSelection.run
@@ -11,7 +11,7 @@
   MS=$CASADEMO"mssel_test_small.ms"
 
   runCmd(){
-      echo "Test:$1 "$2; 
+      #echo "Test:$1 "$2; 
       eval "$2"
       }
 


### PR DESCRIPTION
When re-using an existing MSSelection object, the error handlers were not getting reset before a fresh parsing cycle and would remember the last error message string.   This issue is fixed with the modification in this PR.  

Added a few more tests to test correctness when freq. specifications over/underflow at the edges of the SPW limits.  