### PR TITLE
CAS-5346 also return stats from getHistograms()

### DIFF
--- a/lattices/LatticeMath/LatticeHistograms.h
+++ b/lattices/LatticeMath/LatticeHistograms.h
@@ -259,6 +259,11 @@ public:
 // A return value of <src>False</src> indicates  that the internal status of the class is bad. 
    Bool getHistograms (Array<T>& values, Array<T>& counts);
 
+   // in this version, the set of stats for each histogram is also returned. The
+   // stats array has the  shape of the display axes.
+   Bool getHistograms (Array<T>& values, Array<T>& counts, Array<Vector<T> >& stats);
+
+
 // This function retrieves the histogram at the specified location 
 // into <src>Vectors</src>.  The histogram is retrieved in the form 
 // specified by the <src>setForm</src> function. The vectors are resized 

--- a/lattices/LatticeMath/LatticeHistograms.tcc
+++ b/lattices/LatticeMath/LatticeHistograms.tcc
@@ -521,79 +521,72 @@ Bool LatticeHistograms<T>::display()
    return True;
 }
 
-
-
-
 template <class T>
-Bool LatticeHistograms<T>::getHistograms (Array<T>& values,
-                                        Array<T>& counts)
-//
-// Retrieve histograms values and counts into arrays
-//
-{
-   if (!goodParameterStatus_p) {
-      return False;
-   }
-
-
-// Generate storage lattices if required
-   
-   if (needStorageLattice_p) {
-      if (!generateStorageLattice()) return False;      
-   }
-
-
-// Set up iterator to work through histogram storage lattice line by line
-// Use the LatticeStepper (default) which will guarentee the access pattern.  
-// There will be no overhang (as tile shape for first axis is length of axis)
-  
-   IPosition cursorShape(pStoreLattice_p->ndim(),1);
-   cursorShape(0) = pStoreLattice_p->shape()(0);
-
-   IPosition vectorAxis(1,0);
-   vectorAxis(0) = 0;
-   
-// Make the stepper explicitly so we can specify the cursorAxes
-// and then vectorCursor will cope with an axis of length 1
-// (it is possible the user could ask for a histogram with one bin !)
-
-   LatticeStepper histStepper(pStoreLattice_p->shape(), cursorShape,
-                              vectorAxis, IPosition::makeAxisPath(pStoreLattice_p->ndim()));
-   RO_LatticeIterator<T> histIterator(*pStoreLattice_p, histStepper);
-
-
-// Resize output arrays and setup vector iterators
-
-   counts.resize(pStoreLattice_p->shape());
-   values.resize(pStoreLattice_p->shape());
-
-   VectorIterator<T> valuesIterator(values);
-   VectorIterator<T> countsIterator(counts);
-
-   Vector<T> stats;
-   T linearSum, linearYMax;
-
-// Iterate through histogram storage lattice
-   
-   for (histIterator.reset(),valuesIterator.origin(),countsIterator.origin(); 
-       !histIterator.atEnd(); histIterator++,valuesIterator.next(),countsIterator.next()) {
- 
-// Find statistics from the data that made this histogram 
-
-      getStatistics (stats, histIterator.position());
-
-
-// Extract the histogram in the appropriate form
- 
-      extractOneHistogram (linearSum, linearYMax, valuesIterator.vector(), 
-                           countsIterator.vector(), stats,
-                           histIterator.vectorCursor());
-   }
-
-   return True;
+Bool LatticeHistograms<T>::getHistograms(
+        Array<T>& values, Array<T>& counts
+) {
+    Array<Vector<T> > stats;
+    return getHistograms(values, counts, stats);
 }
 
+template <class T>
+Bool LatticeHistograms<T>::getHistograms(
+        Array<T>& values, Array<T>& counts, Array<Vector<T> >& stats
+) {
+    if (!goodParameterStatus_p) {
+        return False;
+    }
+    // Generate storage lattices if required
+    if (needStorageLattice_p) {
+        if (!generateStorageLattice()) return False;
+    }
 
+    // Set up iterator to work through histogram storage lattice line by line
+    // Use the LatticeStepper (default) which will guarantee the access pattern.
+    // There will be no overhang (as tile shape for first axis is length of axis)
+    IPosition cursorShape(pStoreLattice_p->ndim(),1);
+    cursorShape(0) = pStoreLattice_p->shape()(0);
+    IPosition vectorAxis(1,0);
+
+    // Make the stepper explicitly so we can specify the cursorAxes
+    // and then vectorCursor will cope with an axis of length 1
+    // (it is possible the user could ask for a histogram with one bin !)
+    LatticeStepper histStepper(
+            pStoreLattice_p->shape(), cursorShape,
+            vectorAxis, IPosition::makeAxisPath(pStoreLattice_p->ndim())
+    );
+    RO_LatticeIterator<T> histIterator(*pStoreLattice_p, histStepper);
+    // Resize output arrays and setup vector iterators
+    IPosition shape = pStoreLattice_p->shape();
+    counts.resize(shape);
+    values.resize(shape);
+    static const IPosition removeAxis(1, 0);
+    stats.resize(
+            shape.size() == 1 ? IPosition(1,1) : shape.removeAxes(removeAxis)
+    );
+    VectorIterator<T> valuesIterator(values);
+    VectorIterator<T> countsIterator(counts);
+    Vector<T> stat;
+    T linearSum, linearYMax;
+    // Iterate through histogram storage lattice
+    for (
+            histIterator.reset(),valuesIterator.origin(),countsIterator.origin();
+            ! histIterator.atEnd();
+            histIterator++,valuesIterator.next(),countsIterator.next()
+    ) {
+        // Find statistics from the data that made this histogram
+        IPosition pos = histIterator.position();
+        getStatistics (stat, pos);
+        stats(pos.size() == 1 ? IPosition(1, 0) : pos.removeAxes(removeAxis)).assign(stat);
+        // Extract the histogram in the appropriate form
+        extractOneHistogram(
+                linearSum, linearYMax, valuesIterator.vector(),
+                countsIterator.vector(), stat,
+                histIterator.vectorCursor()
+        );
+    }
+    return True;
+}
 
 template <class T>
 Bool LatticeHistograms<T>::getHistogram (Vector<T>& values,


### PR DESCRIPTION
Requirement to return stats for each histogram, so overloaded getHistograms() with a version that also returns the stats array. Much of the changes are formatting only changes (eg indent 4 spaces not 3, and elimnate a lot of unnecessary blank lines). Also added tests for new method version.