### PR TITLE
various coordinate performance improvements

### DIFF
--- a/casa/Quanta/Euler.h
+++ b/casa/Quanta/Euler.h
@@ -33,6 +33,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Quanta/Quantum.h>
+#include <utility>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -189,10 +190,13 @@ class Euler
 
 private:
 //# Data
-// Actual vector with 3 Euler angles
-    Vector<Double> euler;
-// Axes
-    Vector<Int> axes;
+    typedef std::pair<Vector<Double> *, Vector<Int> *> DataArrays;
+// data container
+    DataArrays data;
+// vector with 3 Euler angles (data.first)
+    Vector<Double> & euler;
+// Axes (data.second)
+    Vector<Int> & axes;
 
 //# Private Member Functions
 // The makeRad functions check and convert the input Quantities to radians
@@ -200,6 +204,12 @@ private:
     static Double makeRad(const Quantity &in);
     static Vector<Double> makeRad(const Quantum<Vector<Double> > &in);
 // </group>
+    DataArrays get_arrays();
+    void return_arrays(DataArrays array);
+#if defined(AIPS_CXX11) && !defined(__APPLE__)
+    static thread_local DataArrays arrays[50];
+    static thread_local size_t available;
+#endif
 };
 
 

--- a/casa/Quanta/MVEpoch.cc
+++ b/casa/Quanta/MVEpoch.cc
@@ -40,6 +40,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Constants
 const Double MVEpoch::secInDay(3600*24);
+const Unit MVEpoch::unitDay("d");
 
 //# Constructors
 MVEpoch::MVEpoch() :
@@ -178,7 +179,7 @@ Double MVEpoch::get() const {
 }
 
 Quantity MVEpoch::getTime() const {
-  return (Quantity(get(), "d"));
+  return (Quantity(get(), unitDay));
 }
 
 Quantity MVEpoch::getTime(const Unit &unit) const {
@@ -249,7 +250,7 @@ Bool MVEpoch::putValue(const Vector<Quantum<Double> > &in) {
 
 Double MVEpoch::makeDay(const Quantity &in) const {
   in.assure(UnitVal::TIME);
-  return in.get("d").getValue();
+  return in.get(unitDay).getValue();
 }
 
 void MVEpoch::addTime(Double in) {

--- a/casa/Quanta/MVEpoch.h
+++ b/casa/Quanta/MVEpoch.h
@@ -141,6 +141,7 @@ public:
   //# General Member Functions
   // Constants
   static const Double secInDay;
+  static const Unit unitDay;
   
   // Tell me your type
   // <group>

--- a/casa/Quanta/MVPosition.cc
+++ b/casa/Quanta/MVPosition.cc
@@ -273,14 +273,12 @@ MVPosition MVPosition::operator-(const MVPosition &right) const{
 }
 
 MVPosition &MVPosition::operator*=(const RotMatrix &right) {
-  MVPosition result;
-  for (Int i=0; i<3; i++) {
-    result(i) = 0;
-    for (Int j=0; j<3; j++) {
-      result(i) += xyz(j) * right(j,i);
-    }
-  }
-  *this = result;
+  Double x = xyz(0);
+  Double y = xyz(1);
+  Double z = xyz(2);
+  xyz(0) = x * right(0, 0) + y * right(1, 0) + z * right(2, 0);
+  xyz(1) = x * right(0, 1) + y * right(1, 1) + z * right(2, 1);
+  xyz(2) = x * right(0, 2) + y * right(1, 2) + z * right(2, 2);
   return *this;
 }
 

--- a/casa/Quanta/MVPosition.cc
+++ b/casa/Quanta/MVPosition.cc
@@ -46,15 +46,44 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 const Double MVPosition::loLimit = 743.568;
 const Double MVPosition::hiLimit = 743.569;
 
+// simplistic vector(3) cache to reduce allocation overhead for temporaries
+#if defined(AIPS_CXX11) && !defined(__APPLE__)
+static thread_local size_t available = 0;
+static thread_local Vector<Double> * arrays[50];
+#endif
+
+Vector<Double> * get_array()
+{
+#if defined(AIPS_CXX11) && !defined(__APPLE__)
+  if (available > 0) {
+    return arrays[--available];
+  }
+#endif
+  return new Vector<Double>(3);
+}
+
+void return_array(Vector<Double> * array)
+{
+#if defined(AIPS_CXX11) && !defined(__APPLE__)
+  if (available < sizeof(arrays) / sizeof(arrays[0]) &&
+		  array->size() == 3 &&
+		  array->nrefs() == 1) {
+    arrays[available++] = array;
+    return;
+  }
+#endif
+  delete array;
+}
+
 //# Constructors
 MVPosition::MVPosition() :
-  xyz(3) {
+  xyz(*get_array()) {
     xyz = Double(0.0);
 }
 
 MVPosition::MVPosition(const MVPosition &other) : 
   MeasValue(),
-  xyz(3)
+  xyz(*get_array())
 {
   xyz = other.xyz;
 }
@@ -67,27 +96,27 @@ MVPosition &MVPosition::operator=(const MVPosition &other) {
 }
 
 MVPosition::MVPosition(Double in) :
-  xyz(3) {
+	xyz(*get_array()) {
     xyz = Double(0.0);
     xyz(2) = in;
   }
 
 MVPosition::MVPosition(const Quantity &l) :
-  xyz(3) {
+  xyz(*get_array()) {
     xyz = Double(0.0);
     l.assure(UnitVal::LENGTH);
     xyz(2) = l.getBaseValue();
   }
 
 MVPosition::MVPosition(Double in0, Double in1, Double in2) : 
-  xyz(3) {
+	xyz(*get_array()) {
     xyz(0) = in0;
     xyz(1) = in1;
     xyz(2) = in2;
   }
 
 MVPosition::MVPosition(const Quantity &l, Double angle0, Double angle1) : 
-  xyz(3) {
+  xyz(*get_array()) {
   Double loc = std::cos(angle1);
   xyz(0) = std::cos(angle0)*loc;
   xyz(1) = std::sin(angle0)*loc;
@@ -100,7 +129,7 @@ MVPosition::MVPosition(const Quantity &l, Double angle0, Double angle1) :
 
 MVPosition::MVPosition(const Quantity &l, const Quantity &angle0, 
 		       const Quantity &angle1) : 
-  xyz(3) {
+  xyz(*get_array()) {
   Double loc = (cos(angle1)).getValue();
   xyz(0) = ((cos(angle0)).getValue()) * loc;
   xyz(1) = ((sin(angle0)).getValue()) * loc;
@@ -113,7 +142,7 @@ MVPosition::MVPosition(const Quantity &l, const Quantity &angle0,
 }
 
 MVPosition::MVPosition(const Quantum<Vector<Double> > &angle) :
-  xyz(3) {
+  xyz(*get_array()) {
   uInt i; i = angle.getValue().nelements();
   if (i > 3 ) {
     throw (AipsError("Illegeal vector length in MVPosition constructor"));
@@ -139,7 +168,7 @@ MVPosition::MVPosition(const Quantum<Vector<Double> > &angle) :
 
 MVPosition::MVPosition(const Quantity &l, 
 		       const Quantum<Vector<Double> > &angle) :
-  xyz(3) {
+	xyz(*get_array()) {
     uInt i; i = angle.getValue().nelements();
     if (i > 3 ) {
       throw (AipsError("Illegal vector length in MVPosition constructor"));
@@ -166,7 +195,7 @@ MVPosition::MVPosition(const Quantity &l,
   }
 
 MVPosition::MVPosition(const Vector<Double> &other) :
-  xyz(3) {
+	xyz(*get_array()) {
     uInt i; i = other.nelements();
     if (i > 3 ) {
       throw (AipsError("Illegal vector length in MVPosition constructor"));
@@ -190,14 +219,17 @@ MVPosition::MVPosition(const Vector<Double> &other) :
   }
 
 MVPosition::MVPosition(const Vector<Quantity> &other) :
-  xyz(3) {
+  xyz(*get_array()) {
   if (!putValue(other)) {
     throw (AipsError("Illegal quantum vector in MVPosition constructor"));
   }
 }
 
 //# Destructor
-MVPosition::~MVPosition() {}
+MVPosition::~MVPosition()
+{
+  return_array(&xyz);
+}
 
 //# Operators
 Bool MVPosition::

--- a/casa/Quanta/MVPosition.h
+++ b/casa/Quanta/MVPosition.h
@@ -155,7 +155,7 @@ public:
   MVPosition &operator=(const MVPosition &other);
   
   // Destructor
-  ~MVPosition();
+  virtual ~MVPosition();
   
   //# Operators
   // Multiplication defined as in-product
@@ -279,7 +279,7 @@ protected:
   Double getLat(Double ln) const;
   //# Data
   // Position vector (in m)
-  Vector<Double> xyz;
+  Vector<Double> & xyz;
 };
 
 //# Global functions

--- a/casa/Quanta/test/CMakeLists.txt
+++ b/casa/Quanta/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (tests
 tMVAngle
+tMVPosition
 tMVTime
 tQuantum
 tQuantumHolder

--- a/casa/Quanta/test/tMVPosition.cc
+++ b/casa/Quanta/test/tMVPosition.cc
@@ -1,0 +1,73 @@
+//# tMVPosition.cc: test program for MVPosition class
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+
+#include <casacore/casa/aips.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/Exceptions/Error.h>
+#include <casacore/casa/Quanta/MVPosition.h>
+#include <casacore/casa/Quanta/RotMatrix.h>
+
+#include <casacore/casa/namespace.h>
+
+int main ()
+{
+  try {
+    MVPosition pos, pos2;
+    pos(0) = 1;
+    pos(1) = 2;
+    pos(2) = 3;
+    AlwaysAssertExit(pos(0) == 1);
+    AlwaysAssertExit(pos(1) == 2);
+    AlwaysAssertExit(pos(2) == 3);
+    pos2 = pos * 2;
+    AlwaysAssertExit(pos2(0) == 2);
+    AlwaysAssertExit(pos2(1) == 4);
+    AlwaysAssertExit(pos2(2) == 6);
+    pos *= 2.;
+    AlwaysAssertExit(pos(0) == 2);
+    AlwaysAssertExit(pos(1) == 4);
+    AlwaysAssertExit(pos(2) == 6);
+    AlwaysAssertExit(pos == pos2);
+    RotMatrix rot;
+    for (int i = 0; i < 9; i++) {
+        rot(i / 3, i % 3) = i;
+        AlwaysAssertExit(rot(i / 3, i % 3) == i);
+    }
+    pos2 = pos * rot;
+    AlwaysAssertExit(pos2(0) == 48);
+    AlwaysAssertExit(pos2(1) == 60);
+    AlwaysAssertExit(pos2(2) == 72);
+    pos *= rot;
+    AlwaysAssertExit(pos(0) == 48);
+    AlwaysAssertExit(pos(1) == 60);
+    AlwaysAssertExit(pos(2) == 72);
+    AlwaysAssertExit(pos2 == pos);
+  } catch (AipsError& x) {
+    cout << "Unexpected exception: " << x.getMesg() << endl;
+    return 1;
+  } 
+  return 0;
+}

--- a/measures/Measures/Aberration.cc
+++ b/measures/Measures/Aberration.cc
@@ -167,9 +167,8 @@ void Aberration::calcAber(Double t) {
     case B1950:
       {
         for (i=0; i<12; i++) {
-          const Polynomial<Double>& aberArgP = MeasTable::aber1950Arg(i);
-          fa(i) = aberArgP(t);
-          dfa(i) = (aberArgP.derivative())(t);
+          fa(i) = MeasTable::aber1950Arg(i)(t);
+          dfa(i) = MeasTable::aber1950ArgDeriv(i)(t);
         }
 	CountedPtr<Matrix<Double> > mul = MeasTable::mulAber1950(t, 1e-6);
         DebugAssert (mul->contiguousStorage(), AipsError);
@@ -213,10 +212,8 @@ void Aberration::calcAber(Double t) {
 	}
       } else {
 	for (i=0; i<13; i++) {
-	  const Polynomial<Double>& aberArgP = MeasTable::aberArg(i);
-
-	  fa(i) = aberArgP(t);
-	  dfa(i) = (aberArgP.derivative())(t);
+	  fa(i) = MeasTable::aberArg(i)(t);
+	  dfa(i) = MeasTable::aberArgDeriv(i)(t);
 	}
 	CountedPtr<Matrix<Double> > mul = MeasTable::mulAber(t, 1e-6);
         DebugAssert (mul->contiguousStorage(), AipsError);

--- a/measures/Measures/MeasTable.cc
+++ b/measures/Measures/MeasTable.cc
@@ -3236,6 +3236,28 @@ const Polynomial<Double> &MeasTable::aberArg(uInt which) {
   return polyArray[which];
 }
 
+// Derivative aber
+const Polynomial<Double> &MeasTable::aberArgDeriv(uInt which) {
+  static volatile Bool needInit = True;
+  static Polynomial<Double> polyArray[13];
+
+  if (needInit) {
+	const Polynomial<Double> * polyArray_ptrs[13];
+    for (int i=0; i<13; i++) {
+	  polyArray_ptrs[i] = &aberArg(i);
+    }
+    ScopedMutexLock locker(theirMutex);
+    if (needInit) {
+      for (int i=0; i<13; i++) {
+        polyArray[i] = polyArray_ptrs[i]->derivative();
+      }
+      needInit = False;
+    }
+  }
+  DebugAssert(which < 13, AipsError);
+  return polyArray[which];
+}
+
 const Polynomial<Double> &MeasTable::aber1950Arg(uInt which) {
   static volatile Bool needInit = True;
   static Polynomial<Double> polyArray[12];
@@ -3263,6 +3285,28 @@ const Polynomial<Double> &MeasTable::aber1950Arg(uInt which) {
           polyArray[i].setCoefficient(j,
                                       ABERFUND[i][j]*C::arcsec);
         }
+      }
+      needInit = False;
+    }
+  }
+  DebugAssert(which < 12, AipsError);
+  return polyArray[which];
+}
+
+// Derivative aber1950
+const Polynomial<Double> &MeasTable::aber1950ArgDeriv(uInt which) {
+  static volatile Bool needInit = True;
+  static Polynomial<Double> polyArray[12];
+
+  if (needInit) {
+	const Polynomial<Double> * polyArray_ptrs[12];
+    for (int i=0; i<12; i++) {
+	  polyArray_ptrs[i] = &aber1950Arg(i);
+    }
+    ScopedMutexLock locker(theirMutex);
+    if (needInit) {
+      for (int i=0; i<12; i++) {
+        polyArray[i] = polyArray_ptrs[i]->derivative();
       }
       needInit = False;
     }
@@ -3826,6 +3870,29 @@ const Polynomial<Double> &MeasTable::posArg(uInt which) {
           polyArray[i].setCoefficient(j,
                                       POSFUND[i][j]*C::degree);
         }
+      }
+
+      needInit = False;
+    }
+  }
+  DebugAssert(which < 12, AipsError);
+  return polyArray[which];
+}
+
+// Derivative of Earth and Sun position polynomial
+const Polynomial<Double> &MeasTable::posArgDeriv(uInt which) {
+  static volatile Bool needInit = True;
+  static Polynomial<Double> polyArray[12];
+
+  if (needInit) {
+	const Polynomial<Double> * polyArray_ptrs[12];
+    for (int i=0; i<12; i++) {
+	  polyArray_ptrs[i] = &posArg(i);
+    }
+    ScopedMutexLock locker(theirMutex);
+    if (needInit) {
+      for (int i=0; i<12; i++) {
+        polyArray[i] = polyArray_ptrs[i]->derivative();
       }
       needInit = False;
     }

--- a/measures/Measures/MeasTable.h
+++ b/measures/Measures/MeasTable.h
@@ -289,7 +289,9 @@ public:
   // (B1950). 
   // <group>
   static const Polynomial<Double> &aberArg(uInt which);
+  static const Polynomial<Double> &aberArgDeriv(uInt which);
   static const Polynomial<Double> &aber1950Arg(uInt which);
+  static const Polynomial<Double> &aber1950ArgDeriv(uInt which);
   // </group>
   
   // Generate the 'which' vector of the aberration series arguments
@@ -344,6 +346,8 @@ public:
   // Fundamental arguments for Soma et al. methods
   // <group>
   static const Polynomial<Double> &posArg(uInt which);
+  // Precomputed derivative of PosArg
+  static const Polynomial<Double> &posArgDeriv(uInt which);
   // </group>
   // Generate the which' vector of the position series arguments
   // <group>

--- a/measures/Measures/SolarPos.cc
+++ b/measures/Measures/SolarPos.cc
@@ -226,7 +226,7 @@ void SolarPos::calcEarth(Double t) {
 	      } else {
 		for (i=0; i<12; i++) {
 		  fa(i) = MeasTable::posArg(i)(t);
-		  dfa(i) = (MeasTable::posArg(i).derivative())(t);
+		  dfa(i) = MeasTable::posArgDeriv(i)(t);
 		}
                 CountedPtr<Matrix<Double> > mul = MeasTable::mulPosEarthXY(t, 1e-6);
                 DebugAssert (mul->contiguousStorage(), AipsError);
@@ -301,7 +301,7 @@ void SolarPos::calcSun(Double t) {
               } else {
 		for (i=0; i<12; i++) {
 		  fa(i) = MeasTable::posArg(i)(t);
-		  dfa(i) = (MeasTable::posArg(i).derivative())(t);
+		  dfa(i) = MeasTable::posArgDeriv(i)(t);
 		}
                 CountedPtr<Matrix<Double> > mul = MeasTable::mulPosSunXY(t, 1e-6);
                 DebugAssert (mul->contiguousStorage(), AipsError);

--- a/measures/Measures/SolarPos.cc
+++ b/measures/Measures/SolarPos.cc
@@ -237,12 +237,16 @@ void SolarPos::calcEarth(Double t) {
 		    dtmp += MeasTable::mulPosEarthXYArg(i)[j] * fa[j];
 		    ddtmp += MeasTable::mulPosEarthXYArg(i)[j] * dfa[j];
 		  }
-		  eval[0] += mulPosEarthXY[1] * sin(dtmp + mulPosEarthXY[0]);
-		  eval[1] += mulPosEarthXY[3] * sin(dtmp + mulPosEarthXY[2]);
-		  deval[0] += mulPosEarthXY[5] * sin(dtmp + mulPosEarthXY[0]) +
-		    mulPosEarthXY[1] * cos(dtmp + mulPosEarthXY[0]) * ddtmp;
-		  deval[1] += mulPosEarthXY[7] * sin(dtmp + mulPosEarthXY[2]) +
-		    mulPosEarthXY[3] * cos(dtmp + mulPosEarthXY[2]) * ddtmp;
+		  const Double sinpos0 = sin(dtmp + mulPosEarthXY[0]);
+		  const Double cospos0 = cos(dtmp + mulPosEarthXY[0]);
+		  const Double sinpos2 = sin(dtmp + mulPosEarthXY[2]);
+		  const Double cospos2 = cos(dtmp + mulPosEarthXY[2]);
+		  eval[0] += mulPosEarthXY[1] * sinpos0;
+		  eval[1] += mulPosEarthXY[3] * sinpos2;
+		  deval[0] += mulPosEarthXY[5] * sinpos0 +
+		    mulPosEarthXY[1] * cospos0 * ddtmp;
+		  deval[1] += mulPosEarthXY[7] * sinpos2 +
+		    mulPosEarthXY[3] * cospos2 * ddtmp;
                   mulPosEarthXY += 8;
 		}
                 mul = MeasTable::mulPosEarthZ(t, 1e-6);
@@ -254,9 +258,11 @@ void SolarPos::calcEarth(Double t) {
 		    dtmp += MeasTable::mulPosEarthZArg(i)[j] * fa[j];
 		    ddtmp += MeasTable::mulPosEarthZArg(i)[j] * dfa[j];
 		  }
-		  eval[2] += mulPosEarthZ[1] * sin(dtmp + mulPosEarthZ[0]);
-		  deval[2] += mulPosEarthZ[3] * sin(dtmp + mulPosEarthZ[0]) +
-		    mulPosEarthZ[1] * cos(dtmp + mulPosEarthZ[0]) * ddtmp;
+		  const Double sinpos0 = sin(dtmp + mulPosEarthZ[0]);
+		  const Double cospos0 = cos(dtmp + mulPosEarthZ[0]);
+		  eval[2] += mulPosEarthZ[1] * sinpos0;
+		  deval[2] += mulPosEarthZ[3] * sinpos0 +
+		    mulPosEarthZ[1] * cospos0 * ddtmp;
                   mulPosEarthZ += 4;
 		}
 		for (i=0; i<3; i++) {


### PR DESCRIPTION
coordinate transformations in casa are spending most of their time allocating memory instead of actually computing. This set of patches improves this a situation a bit via a few small changes, see the commits for details.

The largest change is using a small Vector cache to avoid creating new Vectors for each MVPosition and Euler temporary object that are created en mass in the conversion code.
This cache could in theory be moved lower into the stack, e.g. in the allocator itself and the Array object would need to use placement new's to create its Block object, though this is quite tricky to get right so I opted for the simpler change of just caching the objects that are problematic.
A disadvantage is that the small cache is never free'd so it would show up in valgrind, but that can be handled with a suppression file.