### PR TITLE
Optimization of MSMetaData::getPointingDirection (CAS-7643).

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3878,17 +3878,23 @@ std::pair<MDirection, MDirection> MSMetaData::getPointingDirection(
 		row >= this->nRows(),
 		"Row number exceeds number of rows in the MS"
 	);
-	SHARED_PTR<Vector<Int> > ant1, ant2;
-	_getAntennas(ant1, ant2);
-	antenna1 = (*ant1)[row];
-	antenna2 = (*ant2)[row];
-	time = (*_getTimes())[row];
+	// KS note: 2015/10/30
+	// getColum method (also used in _getAntennas and _getTimes) is
+	// too expesive for the current purpose of getting single cell.
+	String ant1ColName = MeasurementSet::columnName(MSMainEnums::ANTENNA1);
+	String ant2ColName = MeasurementSet::columnName(MSMainEnums::ANTENNA2);
+	antenna1 = ROScalarColumn<Int>(*_ms, ant1ColName).get(row);
+	antenna2 = ROScalarColumn<Int>(*_ms, ant2ColName).get(row);
+	bool autocorr = (antenna1==antenna2);
+	String timeColName = MeasurementSet::columnName(MSMainEnums::TIME);
+	time = ScalarColumn<Double>(*_ms, timeColName).get(row);
 	ROMSPointingColumns pCols(_ms->pointing());
 	Int pidx1, pidx2;
 	pidx1 = pCols.pointingIndex(antenna1, time, initialguess);
-	pidx2 = pCols.pointingIndex(antenna2, time, initialguess);
+	if (autocorr) pidx2 = pidx1;
+	else pidx2 = pCols.pointingIndex(antenna2, time, initialguess);
 	String intervalColName = MeasurementSet::columnName(MSMainEnums::INTERVAL);
-	Double interval = ScalarColumn<Double>(*_ms, intervalColName).getColumn()[row];
+	Double interval = ScalarColumn<Double>(*_ms, intervalColName).get(row);
 	MDirection dir1, dir2;
 	if (!interpolate || interval >= pCols.interval()(pidx1)) {
 		dir1 = pCols.directionMeas(pidx1);
@@ -3896,7 +3902,10 @@ std::pair<MDirection, MDirection> MSMetaData::getPointingDirection(
 	else {
 		dir1 = _getInterpolatedDirection(pCols, pidx1, time);
 	}
-	if (!interpolate || interval >= pCols.interval()(pidx2)) {
+	if (autocorr) {
+	  dir2 = dir1;
+	}
+	else if (!interpolate || interval >= pCols.interval()(pidx2)) {
 		dir2 = pCols.directionMeas(pidx2);
 	}
 	else {


### PR DESCRIPTION
Two changes are made to optimize MSMetaData::getPointingDirection (CAS-7643).
1. use ScalarColumn::get to access a cell instead of generating a vector of column values in all rows by ScalarColumn::getColumn. The latter causes severe performance degrade.
2. omitt redundant operation for rows of auto-correlation.
See https://bugs.nrao.edu/browse/CAS-7643 for more details.