### PR TITLE
CAS-7980 control the amount of contiguous memory required

### DIFF
--- a/lattices/LatticeMath/LatticeApply.tcc
+++ b/lattices/LatticeMath/LatticeApply.tcc
@@ -391,7 +391,7 @@ void LatticeApply<T,U>::tiledApply (
 
     const IPosition& inShape = latticeIn.shape();
     const uInt inDim = inShape.nelements();
-    IPosition inTileShape = latticeIn.niceCursorShape();
+    IPosition inTileShape = latticeIn.niceCursorShape(1024*1024);
     TileStepper inNav(inShape, inTileShape, collapseAxes);
     RO_LatticeIterator<T> inIter(latticeIn, inNav);
 


### PR DESCRIPTION
This was trying to load all pixel values into a contigous slice of memory, and failing for large values. So, I've added code to make the required memory chunks no larger than 1024*1024 pixels.