### PR TITLE
OSX bug fix to recent MSSummary commit

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -209,7 +209,7 @@ std::set<Int> MSMetaData::getScanNumbers(Int obsID, Int arrayID) const {
 
 uInt MSMetaData::nScans() {
 	if (_nScans == 0) {
-		_nScans = _getScanKeys().size();
+		_nScans = getScanKeys().size();
 	}
 	return _nScans;
 }
@@ -666,7 +666,7 @@ std::map<ScanKey, std::set<Int> > MSMetaData::_getScanToStatesMap() const {
 	std::map<ScanKey, std::set<Int> > myScanToStatesMap;
 	if (nStates() == 0) {
 		std::set<Int> empty;
-		std::set<ScanKey> scanKeys = _getScanKeys();
+		std::set<ScanKey> scanKeys = getScanKeys();
 		//std::set<SubScanKey> subScanKeys;
 		//_getSubScanKeys(subScanKeys, scanKeys);
 		std::set<ScanKey>::const_iterator end = scanKeys.end();
@@ -1136,7 +1136,7 @@ std::set<String> MSMetaData::getFieldNamesForSpw(const uInt spw) {
 	return fieldNames;
 }
 
-std::set<ScanKey> MSMetaData::_getScanKeys() const {
+std::set<ScanKey> MSMetaData::getScanKeys() const {
 	if (! _scanKeys.empty()) {
 		return _scanKeys;
 	}
@@ -1155,7 +1155,7 @@ std::set<ScanKey> MSMetaData::_getScanKeys() const {
 }
 
 std::set<ScanKey> MSMetaData::getScanKeys(const ArrayKey& arrayKey) const {
-	std::set<ScanKey> allScanKeys = _getScanKeys();
+	std::set<ScanKey> allScanKeys = getScanKeys();
 	Bool doAllObsIDs = arrayKey.obsID < 0;
 	Bool doAllArrayIDs = arrayKey.arrayID < 0;
 	if (doAllObsIDs && doAllArrayIDs) {
@@ -2047,7 +2047,7 @@ std::set<Double> MSMetaData::getTimesForScans(
 	// std::set<Int> scanNumbers = getScanNumbers();
 	std::set<ScanKey>::const_iterator scan = scans.begin();
 	std::set<ScanKey>::const_iterator end = scans.end();
-	std::set<ScanKey> scanKeys = _getScanKeys();
+	std::set<ScanKey> scanKeys = getScanKeys();
 	while (scan != end) {
 		_checkScan(*scan);
 		times.insert(
@@ -4120,7 +4120,7 @@ void MSMetaData::_checkField(uInt fieldID) const {
 }
 
 void MSMetaData::_checkScan(const ScanKey& key) const {
-	std::set<ScanKey> allKeys = _getScanKeys();
+	std::set<ScanKey> allKeys = getScanKeys();
 	ThrowIf(
 		allKeys.find(key) == allKeys.end(),
 		"Unknown scan " + toString(key)
@@ -4128,7 +4128,7 @@ void MSMetaData::_checkScan(const ScanKey& key) const {
 }
 
 void MSMetaData::_checkScans(const std::set<ScanKey>& scanKeys) const {
-	std::set<ScanKey> allKeys = _getScanKeys();
+	std::set<ScanKey> allKeys = getScanKeys();
 	std::set<ScanKey>::const_iterator iter = scanKeys.begin();
 	std::set<ScanKey>::const_iterator end = scanKeys.end();
 	while (iter != end) {

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -364,6 +364,9 @@ public:
 	// get the phase directions from the FIELD subtable
 	vector<MDirection> getPhaseDirs() const;
 
+	// get all ScanKeys in the dataset
+	std::set<ScanKey> getScanKeys() const;
+
 	// get all ScanKeys in the dataset that have the specified <src>arrayKey</src>.
 	// If negative values for either the obsID and/or arrayID portions of the ArrayKey
 	// indicate that all obsIDs and/or arrayIDs should be used.
@@ -535,9 +538,6 @@ private:
 		// RESOLUTION
 		QVD resolution;
 	};
-
-
-
 
 	// represents non-primary key data for a SOURCE table row
 	struct SourceProperties {
@@ -783,9 +783,6 @@ private:
 		SHARED_PTR<vector<uInt> >& fieldToNACRowsMap,
 		SHARED_PTR<vector<uInt> >& fieldToNXCRowsMap
 	) const;
-
-	// get all ScanKeys in the dataset
-	std::set<ScanKey> _getScanKeys() const;
 
 	// get the scan keys in the specified set that have the associated arrayKey
 	std::set<ScanKey> _getScanKeys(

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -324,10 +324,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
 	//Limiting record length
 	Int recLength=0;
 	const Int maxRecLength=10000; //limiting for speed and size sake
-	ArrayKey aryKey;
-	aryKey.arrayID = -1;
-	set<ScanKey> allScanKeys = _msmd->getScanKeys(aryKey);
-	set<ArrayKey> allArrayKeys = uniqueArrayKeys(allScanKeys);
+	set<ArrayKey> allArrayKeys = uniqueArrayKeys(_msmd->getScanKeys());
 
 	set<ArrayKey>::const_iterator iter = allArrayKeys.begin();
 	set<ArrayKey>::const_iterator end = allArrayKeys.end();

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2161,6 +2161,22 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(props.nrows == 367, AipsError);
         }
         {
+        	cout << "*** test getScanKeys()" << endl;
+        	std::set<ScanKey> keys = md.getScanKeys();
+        	ScanKey expec;
+        	expec.arrayID = 0;
+        	expec.obsID = 0;
+        	for (Int i=1; i<34; ++i) {
+            	expec.scan = i;
+            	if (i == 33) {
+            		AlwaysAssert(keys.find(expec) == keys.end(), AipsError);
+            	}
+            	else {
+            		AlwaysAssert(keys.find(expec) != keys.end(), AipsError);
+            	}
+        	}
+        }
+        {
 			cout << "*** cache size " << md.getCache() << endl;
 		}
 	}


### PR DESCRIPTION
This commit ultimately fixes a defect exposed on OSX in my recent MSSummary commit. To avoid this same issue in the future, I've made MSMetaData::getScanKeys() (with no parameters) public.