### PR TITLE
Fix endian detection for ARM

### DIFF
--- a/casa/aipsenv.h
+++ b/casa/aipsenv.h
@@ -175,7 +175,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #define AIPS_CRAY_CATAMOUNT
 #endif
 
-#if (defined(__ia64) || defined(__x86_64__))
+#if (defined(__ia64) || defined(__x86_64__) || defined(__aarch64__))
 # if !defined(AIPS_64B)
 # define AIPS_64B
 # endif
@@ -203,10 +203,17 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 # endif
 #endif
 
-//  Automatically configure for known LITTLE ENDIAN systems
+//  If the compiler specifies endianness, use that
 #if !(defined(AIPS_LITTLE_ENDIAN))
-#if (defined(AIPS_ALPHA) || defined(AIPS_I386) || defined(__x86_64__))
+#if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__))
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define AIPS_LITTLE_ENDIAN
+#endif
+#else
+//  Automatically configure for known LITTLE ENDIAN systems
+#if (defined(AIPS_ALPHA) || defined(AIPS_I386) || defined(__x86_64__) || defined(__ARMEL__) || defined(__AARCH64EL__))
+#define AIPS_LITTLE_ENDIAN
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This is a belt-and-braces fix: if `__BYTE_ORDER__` is set (defined by GCC and
Clang), then that is used instead of trying to guess based on a list of known architectures. The architecture list is still there as a fallback, and I've added armel and aarch64el to the list of little-endian architectures.

I've also added aarch64 to the list of 64-bit architectures.

I've tested that this works on an armel system, which was previously unable to
read a measurement set due to the endianness being mis-detected. The aarch64
support is untested.