### PR TITLE
Add -fsigned-char to compiler arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ endif (ENABLE_SHARED)
 # Casacore uses longlong, so no warnings for it.
 # Clang gives warning on bison generated code; disable unneeded-internal-declaration.
 if (NOT CMAKE_CXX_FLAGS)
-    set (CMAKE_CXX_FLAGS "-Wextra -Wall -W -Wpointer-arith -Woverloaded-virtual -Wwrite-strings -pedantic -Wno-long-long")
+    set (CMAKE_CXX_FLAGS "-Wextra -Wall -W -Wpointer-arith -Woverloaded-virtual -Wwrite-strings -pedantic -Wno-long-long -fsigned-char")
 #SET(CMAKE_CXX_FLAGS="-g -O0 -Wall -Wextra -Wshadow -Wunused-variable
 # -Wunused-parameter -Wunused-function -Wunused -Wno-system-headers
 # -Wno-deprecated -Woverloaded-virtual -Wwrite-strings -fprofile-arcs


### PR DESCRIPTION
casacore assumes in several places that char is signed, even though C/C++
does not guarantee it. Passing -fsigned-char forces the compiler to treat it as
signed even on architectures (such as ARM) where it is normally unsigned.

This is potentially risky if inlined header code in any included library
assumes that char is unsigned, but this change makes all the unit tests pass
so it is almost certainly better than not using it.

See #249.