### PR TITLE
fix regression from gh-272

### DIFF
--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -1013,6 +1013,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (BITPIX>0) {
       header.define("datamin", minPix);
       header.define("datamax", maxPix);
+      fhi.minPix = minPix;
+      fhi.maxPix = maxPix;
+    }
+    else {
+      fhi.minPix = 1.0;
+      fhi.maxPix = -1.0;
     }
     //
     const ImageInfo& ii = image.imageInfo();
@@ -1406,9 +1412,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
               if (isNaN(ptr[j]) || !maskPtr[j]) {
                 buffer16[j] = fhi.minshort;
               } else {
-                if (ptr[j] > maxPix) {
+                if (ptr[j] > fhi.maxPix) {
                   buffer16[j] = fhi.maxshort;
-                } else if (ptr[j] < minPix) {
+                } else if (ptr[j] < fhi.minPix) {
                   buffer16[j] = fhi.minshort + blankOffset;
                 } else {
                   buffer16[j] = Short((ptr[j] - fhi.bzero)/fhi.bscale);
@@ -1422,9 +1428,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
               if (isNaN(ptr[j])) {
                 buffer16[j] = fhi.minshort;
               } else {
-                if (ptr[j] > maxPix) {
+                if (ptr[j] > fhi.maxPix) {
                   buffer16[j] = fhi.maxshort;
-                } else if (ptr[j] < minPix) {
+                } else if (ptr[j] < fhi.minPix) {
                   buffer16[j] = fhi.minshort + blankOffset;
                 } else {
                   buffer16[j] = Short((ptr[j] - fhi.bzero)/fhi.bscale);

--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -1483,7 +1483,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
       //
       if (pMeter) delete pMeter;
-      if (fhi.pMask!=0) delete fhi.pMask;
     }
     catch (const AipsError& x) {
       error = "Unknown error copying image to FITS file";

--- a/images/Images/ImageFITSConverter.h
+++ b/images/Images/ImageFITSConverter.h
@@ -35,6 +35,8 @@
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/DataType.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
+
 
 #ifndef WCSLIB_GETWCSTAB
 #define WCSLIB_GETWCSTAB
@@ -77,7 +79,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     IPosition newShape;
     IPosition cursorOrder;
     FitsKeywordList kw;
-    Array<Bool>* pMask;
+    CountedPtr<Array<Bool> > pMask;
   };
 
 

--- a/images/Images/ImageFITSConverter.h
+++ b/images/Images/ImageFITSConverter.h
@@ -72,6 +72,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Double bscale;
     Short minshort;
     Short maxshort;
+    double minPix;
+    double maxPix;
     IPosition newShape;
     IPosition cursorOrder;
     FitsKeywordList kw;


### PR DESCRIPTION
gh-272 introduced a regression in BITPIX 16 storing as the min and max pixel values where not progated from the fits header function to the fits output function.

also use a CountedPtr for the header structure to avoid leaking the mask from the header structure (like the one in the testsuite)