### PR TITLE
Meake measures data search path smaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build/
 *table.lock
 *CMakeCache.txt
 *CMakeFiles
+.project
+.cproject
+.settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,19 +339,13 @@ if(USE_THREADS)
 endif(USE_THREADS)
 
 # Check whether DATA_DIR contains data (only if measures is build)
-# Warning: this check is not exhaustive
+if (NOT DATA_DIR)
+   set (DATA_DIR ${CMAKE_INSTALL_PREFIX}/share/data/casacore)
+endif (NOT DATA_DIR)
 if (";${_modules};" MATCHES ";measures;")
-    if (DATA_DIR)
-        get_filename_component(ABS_DATA_DIR "${DATA_DIR}" ABSOLUTE)
-        if (NOT EXISTS "${ABS_DATA_DIR}/ephemerides/"
-            AND NOT EXISTS "${ABS_DATA_DIR}/share/casacore/data/ephemerides")
-            message(FATAL_ERROR "No ephemerides data found in the specified DATA_DIR")
-        endif()
-    elseif (NOT EXISTS "${CMAKE_INSTALL_PREFIX}/data/ephemerides"
-        AND NOT EXISTS "/usr/local/share/casacore/data/ephemerides")
-            message(WARNING
-              "No ephemerides data found in the default data locations, so the location must be specified at runtime. If you have preinstalled casacore data, specify it with -DDATA_DIR."
-            )
+    get_filename_component(ABS_DATA_DIR "${DATA_DIR}" ABSOLUTE)
+    if (NOT EXISTS "${ABS_DATA_DIR}/ephemerides/")
+        message(WARNING "No ephemerides data found in the specified DATA_DIR (\"${DATA_DIR}\"), so the location must be specified at runtime. If you have preinstalled casacore data, specify the location with -DDATA_DIR.")
     endif()
 endif()
 
@@ -446,7 +440,7 @@ endif (BUILD_PYTHON3)
 #  USE_THREADS                   NO
 #  USE_OPENMP                    NO
 #  USE_STACKTRACE                NO
-#  DATA_DIR                      ""
+#  DATA_DIR                      ${CMAKE_INSTALL_PREFIX}/share/casacore/data
 #  MODULE                        all
 #                                Values for MODULE (incremental list):
 #                                - casa

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ cmake -DUSE_FFTW3=ON -DDATA_DIR=/usr/share/casacore/data -DUSE_OPENMP=ON \
 ```
 
 The `DATA_DIR` should point to the location where you extracted the measures
-data.
+data. Special variables `%CASAROOT%` and `%CASAHOME%` can be used here, which can be set at run time through the `.casarc` file.
 
 We have expirmental support for Python3 now. You can build python3 support using
 `-DBUILD_PYTHON3=on`. Note that CMake may have problems detecting the correct

--- a/measures/Measures/MeasIERS.cc
+++ b/measures/Measures/MeasIERS.cc
@@ -385,55 +385,38 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
       else{
         String udir;
 
-        if(!dir.empty())
+        if(!dir.empty()) {
           udir = dir + '/';
-        ldir = "./";
-        searched.resize(searched.nelements()+1, True);
-        searched[searched.nelements()-1] = ldir;
-        if (!Table::isReadable(ldir + name)) {
-          ldir = "./data/";
-          searched.resize(searched.nelements() + 1, True);
-          searched[searched.nelements()-1] = ldir;
-          if (!Table::isReadable(ldir + name)) {
-            Bool found = False;
-            String mdir;
-            if (Aipsrc::find(mdir, "measures.directory")) {
-              mdir.trim();
-              Path mpath = Path(mdir);
-              mpath.append(udir);
-              ldir = mpath.absoluteName()+"/";
-              searched.resize(searched.nelements()+1, True);
-              searched[searched.nelements()-1] = ldir;
-              if  (Table::isReadable(ldir+name)) {
-                found = True;
-              }
-              if (!found) {
-                for (Int i=0; i<2; i++) {
-                  Path mpath = Path(mdir +"/" + path[i]);
-                  ldir = mpath.absoluteName()+"/";
-                  searched.resize(searched.nelements()+1, True);
-                  searched[searched.nelements()-1] = ldir;
-                  if  (Table::isReadable(ldir+name)) {
-                    found = True;
-                    break;
-                  }
-                }
-              }
+        }
+        Bool found = False;
+        String mdir;
+        if (Aipsrc::find(mdir, "measures.directory")) {
+          mdir.trim();
+          Path mpath = Path(mdir);
+          mpath.append(udir);
+          for (Int i=0; i<2; i++) {
+            Path mpath = Path(mdir +"/" + path[i]);
+            ldir = mpath.absoluteName()+"/";
+            searched.resize(searched.nelements()+1, True);
+            searched[searched.nelements()-1] = ldir;
+            if  (Table::isReadable(ldir+name)) {
+              found = True;
+              break;
             }
-            if (!found) {
-              String casadata=String(CASADATA);
-              casadata.gsub("%CASAROOT%", Aipsrc::aipsRoot());
-              casadata.gsub("%CASAHOME%", Aipsrc::aipsHome());
-              Path cdatapath(casadata);
-              for (Int i=0; i<2; i++) {
-                ldir = cdatapath.absoluteName() + path[i];
-                searched.resize(searched.nelements() + 1, True);
-                searched[searched.nelements() - 1] = ldir;
-                if (Table::isReadable(ldir + name)) {
-                  found = True;
-                  break;
-                }
-              }
+          }
+        }
+        if (!found) {
+          String casadata=String(CASADATA);
+          casadata.gsub("%CASAROOT%", Aipsrc::aipsRoot());
+          casadata.gsub("%CASAHOME%", Aipsrc::aipsHome());
+          Path cdatapath(casadata);
+          for (Int i=0; i<2; i++) {
+            ldir = cdatapath.absoluteName() + path[i];
+            searched.resize(searched.nelements() + 1, True);
+            searched[searched.nelements() - 1] = ldir;
+            if (Table::isReadable(ldir + name)) {
+              found = True;
+              break;
             }
           }
         }

--- a/measures/Measures/MeasIERS.cc
+++ b/measures/Measures/MeasIERS.cc
@@ -66,9 +66,9 @@ Mutex MeasIERS::theirMutex;
 
 //# Member functions
 Bool MeasIERS::get(Double &returnValue,
-		   MeasIERS::Files file, 
-		   MeasIERS::Types type, 
-		   Double date) {
+                   MeasIERS::Files file,
+                   MeasIERS::Types type,
+                   Double date) {
   returnValue = 0.0;
   if (needInit) {
     ScopedMutexLock locker(theirMutex);
@@ -114,7 +114,7 @@ Bool MeasIERS::get(Double &returnValue,
         } else {
           os << LogIO::NORMAL
              << "Requested JD " << date
-             << " is outside the range of the IERS (Earth axis data) table." 	 
+             << " is outside the range of the IERS (Earth axis data) table."
              << "\nCalculations will proceed with less precision"
              << LogIO::POST;
         }
@@ -240,12 +240,12 @@ void MeasIERS::closeTables() {
 
 // Table handling
 Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
-			RORecordFieldPtr<Double> rfp[],
-			String &vs, Double &dt,
-			Int N, const String rfn[],
-			const String &name,
-			const String &rc, const String &dir,
-			const Table *tabin) {
+                        RORecordFieldPtr<Double> rfp[],
+                        String &vs, Double &dt,
+                        Int N, const String rfn[],
+                        const String &name,
+                        const String &rc, const String &dir,
+                        const Table *tabin) {
   Table tab;
   Bool ok = findTab(tab, tabin, rc, dir, name);
 
@@ -253,12 +253,12 @@ Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
     return false;            // findTab logs its own errors.
   
   LogIO os(LogOrigin("MeasIERS",
-		     String("getTable(Table &, TableRecord &, "
-			    "ROTableRow &, RORecordFieldPtr<Double> *, "
-			    "String &vs, Double &dt, "
-			    "Int N, const String *, const String &, "
-			    "const String &, const String &)"),
-		     WHERE));
+                     String("getTable(Table &, TableRecord &, "
+                            "ROTableRow &, RORecordFieldPtr<Double> *, "
+                            "String &vs, Double &dt, "
+                            "Int N, const String *, const String &, "
+                            "const String &, const String &)"),
+                     WHERE));
 
   TableRecord ks(tab.keywordSet());
 
@@ -269,10 +269,10 @@ Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
     // Check that the table is not missing any expected columns.
     for (Int i=0; i < N; i++) {
       if (!rw.record().isDefined(rfn[i])) {
-	os << LogIO::SEVERE
-	   << "Column " << rfn[i] << " is missing."
-	   << LogIO::POST;
-	ok = False;// break;
+        os << LogIO::SEVERE
+           << "Column " << rfn[i] << " is missing."
+           << LogIO::POST;
+        ok = False;// break;
       }
     }
   }
@@ -291,13 +291,13 @@ Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
 }
 
 Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
-			Vector<RORecordFieldPtr<Double> >& rfp,
-			String &vs, Double &dt,
-			const Vector<String>& reqcols,
-			Vector<String>& optcols,
-			const String &name,
-			const String &rc, const String &dir,
-			const Table *tabin)
+                        Vector<RORecordFieldPtr<Double> >& rfp,
+                        String &vs, Double &dt,
+                        const Vector<String>& reqcols,
+                        Vector<String>& optcols,
+                        const String &name,
+                        const String &rc, const String &dir,
+                        const Table *tabin)
 {
   Table tab;
   Bool ok = findTab(tab, tabin, rc, dir, name);
@@ -306,7 +306,7 @@ Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
     return false;            // findTab logs its own errors.
   
   LogIO os(LogOrigin("MeasIERS", "getTable(Vector<String>& optcols)",
-		     WHERE));
+                     WHERE));
 
   TableRecord ks(tab.keywordSet());
 
@@ -317,10 +317,10 @@ Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
     // Check that the table is not missing any required columns.
     for(Int i = reqcols.nelements(); i--;){
       if(!rw.record().isDefined(reqcols[i])){
-	os << LogIO::SEVERE
-	   << "Required column " << reqcols[i] << " is missing."
-	   << LogIO::POST;
-	ok = False;// break;
+        os << LogIO::SEVERE
+           << "Required column " << reqcols[i] << " is missing."
+           << LogIO::POST;
+        ok = False;// break;
       }
     }
   }
@@ -359,45 +359,45 @@ Bool MeasIERS::getTable(Table &table, TableRecord &kws, ROTableRow &row,
 
 // Helper function for getTable().
 Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
-		       const String &dir, const String &name)
+                       const String &dir, const String &name)
 {
   Bool ok = true;
   LogIO os(LogOrigin("MeasIERS", "findTab", WHERE));
   
-  if(!tabin){				// No table object given: search name
+  if(!tabin){                                // No table object given: search name
     String ldir;
     Vector<String> searched;
 
-    if(name[0] == '/'){			// Absolute path given.
+    if(name[0] == '/'){                        // Absolute path given.
       ldir = "";
     }
     else{
       const String path[2] = {
-	"/ephemerides/",
-	"/geodetic/"
+        "/ephemerides/",
+        "/geodetic/"
       };
 
       if (Aipsrc::find(ldir, rc)){
-	ldir += '/';
-	searched.resize(searched.nelements() + 1, True);
-	searched[searched.nelements() - 1] = ldir;
+        ldir += '/';
+        searched.resize(searched.nelements() + 1, True);
+        searched[searched.nelements() - 1] = ldir;
       }
       else{
-	String udir;
+        String udir;
 
-	if(!dir.empty())
-	  udir = dir + '/';
-	ldir = "./";
-	searched.resize(searched.nelements()+1, True);
-	searched[searched.nelements()-1] = ldir;
-	if (!Table::isReadable(ldir + name)) {
-	  ldir = "./data/";
-	  searched.resize(searched.nelements() + 1, True);
-	  searched[searched.nelements()-1] = ldir;
-	  if (!Table::isReadable(ldir + name)) {
-	    Bool found = False;
-	    String mdir;
-	    if (Aipsrc::find(mdir, "measures.directory")) {
+        if(!dir.empty())
+          udir = dir + '/';
+        ldir = "./";
+        searched.resize(searched.nelements()+1, True);
+        searched[searched.nelements()-1] = ldir;
+        if (!Table::isReadable(ldir + name)) {
+          ldir = "./data/";
+          searched.resize(searched.nelements() + 1, True);
+          searched[searched.nelements()-1] = ldir;
+          if (!Table::isReadable(ldir + name)) {
+            Bool found = False;
+            String mdir;
+            if (Aipsrc::find(mdir, "measures.directory")) {
               mdir.trim();
               Path mpath = Path(mdir);
               mpath.append(udir);
@@ -419,66 +419,66 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
                   }
                 }
               }
-	    }
-	    if (!found) {
-	      for (Int i=0; i<2; i++) {
-		ldir = Aipsrc::aipsHome() + "/data/" + path[i];
-		searched.resize(searched.nelements()+1, True);
-		searched[searched.nelements()-1] = ldir;
-		if (Table::isReadable(ldir + name)) {
-		  found = True;
-		  break;
-		}
-		ldir = Aipsrc::aipsRoot() + "/data/" + path[i];
-		searched.resize(searched.nelements()+1, True);
-		searched[searched.nelements()-1] = ldir;
-		if (Table::isReadable(ldir + name)) {
-		  found = True;
-		  break;
-		}
-		ldir = Aipsrc::aipsHome() + "/share/casacore/data/" + path[i];
-		searched.resize(searched.nelements()+1, True);
-		searched[searched.nelements()-1] = ldir;
-		if (Table::isReadable(ldir + name)) {
-		  found = True;
-		  break;
-		}
-		ldir = Aipsrc::aipsRoot() + "/share/casacore/data/" + path[i];
-		searched.resize(searched.nelements()+1, True);
-		searched[searched.nelements()-1] = ldir;
-		if (Table::isReadable(ldir + name)) {
-		  found = True;
-		  break;
-		}
-		Path cdatapath(String(CASADATA));
-		ldir = cdatapath.absoluteName() + path[i];
-		searched.resize(searched.nelements() + 1, True);
-		searched[searched.nelements() - 1] = ldir;
-		if (Table::isReadable(ldir + name)) {
-		  found = True;
-		  break;
-		}
-		ldir = cdatapath.absoluteName() + "/share/casacore/data/" \
-		  + path[i];
-		ldir = cdatapath.absoluteName() + path[i];
-		searched.resize(searched.nelements() + 1, True);
-		searched[searched.nelements() - 1] = ldir;
-		if (Table::isReadable(ldir + name)) {
-		  found = True;
-		  break;
-		}              
-	      }
-	    }
-	  }
-	}
+            }
+            if (!found) {
+              for (Int i=0; i<2; i++) {
+                ldir = Aipsrc::aipsHome() + "/data/" + path[i];
+                searched.resize(searched.nelements()+1, True);
+                searched[searched.nelements()-1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
+                ldir = Aipsrc::aipsRoot() + "/data/" + path[i];
+                searched.resize(searched.nelements()+1, True);
+                searched[searched.nelements()-1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
+                ldir = Aipsrc::aipsHome() + "/share/casacore/data/" + path[i];
+                searched.resize(searched.nelements()+1, True);
+                searched[searched.nelements()-1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
+                ldir = Aipsrc::aipsRoot() + "/share/casacore/data/" + path[i];
+                searched.resize(searched.nelements()+1, True);
+                searched[searched.nelements()-1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
+                Path cdatapath(String(CASADATA));
+                ldir = cdatapath.absoluteName() + path[i];
+                searched.resize(searched.nelements() + 1, True);
+                searched[searched.nelements() - 1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
+                ldir = cdatapath.absoluteName() + "/share/casacore/data/" \
+                  + path[i];
+                ldir = cdatapath.absoluteName() + path[i];
+                searched.resize(searched.nelements() + 1, True);
+                searched[searched.nelements() - 1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
+              }
+            }
+          }
+        }
       }
     }
     if(!Table::isReadable(ldir + name)){
       os << LogIO::WARN <<
-	String("Requested data table ") << name <<
-	String(" cannot be found in the searched directories:\n");
+        String("Requested data table ") << name <<
+        String(" cannot be found in the searched directories:\n");
       for(uInt i = 0; i < searched.nelements(); ++i)
-	os << searched[i] << "\n";
+        os << searched[i] << "\n";
       os << LogIO::POST;
       return False;
     }
@@ -492,7 +492,7 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
 
 // Helper function for getTable().
 Bool MeasIERS::handle_keywords(Double &dt, String &vs, const TableRecord& ks,
-			       const Table& tab)
+                               const Table& tab)
 {
   LogIO os(LogOrigin("MeasIERS", "handle_keywords", WHERE));
   Bool ok = true;

--- a/measures/Measures/MeasIERS.cc
+++ b/measures/Measures/MeasIERS.cc
@@ -43,7 +43,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 #ifndef CASADATA
-#define CASADATA "/usr/local"
+#define CASADATA "/usr/local/share/data/casacore"
 #endif
 
 //# Constants
@@ -421,45 +421,11 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
               }
             }
             if (!found) {
+              String casadata=String(CASADATA);
+              casadata.gsub("%CASAROOT%", Aipsrc::aipsRoot());
+              casadata.gsub("%CASAHOME%", Aipsrc::aipsHome());
+              Path cdatapath(casadata);
               for (Int i=0; i<2; i++) {
-                ldir = Aipsrc::aipsHome() + "/data/" + path[i];
-                searched.resize(searched.nelements()+1, True);
-                searched[searched.nelements()-1] = ldir;
-                if (Table::isReadable(ldir + name)) {
-                  found = True;
-                  break;
-                }
-                ldir = Aipsrc::aipsRoot() + "/data/" + path[i];
-                searched.resize(searched.nelements()+1, True);
-                searched[searched.nelements()-1] = ldir;
-                if (Table::isReadable(ldir + name)) {
-                  found = True;
-                  break;
-                }
-                ldir = Aipsrc::aipsHome() + "/share/casacore/data/" + path[i];
-                searched.resize(searched.nelements()+1, True);
-                searched[searched.nelements()-1] = ldir;
-                if (Table::isReadable(ldir + name)) {
-                  found = True;
-                  break;
-                }
-                ldir = Aipsrc::aipsRoot() + "/share/casacore/data/" + path[i];
-                searched.resize(searched.nelements()+1, True);
-                searched[searched.nelements()-1] = ldir;
-                if (Table::isReadable(ldir + name)) {
-                  found = True;
-                  break;
-                }
-                Path cdatapath(String(CASADATA));
-                ldir = cdatapath.absoluteName() + path[i];
-                searched.resize(searched.nelements() + 1, True);
-                searched[searched.nelements() - 1] = ldir;
-                if (Table::isReadable(ldir + name)) {
-                  found = True;
-                  break;
-                }
-                ldir = cdatapath.absoluteName() + "/share/casacore/data/" \
-                  + path[i];
                 ldir = cdatapath.absoluteName() + path[i];
                 searched.resize(searched.nelements() + 1, True);
                 searched[searched.nelements() - 1] = ldir;

--- a/measures/Measures/MeasTable.cc
+++ b/measures/Measures/MeasTable.cc
@@ -56,7 +56,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 #ifndef CASADATA
-#define CASADATA "/usr/local"
+#define CASADATA "/usr/local/share/data/casacore"
 #endif
 
 
@@ -2988,23 +2988,11 @@ Bool MeasTable::AntennaResponsesPath(String &antRespPath, const String &nam) {
 	isValid = Table::isReadable(absPathName);
       }
       if(!isValid){
-	Path lPath(Aipsrc::aipsHome() + "/data/" + antRespPath);
-	isValid = Table::isReadable(absPathName);
-      }
-      if(!isValid){
-	Path lPath(Aipsrc::aipsRoot() + "/data/" + antRespPath);
-	absPathName = lPath.absoluteName();
-	isValid = Table::isReadable(absPathName);
-      }
-      if(!isValid){
-	Path lPath(String(CASADATA) + "/" + antRespPath);
-	absPathName = lPath.absoluteName();
-	isValid = Table::isReadable(absPathName);
-      }
-      if(!isValid){
-	Path lPath(String(CASADATA)+ "/share/casacore/data/" + antRespPath);
-	absPathName = lPath.absoluteName();
-	isValid = Table::isReadable(absPathName);
+        String casadata=String(CASADATA);
+        casadata.gsub("%CASAROOT%", Aipsrc::aipsRoot());
+        casadata.gsub("%CASAHOME%", Aipsrc::aipsHome());
+        Path lPath(casadata + "/" + antRespPath);
+        isValid = Table::isReadable(absPathName);
       }
       if(!isValid){
 	return False; // table not found


### PR DESCRIPTION
Philosophy: only two paths are searched.
1. A user path, set in .casarc
2. A system path, set at compile time (actually cmake time)

This change removes hardcoded paths like /share/casacore/data. For compatibility, I kept the special paths casahome() and casaroot(), which can be specified at compile time with %CASAHOME% and %CASAROOT% and will be expanded at run time.