### PR TITLE
Fix taql if readline is not available

### DIFF
--- a/tables/apps/taql.cc
+++ b/tables/apps/taql.cc
@@ -77,7 +77,7 @@ bool readLine (String& line, const String& prompt)
 {
   if (!prompt.empty()) cerr << prompt;
   getline (cin, line);
-  return cin;
+  return cin.good();
 }
 #endif
 


### PR DESCRIPTION
This fixes the following compile error (with CXX11=True, but probably it's a bug everywhere). Probably just a typo.

```
[ 37%] Building CXX object tables/apps/CMakeFiles/taql.dir/taql.cc.o
/root/lofar/casacore/src/tables/apps/taql.cc: In function 'bool readLine(casa::String&, const casa::String&)':
/root/lofar/casacore/src/tables/apps/taql.cc:80:10: error: cannot convert 'std::istream {aka std::basic_istream<char>}' to 'bool' in return
   return cin;
          ^
tables/apps/CMakeFiles/taql.dir/build.make:62: recipe for target 'tables/apps/CMakeFiles/taql.dir/taql.cc.o' failed
make[2]: *** [tables/apps/CMakeFiles/taql.dir/taql.cc.o] Error 1
CMakeFiles/Makefile2:7731: recipe for target 'tables/apps/CMakeFiles/taql.dir/all' failed
make[1]: *** [tables/apps/CMakeFiles/taql.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
```