### PR TITLE
Added MS feed selection to MSSelection

### DIFF
--- a/ms/CMakeLists.txt
+++ b/ms/CMakeLists.txt
@@ -7,6 +7,7 @@ parser_inputs
 MSAntennaGram
 MSArrayGram
 MSCorrGram
+MSFeedGram
 MSFieldGram
 MSObservationGram
 MSScanGram
@@ -79,7 +80,9 @@ MSSel/MSCorrGram.cc
 MSSel/MSCorrParse.cc
 MSSel/MSDataDescIndex.cc
 MSSel/MSDopplerIndex.cc
+MSSel/MSFeedGram.cc
 MSSel/MSFeedIndex.cc
+MSSel/MSFeedParse.cc
 MSSel/MSFieldGram.cc
 MSSel/MSFieldIndex.cc
 MSSel/MSFieldParse.cc
@@ -134,6 +137,8 @@ ${BISON_MSArrayGram_OUTPUTS}
 ${FLEX_MSArrayGram_OUTPUTS}
 ${BISON_MSCorrGram_OUTPUTS}
 ${FLEX_MSCorrGram_OUTPUTS}
+${BISON_MSFeedGram_OUTPUTS}
+${FLEX_MSFeedGram_OUTPUTS}
 ${BISON_MSFieldGram_OUTPUTS}
 ${FLEX_MSFieldGram_OUTPUTS}
 ${BISON_MSScanGram_OUTPUTS}

--- a/ms/MSSel/MSFeedGram.cc
+++ b/ms/MSSel/MSFeedGram.cc
@@ -1,0 +1,189 @@
+//# MSFeedGram.cc: Grammar for feed expressions
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+// MSFeedGram; grammar for feed command lines based on antenna grammar
+
+// This file includes the output files of bison and flex for
+// parsing command lines operating on lattices.
+
+#include <casacore/tables/TaQL/ExprNode.h>
+#include <casacore/ms/MeasurementSets/MeasurementSet.h>
+#include <casacore/ms/MSSel/MSFeedGram.h>
+#include <casacore/ms/MSSel/MSFeedParse.h> // routines used by bison actions
+#include <casacore/ms/MSSel/MSFeedIndex.h>
+#include <casacore/ms/MSSel/MSSelectionError.h>
+
+//# stdlib.h is needed for bison 1.28 and needs to be included here
+//# (before the flex/bison files).
+#include <casacore/casa/stdlib.h>
+//# Define register as empty string to avoid warnings in C++11 compilers
+//# because keyword register is not supported anymore.
+#define register
+#include "MSFeedGram.ycc"                  // bison output
+#include "MSFeedGram.lcc"                  // flex output
+
+// Define the yywrap function for flex.
+int MSFeedGramwrap()
+{
+    return 1;
+}
+
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+//# Declare a file global pointer to a char* for the input string.
+  static const char*           strpMSFeedGram = 0;
+  static Int                   posMSFeedGram = 0;
+
+//# Parse the command.
+//# Do a yyrestart(yyin) first to make the flex scanner reentrant.
+  TableExprNode baseMSFeedGramParseCommand(MSFeedParse* parser, const String& command,
+					      Vector<Int>& selectedFeeds1,
+					      Vector<Int>& selectedFeeds2,
+					      Matrix<Int>& selectedFeedPairs)
+  {
+    try 
+      {
+	MSFeedGramrestart (MSFeedGramin);
+	yy_start = 1;
+	strpMSFeedGram = command.chars();     // get pointer to command string
+	posMSFeedGram  = 0;                   // initialize string position
+	MSFeedParse::thisMSFParser = parser; // The global pointer to the parser
+	MSFeedGramparse();                    // parse command string
+	
+	selectedFeeds1.reference (parser->selectedFeed1());
+	selectedFeeds2.reference (parser->selectedFeed2());
+	selectedFeedPairs.reference (parser->selectedFeedPairs());
+	return parser->node();
+      } 
+    catch (MSSelectionFeedError& x) 
+      {
+	String newMesgs;
+	newMesgs = constructMessage(msFeedGramPosition(),command);
+	x.addMessage(newMesgs);
+	throw;
+      }
+  }					      
+
+
+  TableExprNode msFeedGramParseCommand (Table& subTable,
+					   TableExprNode& col1TEN,
+					   TableExprNode& col2TEN,
+                       const String& command, 
+                       Vector<Int>& selectedFeeds1,
+                       Vector<Int>& selectedFeeds2,
+                       Matrix<Int>& selectedFeedPairs) 
+  {
+
+    TableExprNode feedTEN;
+    MSFeedParse thisParser(subTable, col1TEN, col2TEN);
+    try
+      {
+	feedTEN = baseMSFeedGramParseCommand(&thisParser, command, 
+						   selectedFeeds1, selectedFeeds2,
+						   selectedFeedPairs);
+      }
+    catch(MSSelectionFeedError &x)
+      {
+	    throw;
+      }
+    
+    return feedTEN;
+  }
+
+  TableExprNode msFeedGramParseCommand (MSFeedParse* thisParser,
+                                           const String& command, 
+                                           Vector<Int>& selectedFeeds1,
+                                           Vector<Int>& selectedFeeds2,
+                                           Matrix<Int>& selectedFeedPairs) 
+  {
+    TableExprNode feedTEN;
+    try
+      {
+	feedTEN=baseMSFeedGramParseCommand(thisParser, command, 
+						 selectedFeeds1, selectedFeeds2,
+						 selectedFeedPairs);
+      }
+    catch(MSSelectionFeedError &x)
+      {
+	delete thisParser;
+	throw;
+      }
+    delete thisParser;
+    return feedTEN;
+  }
+
+  TableExprNode msFeedGramParseCommand (const MeasurementSet* ms,
+                                           const String& command, 
+                                           Vector<Int>& selectedFeeds1,
+                                           Vector<Int>& selectedFeeds2,
+                                           Matrix<Int>& selectedFeedPairs) 
+  {
+    TableExprNode feedTEN;
+    TableExprNode col1AsTEN = ms->col(ms->columnName(MS::FEED1)),
+    col2AsTEN = ms->col(ms->columnName(MS::FEED2));
+    MSFeedParse *thisParser = new MSFeedParse(ms->feed(),col1AsTEN, col2AsTEN);
+    try
+      {
+	    feedTEN=baseMSFeedGramParseCommand(thisParser, command, 
+						 selectedFeeds1, selectedFeeds2,
+						 selectedFeedPairs);
+      }
+    catch(MSSelectionFeedError &x)
+      {
+	delete thisParser;
+	throw;
+      }
+    delete thisParser;
+    return feedTEN;
+  }
+  
+  //# Give the string position.
+  Int& msFeedGramPosition()
+  {
+    return posMSFeedGram;
+  }
+  
+  //# Get the next input characters for flex.
+  int msFeedGramInput (char* buf, int max_size)
+  {
+    int nr=0;
+    while (*strpMSFeedGram != 0) {
+      if (nr >= max_size) {
+	break;                         // get max. max_size char.
+      }
+      buf[nr++] = *strpMSFeedGram++;
+    }
+    return nr;
+  }
+  
+  void MSFeedGramerror (const char*)
+  {
+    throw (MSSelectionFeedParseError ("Feed Expression: Parse error at or near '" +
+					 String(MSFeedGramtext) + "'"));
+  }
+  
+} //# NAMESPACE CASACORE - END

--- a/ms/MSSel/MSFeedGram.h
+++ b/ms/MSSel/MSFeedGram.h
@@ -1,0 +1,122 @@
+//# MSFeedGram.h: Grammar for ms feed sub-expressions
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#ifndef MS_MSFEEDGRAM_H
+#define MS_MSFEEDGRAM_H
+
+
+//# Includes
+#include <casacore/casa/aips.h>
+#include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/Arrays/Matrix.h>
+#include <casacore/ms/MSSel/MSFeedParse.h> // routines used by bison actions
+
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+//# Forward Declarations
+class MeasurementSet;
+class TableExprNode;
+
+// <summary>
+// Global functions for flex/bison scanner/parser for MSFeedGram
+// </summary>
+  
+// <use visibility=local>
+  
+// <reviewed reviewer="" date="" tests="">
+// </reviewed>
+  
+// <prerequisite>
+//# Classes you should understand before using this one.
+//  <li> MSFeedGram.l and .y  (flex and bison grammar)
+// </prerequisite>
+  
+// <synopsis> 
+// Global functions are needed to define the input of the flex scanner
+// and to start the bison parser.
+// The input is taken from a string.
+// </synopsis> 
+  
+// <motivation>
+// It is necessary to be able to give an image expression in ASCII.
+// This can be used in glish.
+// </motivation>
+// <todo asof="$DATE:$">
+//# A List of bugs, limitations, extensions or planned refinements.
+// </todo>
+  
+  
+// <group name=MSFeedGramFunctions>
+  
+// Declare the bison parser (is implemented by bison command).
+// It returns a TaQL expression tree.
+  TableExprNode msFeedGramParseCommand (MSFeedParse* thisParser,
+					   const TableExprNode& col1TEN,
+					   const TableExprNode& col2TEN,
+                                           const String& command, 
+                                           Vector<Int>& selectedFeeds1,
+                                           Vector<Int>& selectedFeeds2,
+                                           Matrix<Int>& selectedFeedPairs) ;
+  TableExprNode msFeedGramParseCommand (Table& subTable,
+					   TableExprNode& col1TEN,
+					   TableExprNode& col2TEN,
+                                           const String& command, 
+                                           Vector<Int>& selectedFeeds1,
+                                           Vector<Int>& selectedFeeds2,
+                                           Matrix<Int>& selectedFeedPairs) ;
+  TableExprNode msFeedGramParseCommand (const MeasurementSet *ms,
+					   const String& command,
+					   Vector<Int>& selectedFeeds1,
+					   Vector<Int>& selectedFeeds2,
+					   Matrix<Int>& selectedFeedPairs);
+  
+  TableExprNode baseMSFeedGramParseCommand(MSFeedParse* parser, const String& command,
+					      Vector<Int>& selectedFeeds1,
+					      Vector<Int>& selectedFeeds2,
+					      Matrix<Int>& selectedFeedPairs);
+  // The yyerror function for the parser.
+  // It throws an exception with the current token.
+    void MSFeedGramerror (const char*);
+  
+  // Give the current position in the string.
+  // This can be used when parse errors occur.
+  Int& msFeedGramPosition();
+  
+  // Declare the input routine for flex/bison.
+  int msFeedGramInput (char* buf, int max_size);
+  
+  // A function to remove escaped characters.
+  //String msFeedGramRemoveEscapes (const String& in);
+  
+  // A function to remove quotes from a quoted string.
+  //String msFeedGramRemoveQuotes (const String& in);
+  
+  // </group>
+  
+} //# NAMESPACE CASACORE - END
+
+#endif

--- a/ms/MSSel/MSFeedGram.ll
+++ b/ms/MSSel/MSFeedGram.ll
@@ -1,0 +1,75 @@
+/* -*- C -*-
+    MSFeedGram.l: Lexical analyzer for ms feed selection commands
+    Copyright (C) 2015
+    Associated Universities, Inc. Washington DC, USA.
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Library General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or (at your
+    option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+    License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; if not, write to the Free Software Foundation,
+    Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+
+    Correspondence concerning AIPS++ should be addressed as follows:
+           Internet email: aips2-request@nrao.edu.
+           Postal address: AIPS++ Project Office
+                           National Radio Astronomy Observatory
+                           520 Edgemont Road
+                           Charlottesville, VA 22903-2475 USA
+
+    $Id$
+*/
+
+/* yy_unput is not used, so let flex not generate it, otherwise picky
+   compilers will issue warnings. */
+%option nounput
+
+%{
+#undef YY_INPUT
+#define YY_INPUT(buf,result,max_size) result=msFeedGramInput(buf,max_size)
+
+#undef YY_DECL
+#define YY_DECL int MSFeedGramlex (YYSTYPE* lvalp)
+%}
+
+WHITE     [ \t\n]*
+DIGIT     [0-9]
+INT       {DIGIT}+
+
+/* rules */
+%%
+
+{INT}     {
+             msFeedGramPosition() += yyleng;
+             lvalp->str = (char*)malloc(strlen(MSFeedGramtext) + 1);
+             strcpy(lvalp->str, MSFeedGramtext);
+             return INT;
+          }
+
+
+";"       { msFeedGramPosition() += yyleng; return SEMICOLON; }
+"&"       { msFeedGramPosition() += yyleng; return AMPERSAND; }
+"~"       { msFeedGramPosition() += yyleng; return DASH; }
+","       { msFeedGramPosition() += yyleng; return COMMA;}
+"!"       { msFeedGramPosition() += yyleng; return NOT;}
+
+
+{WHITE}   { msFeedGramPosition() += yyleng;} /* Eat whitespace */
+
+ /* An unterminated string is an error */
+\'|\"     { throw MSSelectionFeedError ("Unterminated string"); }
+
+ /* terminate on EOF */
+<<EOF>>   { yyterminate(); }
+
+ /* Any other character is invalid */
+.         { return YYERRCODE; }
+
+%%

--- a/ms/MSSel/MSFeedGram.yy
+++ b/ms/MSSel/MSFeedGram.yy
@@ -1,0 +1,177 @@
+/*-*- C++ -*-
+    MSFeedGram.y: Parser for feed expressions based on antenna parser
+    Copyright (C) 2015
+    Associated Universities, Inc. Washington DC, USA.
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Library General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or (at your
+    option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+    License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; if not, write to the Free Software Foundation,
+    Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+
+    Correspondence concerning AIPS++ should be addressed as follows:
+           Internet email: aips2-request@nrao.edu.
+           Postal address: AIPS++ Project Office
+                           National Radio Astronomy Observatory
+                           520 Edgemont Road
+                           Charlottesville, VA 22903-2475 USA
+
+    $Id$
+*/
+
+%{
+  using namespace casacore;
+%}
+
+%pure-parser                /* make parser re-entrant */
+
+%union {
+  const TableExprNode* node;
+  char* str;
+  Vector<Int>* iv;
+  std::vector<String>* sv;
+}
+
+
+%token COMMA
+%token SEMICOLON
+%token AMPERSAND
+%token DASH
+%token NOT
+
+%token <str> INT
+
+%type <node> feedstatement
+%type <node> indexcombexpr
+%type <node> feedpairs
+%type <node> gfeedpairs
+%type <iv> feedlist
+%type <iv> feedids
+
+
+%{
+#include <casacore/casa/Logging/LogIO.h>
+#include <casacore/ms/MSSel/MSSelectionTools.h>
+
+  int MSFeedGramlex (YYSTYPE*);
+  Bool MSFeedGramNegate=False;
+%}
+
+%%
+feedstatement: indexcombexpr                
+                   {
+		     $$ = $1; 
+		   }
+
+indexcombexpr: gfeedpairs                         {$$=$1;}
+             | indexcombexpr SEMICOLON gfeedpairs
+                {
+		  $$ = $1;
+                }
+
+gfeedpairs: NOT {MSFeedGramNegate=True;}  feedpairs {$$=$3;}
+         |     {MSFeedGramNegate=False;} feedpairs {$$=$2;}
+
+feedpairs: feedlist AMPERSAND feedlist  // Two non-identical lists for the '&' operator
+           {
+	     MSFeedIndex myMSFI(MSFeedParse::thisMSFParser->subTable());
+	     Vector<Int> f1 = myMSFI.matchFeedId(*($1)); 
+	     Vector<Int> f2 = myMSFI.matchFeedId(*($3)); 
+	     $$ = MSFeedParse::thisMSFParser->selectFeedIds
+	       (f1,f2, MSFeedParse::CrossOnly, MSFeedGramNegate); 
+	     delete $1;
+	     delete $3;
+	   } 
+        | feedlist AMPERSAND  // Implicit same list on the RHS of '&' operator
+           {
+		 MSFeedIndex myMSFI(MSFeedParse::thisMSFParser->subTable());
+		 Vector<Int> f1 = myMSFI.matchFeedId(*($1)); 
+		 $$ = MSFeedParse::thisMSFParser->selectFeedIds
+		   (f1,f1, MSFeedParse::CrossOnly, MSFeedGramNegate); 
+	     delete $1;
+	   }
+        | feedlist           //Match FEEDLIST & ALLFEEDS (implicit "&*")
+           {
+	     MSFeedIndex myMSFI(MSFeedParse::thisMSFParser->subTable());
+	     Vector<Int> f1 = myMSFI.matchFeedId(*($1)); 
+	     $$ = MSFeedParse::thisMSFParser->selectFeedIds
+	       (f1, MSFeedParse::CrossOnly, MSFeedGramNegate); 
+	     delete $1;
+	   }
+        | feedlist AMPERSAND AMPERSAND feedlist //Include self-correlations
+           {
+	     MSFeedIndex myMSFI(MSFeedParse::thisMSFParser->subTable());
+	     Vector<Int> f1 = myMSFI.matchFeedId(*($1)); 
+	     Vector<Int> f2 = myMSFI.matchFeedId(*($4)); 
+	     $$ = MSFeedParse::thisMSFParser->selectFeedIds
+	       (f1, f2, MSFeedParse::AutoCorrAlso, MSFeedGramNegate); 
+	     delete $1;
+	     delete $4;
+	   } 
+        | feedlist AMPERSAND AMPERSAND // Include self-correlations 
+           {
+	     MSFeedIndex myMSFI(MSFeedParse::thisMSFParser->subTable());
+	     Vector<Int> f1 = myMSFI.matchFeedId(*($1)); 
+	     $$ = MSFeedParse::thisMSFParser->selectFeedIds
+	       (f1, f1, MSFeedParse::AutoCorrAlso, MSFeedGramNegate); 
+	     delete $1;
+	   }
+        | feedlist AMPERSAND AMPERSAND AMPERSAND // Only self-correlations
+           {
+	     MSFeedIndex myMSFI(MSFeedParse::thisMSFParser->subTable());
+	     Vector<Int> f1 = myMSFI.matchFeedId(*($1)); 
+	     $$ = MSFeedParse::thisMSFParser->selectFeedIds
+	       (f1, MSFeedParse::AutoCorrOnly, MSFeedGramNegate); 
+	     delete $1;
+	   }
+
+
+feedlist: feedids  // single feed or range
+          {
+	    if (!($$)) delete $$;
+	    $$ = new Vector<Int>(*$1);
+	    delete $1;
+	  }
+       | feedlist COMMA feedids  // feedID, feedID,...
+          {
+	    Int N0=(*($1)).nelements(), N1 = (*($3)).nelements();
+	    (*($$)).resize(N0+N1,True);  // Resize the existing list
+	    for(Int i=N0;i<N0+N1;i++) (*($$))(i) = (*($3))(i-N0);
+	    delete $3;
+	  }
+
+feedids: INT // A single feed index
+             {
+	       if (!($$)) delete $$;
+	       $$ = new Vector<Int>(1);
+	       (*($$))(0) = atoi($1);
+	       free($1);
+	     }
+           | INT DASH INT // A range of integer feed indices feedID~feedID
+              {
+		Int start = atoi($1);
+		Int end   = atoi($3);
+		Int len = end - start + 1;
+		Vector<Int> feedids(len);
+		for(Int i = 0; i < len; i++) feedids[i] = start + i;
+
+		if (!($$)) delete $$;
+		$$ = new Vector<Int>(len);
+
+		for (Int i=0; i<len; i++) 
+		  {
+		    ((*$$))[i] = feedids[i];
+		  }
+		free($1);
+		free($3);
+	      }
+
+%%

--- a/ms/MSSel/MSFeedIndex.cc
+++ b/ms/MSSel/MSFeedIndex.cc
@@ -33,6 +33,9 @@
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Arrays/Slicer.h>
 #include <casacore/ms/MeasurementSets/MSFeed.h>
+#include <casacore/ms/MSSel/MSSelectionTools.h>
+#include <casacore/ms/MSSel/MSSelectionError.h>
+#include <casacore/ms/MSSel/MSFeedParse.h>
 #include <casacore/tables/Tables/TableError.h>
 #include <casacore/casa/Quanta/MVAngle.h>
 #include <casacore/casa/Quanta/QLogical.h>
@@ -179,6 +182,23 @@ Vector<Int> MSFeedIndex::matchAntennaId (const Int& antennaId,
   return maskFeedIds.getCompressedArray();
 }
 
+Vector<Int> MSFeedIndex::matchFeedId(const Vector<Int>& sourceId)
+{
+    Vector<Int> feedIds = msFeedCols_p->feedId().getColumn();
+    Vector<Int> IDs = set_intersection(sourceId, feedIds);
+    if (IDs.nelements() == 0)
+      {
+        ostringstream mesg;
+        mesg << "No match found for requested feeds [ID(s): " << sourceId << "]";
+        // Use the error handler if defined, otherwise throw.
+        if (MSFeedParse::thisMSFErrorHandler) {
+          MSFeedParse::thisMSFErrorHandler->reportError ("", mesg.str());
+        } else {
+          throw (MSSelectionFeedParseError(mesg));
+        }
+      }
+    return IDs;
+}
 
 } //# NAMESPACE CASACORE - END
 

--- a/ms/MSSel/MSFeedIndex.h
+++ b/ms/MSSel/MSFeedIndex.h
@@ -109,6 +109,9 @@ public:
   // return feed id.'s (and associated row numbers) for a given antenna id.
   Vector<Int> matchAntennaId(const Int& antennaId, Vector<Int>& rowNumbers);
 
+  // return valid feed id.'s for a given list of feed id.'s.
+  Vector<Int> matchFeedId(const Vector<Int>& sourceId);
+
 protected:
   // the specialized compare function to pass to the
   // <linkto class=ColumnsIndex>ColumnsIndex</linkto> object.  This supports -1

--- a/ms/MSSel/MSFeedParse.cc
+++ b/ms/MSSel/MSFeedParse.cc
@@ -1,0 +1,224 @@
+//# MSFeedParse.cc: Classes to hold results from feed grammar parser
+//# Copyright (C) 1994,1995,1997,1998,1999,2000,2001,2003
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/ms/MSSel/MSFeedParse.h>
+#include <casacore/ms/MSSel/MSFeedIndex.h>
+#include <casacore/ms/MSSel/MSSelectionError.h>
+#include <casacore/ms/MeasurementSets/MSFeedColumns.h>
+#include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/Logging/LogIO.h>
+#include <casacore/ms/MSSel/MSSelectionTools.h>
+#include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+ // Global pointer to the parser object
+  MSFeedParse* MSFeedParse::thisMSFParser = 0;
+  TableExprNode MSFeedParse::column1AsTEN_p, MSFeedParse::column2AsTEN_p;
+  MSSelectionErrorHandler* MSFeedParse::thisMSFErrorHandler = 0;
+  
+  //# Constructor
+  MSFeedParse::MSFeedParse ()
+    : MSParse(),
+      colName1(MS::columnName(MS::FEED1)),
+      colName2(MS::columnName(MS::FEED2)),
+      feed1List(0),feed2List(0), feedPairList(0,2)
+  {
+  }
+  
+  //# Constructor with given ms name.
+  MSFeedParse::MSFeedParse (const MSFeed& feedSubTable, 
+				  const TableExprNode& feed1AsTEN, const TableExprNode& feed2AsTEN)
+    : MSParse(),
+      colName1(MS::columnName(MS::FEED1)),
+      colName2(MS::columnName(MS::FEED2)),
+      feed1List(0),feed2List(0), feedPairList(0,2),
+      msSubTable_p(feedSubTable)
+      
+  {
+    column1AsTEN_p = feed1AsTEN;
+    column2AsTEN_p = feed2AsTEN;
+  }
+
+  //# Constructor with given ms name.
+  MSFeedParse::MSFeedParse (const MeasurementSet* myms)
+    : MSParse(myms, "Feed"),
+      colName1(MS::columnName(MS::FEED1)),
+      colName2(MS::columnName(MS::FEED2)),
+      feed1List(0),feed2List(0), feedPairList(0,2),
+      msSubTable_p(myms->feed())
+  {
+    column1AsTEN_p = myms->col(myms->columnName(MS::FEED1));
+    column2AsTEN_p = myms->col(myms->columnName(MS::FEED2));
+  }
+
+  // Add the current condition to the TableExprNode tree.  Mask auto
+  // correlations if baselineType==CrossOnly
+  // 
+  const TableExprNode* MSFeedParse::setTEN(TableExprNode& condition, 
+                                              BaselineListType baselineType,
+                                              Bool negate)
+  {
+    if (baselineType==CrossOnly) 
+      {
+	TableExprNode noAutoCorr = (column1AsTEN_p != column2AsTEN_p);
+	condition = noAutoCorr && condition;
+      }
+    if (negate) condition = !condition;
+    if(node_p.isNull()) node_p = condition;
+    else
+      if (negate) node_p = node_p && condition;
+      else        node_p = node_p || condition;
+
+    return &node_p;
+  }
+
+  const TableExprNode* MSFeedParse::selectFeedIds(const Vector<Int>& feedIds, 
+							BaselineListType baselineType,
+							Bool negate) 
+  {
+    TableExprNode condition;
+    if ((baselineType==AutoCorrAlso) || (baselineType==AutoCorrOnly)) 
+      {
+	Int n=feedIds.nelements();
+	if (n) 
+	  {
+	    condition = ((column1AsTEN_p == feedIds[0]) &&
+			 (column2AsTEN_p == feedIds[0]));
+	    for (Int i=1;i<n;i++) 
+	      {
+		condition = condition || 
+		  ((column1AsTEN_p == feedIds[i]) && (column2AsTEN_p == feedIds[i]));
+	      }
+	  }
+      } 
+    else 
+      {
+	condition =
+	  (column1AsTEN_p.in(feedIds) ||
+	   column2AsTEN_p.in(feedIds)); 
+      }
+    {
+      // cannot use indgen for this, rows of feed table may have same feed ID
+      ROMSFeedColumns* msfc = new ROMSFeedColumns(subTable());
+      Vector<Int> f2 = msfc->feedId().getColumn();
+      delete msfc;
+      /*
+      Int nrows_p = subTable().nrow();
+      Vector<Int> f2(nrows_p);
+      f2.resize(nrows_p);
+      indgen(f2);
+      */
+
+      makeFeedList(feed1List, feedIds, negate);
+      makeFeedList(feed2List, f2);
+      if (negate) makeFeedPairList(-feedIds,f2,feedPairList,baselineType, negate);
+      else        makeFeedPairList( feedIds,f2,feedPairList,baselineType, negate);
+    }
+    return setTEN(condition, baselineType, negate);
+  }
+
+  void MSFeedParse::makeFeedList(Vector<Int>& feedList,const Vector<Int>& thisList,
+				       Bool negate)
+  {
+    Vector<Int> f2;
+    if (negate) f2=-thisList;
+    else        f2=thisList;
+
+    Vector<Int> tmp1(set_union(f2,feedList));
+    feedList.resize(tmp1.nelements());feedList = tmp1;
+  }
+  
+  const TableExprNode* MSFeedParse::selectFeedIds(const Vector<Int>& feedIds1,
+							const Vector<Int>& feedIds2,
+							BaselineListType baselineType,
+							Bool negate)
+  {
+    TableExprNode condition;
+
+    condition =
+      (column1AsTEN_p.in(feedIds1)  && column2AsTEN_p.in(feedIds2)) ||
+      (column1AsTEN_p.in(feedIds2)  && column2AsTEN_p.in(feedIds1));
+    makeFeedList(feed1List, feedIds1, negate);
+    makeFeedList(feed2List, feedIds2, negate);
+
+    if (negate) makeFeedPairList(-feedIds1, -feedIds2, feedPairList, baselineType, negate);
+    else        makeFeedPairList( feedIds1,  feedIds2, feedPairList, baselineType, negate);
+
+    return setTEN(condition,baselineType,negate);
+  }
+
+  Bool MSFeedParse::addFeedPair(const Matrix<Int>& feedpairlist,
+                                   const Int feed1, const Int feed2, 
+ 				   BaselineListType baselineType)
+  {
+    Bool doAutoCorr;
+    doAutoCorr = (baselineType==AutoCorrAlso) || (baselineType==AutoCorrOnly);
+    if ((feed1 == feed2) && (!doAutoCorr)) return False;
+    if ((baselineType==AutoCorrOnly) && (feed1!=feed2)) return False;
+
+    Int n=feedpairlist.shape()(0);
+    for (Int i=0;i<n;i++) {
+      if (((feedpairlist(i,0)==feed1) && (feedpairlist(i,1)==feed2)) ||
+          ((feedpairlist(i,1)==feed1) && (feedpairlist(i,0)==feed2))) {
+        return False;
+      }
+    }
+    return True;
+  }
+  //
+  // Method to make a list of unique feed pairs, given a list of
+  // feed1 and feed2.  The feed pairs list is appended to the
+  // existing list.  The required sizing could be done better.
+  //
+  void MSFeedParse::makeFeedPairList(const Vector<Int>& f1,
+                    const Vector<Int>& f2, 
+					Matrix<Int>& feedpairlist, 
+					BaselineListType baselineType,
+					Bool /*negate*/)
+  {
+    Int n1,n2,nb0;
+    n1=f1.nelements();  n2=f2.nelements();
+    nb0=feedpairlist.shape()(0);
+    IPosition newSize(2,nb0,2);
+
+    for (Int i1=0;i1<n1;i1++) {
+      for (int i2=0;i2<n2;i2++) {
+        Int feed1, feed2;
+        feed1=f1[i1]; feed2=f2[i2];
+        if (addFeedPair(feedpairlist,feed1,feed2,baselineType)) {
+          nb0++;
+          newSize[0]=nb0;
+          feedpairlist.resize(newSize,True);
+          feedpairlist(nb0-1,0)=feed1;
+          feedpairlist(nb0-1,1)=feed2;
+        }
+      }
+    }
+  }
+  
+} //# NAMESPACE CASACORE - END

--- a/ms/MSSel/MSFeedParse.h
+++ b/ms/MSSel/MSFeedParse.h
@@ -1,0 +1,160 @@
+//# MSFeedParse.h: Classes to hold results from feed grammar parser
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#ifndef MS_MSFEEDPARSE_H
+#define MS_MSFEEDPARSE_H
+
+//# Includes
+#include <casacore/casa/aips.h>
+#include <casacore/ms/MSSel/MSParse.h>
+#include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
+#include <casacore/casa/Arrays/Matrix.h>
+
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+  
+  //# Forward Declarations
+  
+  // <summary>
+  // Class to hold values from feed grammar parser
+  // </summary>
+  
+  // <use visibility=local>
+  
+  // <reviewed reviewer="" date="" tests="">
+  // </reviewed>
+  
+  // <prerequisite>
+  //# Classes you should understand before using this one.
+  // </prerequisite>
+  
+  // <etymology>
+  // MSFeedParse is the class used to parse a feed command.
+  // </etymology>
+  
+  // <synopsis>
+  // MSFeedParse is used by the parser of feed sub-expression statements.
+  // The parser is written in Bison and Flex in files MSFeedGram.yy and .ll.
+  // The statements there use the routines in this file to act
+  // upon a reduced rule.
+  // Since multiple tables can be given (with a shorthand), the table
+  // names are stored in a list. The variable names can be qualified
+  // by the table name and will be looked up in the appropriate table.
+  //
+  // The class MSFeedParse only contains information about a table
+  // used in the table command. Global variables (like a list and a vector)
+  // are used in MSFeedParse.cc to hold further information.
+  //
+  // Global functions are used to operate on the information.
+  // The main function is the global function msFeedCommand.
+  // It executes the given STaQL command and returns the resulting ms.
+  // This is, in fact, the only function to be used by a user.
+  // </synopsis>
+  
+  // <motivation>
+  // It is necessary to be able to give a ms command in ASCII.
+  // This can be used in a CLI or in the table browser to get a subset
+  // of a table or to sort a table.
+  // </motivation>
+  
+  //# <todo asof="$DATE:$">
+  //# A List of bugs, limitations, extensions or planned refinements.
+  //# </todo>
+  
+  
+  class MSFeedParse : public MSParse
+  {
+    
+  public:
+    // Define the operator types (&&&, &&, and &).
+    // NB: Keeping the same notation as Antenna parser, even tho not a baseline here!
+    enum BaselineListType {AutoCorrOnly=0, AutoCorrAlso, CrossOnly};
+
+    // Default constructor
+    MSFeedParse();
+    
+    // Associate the ms.
+    MSFeedParse (const MeasurementSet* ms);
+
+    MSFeedParse (const MSFeed& feedSubTable, 
+		    const TableExprNode& feed1AsTEN, const TableExprNode& feed2AsTEN);
+
+    ~MSFeedParse() {column1AsTEN_p=TableExprNode();column2AsTEN_p=TableExprNode();}
+
+    // Add the given feed selection.
+    const TableExprNode* selectFeedIds(const Vector<Int>& feedIds, 
+					  BaselineListType baselineType=CrossOnly,
+                                          Bool negate=False);
+
+    // Add the given "baseline" selection.
+    const TableExprNode* selectFeedIds(const Vector<Int>& feedIds1,
+                      const Vector<Int>& feedIds2, 
+					  BaselineListType baselineType=CrossOnly,
+                      Bool negate=False);
+
+    // Get a pointer to the table expression node object.
+    TableExprNode node() const
+      { return node_p; }
+    const Vector<Int>& selectedFeed1() const
+      { return feed1List; }
+    const Vector<Int>& selectedFeed2() const
+      { return feed2List; }
+    const Matrix<Int>& selectedFeedPairs() const
+      { return feedPairList; }
+
+    MSFeed& subTable() {return msSubTable_p;}
+
+  private:
+
+    const TableExprNode* setTEN(TableExprNode& condition, 
+                                BaselineListType baselineType=CrossOnly,
+                                Bool negate=False);
+    void makeFeedPairList(const Vector<Int>&f1, const Vector<Int>&f2, Matrix<Int>&fp, 
+			  BaselineListType baselineType=CrossOnly,
+			  Bool negate=False);
+    void makeFeedList(Vector<Int>& feedList,const Vector<Int>& thisList,
+                         Bool negate=False);
+    Bool addFeedPair(const Matrix<Int>& feedpairlist,
+                     const Int feed1, const Int feed2, 
+ 		     BaselineListType baselineType=CrossOnly);
+
+    //# Data members.
+  public:
+    static MSFeedParse* thisMSFParser;
+    static MSSelectionErrorHandler* thisMSFErrorHandler;
+    static void cleanupErrorHandler() {if (thisMSFErrorHandler) delete thisMSFErrorHandler;thisMSFErrorHandler=0x0;}
+  private:
+    TableExprNode node_p;
+    const String colName1, colName2;
+    Vector<Int> feed1List, feed2List;
+    Matrix<Int> feedPairList;
+    MSFeed msSubTable_p;
+    static TableExprNode column1AsTEN_p,column2AsTEN_p;
+  };
+  
+} //# NAMESPACE CASACORE - END
+
+#endif

--- a/ms/MSSel/MSSelection.cc
+++ b/ms/MSSel/MSSelection.cc
@@ -38,6 +38,7 @@
 #include <casacore/ms/MSSel/MSPolnGram.h>
 #include <casacore/ms/MSSel/MSStateGram.h>
 #include <casacore/ms/MSSel/MSObservationGram.h>
+#include <casacore/ms/MSSel/MSFeedGram.h>
 #include <casacore/ms/MeasurementSets/MSRange.h>
 #include <casacore/tables/TaQL/TableParse.h>
 #include <casacore/tables/TaQL/RecordGram.h>
@@ -72,8 +73,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     fullTEN_p(),ms_p(NULL),  antennaExpr_p(""), fieldExpr_p(""),
     spwExpr_p(""), scanExpr_p(""), arrayExpr_p(""), timeExpr_p(""), uvDistExpr_p(""),
     polnExpr_p(""), taqlExpr_p(""), stateExpr_p(""), observationExpr_p(""),
-    exprOrder_p(MAX_EXPR, NO_EXPR), antenna1IDs_p(), antenna2IDs_p(), fieldIDs_p(), 
-    spwIDs_p(), scanIDs_p(), arrayIDs_p(), ddIDs_p(), observationIDs_p(), baselineIDs_p(),
+    feedExpr_p(""), exprOrder_p(MAX_EXPR, NO_EXPR), antenna1IDs_p(), antenna2IDs_p(),
+    fieldIDs_p(), spwIDs_p(), scanIDs_p(), arrayIDs_p(), ddIDs_p(), observationIDs_p(),
+    feed1IDs_p(), feed2IDs_p(), baselineIDs_p(), feedPairIDs_p(),
     selectedTimesList_p(), selectedUVRange_p(),selectedUVUnits_p(),
     selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0)),
     maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), 
@@ -101,14 +103,15 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			   const String& scanExpr,
 			   const String& arrayExpr,
 			   const String& stateExpr,
-			   const String& observationExpr):
+			   const String& observationExpr,
+			   const String& feedExpr):
     fullTEN_p(), ms_p(&ms), antennaExpr_p(""), fieldExpr_p(""),
     spwExpr_p(""), scanExpr_p(""), arrayExpr_p(""), timeExpr_p(""), uvDistExpr_p(""),
     polnExpr_p(""),taqlExpr_p(""), stateExpr_p(""), observationExpr_p(""),
-    exprOrder_p(MAX_EXPR, NO_EXPR), antenna1IDs_p(), antenna2IDs_p(), fieldIDs_p(), 
-    spwIDs_p(), scanIDs_p(),ddIDs_p(),baselineIDs_p(), selectedTimesList_p(),
-    selectedUVRange_p(),selectedUVUnits_p(),selectedPolMap_p(Vector<Int>(0)),
-    selectedSetupMap_p(Vector<Vector<Int> >(0)),
+    feedExpr_p(""), exprOrder_p(MAX_EXPR, NO_EXPR), antenna1IDs_p(), antenna2IDs_p(),
+    fieldIDs_p(), spwIDs_p(), scanIDs_p(),ddIDs_p(),baselineIDs_p(), feedPairIDs_p(),
+    selectedTimesList_p(), selectedUVRange_p(),selectedUVUnits_p(),
+    selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0)),
     maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), 
     isMS_p(True), toTENCalled_p(False)
   {
@@ -134,7 +137,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	  scanExpr,
 	  arrayExpr,
 	  stateExpr,
-	  observationExpr);
+	  observationExpr,
+      feedExpr);
   }
   
   
@@ -152,7 +156,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			  const String& scanExpr,
 			  const String& arrayExpr,
 			  const String& stateExpr,
-			  const String& observationExpr)
+			  const String& observationExpr,
+			  const String& feedExpr)
   {
     ms_p=msLike.asMS();
     isMS_p=msLike.isMS();
@@ -174,6 +179,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     setTaQLExpr(taqlExpr);
     setStateExpr(stateExpr);
     setObservationExpr(observationExpr);
+    setFeedExpr(feedExpr);
     //clearErrorHandlers();
 
     if (mode==PARSE_NOW)
@@ -191,7 +197,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			  const String& scanExpr,
 			  const String& arrayExpr,
 			  const String& stateExpr,
-			  const String& observationExpr)
+			  const String& observationExpr,
+			  const String& feedExpr)
   {
     //
     // Do not initialize the private string variables directly. Instead
@@ -212,6 +219,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     setTaQLExpr(taqlExpr);
     setStateExpr(stateExpr);
     setObservationExpr(observationExpr);
+    setFeedExpr(feedExpr);
 
     if (mode==PARSE_NOW)
       fullTEN_p = toTableExprNode(ms_p);
@@ -231,9 +239,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   MSSelection::MSSelection(const Record& selectionItem) : 
     antennaExpr_p(""), fieldExpr_p(""), spwExpr_p(""), scanExpr_p(""), arrayExpr_p(""), 
     timeExpr_p(""), uvDistExpr_p(""), polnExpr_p(""),taqlExpr_p(""),stateExpr_p(""), 
-    observationExpr_p(""), antenna1IDs_p(), antenna2IDs_p(), fieldIDs_p(), spwIDs_p(),
-    ddIDs_p(),baselineIDs_p(), selectedPolMap_p(Vector<Int>(0)), 
-    selectedSetupMap_p(Vector<Vector<Int> >(0))
+    observationExpr_p(""), feedExpr_p(""),
+    antenna1IDs_p(), antenna2IDs_p(), fieldIDs_p(), spwIDs_p(), ddIDs_p(),
+    feed1IDs_p(), feed2IDs_p(), baselineIDs_p(), feedPairIDs_p(),
+    selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0))
     
   {
     // Construct from a record representing a selection item
@@ -277,6 +286,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       this->taqlExpr_p    = other.taqlExpr_p;
       this->polnExpr_p    = other.polnExpr_p;
       this->stateExpr_p   = other.stateExpr_p;
+      this->feedExpr_p    = other.feedExpr_p;
       this->exprOrder_p   = other.exprOrder_p;
     }
   }
@@ -302,6 +312,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       this->taqlExpr_p    = other.taqlExpr_p;
       this->polnExpr_p    = other.polnExpr_p;
       this->stateExpr_p   = other.stateExpr_p;
+      this->feedExpr_p    = other.feedExpr_p;
       this->exprOrder_p   = other.exprOrder_p;
       this->isMS_p        = other.isMS_p;
     }
@@ -382,6 +393,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     MSAntennaParse::cleanupErrorHandler();
     MSStateParse::cleanupErrorHandler();
     MSSpwParse::cleanupErrorHandler();
+    MSFeedParse::cleanupErrorHandler();
   }
   
   void MSSelection::deleteNodes()
@@ -458,6 +470,17 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    MSAntennaParse::thisMSAErrorHandler->reset();
 	  break;
 	}
+      case FEED_EXPR:
+	{
+	  if (MSFeedParse::thisMSFErrorHandler == NULL)
+	    {
+	      MSSelectionErrorHandler* tt = new MSSelectionErrorHandler();
+	      setErrorHandler(FEED_EXPR, tt, True);
+	    }
+	  else
+	    MSFeedParse::thisMSFErrorHandler->reset();
+	  break;
+	}
       case STATE_EXPR:
 	{
 	  if (MSStateParse::thisMSSErrorHandler == NULL)
@@ -519,6 +542,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     initErrorHandler(ANTENNA_EXPR);
     initErrorHandler(STATE_EXPR);
     initErrorHandler(SPW_EXPR);
+    initErrorHandler(FEED_EXPR);
 
     try
       {
@@ -601,6 +625,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		  arrayIDs_p.resize(0);
 		  if(arrayExpr_p != "")
 		    node = msArrayGramParseCommand(ms, arrayExpr_p, arrayIDs_p, maxArray_p);
+		  break;
+		}
+	      case FEED_EXPR:
+		{
+		  if(feedExpr_p != "")
+		    feed1IDs_p.resize(0);
+            feed2IDs_p.resize(0);
+		    feedPairIDs_p.resize(0,2);
+		    node = msFeedGramParseCommand(ms, feedExpr_p, feed1IDs_p, feed2IDs_p,
+                    feedPairIDs_p);
 		  break;
 		}
 	      case UVDIST_EXPR:
@@ -750,6 +784,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    }
 	  break;
 	}
+      case FEED_EXPR:
+	{
+	  if (overRide)
+	    {
+	      if (mssEH == NULL) MSFeedParse::thisMSFErrorHandler = mssEH;
+	      else MSFeedParse::thisMSFErrorHandler = mssEH->clone();
+	    }
+	  else if (MSFeedParse::thisMSFErrorHandler == NULL)
+	    {
+	      if (mssEH == NULL) MSFeedParse::thisMSFErrorHandler = mssEH;
+	      else MSFeedParse::thisMSFErrorHandler = mssEH->clone();
+	    }
+	  break;
+	}
       case STATE_EXPR:
 	{
 	  if (overRide)
@@ -870,6 +918,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     setErrorHandler(STATE_EXPR,NULL,True);
     setErrorHandler(SPW_EXPR,NULL,True);
     setErrorHandler(ANTENNA_EXPR,NULL,True);
+    setErrorHandler(FEED_EXPR,NULL,True);
   }
   //----------------------------------------------------------------------------
   void MSSelection::clear(const MSExprType type)
@@ -951,7 +1000,27 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     
     return False;
   }
+
+  //----------------------------------------------------------------------------
   
+  Bool MSSelection::setFeedExpr(const String& feedExpr)
+  {
+    // Set the feed
+    // Input:
+    //    feedExpr       const String&  Supplementary feed expression
+    // Output to private data:
+    //    feedExpr_p     String         Supplementary feed expression
+    //
+    if(setOrder(FEED_EXPR))
+      {
+	feedExpr_p = feedExpr;
+	resetTEN();
+	return True;
+      }
+    
+    return False;
+  }
+
   //----------------------------------------------------------------------------
   
   Bool MSSelection::setFieldExpr(const String& fieldExpr)

--- a/ms/MSSel/MSSelection.h
+++ b/ms/MSSel/MSSelection.h
@@ -508,14 +508,44 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	       const String& scanExpr        = "",
 	       const String& arrayExpr       = "",
 	       const String& stateExpr       = "",
+	       const String& observationExpr = "");
+
+    // Add feedExpr; keep old signature for backwards compatibility
+    void reset2(const MeasurementSet& ms,
+	       const MSSMode& mode           = PARSE_NOW,
+	       const String& timeExpr        = "",
+	       const String& antennaExpr     = "",
+	       const String& fieldExpr       = "",
+	       const String& spwExpr         = "",
+	       const String& uvDistExpr      = "",
+	       const String& taqlExpr        = "",
+	       const String& polnExpr        = "",
+	       const String& scanExpr        = "",
+	       const String& arrayExpr       = "",
+	       const String& stateExpr       = "",
 	       const String& observationExpr = "",
 	       const String& feedExpr        = "");
 
-    // This version of reset() works with generic MSSeletableTable
+    // This version of reset() works with generic MSSelectableTable
     // object.  Accessing the services of the MSSelection module via
     // this interface is recommended over the version of reset() that
     // uses MeasurementSet.
     void reset(MSSelectableTable& msLike,
+	       const MSSMode& mode           = PARSE_NOW,
+	       const String& timeExpr        = "",
+	       const String& antennaExpr     = "",
+	       const String& fieldExpr       = "",
+	       const String& spwExpr         = "",
+	       const String& uvDistExpr      = "",
+	       const String& taqlExpr        = "",
+	       const String& polnExpr        = "",
+	       const String& scanExpr        = "",
+	       const String& arrayExpr       = "",
+	       const String& stateExpr       = "",
+	       const String& observationExpr = "");
+
+    // Add feedExpr; keep old signature for backwards compatibility
+    void reset2(MSSelectableTable& msLike,
 	       const MSSMode& mode           = PARSE_NOW,
 	       const String& timeExpr        = "",
 	       const String& antennaExpr     = "",

--- a/ms/MSSel/MSSelection.h
+++ b/ms/MSSel/MSSelection.h
@@ -130,6 +130,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		     POLN_EXPR,
 		     STATE_EXPR,
 		     OBSERVATION_EXPR,
+		     FEED_EXPR,
 		     TAQL_EXPR,
 		     MAX_EXPR = TAQL_EXPR};
     enum MSSMode {PARSE_NOW=0, PARSE_LATE};
@@ -154,7 +155,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		const String& scanExpr="",
 		const String& arrayExpr="",
 		const String& stateExpr="",
-		const String& observationExpr="");
+		const String& observationExpr="",
+		const String& feedExpr="");
     
     // Construct from a record representing a selection item at the
     // CLI or user interface level.  This is functionally same as the
@@ -186,7 +188,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Bool setTaQLExpr(const String& taqlExpr);
     Bool setPolnExpr(const String& polnExpr);
     Bool setStateExpr(const String& stateExpr);
-    Bool setObservationExpr(const String& obervationExpr);
+    Bool setObservationExpr(const String& observationExpr);
+    Bool setFeedExpr(const String& feedExpr);
 
     // Accessor for the various selection expressions as strings.
     const String getExpr(const MSExprType type=NO_EXPR);
@@ -204,6 +207,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     inline Vector<Int> getObservationList(const MeasurementSet* ms=NULL) 
     {getTEN(ms); return observationIDs_p;}
 
+    // Accessor for the list of the selected feed1 IDs.
+    inline Vector<Int> getFeed1List(const MeasurementSet* ms=NULL) 
+    {getTEN(ms); return feed1IDs_p;}
+
+    // Accessor for the list of the selected feed2 IDs.
+    inline Vector<Int> getFeed2List(const MeasurementSet* ms=NULL) 
+    {getTEN(ms); return feed2IDs_p;}
+
+    // Similar to baselines for antennas
+    inline Matrix<Int> getFeedPairList(const MeasurementSet* ms=NULL) 
+    {getTEN(ms); return feedPairIDs_p;}
+    
     // Accessor for the list of selected sub-array IDs.
     inline Vector<Int> getSubArrayList(const MeasurementSet* ms=NULL) 
     {getTEN(ms); return arrayIDs_p;}
@@ -493,7 +508,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	       const String& scanExpr        = "",
 	       const String& arrayExpr       = "",
 	       const String& stateExpr       = "",
-	       const String& observationExpr = "");
+	       const String& observationExpr = "",
+	       const String& feedExpr        = "");
 
     // This version of reset() works with generic MSSeletableTable
     // object.  Accessing the services of the MSSelection module via
@@ -511,7 +527,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	       const String& scanExpr        = "",
 	       const String& arrayExpr       = "",
 	       const String& stateExpr       = "",
-	       const String& observationExpr = "");
+	       const String& observationExpr = "",
+	       const String& feedExpr        = "");
 
     // Set the maximum value acceptable for SCAN, OBSERVATION or
     // SUB-ARRAY IDs. The main-table columns for these do not refere
@@ -571,12 +588,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     String taqlExpr_p;
     String stateExpr_p;
     String observationExpr_p;
+    String feedExpr_p;
     // Priority
     Vector<Int> exprOrder_p;
     Vector<Int> antenna1IDs_p,antenna2IDs_p,fieldIDs_p, spwIDs_p, scanIDs_p, arrayIDs_p,
-      ddIDs_p,stateObsModeIDs_p, observationIDs_p, spwDDIDs_p;
+      ddIDs_p,stateObsModeIDs_p, observationIDs_p, spwDDIDs_p, feed1IDs_p, feed2IDs_p;
     Matrix<Int> chanIDs_p;
     Matrix<Int> baselineIDs_p;
+    Matrix<Int> feedPairIDs_p;
     Matrix<Double> selectedTimesList_p;
     Matrix<Double> selectedUVRange_p;
     Vector<Bool> selectedUVUnits_p;

--- a/ms/MSSel/MSSelectionError.cc
+++ b/ms/MSSel/MSSelectionError.cc
@@ -241,5 +241,20 @@ MSSelectionObservationParseError::MSSelectionObservationParseError (const String
 MSSelectionObservationParseError::~MSSelectionObservationParseError () throw()
 {}
 
+//
+//-----------------------------------------------------------------------------------
+//
+MSSelectionFeedError::MSSelectionFeedError (const String& str,Category c)
+: MSSelectionError(str,c)
+{}
+MSSelectionFeedError::~MSSelectionFeedError () throw()
+{}
+
+MSSelectionFeedParseError::MSSelectionFeedParseError (const String& str,Category c)
+: MSSelectionFeedError(str,c)
+{}
+MSSelectionFeedParseError::~MSSelectionFeedParseError () throw()
+{}
+
 } //# NAMESPACE CASACORE - END
 

--- a/ms/MSSel/MSSelectionError.h
+++ b/ms/MSSel/MSSelectionError.h
@@ -295,6 +295,22 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   //
   //-------------------------------------------------------------------
   //  
+  class MSSelectionFeedError : public MSSelectionError {
+  public:
+    // Add given message to string "MSSelection time error: ".
+    MSSelectionFeedError (const String& message,Category c=GENERAL);
+    ~MSSelectionFeedError () throw();
+  };
+  
+  class MSSelectionFeedParseError: public MSSelectionFeedError {
+  public:
+    MSSelectionFeedParseError (const String& message,Category c=GENERAL);
+    ~MSSelectionFeedParseError () throw();
+  };
+
+  //
+  //-------------------------------------------------------------------
+  //  
   String constructMessage(const Int pos, const String& command);
 } //# NAMESPACE CASACORE - END
 

--- a/ms/MSSel/MSSelectionTools.cc
+++ b/ms/MSSel/MSSelectionTools.cc
@@ -29,6 +29,7 @@
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/ms/MSSel/MSSelection.h>
+#include <casacore/ms/MSSel/MSSelectionTools.h>
 #include <string.h>
 #include <iostream>
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -99,6 +100,29 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		  MSSelection *mymss
 		  )
   {
+      return mssSetData2(ms, selectedMS, outMSName, timeExpr, antennaExpr, fieldExpr,
+              spwExpr, uvDistExpr, taQLExpr, polnExpr, scanExpr, arrayExpr,
+              stateExpr, obsExpr, "", mymss);
+  }
+
+  Bool mssSetData2(const MeasurementSet& ms, 
+		  MeasurementSet& selectedMS,
+		  const String& outMSName,
+		  const String& timeExpr,
+		  const String& antennaExpr,
+		  const String& fieldExpr,
+		  const String& spwExpr,
+		  const String& uvDistExpr,
+		  const String& taQLExpr,
+		  const String& polnExpr,
+		  const String& scanExpr,
+		  const String& arrayExpr,
+		  const String& stateExpr,
+		  const String& obsExpr,
+		  const String& feedExpr,
+		  MSSelection *mymss
+		  )
+  {
     //
     // Parse the various expressions and produce the accmuluated TEN
     // internally.
@@ -113,7 +137,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	mss->reset(ms,MSSelection::PARSE_NOW,
 		   timeExpr,antennaExpr,fieldExpr,spwExpr,
 		   uvDistExpr,taQLExpr,polnExpr,scanExpr,arrayExpr,
-		   stateExpr, obsExpr);
+		   stateExpr, obsExpr, feedExpr);
 	//
 	// Apply the internal accumulated TEN to the MS and produce the
 	// selected MS.  
@@ -132,6 +156,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (mymss==NULL) delete mss;
     return rstat;
   }
+
   //
   //----------------------------------------------------------------------------
   //
@@ -155,6 +180,34 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		  MSSelection *mymss
 		  )
   {
+      return mssSetData2(ms, selectedMS, chanSlices, corrSlices, outMSName, 
+              timeExpr, antennaExpr, fieldExpr, spwExpr, uvDistExpr,
+              taQLExpr, polnExpr, scanExpr, arrayExpr, stateExpr, 
+              obsExpr, "", defaultChanStep, mymss);
+  }
+
+
+  Bool mssSetData2(const MeasurementSet& ms, 
+		  MeasurementSet& selectedMS,
+		  Vector<Vector<Slice> >& chanSlices,
+		  Vector<Vector<Slice> >& corrSlices,
+		  const String& outMSName,
+		  const String& timeExpr,
+		  const String& antennaExpr,
+		  const String& fieldExpr,
+		  const String& spwExpr,
+		  const String& uvDistExpr,
+		  const String& taQLExpr,
+		  const String& polnExpr,
+		  const String& scanExpr,
+		  const String& arrayExpr,
+		  const String& stateExpr,
+		  const String& obsExpr,
+		  const String& feedExpr,
+		  const Int defaultChanStep,
+		  MSSelection *mymss
+		  )
+  {
     //
     // Parse the various expressions and produce the accmuluated TEN
     // internally.
@@ -168,7 +221,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	mss->reset(ms,MSSelection::PARSE_NOW,
 		   timeExpr,antennaExpr,fieldExpr,spwExpr,
 		   uvDistExpr,taQLExpr,polnExpr,scanExpr,arrayExpr,
-		   stateExpr, obsExpr);
+		   stateExpr, obsExpr, feedExpr);
 	//
 	// Apply the internal accumulated TEN to the MS and produce the
 	// selected MS.  
@@ -190,6 +243,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (mymss == NULL) delete mss;
     return rstat;
   }
+
   //
   //----------------------------------------------------------------------------
   //
@@ -223,6 +277,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Vector<Int> spwDDIDList=thisSelection.getSPWDDIDList();
     Vector<Int> stateIDList=thisSelection.getStateObsModeList();
     Vector<Int> observationIDList=thisSelection.getObservationList();
+    Vector<Int> feed1List=thisSelection.getFeed1List();
+    Vector<Int> feed2List=thisSelection.getFeed2List();
+    Vector<Int> feedPairList=thisSelection.getFeedPairList();
     OrderedMap<Int, Vector<Int > > polMap=thisSelection.getPolMap();
     OrderedMap<Int, Vector<Vector<Int> > > corrMap=thisSelection.getCorrMap();
     Vector<Int> allDDIDList;
@@ -242,6 +299,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     retval.define("dd",allDDIDList);
     retval.define("stateid",stateIDList);
     retval.define("observationid",observationIDList);
+    retval.define("feed1",feed1List);
+    retval.define("feed2",feed2List);
+    retval.define("feedpairs",feedPairList);
 
     return retval;
   }

--- a/ms/MSSel/MSSelectionTools.cc
+++ b/ms/MSSel/MSSelectionTools.cc
@@ -134,7 +134,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     
     try
       {
-	mss->reset(ms,MSSelection::PARSE_NOW,
+	mss->reset2(ms,MSSelection::PARSE_NOW,
 		   timeExpr,antennaExpr,fieldExpr,spwExpr,
 		   uvDistExpr,taQLExpr,polnExpr,scanExpr,arrayExpr,
 		   stateExpr, obsExpr, feedExpr);
@@ -218,7 +218,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
     try
       {
-	mss->reset(ms,MSSelection::PARSE_NOW,
+	mss->reset2(ms,MSSelection::PARSE_NOW,
 		   timeExpr,antennaExpr,fieldExpr,spwExpr,
 		   uvDistExpr,taQLExpr,polnExpr,scanExpr,arrayExpr,
 		   stateExpr, obsExpr, feedExpr);

--- a/ms/MSSel/MSSelectionTools.h
+++ b/ms/MSSel/MSSelectionTools.h
@@ -55,6 +55,27 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		  const String& obsExpr="",
 		  MSSelection *mss=NULL
 		  );
+
+  // Added feedExpr
+  Bool mssSetData2(const MeasurementSet& ms, 
+		  MeasurementSet& selectedMS,
+		  const String& outMSName="",
+		  const String& timeExpr="",
+		  const String& antennaExpr="",
+		  const String& fieldExpr="",
+		  const String& spwExpr="",
+		  const String& uvDistExpr="",
+		  const String& taQLExpr="",
+		  const String& polnExpr="",
+		  const String& scanExpr="",
+		  const String& arrayExpr="",
+		  const String& stateExpr="",
+		  const String& obsExpr="",
+		  const String& feedExpr="",
+		  MSSelection *mss=NULL
+		  );
+
+
   // Collective selection also returning in-row (corr/chan) slices
   Bool mssSetData(const MeasurementSet& ms, 
 		  MeasurementSet& selectedMS,
@@ -75,7 +96,29 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		  const Int defaultChanStep=1,
 		  MSSelection *mss=NULL
 		  );
-  
+
+  // Added feedExpr
+  Bool mssSetData2(const MeasurementSet& ms, 
+		  MeasurementSet& selectedMS,
+		  Vector<Vector<Slice> >& chanSlices,
+		  Vector<Vector<Slice> >& corrSlices,
+		  const String& outMSName="",
+		  const String& timeExpr="",
+		  const String& antennaExpr="",
+		  const String& fieldExpr="",
+		  const String& spwExpr="",
+		  const String& uvDistExpr="",
+		  const String& taQLExpr="",
+		  const String& polnExpr="",
+		  const String& scanExpr="",
+		  const String& arrayExpr="",
+		  const String& stateExpr="",
+		  const String& obsExpr="",
+		  const String& feedExpr="",
+		  const Int defaultChanStep=1,
+		  MSSelection *mss=NULL
+		  );
+
   Bool getSelectedTable(Table& selectedTab,     const Table& baseTab,
 			TableExprNode& fullTEN,	const String& outName);
 

--- a/ms/MSSel/test/CMakeLists.txt
+++ b/ms/MSSel/test/CMakeLists.txt
@@ -3,6 +3,7 @@ tMSAntennaGram
 tMSAntennaGram2
 tMSAntennaGram3
 tMSCorrGram
+tMSFeedGram
 tMSFieldGram
 tMSScanGram
 tMSSpwGram

--- a/ms/MSSel/test/tMSFeedGram.cc
+++ b/ms/MSSel/test/tMSFeedGram.cc
@@ -1,0 +1,106 @@
+//# Copyright (C) 1995,1996,1997,1999,2001,2002,2005
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This program is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU General Public License as published by the Free
+//# Software Foundation; either version 2 of the License, or (at your option)
+//# any later version.
+//#
+//# This program is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+//# more details.
+//#
+//# You should have received a copy of the GNU General Public License along
+//# with this program; if not, write to the Free Software Foundation, Inc.,
+//# 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/casa/aips.h>
+#include <casacore/casa/Exceptions/Error.h>
+#include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/iostream.h>
+
+
+#include <casacore/tables/TaQL/ExprNode.h>
+#include <casacore/tables/Tables/RefRows.h>
+#include <casacore/ms/MeasurementSets/MSColumns.h>
+#include <casacore/casa/Arrays/Matrix.h>
+#include <casacore/casa/Arrays/Cube.h>
+#include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/Arrays/ArrayUtil.h>
+#include <casacore/casa/Logging/LogIO.h>
+#include <casacore/casa/OS/File.h>
+#include <casacore/casa/Containers/Record.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/IO/AipsIO.h>
+#include <casacore/casa/IO/ByteIO.h>
+
+
+#include <casacore/ms/MSSel/MSFeedGram.h>
+#include <casacore/ms/MeasurementSets/MeasurementSet.h>
+#include <casacore/ms/MSSel/MSSelection.h>
+#include <casacore/tables/Tables/Table.h>
+#include <casacore/tables/Tables/TableDesc.h>
+#include <casacore/tables/Tables/TableRecord.h>
+
+#include <casacore/casa/iostream.h>
+
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/Inputs.h>
+
+#include <casacore/casa/namespace.h>
+
+
+int main(int argc, const char* argv[])
+{
+  try {
+    if(argc < 3) {
+      cout << "Please input ms file and selection string on command line " << endl;
+      return 3;
+    } 
+    const String msName = argv[1];
+    cout << "ms file is  " << msName << endl;
+    MeasurementSet ms(msName);
+    MSSelection mss;
+    mss.setFeedExpr(String(argv[2]));
+    cout << "feed selection is " << String(argv[2]) << endl;
+    TableExprNode node = mss.toTableExprNode(&ms);
+
+    cout << "Original table has rows " << ms.nrow() << endl;
+    Vector<Int> selectedFeed1, selectedFeed2;
+    Matrix<Int> selectedFeedPairs;
+    node = msFeedGramParseCommand(&ms, argv[2],
+                                     selectedFeed1, selectedFeed2,
+                                     selectedFeedPairs);
+    if(node.isNull()) {
+      cout << "NULL node " << endl;
+      return 0;
+    }
+    Table tablesel(ms.tableName(), Table::Update);
+    MeasurementSet* mssel = new MeasurementSet(tablesel(node, node.nrow() ));
+    mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::New);
+    mssel->flush();
+    if(mssel->nrow()==0) {
+      cout << "Check your input, No data selected" << endl;
+    }
+    else {
+      cout << "Selected table has nrows " << mssel->nrow() << endl;
+      cout << "Selected feed1 = " << selectedFeed1 << endl
+           << "Selected feed2 = " << selectedFeed2 << endl;
+    }
+    delete mssel;
+  } catch (AipsError& x) {
+    cout << "ERROR: " << x.getMesg() << endl;
+    return 1;
+  } 
+  return 0;
+}

--- a/ms/MSSel/test/tMSSelection.cc
+++ b/ms/MSSel/test/tMSSelection.cc
@@ -210,10 +210,11 @@ int main(int argc, char **argv)
 	    // defined error handlers having shorter life-cycle than
 	    // the MSSelection object.
 	    //
-	    MSSelectionLogError mssLEA,mssLES, mssLESpw;
+	    MSSelectionLogError mssLEA,mssLES, mssLESpw, mssLEF;
 	    msSelection.setErrorHandler(MSSelection::ANTENNA_EXPR, &mssLEA,True);
 	    msSelection.setErrorHandler(MSSelection::STATE_EXPR, &mssLES,True);
 	    msSelection.setErrorHandler(MSSelection::SPW_EXPR, &mssLESpw,True);
+	    msSelection.setErrorHandler(MSSelection::FEED_EXPR, &mssLEF,True);
 	  }
 
     	// msSelection.reset(ms,MSSelection::PARSE_NOW,


### PR DESCRIPTION
Added code to enable MS feed selection in MSSelection including flex scanner and bison parser files.  Feed selection is a simplified form of antenna selection, as feeds are indices only and not names and there are no stations to select.