### PR TITLE
Support retrieving intents for a given subscan

### DIFF
--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -141,6 +141,8 @@ public:
 
 	std::set<String> getIntentsForScan(const ScanKey& scan) const;
 
+	std::set<String> getIntentsForSubScan(const SubScanKey& subScan) const;
+
 	// get all intents, in no particular (nor guaranteed) order.
 	std::set<String> getIntents() const;
 
@@ -559,14 +561,14 @@ private:
 	mutable vector<uInt> _dataDescIDToSpwMap, _dataDescIDToPolIDMap;
 	std::map<Int, std::set<uInt> > _fieldToSpwMap;
 	mutable std::map<ScanKey, std::set<Int> > _scanToStatesMap, _scanToFieldsMap, _scanToAntennasMap;
-	mutable std::map<Int, std::set<Int> >	_fieldToStatesMap, _stateToFieldsMap, _sourceToFieldsMap /*,
-		_arrayToScansMap, _scanToAntennasMap */;
+	mutable std::map<Int, std::set<Int> >	_fieldToStatesMap, _stateToFieldsMap, _sourceToFieldsMap;
 	mutable std::map<std::pair<uInt, uInt>, uInt> _spwPolIDToDataDescIDMap;
 	mutable std::map<String, uInt> _antennaNameToIDMap;
 	mutable std::map<SubScanKey, SubScanProperties> _subScanProperties;
 
 	mutable std::map<String, std::set<Int> > _intentToFieldIDMap;
 	mutable std::map<String, std::set<ScanKey> > _intentToScansMap;
+	mutable std::map<String, std::set<SubScanKey> > _intentToSubScansMap;
 	mutable std::map<ScanKey, std::pair<Double, Double> > _scanToTimeRangeMap;
 	mutable std::map<std::pair<ScanKey, uInt>, Double> _scanSpwToIntervalMap;
 	mutable std::map<std::pair<ScanKey, uInt>, std::set<Double> > _scanSpwToTimesMap;
@@ -580,6 +582,7 @@ private:
 
 	mutable SHARED_PTR<vector<uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
  	mutable std::map<ScanKey, std::set<String> > _scanToIntentsMap;
+ 	mutable std::map<SubScanKey, std::set<String> > _subScanToIntentsMap;
 	mutable vector<std::set<String> > _stateToIntentsMap, _spwToIntentsMap, _fieldToIntentsMap;
 	mutable vector<SpwProperties> _spwInfo;
 	mutable vector<std::set<Int> > _spwToFieldIDsMap, _obsToArraysMap;
@@ -841,6 +844,11 @@ private:
 	vector<String> _getStationNames();
 
 	std::map<SubScanKey, SubScanProperties> _getSubScanProperties() const;
+
+	void _getSubScansAndIntentsMaps(
+		std::map<SubScanKey, std::set<String> >& subScanToIntentsMap,
+		std::map<String, std::set<SubScanKey> >& intentToSubScansMap
+	) const;
 
 	std::set<SubScanKey> _getSubScanKeys() const;
 

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -355,8 +355,6 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
 		uInt subsetscan = 0;
 		Int lastscan = 0;
 		for (; siter != send; ++siter) {
-			// ms table at this scan
-			// Table t(stiter.table());
 			MSMetaData::SubScanProperties props = _msmd->getSubScanProperties(*siter);
 			Int nrow = props.nrows;
 
@@ -426,7 +424,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
 					os << intToScanMap[*spwiter];
 				}
 				os << "] ";
-				std::set<String> intents = _msmd->getIntentsForScan(scan);
+				std::set<String> intents = _msmd->getIntentsForSubScan(*siter);
 				if (! intents.empty()) {
 					os << intents;
 				}

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -141,8 +141,8 @@ void testIt(MSMetaData& md) {
 	scanKey.obsID = 0;
 	scanKey.arrayID = 0;
 	for (
-			std::set<Int>::const_iterator scanNum = scans.begin();
-			scanNum!=scans.end(); ++scanNum
+		std::set<Int>::const_iterator scanNum = scans.begin();
+		scanNum!=scans.end(); ++scanNum
 	) {
 		scanKey.scan = *scanNum;
 		std::set<String> intents = md.getIntentsForScan(scanKey);
@@ -2174,6 +2174,90 @@ void testIt(MSMetaData& md) {
             	else {
             		AlwaysAssert(keys.find(expec) != keys.end(), AipsError);
             	}
+        	}
+        }
+        {
+        	cout << "*** test getIntentsForSubScan()" << endl;
+        	ArrayKey arrayKey;
+        	arrayKey.obsID = 0;
+        	arrayKey.arrayID = 0;
+        	std::set<SubScanKey> sskeys = md.getSubScanKeys(arrayKey);
+        	std::set<SubScanKey>::const_iterator ssiter = sskeys.begin();
+        	std::set<SubScanKey>::const_iterator ssend = sskeys.end();
+
+        	for (; ssiter!=ssend; ++ssiter) {
+        		std::set<String> intents = md.getIntentsForSubScan(*ssiter);
+        		std::set<String> exp;
+        		Int scan = ssiter->scan;
+        		if (scan == 1 || scan == 5 || scan == 8) {
+        			String mystr[] = {
+        				"CALIBRATE_POINTING#ON_SOURCE", "CALIBRATE_WVR#ON_SOURCE"
+        			};
+        			exp.insert(mystr, mystr+2);
+        		}
+        		else if (scan == 2) {
+        			String mystr[] = {
+        				"CALIBRATE_SIDEBAND_RATIO#OFF_SOURCE",
+						"CALIBRATE_SIDEBAND_RATIO#ON_SOURCE",
+						"CALIBRATE_WVR#OFF_SOURCE",
+						"CALIBRATE_WVR#ON_SOURCE"
+        			};
+        			exp.insert(mystr, mystr+4);
+        		}
+        		else if (
+        			scan == 3 || scan == 6
+					|| scan == 9 || scan == 11
+					|| scan == 13 || scan == 15
+					|| scan == 17 || scan == 19
+					|| scan == 22 || scan == 24
+					|| scan == 26 || scan == 29
+					|| scan == 31
+        		) {
+        			String mystr[] = {
+        				"CALIBRATE_ATMOSPHERE#OFF_SOURCE",
+						"CALIBRATE_ATMOSPHERE#ON_SOURCE",
+						"CALIBRATE_WVR#OFF_SOURCE",
+						"CALIBRATE_WVR#ON_SOURCE"
+        			};
+        			exp.insert(mystr, mystr+4);
+        		}
+        		else if (scan == 4) {
+        			String mystr[] = {
+        				"CALIBRATE_BANDPASS#ON_SOURCE",
+						"CALIBRATE_PHASE#ON_SOURCE",
+						"CALIBRATE_WVR#ON_SOURCE"
+        			};
+        			exp.insert(mystr, mystr+3);
+        		}
+        		else if (scan == 7) {
+        			String mystr[] = {
+        				"CALIBRATE_AMPLI#ON_SOURCE",
+						"CALIBRATE_PHASE#ON_SOURCE",
+						"CALIBRATE_WVR#ON_SOURCE"
+        			};
+        			exp.insert(mystr, mystr+3);
+        		}
+        		else if (
+        			scan == 10 || scan == 14
+					|| scan == 18 || scan == 21
+					|| scan == 25 || scan == 28
+					|| scan == 32
+        		) {
+        			String mystr[] = {
+        				"CALIBRATE_PHASE#ON_SOURCE",
+						"CALIBRATE_WVR#ON_SOURCE"
+        			};
+        			exp.insert(mystr, mystr+2);
+        		}
+        		else if (
+        			scan == 12 || scan == 16
+					|| scan == 20 || scan == 23
+					|| scan == 27 || scan == 30
+        		) {
+        			exp.insert("OBSERVE_TARGET#ON_SOURCE");
+        		}
+        		uniqueIntents.insert(exp.begin(), exp.end());
+        		AlwaysAssert(intents == exp, AipsError);
         	}
         }
         {


### PR DESCRIPTION
Add support for retrieving intents for a specified subscan. MSSummary now logs intents for the subscan, rather than the scan.