### PR TITLE
CAS-3660 bug fix for gaps in AN table, better error handling

### DIFF
--- a/msfits/MSFits/MSFitsInput.h
+++ b/msfits/MSFits/MSFitsInput.h
@@ -402,7 +402,11 @@ private:
   Double epoch_p;
   MDirection::Types epochRef_p; // This is a direction measure reference code
                                 // determined by epoch_p, hence the name and type.
-  Int nAnt_p;
+  // unique antennas found in the visibility data
+  // NOTE These are 1-based
+  std::set<Int> _uniqueAnts;
+  // number of rows in the created MS ANTENNA table
+  Int _nAntRow;
   Int nArray_p;
   Vector<Double> receptorAngle_p;
   MFrequency::Types freqsys_p;
@@ -419,6 +423,8 @@ private:
   Matrix<Double> restFreq_p; // used for UVFITS
   Matrix<Double> sysVel_p;
   Bool _msCreated;
+
+  std::pair<Int, Int> _extractAntennas(Float baseline);
 
 };
 


### PR DESCRIPTION
Cleaned up logic in the method to write the ANTENNA table including defect fixes and better error handling and logging. Refactored common code into a method of its own. Other refactoring. Since I'm the only one working on these files now, I'm using the industry standard _ prefix for private fields and methods. I will slowly be migrating existing fields to this format as I continue refactoring this code.