### PR TITLE
CAS-8292 add option to include ac "baselines" in nBaselines() enumera…

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3325,13 +3325,18 @@ vector<QVD> MSMetaData::getAntennaOffsets() const {
 	return antennaOffsets;
 }
 
-uInt MSMetaData::nBaselines() {
-	Matrix<Bool> baselines = getUniqueBaselines();
-	for (uInt i=0; i<baselines.nrow(); ++i) {
-		// discard autocorrelation "baselines" for calculation
-		baselines(i, i) = False;
+uInt MSMetaData::nBaselines(Bool includeAutoCorrelation) {
+	Matrix<Bool> baselines = getUniqueBaselines().copy();
+	uInt ac = 0;
+	uInt nrows = baselines.nrow();
+	for (uInt i=0; i<nrows; ++i) {
+	    if (includeAutoCorrelation && baselines(i, i)) {
+	        // count autocorrelations separately from cross correlations
+	        ++ac;
+	    }
+	    baselines(i, i) = False;
 	}
-	return ntrue(baselines)/2;
+	return ntrue(baselines)/2 + ac;
 }
 
 Matrix<Bool> MSMetaData::getUniqueBaselines() {
@@ -3352,7 +3357,6 @@ Matrix<Bool> MSMetaData::getUniqueBaselines() {
 		++a1Iter;
 		++a2Iter;
 	}
-	//Matrix<Bool> uBaselines = _getUniqueBaselines(*ant1, *ant2);
 	if (_cacheUpdated(sizeof(Bool)*baselines.size())) {
 		_uniqueBaselines = baselines;
 	}

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -416,8 +416,9 @@ public:
 	Matrix<Bool> getUniqueBaselines();
 
 	// get the number of unique baselines represented in the main MS table which in theory can be
-	// less than n*(n-1)/2
-	virtual uInt nBaselines();
+	// less than n*(n-1)/2. If <src>includeAutoCorrelation</src> is True, include autocorrelation
+	// "baselines" in the enumeration.
+	virtual uInt nBaselines(Bool includeAutoCorrelation=False);
 
 	// get the effective total exposure time. This is the effective time spent collecting unflagged data.
 	Quantity getEffectiveTotalExposureTime();

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -1214,7 +1214,8 @@ void testIt(MSMetaData& md) {
 		}
 		{
 			cout << "*** test getUniqueBaselines() and nBaselines()" << endl;
-			AlwaysAssert(md.nBaselines() == 21, AipsError);
+			AlwaysAssert(md.nBaselines(False) == 21, AipsError);
+			AlwaysAssert(md.nBaselines(True) == 25, AipsError);
 		}
 		{
 			cout << "*** test getEffectiveTotalExposureTime()" << endl;


### PR DESCRIPTION
…tion

add option to include autocorrelation "baselines" in nBaselines() enumeration.

Added optional Bool parameter to this method (default is False to preserve backward compatibility). 