### PR TITLE
Fix multi-threaded MS creation

### DIFF
--- a/ms/MeasurementSets/MSTableImpl.cc
+++ b/ms/MeasurementSets/MSTableImpl.cc
@@ -110,6 +110,7 @@ void MSTableImpl::addMeasColumn(TableDesc& td, const String& column,
 }
 
 
+Mutex MSTableImpl::initialized_mutex(Mutex::Recursive);
 Bool MSTableImpl::initialized_p(False);
 
 Int MSTableImpl::mapType(const SimpleOrderedMap<Int,String>& columnMap,
@@ -568,6 +569,7 @@ Table MSTableImpl::referenceCopy(const Table& tab, const String& newTableName,
 
 void MSTableImpl::init()
 {
+    ScopedMutexLock lock(initialized_mutex);
     if (initialized_p) return;
     initialized_p = True;
     MeasurementSet::init();

--- a/ms/MeasurementSets/MSTableImpl.h
+++ b/ms/MeasurementSets/MSTableImpl.h
@@ -38,6 +38,7 @@
 #include <casacore/tables/Tables/TableDesc.h>
 #include <casacore/casa/Utilities/Fallible.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <casacore/casa/OS/Mutex.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -168,6 +169,7 @@ public:
     static void init();
     
 private:
+    static Mutex initialized_mutex;
     static Bool initialized_p;
 };
 


### PR DESCRIPTION
For WSRT-APERTIF we need to create many MS quickly. The call to `MS::requiredTableDesc()` initializes some data structures once, but is not thread-safe. Add a mutex to resolve this. We need a recursive mutex, because the underlying `MSTableImpl::init()` function calls init() functions that call the original init() function again.