### PR TITLE
CAS-7696: Turn off extended filename support if specified file exists

### DIFF
--- a/fits/FITS/blockio.cc
+++ b/fits/FITS/blockio.cc
@@ -75,7 +75,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	// using cfitsio of NASA to open fits file for writting and reading.
 	int l_status, iomode;
 	File myfile(m_filename);
-	if (myfile.exists() && myfile.isReadable()) {
+	if (myfile.isReadable()) {
 	    // the file name does not use fits extensions
 	    l_status = OPEN_DISK_FILE;
 	}

--- a/fits/FITS/blockio.cc
+++ b/fits/FITS/blockio.cc
@@ -28,6 +28,7 @@
 # include <casacore/casa/sstream.h>
 # include <casacore/fits/FITS/blockio.h>
 # include <casacore/casa/string.h>
+#include <casacore/casa/OS/File.h>
 #include <unistd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -73,7 +74,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	strcpy(m_filename,f);
 	// using cfitsio of NASA to open fits file for writting and reading.
 	int l_status, iomode;
-	l_status = 0; 
+	File myfile(m_filename);
+	if (myfile.exists() && myfile.isReadable()) {
+	    // the file name does not use fits extensions
+	    l_status = OPEN_DISK_FILE;
+	}
+	else {
+	    l_status = 0;
+	}
 	if (m_options & O_CREAT){
 	    if (fits_create_file(&m_fptr, m_filename, &l_status)){ /*create FITS file*/
 		fits_report_error(stderr, l_status); /* print error report */

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -280,14 +280,7 @@ MSFitsInput::MSFitsInput(const String& msFile, const String& fitsFile,
 
     if (_infile) {
         if (_infile->err() == FitsIO::IOERR) {
-            ostringstream oss;
-            oss << "Failed to read file " << fitsFile
-                << ". It appears the file exists and is readable, so "
-                << "you may have stumbled across a file name cfitsio does "
-                << "not like. You should try renaming your file, perhaps "
-                << "by adding a .uvfits extension and/or by removing any "
-                << "non-alphanumeric characters from the name";
-            ThrowCc(oss.str());
+            ThrowCc("Failed to read file " + fitsFile);
         }
         else if (_infile->err()) {
             _log << LogOrigin("MSFitsInput", "MSFitsInput")


### PR DESCRIPTION
Before this change, importing uvfits files with certain names would fail because FITS extended filename support was enabled. Now we first check the file name, and if that file exists, this support is disabled to allow import of those files which would otherwise fail if such support was enabled.