### PR TITLE
CAS-3883: add log message when filling source table tha it make take …

### DIFF
--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -2425,8 +2425,8 @@ void MSFitsInput::fillExtraTables() {
     // table entries for each field/spw combination
 
     if (_addSourceTable)
-        _log << LogOrigin("MSFitsInput", "fillExtraTables")
-               << LogIO::NORMAL << "Filling SOURCE table." << LogIO::POST;
+        _log << LogOrigin("MSFitsInput", __func__)
+               << LogIO::NORMAL << "Filling SOURCE table (this may take some time)." << LogIO::POST;
 
     Int nrow = _ms.nrow();
     Int nAnt = _ms.antenna().nrow();


### PR DESCRIPTION
…some time. Apparently a user had a data set for which the import of the source table took a long time, and he was confused why nothing seemed to be happening.