### PR TITLE
CAS-7927: Allow clients to choose between native and conversion layer…

### DIFF
--- a/coordinates/Coordinates/Coordinate.h
+++ b/coordinates/Coordinates/Coordinate.h
@@ -201,9 +201,12 @@ public:
     // errorMessage contains an error message. The input vector must be of length
     // <src>nPixelAxes</src> or <src>nWorldAxes</src>.  The output vector
     // is resized appropriately.
+    // if <src>useConversionFrame</src>, if the coordinate has a conversion layer frame
+    // (such as can be present in spectral and direction coordinates), it
+    // is used. Else, the native frame is used for the conversion.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-			 const Vector<Double> &pixel) const = 0;
+			 const Vector<Double> &pixel, Bool useConversionFrame=True) const = 0;
     virtual Bool toPixel(Vector<Double> &pixel, 
 			 const Vector<Double> &world) const = 0;
     // </group>

--- a/coordinates/Coordinates/CoordinateSystem.cc
+++ b/coordinates/Coordinates/CoordinateSystem.cc
@@ -1057,7 +1057,7 @@ Vector<Double> CoordinateSystem::toWorld(const IPosition& pixel) const {
 }
 
 Bool CoordinateSystem::toWorld(Vector<Double> &world, 
-			       const Vector<Double> &pixel) const
+			       const Vector<Double> &pixel, Bool useConversionFrame) const
 {
     if(pixel.nelements() != nPixelAxes()){
 	ostringstream oss;
@@ -1093,7 +1093,7 @@ Bool CoordinateSystem::toWorld(Vector<Double> &world,
 	}
 	Bool oldok = ok;
 	ok = coordinates_p[i]->toWorld(
-		       *(world_tmps_p[i]), *(pixel_tmps_p[i]));
+		       *(world_tmps_p[i]), *(pixel_tmps_p[i]), useConversionFrame);
 
 	if (!ok) {
 

--- a/coordinates/Coordinates/CoordinateSystem.h
+++ b/coordinates/Coordinates/CoordinateSystem.h
@@ -424,9 +424,12 @@ public:
     // <src>errorMessage()</src> contains an error message. 
     // The input vector must be of length <src>nPixelAxes</src> or
     // <src>nWorldAxes</src>.  The output vector  is resized appropriately.
+    // if <src>useConversionFrame</src>, if the coordinate has a conversion layer frame
+    // (such as can be present in spectral and direction coordinates), it
+    // is used. Else, the native frame is used for the conversion.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-			 const Vector<Double> &pixel) const;
+			 const Vector<Double> &pixel, Bool useConversionFrame=True) const;
     // This one throws an exception rather than returning False. After all, that's
     // what exceptions are for.
     virtual Vector<Double> toWorld(const Vector<Double> &pixel) const;

--- a/coordinates/Coordinates/DirectionCoordinate.cc
+++ b/coordinates/Coordinates/DirectionCoordinate.cc
@@ -297,7 +297,7 @@ void DirectionCoordinate::setReferenceConversion (MDirection::Types type)
 }
 
 Bool DirectionCoordinate::toWorld(Vector<Double> &world,
- 				  const Vector<Double> &pixel) const
+ 				  const Vector<Double> &pixel, Bool useConversionFrame) const
 {
 
 // To World with wcs
@@ -310,7 +310,9 @@ Bool DirectionCoordinate::toWorld(Vector<Double> &world,
 
 // Convert to specified conversion reference type
   
-       convertTo(world);  
+       if (useConversionFrame) {
+           convertTo(world);
+       }
        return True;
     } else {
        return False;

--- a/coordinates/Coordinates/DirectionCoordinate.h
+++ b/coordinates/Coordinates/DirectionCoordinate.h
@@ -326,9 +326,11 @@ public:
     // if the conversion succeeds, otherwise it returns False and method
     // errorMessage returns its error message.
     // The output vectors are appropriately resized.
+    // if <src>useConversionFrame</src>, if the coordinate has a conversion
+    // layer frame, it is used. Else, the native frame is used for the conversion.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-			 const Vector<Double> &pixel) const;
+			 const Vector<Double> &pixel, Bool useConversionFrame=True) const;
     virtual Bool toPixel(Vector<Double> &pixel, 
 			 const Vector<Double> &world) const;
     // </group>

--- a/coordinates/Coordinates/LinearCoordinate.cc
+++ b/coordinates/Coordinates/LinearCoordinate.cc
@@ -207,7 +207,7 @@ uInt LinearCoordinate::nWorldAxes() const
 }
 
 Bool LinearCoordinate::toWorld(Vector<Double> &world, 
-			       const Vector<Double> &pixel) const
+			       const Vector<Double> &pixel, Bool) const
 {
    return toWorldWCS (world, pixel, wcs_p);
 }

--- a/coordinates/Coordinates/LinearCoordinate.h
+++ b/coordinates/Coordinates/LinearCoordinate.h
@@ -174,10 +174,12 @@ public:
     // Convert a pixel position to a worl position or vice versa. Returns True
     // if the conversion succeeds, otherwise it returns False and method
     // errorMessage returns an error message.  The output 
-    // vectors are appropriately resized.
+    // vectors are appropriately resized. The value of the Bool parameter passed
+    // to toWorld() has no effect as this type of coordinate does not support a
+    // conversion layer frame.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-			 const Vector<Double> &pixel) const;
+			 const Vector<Double> &pixel, Bool=True) const;
     virtual Bool toPixel(Vector<Double> &pixel, 
 			 const Vector<Double> &world) const;
     // </group>

--- a/coordinates/Coordinates/QualityCoordinate.cc
+++ b/coordinates/Coordinates/QualityCoordinate.cc
@@ -144,7 +144,7 @@ Bool QualityCoordinate::toPixel(Int& pixel, Quality::QualityTypes quality) const
 
 
 Bool QualityCoordinate::toWorld(Vector<Double>& world,
-			       const Vector<Double>& pixel) const
+			       const Vector<Double>& pixel, Bool) const
 {
 	// tested: tQualityCoordinate: 403
     DebugAssert(pixel.nelements()==1, AipsError);

--- a/coordinates/Coordinates/QualityCoordinate.h
+++ b/coordinates/Coordinates/QualityCoordinate.h
@@ -110,9 +110,11 @@ public:
     // if the conversion succeeds, otherwise it returns False and method
     // <src>errorMessage</src> returns an error message.
     // The output vectors are appropriately resized before use.
+    // The Bool parameter in toWorld() is ignored as this coordinate does not
+    // support a conversion layer frame.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-                                const Vector<Double> &pixel) const;
+                                const Vector<Double> &pixel, Bool=True) const;
     virtual Bool toPixel(Vector<Double> &pixel, 
                                 const Vector<Double> &world) const;
     // </group>

--- a/coordinates/Coordinates/SpectralCoordinate.cc
+++ b/coordinates/Coordinates/SpectralCoordinate.cc
@@ -442,7 +442,7 @@ uInt SpectralCoordinate::nWorldAxes() const
 
 
 Bool SpectralCoordinate::toWorld (Vector<Double> &world,
-                                  const Vector<Double> &pixel) const
+                                  const Vector<Double> &pixel, Bool useConversionFrame) const
 {
 
 // Convert to World (Hz)
@@ -462,7 +462,9 @@ Bool SpectralCoordinate::toWorld (Vector<Double> &world,
 
 // Convert to output reference type
 
-    convertTo(world);    
+    if (useConversionFrame) {
+        convertTo(world);
+    }
 //
     return ok;
 }

--- a/coordinates/Coordinates/SpectralCoordinate.h
+++ b/coordinates/Coordinates/SpectralCoordinate.h
@@ -283,9 +283,11 @@ public:
     // <src>errorMessage()</src> contains an error message.  The input vectors
     // must be of length one and the output vectors are resized if they are not
     // already of length one.
+    // if <src>useConversionFrame</src>, if the coordinate has a conversion
+    // layer frame, it is used. Else, the native frame is used for the conversion.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-  		         const Vector<Double> &pixel) const;
+  		         const Vector<Double> &pixel, Bool useConversionFrame=True) const;
     virtual Bool toPixel(Vector<Double> &pixel, 
   		         const Vector<Double> &world) const;
     Bool toWorld(Double& world, const Double& pixel) const;

--- a/coordinates/Coordinates/StokesCoordinate.cc
+++ b/coordinates/Coordinates/StokesCoordinate.cc
@@ -136,7 +136,7 @@ Bool StokesCoordinate::toPixel(Int& pixel, Stokes::StokesTypes stokes) const
 
 
 Bool StokesCoordinate::toWorld(Vector<Double>& world, 
-			       const Vector<Double>& pixel) const
+			       const Vector<Double>& pixel, Bool) const
 {
     DebugAssert(pixel.nelements()==1, AipsError);
     world.resize(1);

--- a/coordinates/Coordinates/StokesCoordinate.h
+++ b/coordinates/Coordinates/StokesCoordinate.h
@@ -138,9 +138,11 @@ public:
     // if the conversion succeeds, otherwise it returns False and method
     // <src>errorMessage</src> returns an error message.
     // The output vectors are appropriately resized before use.
+    // The Bool parameter in toWorld() is ignored as this coordinate does not
+    // support a conversion layer frame.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-                                const Vector<Double> &pixel) const;
+                                const Vector<Double> &pixel, Bool=True) const;
     virtual Bool toPixel(Vector<Double> &pixel, 
                                 const Vector<Double> &world) const;
     // </group>

--- a/coordinates/Coordinates/TabularCoordinate.cc
+++ b/coordinates/Coordinates/TabularCoordinate.cc
@@ -241,7 +241,7 @@ Bool TabularCoordinate::toPixel(Double &pixel, Double world) const
 }
 
 Bool TabularCoordinate::toWorld(Vector<Double> &world, 
-  	                        const Vector<Double> &pixel) const
+  	                        const Vector<Double> &pixel, Bool) const
 {
    Bool rval = True;
    world.resize(pixel.nelements());

--- a/coordinates/Coordinates/TabularCoordinate.h
+++ b/coordinates/Coordinates/TabularCoordinate.h
@@ -178,9 +178,11 @@ public:
     // if the conversion succeeds, otherwise it returns False and method
     // errorMessage contains an error message.  The output
     // vectors are appropriately resized.
+    // The Bool parameter in toWorld() has no effect as this coordinate does
+    // not support a conversion layer frame.
     // <group>
     virtual Bool toWorld(Vector<Double> &world, 
-			 const Vector<Double> &pixel) const;
+			 const Vector<Double> &pixel, Bool=True) const;
     virtual Bool toPixel(Vector<Double> &pixel, 
 			 const Vector<Double> &world) const;
     Bool toWorld(Double &world, Double pixel) const;

--- a/coordinates/Coordinates/test/tCoordinateSystem.cc
+++ b/coordinates/Coordinates/test/tCoordinateSystem.cc
@@ -447,6 +447,46 @@ int main()
     	  cerr << "The input was verified" << endl;
 
       }
+      {
+          cout << "*** test toWorld using both native and conversion layer frames" << endl;
+          CoordinateSystem csys = CoordinateUtil::defaultCoords(4);
+          Matrix<Double> xform(2, 2, 0);
+          xform.diagonal() = 1;
+          DirectionCoordinate dc(
+              MDirection::J2000, Projection::SIN, Quantity(0, "deg"), Quantity(0, "deg"),
+              Quantity(-1, "arcsec"), Quantity(1, "arcsec"), xform, 0, 0
+          );
+          dc.setReferenceConversion(MDirection::GALACTIC);
+          SpectralCoordinate sc(
+              MFrequency::LSRK, Quantity(1500, "MHz"), Quantity(1, "kHz"),
+              0, Quantity(1500, "MHz")
+          );
+          MEpoch epoch(Quantity(60000, "d"), MEpoch::UTC);
+          MPosition position(
+              Quantity(10, "m"), Quantity(135, "deg"), Quantity(40, "deg"), MPosition::ITRF
+          );
+          MDirection direction(Quantity(20, "deg"), Quantity(50, "deg"), MDirection::J2000);
+          sc.setReferenceConversion(MFrequency::CMB, epoch, position, direction);
+          csys.replaceCoordinate(dc, 0);
+          csys.replaceCoordinate(sc, 2);
+          Vector<Double> pixel(4, 0);
+          pixel[0] = 60;
+          pixel[1] = 60;
+          pixel[3] = 10;
+          Vector<Double> world(4);
+          csys.toWorld(world, pixel);
+          AlwaysAssert(near(world[0], 1.6811, 1e-5), AipsError);
+          AlwaysAssert(near(world[1], -1.05011, 1e-5), AipsError);
+          AlwaysAssert(near(world[3], 1.50121e+09, 1e-5), AipsError);
+          csys.toWorld(world, pixel, True);
+          AlwaysAssert(near(world[0], 1.6811, 1e-5), AipsError);
+          AlwaysAssert(near(world[1], -1.05011, 1e-5), AipsError);
+          AlwaysAssert(near(world[3], 1.50121e+09, 1e-5), AipsError);
+          csys.toWorld(world, pixel, False);
+          AlwaysAssert(near(world[0], 6.28289, 1e-5), AipsError);
+          AlwaysAssert(near(world[1], 2.90888e-4, 1e-5), AipsError);
+          AlwaysAssert(world[3] == 1.50001e+09, AipsError);
+      }
 
    }
    catch (const AipsError& x) {

--- a/coordinates/Coordinates/test/tDirectionCoordinate.cc
+++ b/coordinates/Coordinates/test/tDirectionCoordinate.cc
@@ -474,6 +474,28 @@ int main()
     	  );
     	  AlwaysAssert(! dc.isNCP(), AipsError);
       }
+      {
+          cout << "*** test toWorld without converting to conversion layer frame" << endl;
+          Matrix<Double> xform(2, 2, 0);
+          xform.diagonal() = 1;
+          DirectionCoordinate dc(
+              MDirection::J2000, Projection::SIN, Quantity(0, "deg"), Quantity(0, "deg"),
+              Quantity(-1, "arcsec"), Quantity(1, "arcsec"), xform, 0, 0
+          );
+          dc.setReferenceConversion(MDirection::GALACTIC);
+          Vector<Double> pixel(2, 60);
+          Vector<Double> world(2);
+          // default uses True
+          dc.toWorld(world, pixel);
+          AlwaysAssert(near(world[0], 1.6811, 1e-5), AipsError);
+          AlwaysAssert(near(world[1], -1.05011, 1e-5), AipsError);
+          dc.toWorld(world, pixel, True);
+          AlwaysAssert(near(world[0], 1.6811, 1e-5), AipsError);
+          AlwaysAssert(near(world[1], -1.05011, 1e-5), AipsError);
+          dc.toWorld(world, pixel, False);
+          AlwaysAssert(near(world[0], 6.28289, 1e-5), AipsError);
+          AlwaysAssert(near(world[1], 2.90888e-4, 1e-5), AipsError);
+      }
 
   } catch (const AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;

--- a/coordinates/Coordinates/test/tSpectralCoordinate.cc
+++ b/coordinates/Coordinates/test/tSpectralCoordinate.cc
@@ -1020,27 +1020,31 @@ int main()
          }
          delete plc;
       }
-//
-// Test FITS conversion
-//
-/*
       {
-         LogIO os(LogOrigin("tSpectralCoordinate", "main()", WHERE));
-         SpectralCoordinate lc = makeLinearCoordinate(MFrequency::TOPO, f0, finc, refchan, restFreq);
-         Record rec;
-         lc.toFITS(rec, 0, os, False, True);
-//
-//          SpectralCoordinate lc2;
-//          String errMsg;
-//          if (!SpectralCoordinate::fromFITSOld(lc2, errMsg, rec, 0, os,  True)) {
-//             throw(AipsError(String("fromFITSOld function failed because") + errMsg));  
-//          }
-//          if (!lc.near(lc2, 1e-6)) {
-//             throw(AipsError("FITS reflection failed"));  
-//          }
+          cout << "Test toWorld using both native and conversion layer frames" << endl;
+          SpectralCoordinate sc(
+              MFrequency::LSRK, Quantity(1500, "MHz"), Quantity(1, "kHz"),
+              0, Quantity(1500, "MHz")
+          );
+          MEpoch epoch(Quantity(60000, "d"), MEpoch::UTC);
+          MPosition position(
+              Quantity(10, "m"), Quantity(135, "deg"), Quantity(40, "deg"), MPosition::ITRF
+          );
+          MDirection direction(Quantity(20, "deg"), Quantity(50, "deg"), MDirection::J2000);
+          sc.setReferenceConversion(MFrequency::CMB, epoch, position, direction);
+          Vector<Double> pixel(1, 10);
+          Vector<Double> world(1);
+          sc.toWorld(world, pixel);
+          AlwaysAssert(near(world[0], 1.50121e+09, 1e-5), AipsError);
+          sc.toWorld(world, pixel, True);
+          AlwaysAssert(near(world[0], 1.50121e+09, 1e-5), AipsError);
+          sc.toWorld(world, pixel, False);
+          AlwaysAssert(world[0] == 1.50001e+09, AipsError);
+
       }
-*/
-   } catch (AipsError x) {
+
+   }
+   catch (const AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }


### PR DESCRIPTION
… frames when calling toWorld()

Add a Bool parameter which defaults to True to toWorld(Vector<Double>&, const Vector<Double>&)

If True, conversion layer frame, if present, is used as before. If false, native frame is used for conversion. No effect if coordinate class does not support conversion layer frame (only CoordinateSystem, DirectionCoordinate, and SpectralCoordinate support conversion layer frames at the present time).

Unit tests added for the affected classes.