### PR TITLE
CAS-8329: Throw exception if string to be parsed is empty

### DIFF
--- a/images/Images/ImageExprParse.cc
+++ b/images/Images/ImageExprParse.cc
@@ -141,13 +141,15 @@ ImageExprParse::ImageExprParse (const DComplex& value)
 
 ImageExprParse::ImageExprParse (const Char* value)
 : itsType (TpString),
-  itsSval (String(value))
-{}
+  itsSval (String(value)) {
+    ThrowIf(itsSval.empty(), "Illegal empty expression");
+}
 
 ImageExprParse::ImageExprParse (const String& value)
 : itsType (TpString),
-  itsSval (value)
-{}
+  itsSval (value) {
+    ThrowIf(itsSval.empty(), "Illegal empty expression");
+}
 
 Table& ImageExprParse::getRegionTable (void*, Bool)
 {

--- a/images/Images/test/CMakeLists.txt
+++ b/images/Images/test/CMakeLists.txt
@@ -54,6 +54,7 @@ tImageExpr
 tImageExpr2Gram
 tImageExpr3Gram
 tImageExprGram
+tImageExprParse
 tImageExprParse_addDir
 tImageInfo
 tImageProxy

--- a/images/Images/test/tImageExprParse.cc
+++ b/images/Images/test/tImageExprParse.cc
@@ -1,0 +1,50 @@
+//# tImageExprParse.cc
+//# Copyright (C) 2008
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This program is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU General Public License as published by the Free
+//# Software Foundation; either version 2 of the License, or(at your option)
+//# any later version.
+//#
+//# This program is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+//# more details.
+//#
+//# You should have received a copy of the GNU General Public License along
+//# with this program; if not, write to the Free Software Foundation, Inc.,
+//# 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/images/Images/ImageExprParse.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/iostream.h>
+#include <casacore/casa/namespace.h>
+
+int main() {
+    try {
+        Bool thrown = False;
+        try {
+            ImageExprParse::command("''");
+        }
+        catch (const AipsError& x) {
+            thrown = True;
+        }
+        AlwaysAssert(thrown, AipsError);
+        cout<< "ok"<< endl;
+    }
+    catch (const AipsError& x) {
+        cerr << "Exception caught: " << x.getMesg() << endl;
+        return 1;
+    } 
+    return 0;
+}


### PR DESCRIPTION
Previously, parsing an empty LEL string caused a segfault. Now we check to ensure the string is not empty, and if so, we throw an exception.