### PR TITLE
make String::before() const, provide OO interface to MSFitsOutput

### DIFF
--- a/casa/BasicSL/String.cc
+++ b/casa/BasicSL/String.cc
@@ -166,19 +166,19 @@ SubString String::at(Char c, Int startpos) {
   return _substr(index(c, startpos), 1);
 }
 
-SubString String::before(size_type pos) {
+SubString String::before(size_type pos) const {
   return _substr(0, pos);
 }
 
-SubString String::before(const string &str, size_type startpos) {
+SubString String::before(const string &str, size_type startpos) const {
   return _substr(0, index(str, startpos));
 }
 
-SubString String::before(const Char *s, size_type startpos) {
+SubString String::before(const Char *s, size_type startpos) const {
   return _substr(0, index(s, startpos));
 }
 
-SubString String::before(Char c, size_type startpos) {
+SubString String::before(Char c, size_type startpos) const {
   return _substr(0, index(c, startpos));
 }
 
@@ -389,7 +389,7 @@ SubString String::at(const RegexBase &r, Int startpos) {
   return _substr(first, mlen);
 }
 
-SubString String::before(const RegexBase &r, size_type startpos) {
+SubString String::before(const RegexBase &r, size_type startpos) const {
   Int mlen;
   size_type first = r.search(c_str(), length(), mlen, startpos);
   return _substr(0, first);

--- a/casa/BasicSL/String.h
+++ b/casa/BasicSL/String.h
@@ -788,13 +788,13 @@ class String : public string {
   // Start at startpos and extract the string "before" the argument's 
   // position, exclusive. ** Casacore addition
   // <group name=before>
-  SubString before(size_type pos);
-  SubString before(const string &str, size_type startpos = 0);
-  SubString before(const Char *s, size_type startpos = 0);
-  SubString before(Char c, size_type startpos = 0);
-  SubString before(const RegexBase &r, size_type startpos = 0);
+  SubString before(size_type pos) const;
+  SubString before(const string &str, size_type startpos = 0) const;
+  SubString before(const Char *s, size_type startpos = 0) const;
+  SubString before(Char c, size_type startpos = 0) const;
+  SubString before(const RegexBase &r, size_type startpos = 0) const;
   // Next one for overloading reasons
-  SubString before(Int pos) {
+  SubString before(Int pos) const {
     return before(static_cast<size_type>(pos)); };    
   // </group>
 
@@ -878,7 +878,7 @@ class String : public string {
 private:
   // Helper functions for at, before etc
   // <group>
-  SubString _substr(size_type first, size_type l) {
+  SubString _substr(size_type first, size_type l) const {
     return SubString(*this, first, l); }
   // </group>
 

--- a/msfits/MSFits/MSFitsOutput.h
+++ b/msfits/MSFits/MSFitsOutput.h
@@ -28,15 +28,15 @@
 #ifndef MS_MSFITSOUTPUT_H
 #define MS_MSFITSOUTPUT_H
 
-//# Includes
+#include <casacore/casa/BasicSL/String.h>
+#include <casacore/ms/MeasurementSets/MeasurementSet.h>
+
 #include <casacore/casa/aips.h>
 
 namespace casacore {
 
 //# Forward Declarations
-class String;
 class FitsOutput;
-class MeasurementSet;
 template<class T> class ScalarColumn;
 class Table;
 template<class T> class Block;
@@ -49,6 +49,52 @@ template<class T> class Vector;
 
 class MSFitsOutput {
 public:
+    //  @param fitsfile      Output filename
+    //  @param ms            input
+    //  @param column        specifies which "data" column to write
+    //                       ("observed", "calibrated", "model")
+    MSFitsOutput(
+        const String& fitsfile, const MeasurementSet& ms,
+        const String& column
+    );
+
+    //  @param startchan     1st channel
+    //  @param nchan         # of channels
+    //  @param stepchan      # of channels to stride by
+    //  @param avgchan       average every N channels
+    void setChannelInfo(
+        Int startChan, Int nchan, Int stepChan, Int avgChan
+    );
+
+    //  @param writeSysCal   whether to write the system calibration table
+    void setWriteSysCal(Bool writeSysCal);
+
+    //  @param asMultiSource If true a multi-source UVFits file is written.
+    void setAsMultiSource(Bool asMultiSource);
+
+    //  @param combineSpw    If true it attempts to write the spectral windows as
+    //                       IFs.  This is necessary for many aips tasks, and
+    //                       for difmap.
+    void setCombineSpw(Bool combineSpw);
+
+    //  @param writeStation  If true uses pad instead of antenna names.
+    void setWriteStation(Bool writeStation);
+
+    void setSensitivity(Double sensitivity);
+
+    //  @param padWithFlags  If true and combineSpw==true, fill spws with flags
+    //                       as needed to fit the IF structure.  Does not yet
+    //                       support spws with different shapes.
+    void setPadWitFlags(Bool padWithFlags);
+
+    void setFieldNumber(uInt fieldNumber);
+
+    //  @param overwrite     overwrite existing file?
+    void setOverwrite(Bool overwrite);
+
+    // write the uvfits file.
+    void write() const;
+
     // Convert a MeasurementSet to random group UVFITS.
     //  @param fitsfile      Output filename
     //  @param ms            input
@@ -81,6 +127,15 @@ public:
     );
 
 private:
+    const String _fitsfile, _column;
+    const MeasurementSet _ms;
+    Int _startChan, _nchan, _stepChan, _avgChan;
+    Bool _writeSysCal, _asMultiSource, _combineSpw,
+        _writeStation, _padWithFlags, _overwrite;
+    Double _sensitivity;
+    uInt _fieldNumber;
+
+
     // Write the main table.
     //    @param refPixelFreq
     //    @param refFreq


### PR DESCRIPTION
I provided an OO interface to MSFitsOutput. I moved the implementation of MSFitsOutput::writeFitsFile() to MSFitsOutput::write(), changing variable names to their private counterparts, and changed some style elements. 

For some reason SubString::before() and SubString::_substr() were not const, which required callers to make copies of const Strings. I fixed that.