### PR TITLE
Issue #323; make images with different shapes possible for && and ||

### DIFF
--- a/images/Images/LELImageCoord.cc
+++ b/images/Images/LELImageCoord.cc
@@ -125,9 +125,21 @@ LatticeExprNode LELImageCoord::makeSubLattice
     return SubImage<Float>
                  (ImageExpr<Float> (LatticeExpr<Float>(expr), ""),
 		  region);
+  case TpDouble:
+    return SubImage<Double>
+                 (ImageExpr<Double> (LatticeExpr<Double>(expr), ""),
+		  region);
   case TpComplex:
     return SubImage<Complex>
                  (ImageExpr<Complex> (LatticeExpr<Complex>(expr), ""),
+		  region);
+  case TpDComplex:
+    return SubImage<DComplex>
+                 (ImageExpr<DComplex> (LatticeExpr<DComplex>(expr), ""),
+		  region);
+  case TpBool:
+    return SubImage<Bool>
+                 (ImageExpr<Bool> (LatticeExpr<Bool>(expr), ""),
 		  region);
   default:
     throw (AipsError ("LELImageCoord::makeSubLattice - unknown datatype"));
@@ -150,9 +162,21 @@ LatticeExprNode LELImageCoord::makeExtendLattice
     return ExtendImage<Float>
                 (ImageExpr<Float>(LatticeExpr<Float>(expr), ""),
 		 newShape, newCsys);
+  case TpDouble:
+    return ExtendImage<Double>
+                (ImageExpr<Double>(LatticeExpr<Double>(expr), ""),
+		 newShape, newCsys);
   case TpComplex:
     return ExtendImage<Complex>
                 (ImageExpr<Complex>(LatticeExpr<Complex>(expr), ""),
+		 newShape, newCsys);
+  case TpDComplex:
+    return ExtendImage<DComplex>
+                (ImageExpr<DComplex>(LatticeExpr<DComplex>(expr), ""),
+		 newShape, newCsys);
+  case TpBool:
+    return ExtendImage<Bool>
+                (ImageExpr<Bool>(LatticeExpr<Bool>(expr), ""),
 		 newShape, newCsys);
   default:
     throw (AipsError ("LELImageCoord::makeExtendLattice - unknown datatype"));
@@ -169,9 +193,17 @@ LatticeExprNode LELImageCoord::makeRebinLattice
     return RebinImage<Float>
                  (ImageExpr<Float> (LatticeExpr<Float>(expr), ""),
 		  binning);
+  case TpDouble:
+    return RebinImage<Double>
+                 (ImageExpr<Double> (LatticeExpr<Double>(expr), ""),
+		  binning);
   case TpComplex:
     return RebinImage<Complex>
                  (ImageExpr<Complex> (LatticeExpr<Complex>(expr), ""),
+		  binning);
+  case TpDComplex:
+    return RebinImage<DComplex>
+                 (ImageExpr<DComplex> (LatticeExpr<DComplex>(expr), ""),
 		  binning);
   default:
     throw (AipsError ("LELLattCoord::makeRebinLattice - invalid datatype"));

--- a/images/Images/test/CMakeLists.txt
+++ b/images/Images/test/CMakeLists.txt
@@ -51,6 +51,7 @@ tImageBeamSet
 tImageConcat
 tImageEmpty
 tImageExpr
+tImageExpr2
 tImageExpr2Gram
 tImageExpr3Gram
 tImageExprGram

--- a/images/Images/test/tImageExpr2.cc
+++ b/images/Images/test/tImageExpr2.cc
@@ -1,0 +1,55 @@
+//# tImageExpr2.cc: Test program for boolean images with different shapes
+//# Copyright (C) 2016
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+
+#include <casacore/images/Images/PagedImage.h>
+#include <casacore/images/Regions/ImageRegion.h>
+#include <casacore/coordinates/Coordinates/CoordinateUtil.h>
+#include <stdexcept>
+#include <iostream>
+
+using namespace casacore;
+
+int main()
+{
+  try {
+    {  
+      PagedImage<Float> a(IPosition(4, 20, 20, 1, 20),
+                          CoordinateUtil::defaultCoords4D(), "A.im");
+      PagedImage<Float> b(IPosition(4, 20, 20, 1, 1),
+                          CoordinateUtil::defaultCoords4D(), "B.im");
+    }
+    ImageRegion* reg = 0;
+    reg = ImageRegion::fromLatticeExpression("(A.im + B.im) > 0");
+    delete reg;
+    reg = ImageRegion::fromLatticeExpression("A.im > 0 && B.im < 0");
+    delete reg;
+  } catch (const std::exception& x) {
+    std::cout << x.what() << std::endl;
+  }
+}
+

--- a/lattices/LEL/LatticeExprNode.cc
+++ b/lattices/LEL/LatticeExprNode.cc
@@ -1602,8 +1602,7 @@ LatticeExprNode operator&& (const LatticeExprNode& left,
       return LELRegion::makeIntersection (*left.pExprBool_p,
 					  *right.pExprBool_p);
    }
-   return new LELBinaryBool(LELBinaryEnums::AND, left.makeBool(),
-			    right.makeBool());
+   return LatticeExprNode::newLogBinary (LELBinaryEnums::AND, left, right);
 }
 
 LatticeExprNode operator|| (const LatticeExprNode& left,
@@ -1617,8 +1616,7 @@ LatticeExprNode operator|| (const LatticeExprNode& left,
    if (LatticeExprNode::areRegions (left, right)) {
       return LELRegion::makeUnion (*left.pExprBool_p, *right.pExprBool_p);
    }
-   return new LELBinaryBool(LELBinaryEnums::OR, left.makeBool(),
-			    right.makeBool());
+   return LatticeExprNode::newLogBinary (LELBinaryEnums::OR, left, right);
 }
 
 LatticeExprNode operator! (const LatticeExprNode& expr)
@@ -2084,6 +2082,33 @@ LatticeExprNode LatticeExprNode::newNumBinary (LELBinaryEnums::Operation oper,
 				    expr1.pExprDComplex_p);
   }
   return LatticeExprNode();
+}
+
+
+LatticeExprNode LatticeExprNode::newLogBinary (LELBinaryEnums::Operation oper,
+					       const LatticeExprNode& left,
+					       const LatticeExprNode& right)
+//
+// Create a new node for a logical binary operator.
+// The result has the same data type as the combined input type.
+//
+{
+  DataType dtype = resultDataType (left.dataType(), right.dataType());
+  LatticeExprNode expr0;
+  LatticeExprNode expr1;
+  switch (dtype) {
+  case TpBool:
+    expr0 = left.makeBool();
+    expr1 = right.makeBool();
+    break;
+  default:
+    throw (AipsError ("LatticeExprNode::newLogBinary - "
+		      "Non-Bool argument used in logical binary operation"));
+  }
+  // Make the operands the same dimensionality (if needed and possible).
+  makeEqualDim (expr0, expr1);
+  return new LELBinaryBool (oper, expr0.pExprBool_p,
+                            expr1.pExprBool_p);
 }
 
 

--- a/lattices/LEL/LatticeExprNode.h
+++ b/lattices/LEL/LatticeExprNode.h
@@ -799,6 +799,12 @@ private:
 					const LatticeExprNode& left,
 					const LatticeExprNode& right);
 
+// Create a new node for a logical binary operator.
+// The result has the same data type as the combined input type.
+   static LatticeExprNode newLogBinary (LELBinaryEnums::Operation oper,
+					const LatticeExprNode& left,
+					const LatticeExprNode& right);
+
 // Create a new node for a comparison binary operator.
 // The result has the same data type as the combined input type.
    static LatticeExprNode newBinaryCmp (LELBinaryEnums::Operation oper,


### PR DESCRIPTION
For operator && and || images are now automatically extended.
Also added support for Double and DComplex in LELImageCoord.

Close #323