### PR TITLE
Make :: possible in names of tables to concatenate

### DIFF
--- a/tables/Tables/ConcatRows.cc
+++ b/tables/Tables/ConcatRows.cc
@@ -34,6 +34,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   void ConcatRows::add (uInt nrow)
   {
+    if (Int64(nrow) + itsRows[itsNTable] >= Int64(65536)*65536) {
+      throw TableError ("Concatenation of tables exceeds 2**32 rows");
+    }
     itsNTable++;
     itsRows.resize (itsNTable+1);
     itsRows[itsNTable] = itsRows[itsNTable-1] + nrow;

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -118,13 +118,18 @@ TableProxy::TableProxy (const Vector<String>& tableNames,
 			const Record& lockOptions,
 			int option)
 {
-  Block<String> names(tableNames.size());
-  std::copy (tableNames.begin(), tableNames.end(), names.begin());
+  // Open the tables here (and not by Table ctor) to make it
+  // possible to use the :: syntax for subtables.
+  TableLock lockOpt = makeLockOptions(lockOptions);
+  Block<Table> tabs(tableNames.size());
+  for (uInt i=0; i<tableNames.size(); ++i) {
+    tabs[i] = Table::openTable (tableNames[i], lockOpt,
+                                Table::TableOption(option));
+  }
   Block<String> subNames(concatenateSubTableNames.size());
   std::copy (concatenateSubTableNames.begin(), concatenateSubTableNames.end(),
 	     subNames.begin());
-  table_p = Table (names, subNames, makeLockOptions(lockOptions),
-		   Table::TableOption(option));
+  table_p = Table (tabs, subNames);
 }
  
 TableProxy::TableProxy (const std::vector<TableProxy>& tables,


### PR DESCRIPTION
Issue #325 
Use openTable to be able to use :: in table names;
Check if nrows exceeds 2**32
close #325