### PR TITLE
Cas 8405: logging support for Int64 and uInt64 various MSMetaData/MSSummary mods

### DIFF
--- a/casa/Logging/LogIO.cc
+++ b/casa/Logging/LogIO.cc
@@ -242,6 +242,18 @@ LogIO &operator<<(LogIO &os, uInt item)
     return os;
 }
 
+LogIO &operator<<(LogIO &os, Int64 item)
+{
+    os.output() << item;
+    return os;
+}
+
+LogIO &operator<<(LogIO &os, uInt64 item)
+{
+    os.output() << item;
+    return os;
+}
+
 LogIO &operator<<(LogIO &os, uLong item)
 {
     os.output() << item;

--- a/casa/Logging/LogIO.h
+++ b/casa/Logging/LogIO.h
@@ -292,6 +292,8 @@ LogIO &operator<<(LogIO &os, Complex item);
 LogIO &operator<<(LogIO &os, DComplex item);
 LogIO &operator<<(LogIO &os, Int item);
 LogIO &operator<<(LogIO &os, uInt item);
+LogIO &operator<<(LogIO &os, Int64 item);
+LogIO &operator<<(LogIO &os, uInt64 item);
 LogIO &operator<<(LogIO &os, uLong item);
 LogIO &operator<<(LogIO &os, Long item);
 LogIO &operator<<(LogIO &os, Bool item);

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3630,7 +3630,7 @@ SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > MSMetaDat
     }
     static const uInt iSize = sizeof(Int);
     static const uInt dSize = sizeof(Double);
-	static const uInt structSize = 3*dSize + iSize;
+    static const uInt structSize = 3*dSize + iSize;
     static const uInt keySize = 4*iSize;
     miter = mysubscans->begin();
     uInt64 mapSize = mysubscans->size() * (structSize + keySize);
@@ -3644,7 +3644,7 @@ SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > MSMetaDat
     }
     if (_cacheUpdated(mapSize)) {
         _subScanProperties = mysubscans;
-	}
+    }
     else if (_forceSubScanPropsToCache) {
        _cacheMB += mapSize/1e6;
        _subScanProperties = mysubscans;

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3607,7 +3607,7 @@ SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > MSMetaDat
 		    }
 		}
 	}
-	std::map<SubScanKey, SubScanProperties>::iterator miter = mysubscans->begin();
+    std::map<SubScanKey, SubScanProperties>::iterator miter = mysubscans->begin();
     std::map<SubScanKey, SubScanProperties>::iterator mend = mysubscans->end();
     const Unit& eunit = exposureTimes->getFullUnit();
     for ( ; miter!=mend; ++miter) {

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3643,13 +3643,13 @@ SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > MSMetaDat
         mapSize += (iSize + dSize) * miter->second.meanInterval.size();
     }
     if (_cacheUpdated(mapSize)) {
-        _subScanProperties = mysubscans;
+       _subScanProperties = mysubscans;
     }
     else if (_forceSubScanPropsToCache) {
        _cacheMB += mapSize/1e6;
        _subScanProperties = mysubscans;
     }
-	return mysubscans;
+    return mysubscans;
 }
 
 std::map<Double, Double> MSMetaData::_getTimeToTotalBWMap(

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -230,17 +230,17 @@ uInt MSMetaData::nArrays() {
 	return _nArrays;
 }
 
-uInt64 MSMetaData::nRows() const {
+uInt MSMetaData::nRows() const {
 	return _ms->nrow();
 }
 
-uInt64 MSMetaData::nRows(CorrelationType cType) {
+uInt MSMetaData::nRows(CorrelationType cType) {
 	if (cType == BOTH) {
 		return nRows();
 	}
-	uInt64 nACRows, nXCRows;
-	SHARED_PTR<std::map<SubScanKey, uInt64> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	SHARED_PTR<vector<uInt64> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	uInt nACRows, nXCRows;
+	SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -254,10 +254,10 @@ uInt64 MSMetaData::nRows(CorrelationType cType) {
 	}
 }
 
-SHARED_PTR<const map<SubScanKey, uInt64> > MSMetaData::getNRowMap(CorrelationType cType) const {
-    uInt64 nACRows, nXCRows;
-    SHARED_PTR<std::map<SubScanKey, uInt64> > subScanToNACRowsMap, subScanToNXCRowsMap;
-    SHARED_PTR<vector<uInt64> > fieldToNACRowsMap, fieldToNXCRowsMap;
+SHARED_PTR<const map<SubScanKey, uInt> > MSMetaData::getNRowMap(CorrelationType cType) const {
+    uInt nACRows, nXCRows;
+    SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+    SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
     _getRowStats(
         nACRows, nXCRows, subScanToNACRowsMap,
         subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -269,11 +269,11 @@ SHARED_PTR<const map<SubScanKey, uInt64> > MSMetaData::getNRowMap(CorrelationTyp
     else if (cType == CROSS) {
         return subScanToNXCRowsMap;
     }
-    SHARED_PTR<map<SubScanKey, uInt64> > mymap(
-        new map<SubScanKey, uInt64>()
+    SHARED_PTR<map<SubScanKey, uInt> > mymap(
+        new map<SubScanKey, uInt>()
     );
-    map<SubScanKey, uInt64>::const_iterator iter = subScanToNACRowsMap->begin();
-    map<SubScanKey, uInt64>::const_iterator end = subScanToNACRowsMap->end();
+    map<SubScanKey, uInt>::const_iterator iter = subScanToNACRowsMap->begin();
+    map<SubScanKey, uInt>::const_iterator end = subScanToNACRowsMap->end();
     for (; iter!=end; ++iter) {
         SubScanKey key = iter->first;
         (*mymap)[key] = iter->second + (*subScanToNXCRowsMap)[key];
@@ -281,7 +281,7 @@ SHARED_PTR<const map<SubScanKey, uInt64> > MSMetaData::getNRowMap(CorrelationTyp
     return mymap;
 }
 
-uInt64 MSMetaData::nRows(
+uInt MSMetaData::nRows(
 	CorrelationType cType, Int arrayID, Int observationID,
 	Int scanNumber, Int fieldID
 ) const {
@@ -291,9 +291,9 @@ uInt64 MSMetaData::nRows(
 	subScanKey.scan = scanNumber;
 	subScanKey.fieldID = fieldID;
 	_checkSubScan(subScanKey);
-	uInt64 nACRows, nXCRows;
-	SHARED_PTR<std::map<SubScanKey, uInt64> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	SHARED_PTR<vector<uInt64> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	uInt nACRows, nXCRows;
+	SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
     _getRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -311,11 +311,11 @@ uInt64 MSMetaData::nRows(
 	}
 }
 
-uInt64 MSMetaData::nRows(CorrelationType cType, uInt fieldID) const {
+uInt MSMetaData::nRows(CorrelationType cType, uInt fieldID) const {
 	_checkField(fieldID);
-	uInt64 nACRows, nXCRows;
-	SHARED_PTR<std::map<SubScanKey, uInt64> > subScanToNACRowsMap, subScanToNXCRowsMap;
-	SHARED_PTR<vector<uInt64> > fieldToNACRowsMap, fieldToNXCRowsMap;
+	uInt nACRows, nXCRows;
+	SHARED_PTR<std::map<SubScanKey, uInt> > subScanToNACRowsMap, subScanToNXCRowsMap;
+	SHARED_PTR<vector<uInt> > fieldToNACRowsMap, fieldToNXCRowsMap;
 	_getRowStats(
 		nACRows, nXCRows, subScanToNACRowsMap,
 		subScanToNXCRowsMap, fieldToNACRowsMap,
@@ -414,19 +414,19 @@ Double MSMetaData::nUnflaggedRows(CorrelationType cType, Int fieldID) const {
 }
 
 void MSMetaData::_getRowStats(
-	uInt64& nACRows, uInt64& nXCRows,
-	std::map<SubScanKey, uInt64>*& subScanToNACRowsMap,
-	std::map<SubScanKey, uInt64>*& subScanToNXCRowsMap,
-	vector<uInt64>*& fieldToNACRowsMap,
-	vector<uInt64>*& fieldToNXCRowsMap
+	uInt& nACRows, uInt& nXCRows,
+	std::map<SubScanKey, uInt>*& subScanToNACRowsMap,
+	std::map<SubScanKey, uInt>*& subScanToNXCRowsMap,
+	vector<uInt>*& fieldToNACRowsMap,
+	vector<uInt>*& fieldToNXCRowsMap
 ) const {
 	nACRows = 0;
 	nXCRows = 0;
-	subScanToNACRowsMap = new std::map<SubScanKey, uInt64>();
-	subScanToNXCRowsMap = new std::map<SubScanKey, uInt64>();
+	subScanToNACRowsMap = new std::map<SubScanKey, uInt>();
+	subScanToNXCRowsMap = new std::map<SubScanKey, uInt>();
 	uInt myNFields = nFields();
-	fieldToNACRowsMap = new vector<uInt64>(myNFields, 0);
-	fieldToNXCRowsMap = new vector<uInt64>(myNFields, 0);
+	fieldToNACRowsMap = new vector<uInt>(myNFields, 0);
+	fieldToNXCRowsMap = new vector<uInt>(myNFields, 0);
 	std::set<SubScanKey> subScanKeys = _getSubScanKeys();
 	std::set<SubScanKey>::const_iterator subIter = subScanKeys.begin();
 	std::set<SubScanKey>::const_iterator subEnd = subScanKeys.end();
@@ -474,11 +474,11 @@ void MSMetaData::_getRowStats(
 }
 
 void MSMetaData::_getRowStats(
-	uInt64& nACRows, uInt64& nXCRows,
-	SHARED_PTR<std::map<SubScanKey, uInt64> >& scanToNACRowsMap,
-	SHARED_PTR<std::map<SubScanKey, uInt64> >& scanToNXCRowsMap,
-	SHARED_PTR<vector<uInt64> >& fieldToNACRowsMap,
-	SHARED_PTR<vector<uInt64> >& fieldToNXCRowsMap
+	uInt& nACRows, uInt& nXCRows,
+	SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
+	SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
+	SHARED_PTR<vector<uInt> >& fieldToNACRowsMap,
+	SHARED_PTR<vector<uInt> >& fieldToNXCRowsMap
 ) const {
 	// this method is responsible for setting _nACRows, _nXCRows, _subScanToNACRowsMap,
 	// _subScanToNXCRowsMap, _fieldToNACRowsMap, _fieldToNXCRowsMap
@@ -492,8 +492,8 @@ void MSMetaData::_getRowStats(
 		return;
 	}
 
-	std::map<SubScanKey, uInt64> *myScanToNACRowsMap, *myScanToNXCRowsMap;
-	vector<uInt64> *myFieldToNACRowsMap, *myFieldToNXCRowsMap;
+	std::map<SubScanKey, uInt> *myScanToNACRowsMap, *myScanToNXCRowsMap;
+	vector<uInt> *myFieldToNACRowsMap, *myFieldToNXCRowsMap;
 	_getRowStats(
 		nACRows, nXCRows, myScanToNACRowsMap,
 		myScanToNXCRowsMap, myFieldToNACRowsMap,
@@ -3543,7 +3543,7 @@ SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > MSMetaDat
     std::map<SubScanKey, map<uInt, vector<Double> > > intervalSets;
     SubScanKey subScanKey;
     uInt nrows;
-    uInt64 count = 0;
+    uInt count = 0;
     SHARED_PTR<ProgressMeter> pm;
     if (showProgress) {
         LogIO log;
@@ -3633,7 +3633,7 @@ SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > MSMetaDat
     static const uInt structSize = 3*dSize + iSize;
     static const uInt keySize = 4*iSize;
     miter = mysubscans->begin();
-    uInt64 mapSize = mysubscans->size() * (structSize + keySize);
+    uInt mapSize = mysubscans->size() * (structSize + keySize);
     for ( ; miter != mend; ++miter) {
         mapSize += iSize*(
             miter->second.ddIDs.size() + miter->second.stateIDs.size()

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -191,18 +191,18 @@ public:
 	virtual std::set<uInt> getSpwsForIntent(const String& intent);
 
 	// get the number of visibilities
-	uInt64 nRows() const;
+	uInt nRows() const;
 
-	uInt64 nRows(CorrelationType cType);
+	uInt nRows(CorrelationType cType);
 
-	SHARED_PTR<const map<SubScanKey, uInt64> > getNRowMap(CorrelationType type) const;
+	SHARED_PTR<const map<SubScanKey, uInt> > getNRowMap(CorrelationType type) const;
 
-	uInt64 nRows(
+	uInt nRows(
 		CorrelationType cType, Int arrayID, Int observationID,
 		Int scanNumber, Int fieldID
 	) const;
 
-	uInt64 nRows(CorrelationType cType, uInt fieldID) const;
+	uInt nRows(CorrelationType cType, uInt fieldID) const;
 
 	// get number of spectral windows
 	uInt nSpw(Bool includewvr) const;
@@ -620,9 +620,9 @@ private:
 	mutable std::set<uInt> _avgSpw, _tdmSpw, _fdmSpw, _wvrSpw, _sqldSpw;
 	mutable SHARED_PTR<Vector<Int> > _antenna1, _antenna2, _scans, _fieldIDs,
 		_stateIDs, _dataDescIDs, _observationIDs, _arrayIDs;
-	mutable SHARED_PTR<std::map<SubScanKey, uInt64> > _subScanToNACRowsMap, _subScanToNXCRowsMap;
+	mutable SHARED_PTR<std::map<SubScanKey, uInt> > _subScanToNACRowsMap, _subScanToNXCRowsMap;
 	mutable SHARED_PTR<QVD> _intervals;
-	mutable SHARED_PTR<vector<uInt64> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
+	mutable SHARED_PTR<vector<uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
  	mutable std::map<ScanKey, std::set<String> > _scanToIntentsMap;
  	mutable SHARED_PTR<const std::map<SubScanKey, std::set<String> > > _subScanToIntentsMap;
 	mutable vector<std::set<String> > _stateToIntentsMap, _spwToIntentsMap, _fieldToIntentsMap;
@@ -816,19 +816,19 @@ private:
 	vector<MPosition> _getObservatoryPositions();
 
 	void _getRowStats(
-		uInt64& nACRows, uInt64& nXCRows,
-		std::map<SubScanKey, uInt64>*& subScanToNACRowsMap,
-		std::map<SubScanKey, uInt64>*& subScanToNXCRowsMap,
-		vector<uInt64>*& fieldToNACRowsMap,
-		vector<uInt64>*& fieldToNXCRowsMap
+		uInt& nACRows, uInt& nXCRows,
+		std::map<SubScanKey, uInt>*& subScanToNACRowsMap,
+		std::map<SubScanKey, uInt>*& subScanToNXCRowsMap,
+		vector<uInt>*& fieldToNACRowsMap,
+		vector<uInt>*& fieldToNXCRowsMap
 	) const;
 
 	void _getRowStats(
-		uInt64& nACRows, uInt64& nXCRows,
-		SHARED_PTR<std::map<SubScanKey, uInt64> >& scanToNACRowsMap,
-		SHARED_PTR<std::map<SubScanKey, uInt64> >& scanToNXCRowsMap,
-		SHARED_PTR<vector<uInt64> >& fieldToNACRowsMap,
-		SHARED_PTR<vector<uInt64> >& fieldToNXCRowsMap
+		uInt& nACRows, uInt& nXCRows,
+		SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
+		SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
+		SHARED_PTR<vector<uInt> >& fieldToNACRowsMap,
+		SHARED_PTR<vector<uInt> >& fieldToNXCRowsMap
 	) const;
 
 	// get the scan keys in the specified set that have the associated arrayKey

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -334,7 +334,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
 	SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > ssprops
 	    = _msmd->getSubScanProperties(True);
 	SHARED_PTR<const std::map<SubScanKey, std::set<String> > > ssToIntents = _msmd->getSubScanToIntentsMap();
-	SHARED_PTR<const map<SubScanKey, uInt64> > nrowMap = _msmd->getNRowMap(MSMetaData::BOTH);
+	SHARED_PTR<const map<SubScanKey, uInt> > nrowMap = _msmd->getNRowMap(MSMetaData::BOTH);
 	for (; iter != end; ++iter) {
 		Int obsid = iter->obsID;
 		Int arrid = iter->arrayID;

--- a/ms/MSOper/MSSummary.h
+++ b/ms/MSOper/MSSummary.h
@@ -96,9 +96,12 @@ class MSSummary
 {
 public:
 // Constructor
-   MSSummary (const MeasurementSet&);
-   MSSummary (const MeasurementSet*);
-   MSSummary (const MeasurementSet* ms, const String msname);
+// <group>
+// <src>maxCacheMB</src> is the maximum cache size in MB to use for the created
+// MSMetaData object.
+   MSSummary (const MeasurementSet& ms, Float maxCacheMB = 50.0);
+   MSSummary (const MeasurementSet* ms, Float maxCacheMB = 50.0);
+   MSSummary (const MeasurementSet* ms, const String msname, Float maxCacheMB = 50.0);
 
 // Destructor
   ~MSSummary();
@@ -109,8 +112,10 @@ public:
 // Retrieve image name
    String name() const;
 
-// Set a new MS
-   Bool setMS (const MeasurementSet& ms);
+// Set a new MS. <src>maxCacheMB</src> is the maximum cache size of the
+// created MSMetaData tool. If negative, the cache size used when this object
+// was created is used.
+   Bool setMS (const MeasurementSet& ms, Float maxCacheMB=-1);
 
 // List all header information.
    void list (LogIO& os, Bool verbose=False, Bool oneBased=True) const;
@@ -164,8 +169,8 @@ public:
 
    void setListUnflaggedRowCount(Bool v) { _listUnflaggedRowCount = v; }
 
-   // set the cache size, in MB, for the MSMetaData object.
-   void setMetaDataCacheSizeInMB(Float cacheSize) { _cacheSizeMB = cacheSize; }
+   // OBSOLETE. No longer does anything, kept for compilation backward compatibility.
+   void setMetaDataCacheSizeInMB(Float) {}
 
 private:
 // Pointer to MS

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2381,11 +2381,11 @@ void testIt(MSMetaData& md) {
             key.obsID = 0;
             key.scan = 1;
             key.fieldID = 0;
-            SHARED_PTR<const map<SubScanKey, uInt64> > both = md.getNRowMap(MSMetaData::BOTH);
+            SHARED_PTR<const map<SubScanKey, uInt> > both = md.getNRowMap(MSMetaData::BOTH);
             AlwaysAssert(both->find(key)->second == 367, AipsError);
-            SHARED_PTR<const map<SubScanKey, uInt64> > ac = md.getNRowMap(MSMetaData::AUTO);
+            SHARED_PTR<const map<SubScanKey, uInt> > ac = md.getNRowMap(MSMetaData::AUTO);
             AlwaysAssert(ac->find(key)->second == 51, AipsError);
-            SHARED_PTR<const map<SubScanKey, uInt64> > xc = md.getNRowMap(MSMetaData::CROSS);
+            SHARED_PTR<const map<SubScanKey, uInt> > xc = md.getNRowMap(MSMetaData::CROSS);
             AlwaysAssert(xc->find(key)->second == 316, AipsError);
         }
         {

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2160,6 +2160,9 @@ void testIt(MSMetaData& md) {
             sskey.scan = 1;
             MSMetaData::SubScanProperties props = md.getSubScanProperties(sskey);
             AlwaysAssert(props.nrows == 367, AipsError);
+            SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > allProps
+                = md.getSubScanProperties();
+            AlwaysAssert(allProps->find(sskey)->second.nrows == 367, AipsError);
         }
         {
         	cout << "*** test getScanKeys()" << endl;
@@ -2178,14 +2181,14 @@ void testIt(MSMetaData& md) {
         	}
         }
         {
-        	cout << "*** test getIntentsForSubScan()" << endl;
+        	cout << "*** test getIntentsForSubScan() and getSubScanToIntentsMap()" << endl;
         	ArrayKey arrayKey;
         	arrayKey.obsID = 0;
         	arrayKey.arrayID = 0;
         	std::set<SubScanKey> sskeys = md.getSubScanKeys(arrayKey);
         	std::set<SubScanKey>::const_iterator ssiter = sskeys.begin();
         	std::set<SubScanKey>::const_iterator ssend = sskeys.end();
-
+        	SHARED_PTR<const std::map<SubScanKey, std::set<String> > > mymap = md.getSubScanToIntentsMap();
         	for (; ssiter!=ssend; ++ssiter) {
         		std::set<String> intents = md.getIntentsForSubScan(*ssiter);
         		std::set<String> exp;
@@ -2259,6 +2262,7 @@ void testIt(MSMetaData& md) {
         		}
         		uniqueIntents.insert(exp.begin(), exp.end());
         		AlwaysAssert(intents == exp, AipsError);
+                AlwaysAssert(mymap->find(*ssiter)->second == exp, AipsError);
         	}
         }
         {
@@ -2358,6 +2362,31 @@ void testIt(MSMetaData& md) {
             for (; iter!=end; ++iter, ++i) {
                 AlwaysAssert(*iter == i, AipsError);
             }
+        }
+        {
+            cout << "*** test getScanToTimeRangeMap()" << endl;
+            SHARED_PTR<const std::map<ScanKey, std::pair<Double,Double> > > mymap
+                = md.getScanToTimeRangeMap();
+            ScanKey key;
+            key.arrayID = 0;
+            key.obsID = 0;
+            key.scan = 1;
+            AlwaysAssert(near(mymap->find(key)->second.first,  4842824745.0, 1.0), AipsError);
+            AlwaysAssert(near(mymap->find(key)->second.second, 4842824839.0, 1.0), AipsError);
+        }
+        {
+            cout << "*** test getNRowsMap()" << endl;
+            SubScanKey key;
+            key.arrayID = 0;
+            key.obsID = 0;
+            key.scan = 1;
+            key.fieldID = 0;
+            SHARED_PTR<const map<SubScanKey, uInt64> > both = md.getNRowMap(MSMetaData::BOTH);
+            AlwaysAssert(both->find(key)->second == 367, AipsError);
+            SHARED_PTR<const map<SubScanKey, uInt64> > ac = md.getNRowMap(MSMetaData::AUTO);
+            AlwaysAssert(ac->find(key)->second == 51, AipsError);
+            SHARED_PTR<const map<SubScanKey, uInt64> > xc = md.getNRowMap(MSMetaData::CROSS);
+            AlwaysAssert(xc->find(key)->second == 316, AipsError);
         }
         {
 			cout << "*** cache size " << md.getCache() << endl;


### PR DESCRIPTION
Added support for logging uInt64 and Int64.
Fixed bug in MSMetaData::_getSubScanProps() which caused incorrect size of data structure to be computed.

_getSubScanProperties() -> getSubScanProps() (private to public) to allow caller to hold the entire property structure so it doesn't have to call for each subscan. => performance improvement

added progress meter when running getSubScanProps()

added MSMetaData::getNRowMap() to allow caller to hold entire data structure rather than having to call another method for each separate subscan => performance improvement

Added method to allow caller to specify that MSMetaData should always cache subscan properties structure since it can be very expensive to recompute if max cache size has already been exceeded.

Added MSMetaData::getSubScanToIntentsMap() to allow caller to retrieve entire data structure rather than having to call another method for each subscan => performance improvement.

Changed several row determination methods from uInt to uInt64 because VLA is not writing MSes with > 100 mega rows, so it is just a matter of time before table interface limitations are going to result in overflows.

Made use of various performance improvements in MSSummary.

