### PR TITLE
improve efficiency of tilestmanager

### DIFF
--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -1073,14 +1073,16 @@ void TSMCube::accessSection (const IPosition& start, const IPosition& end,
 
         while (True) {
             if (writeFlag) {
-	      TSMCube_MoveData (dataArray+dataOffset, section+sectionOffset);
-            }else{
-	      TSMCube_MoveData (section+sectionOffset, dataArray+dataOffset);
-	    }
-            dataOffset    += localSize;
+                TSMCube_MoveData(dataArray + dataOffset,
+                                 section + sectionOffset);
+            } else {
+                TSMCube_MoveData(section + sectionOffset,
+                                 dataArray + dataOffset);
+            }
+            dataOffset += localSize;
             sectionOffset += localSize;
-            for (j=1; j<nrdim_p; j++) {
-                dataOffset    += dataIncr(j);
+            for (j = 1; j < nrdim_p; j++) {
+                dataOffset += dataIncr(j);
                 sectionOffset += sectionIncr(j);
                 if (++dataPos(j) <= endPixel(j)) {
                     break;
@@ -1166,11 +1168,12 @@ void TSMCube::accessLine (char* section, uInt pixelOffset,
         // Otherwise loop through all pixels.
         if (contiguous) {
             if (writeFlag) {
-	        TSMCube_MoveData(dataArray,section);
-            }else{
-	        TSMCube_MoveData(section,dataArray);
-	    }
-	    section += localSize;
+                TSMCube_MoveData(dataArray,section);
+            }
+            else {
+                TSMCube_MoveData(section,dataArray);
+            }
+            section += localSize;
         }else{
             // Try to make the data copy as fast as possible.
             // Do this by specializing the cases (which occur very often)
@@ -1438,53 +1441,56 @@ void TSMCube::accessStrided (const IPosition& start, const IPosition& end,
 
         while (True) {
             if (strided) {
-		uInt nrp = nrPixel(0);
+                uInt nrp = nrPixel(0);
                 for (j=0; j<nrp; j++) {
                     if (writeFlag) {
-		      switch (localPixelWords) {
-		      case 2:
-			((Int*)(dataArray+dataOffset))[1] =
-			  ((Int*)(section+sectionOffset))[1];
-		      case 1:
-			((Int*)(dataArray+dataOffset))[0] =
-			  ((Int*)(section+sectionOffset))[0];
-			break;
-		      default:
-			TSMCube_copyChar ((Char*)(dataArray+dataOffset),
-					  (Char*)(section+sectionOffset),
-					  localPixelSize);
-		      }
-                    }else{
-		      switch (localPixelWords) {
-		      case 2:
-			((Int*)(section+sectionOffset))[1] =
-			  ((Int*)(dataArray+dataOffset))[1];
-		      case 1:
-			((Int*)(section+sectionOffset))[0] =
-			  ((Int*)(dataArray+dataOffset))[0];
-			break;
-		      default:
-			TSMCube_copyChar ((Char*)(section+sectionOffset),
-					  (Char*)(dataArray+dataOffset),
-					  localPixelSize);
-		      }
+                        switch (localPixelWords) {
+                            case 2:
+                                ((Int*)(dataArray+dataOffset))[1] =
+                                    ((Int*)(section+sectionOffset))[1];
+                            case 1:
+                                ((Int*)(dataArray+dataOffset))[0] =
+                                    ((Int*)(section+sectionOffset))[0];
+                                break;
+                            default:
+                                TSMCube_copyChar ((Char*)(dataArray+dataOffset),
+                                                  (Char*)(section+sectionOffset),
+                                                  localPixelSize);
+                        }
+                    }
+                    else {
+                        switch (localPixelWords) {
+                            case 2:
+                                ((Int*)(section+sectionOffset))[1] =
+                                    ((Int*)(dataArray+dataOffset))[1];
+                            case 1:
+                                ((Int*)(section+sectionOffset))[0] =
+                                    ((Int*)(dataArray+dataOffset))[0];
+                                break;
+                            default:
+                                TSMCube_copyChar ((Char*)(section+sectionOffset),
+                                                  (Char*)(dataArray+dataOffset),
+                                                  localPixelSize);
+                        }
                     }
                     dataOffset    += strideSize;
                     sectionOffset += localPixelSize;
                 }
-            }else{
+            }
+            else {
                 if (writeFlag) {
                     TSMCube_MoveData (dataArray+dataOffset,
-				      section+sectionOffset);
-                }else{
-		    TSMCube_MoveData (section+sectionOffset,
-				      dataArray+dataOffset);
+                                      section+sectionOffset);
+                }
+                else {
+                    TSMCube_MoveData (section+sectionOffset,
+                                      dataArray+dataOffset);
                 }
                 dataOffset    += localSize;
                 sectionOffset += localSize;
             }
             for (j=1; j<nrdim_p; j++) {
-              // Catch attempt to increment dataOffset below 0
+                // Catch attempt to increment dataOffset below 0
                 DebugAssert(dataIncr(j) >= 0 ||
                             dataOffset >= static_cast<uInt>(-dataIncr(j)),
                             DataManError);

--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -700,9 +700,7 @@ char* TSMCube::initCallBack (void* owner)
 {
     uInt size = ((TSMCube*)owner)->localTileLength();
     char* buffer = new char[size];
-    for (uInt i=0; i<size; i++) {
-        buffer[i] = 0;
-    }
+    memset(buffer, 0, size);
     return buffer;
 }
 

--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -1035,9 +1035,20 @@ void TSMCube::accessSection (const IPosition& start, const IPosition& end,
                             expandedTileShape_p.offsetIncrement (dataLength);
         IPosition sectionIncr = localPixelSize *
                             expandedSectionShape.offsetIncrement (dataLength);
-        uInt localSize    = dataLength(0) * localPixelSize;
 
         while (True) {
+            uInt localSize = dataLength(0) * localPixelSize;
+            /* merge zero increments into one copy */
+            for (j = 1; j < nrdim_p; j++) {
+                if (dataIncr(j) == 0 && sectionIncr(j) == 0) {
+                    localSize *= dataLength(j);
+                    dataPos(j) = endPixel(j);
+                }
+                else {
+                    break;
+                }
+            }
+
             if (writeFlag) {
                 TSMCube_MoveData(dataArray + dataOffset,
                                  section + sectionOffset, localSize);


### PR DESCRIPTION
This changeset aims to improve the cpu efficiency of non-strided part of the tiled storage manager.
I noticed that a CASA task doing nothing but IO is significantly bottlenecked by the cpu and not able to fully utilize a mid-range SSD (700mb/s bandwidth).
The main culprit is the TSMCube::accessSection which reads non-stride tiles. In ALMA and EVLA data the tiles are typically (X, Y, Z) with X being only of size 2 or 4 elements, the main copy-loop in this function loops over each dimension of the tiles so it iterates on a tiny dimension. As the buffers read and written are usually contiguous we can often merge the loops into larger copy calls.

There are four commits, the first just reindents some code, the second refactors the copy loop into a function without using local variables. The third replaces a memset loop with a memset call which is a lot faster, especially with old compilers that can't do this replacement for you.
The loop merging is in the 4th commit.

In total this improves the throughput of our supposedly IO-only task on this hardware by about 25%. But the mileage may vary depending on tileshape, shape of the involved buffers and libc version.