### PR TITLE
Generalize Record::defineFromValueHolder

### DIFF
--- a/casa/Containers/Record.h
+++ b/casa/Containers/Record.h
@@ -43,7 +43,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 template<class T> class Array;
 class IPosition;
 class AipsIO;
-class ValueHolder;
 
 
 // <summary>
@@ -335,8 +334,9 @@ public:
     // Get or define the value as a ValueHolder.
     // This is useful to pass around a value of any supported type.
     // <group>
-    ValueHolder asValueHolder (const RecordFieldId&) const;
-    void defineFromValueHolder (const RecordFieldId&, const ValueHolder&);
+    virtual ValueHolder asValueHolder (const RecordFieldId&) const;
+    virtual void defineFromValueHolder (const RecordFieldId&,
+                                        const ValueHolder&);
     // </group>
 
     // Merge a field from another record into this record.

--- a/casa/Containers/Record2.cc
+++ b/casa/Containers/Record2.cc
@@ -33,141 +33,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 ValueHolder Record::asValueHolder (const RecordFieldId& id) const
 {
-  switch (dataType(id)) {
-  case TpBool:
-    return ValueHolder(asBool(id));
-  case TpUChar:
-    return ValueHolder(asuChar(id));
-  case TpShort:
-    return ValueHolder(asShort(id));
-  case TpInt:
-    return ValueHolder(asInt(id));
-  case TpUInt:
-    return ValueHolder(asuInt(id));
-  case TpInt64:
-    return ValueHolder(asInt64(id));
-  case TpFloat:
-    return ValueHolder(asFloat(id));
-  case TpDouble:
-    return ValueHolder(asDouble(id));
-  case TpComplex:
-    return ValueHolder(asComplex(id));
-  case TpDComplex:
-    return ValueHolder(asDComplex(id));
-  case TpString:
-    return ValueHolder(asString(id));
-  case TpArrayBool:
-    return ValueHolder(asArrayBool(id));
-  case TpArrayUChar:
-    return ValueHolder(asArrayuChar(id));
-  case TpArrayShort:
-    return ValueHolder(asArrayShort(id));
-  case TpArrayInt:
-    return ValueHolder(asArrayInt(id));
-  case TpArrayUInt:
-    return ValueHolder(asArrayuInt(id));
-  case TpArrayInt64:
-    return ValueHolder(asArrayInt64(id));
-  case TpArrayFloat:
-    return ValueHolder(asArrayFloat(id));
-  case TpArrayDouble:
-    return ValueHolder(asArrayDouble(id));
-  case TpArrayComplex:
-    return ValueHolder(asArrayComplex(id));
-  case TpArrayDComplex:
-    return ValueHolder(asArrayDComplex(id));
-  case TpArrayString:
-    return ValueHolder(asArrayString(id));
-  case TpRecord:
+  if (dataType(id) == TpRecord) {
     return ValueHolder(subRecord(id));
-  default:
-    break;
+  } else {
+    return RecordInterface::asValueHolder (id);
   }
-  throw AipsError ("Record::asValueHolder - unknown data type");
 }
 
 void Record::defineFromValueHolder (const RecordFieldId& id,
 				    const ValueHolder& value)
 {
-  switch (value.dataType()) {
-  case TpBool:
-    define (id, value.asBool());
-    break;
-  case TpUChar:
-    define (id, value.asuChar());
-    break;
-  case TpShort:
-    define (id, value.asShort());
-    break;
-  case TpUShort:
-  case TpInt:
-    define (id, value.asInt());
-    break;
-  case TpUInt:
-    define (id, value.asuInt());
-    break;
-  case TpInt64:
-    define (id, value.asInt64());
-    break;
-  case TpFloat:
-    define (id, value.asFloat());
-    break;
-  case TpDouble:
-    define (id, value.asDouble());
-    break;
-  case TpComplex:
-    define (id, value.asComplex());
-    break;
-  case TpDComplex:
-    define (id, value.asDComplex());
-    break;
-  case TpString:
-    define (id, value.asString());
-    break;
-  case TpArrayBool:
-    define (id, value.asArrayBool());
-    break;
-  case TpArrayUChar:
-    define (id, value.asArrayuChar());
-    break;
-  case TpArrayShort:
-    define (id, value.asArrayShort());
-    break;
-  case TpArrayUShort:
-  case TpArrayInt:
-    define (id, value.asArrayInt());
-    break;
-  case TpArrayUInt:
-    define (id, value.asArrayuInt());
-    break;
-  case TpArrayInt64:
-    define (id, value.asArrayInt64());
-    break;
-  case TpArrayFloat:
-    define (id, value.asArrayFloat());
-    break;
-  case TpArrayDouble:
-    define (id, value.asArrayDouble());
-    break;
-  case TpArrayComplex:
-    define (id, value.asArrayComplex());
-    break;
-  case TpArrayDComplex:
-    define (id, value.asArrayDComplex());
-    break;
-  case TpArrayString:
-    define (id, value.asArrayString());
-    break;
-  case TpRecord:
+  if (value.dataType() == TpRecord) {
     defineRecord (id, value.asRecord());
-    break;
-  case TpOther:
-    // An untyped array is handled as an Int array.
-    define (id, value.asArrayInt());
-    break;
-  default:
-    throw AipsError ("Record::defineFromValueHolder - unknown data type");
-    break;
+  } else {
+    RecordInterface::defineFromValueHolder (id, value);
   }
 }
 

--- a/casa/Containers/Record2Interface.cc
+++ b/casa/Containers/Record2Interface.cc
@@ -29,6 +29,7 @@
 
 #include <casacore/casa/Containers/RecordInterface.h>
 #include <casacore/casa/Containers/RecordDesc.h>
+#include <casacore/casa/Containers/ValueHolder.h>
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/IPosition.h>
@@ -109,6 +110,14 @@ Array<Int> RecordInterface::toArrayInt (const RecordFieldId& id) const
       convertArray (arr, tmp);
       break;
     }
+  case TpInt64:
+  case TpArrayInt64:
+    {
+      Array<Int64> tmp = asArrayInt64 (id);
+      arr.resize (tmp.shape());
+      convertArray (arr, tmp);
+      break;
+    }
   default:
     arr = asArrayInt (id);
   }
@@ -140,6 +149,14 @@ Array<uInt> RecordInterface::toArrayuInt (const RecordFieldId& id) const
   case TpArrayInt:
     {
       Array<Int> tmp = asArrayInt (id);
+      arr.resize (tmp.shape());
+      convertArray (arr, tmp);
+      break;
+    }
+  case TpInt64:
+  case TpArrayInt64:
+    {
+      Array<Int64> tmp = asArrayInt64 (id);
       arr.resize (tmp.shape());
       convertArray (arr, tmp);
       break;
@@ -407,6 +424,144 @@ Array<String> RecordInterface::toArrayString (const RecordFieldId& id) const
 {
   return asArrayString(id).copy();
 }
+
+
+ValueHolder RecordInterface::asValueHolder (const RecordFieldId& id) const
+{
+  switch (dataType(id)) {
+  case TpBool:
+    return ValueHolder(asBool(id));
+  case TpUChar:
+    return ValueHolder(asuChar(id));
+  case TpShort:
+    return ValueHolder(asShort(id));
+  case TpInt:
+    return ValueHolder(asInt(id));
+  case TpUInt:
+    return ValueHolder(asuInt(id));
+  case TpInt64:
+    return ValueHolder(asInt64(id));
+  case TpFloat:
+    return ValueHolder(asFloat(id));
+  case TpDouble:
+    return ValueHolder(asDouble(id));
+  case TpComplex:
+    return ValueHolder(asComplex(id));
+  case TpDComplex:
+    return ValueHolder(asDComplex(id));
+  case TpString:
+    return ValueHolder(asString(id));
+  case TpArrayBool:
+    return ValueHolder(asArrayBool(id));
+  case TpArrayUChar:
+    return ValueHolder(asArrayuChar(id));
+  case TpArrayShort:
+    return ValueHolder(asArrayShort(id));
+  case TpArrayInt:
+    return ValueHolder(asArrayInt(id));
+  case TpArrayUInt:
+    return ValueHolder(asArrayuInt(id));
+  case TpArrayInt64:
+    return ValueHolder(asArrayInt64(id));
+  case TpArrayFloat:
+    return ValueHolder(asArrayFloat(id));
+  case TpArrayDouble:
+    return ValueHolder(asArrayDouble(id));
+  case TpArrayComplex:
+    return ValueHolder(asArrayComplex(id));
+  case TpArrayDComplex:
+    return ValueHolder(asArrayDComplex(id));
+  case TpArrayString:
+    return ValueHolder(asArrayString(id));
+  default:
+    break;
+  }
+  throw AipsError ("RecordInterface::asValueHolder - unknown data type");
+}
+
+void RecordInterface::defineFromValueHolder (const RecordFieldId& id,
+                                             const ValueHolder& value)
+{
+  switch (value.dataType()) {
+  case TpBool:
+    define (id, value.asBool());
+    break;
+  case TpUChar:
+    define (id, value.asuChar());
+    break;
+  case TpShort:
+    define (id, value.asShort());
+    break;
+  case TpUShort:
+  case TpInt:
+    define (id, value.asInt());
+    break;
+  case TpUInt:
+    define (id, value.asuInt());
+    break;
+  case TpInt64:
+    define (id, value.asInt64());
+    break;
+  case TpFloat:
+    define (id, value.asFloat());
+    break;
+  case TpDouble:
+    define (id, value.asDouble());
+    break;
+  case TpComplex:
+    define (id, value.asComplex());
+    break;
+  case TpDComplex:
+    define (id, value.asDComplex());
+    break;
+  case TpString:
+    define (id, value.asString());
+    break;
+  case TpArrayBool:
+    define (id, value.asArrayBool());
+    break;
+  case TpArrayUChar:
+    define (id, value.asArrayuChar());
+    break;
+  case TpArrayShort:
+    define (id, value.asArrayShort());
+    break;
+  case TpArrayUShort:
+  case TpArrayInt:
+    define (id, value.asArrayInt());
+    break;
+  case TpArrayUInt:
+    define (id, value.asArrayuInt());
+    break;
+  case TpArrayInt64:
+    define (id, value.asArrayInt64());
+    break;
+  case TpArrayFloat:
+    define (id, value.asArrayFloat());
+    break;
+  case TpArrayDouble:
+    define (id, value.asArrayDouble());
+    break;
+  case TpArrayComplex:
+    define (id, value.asArrayComplex());
+    break;
+  case TpArrayDComplex:
+    define (id, value.asArrayDComplex());
+    break;
+  case TpArrayString:
+    define (id, value.asArrayString());
+    break;
+  case TpOther:
+    // An untyped array is handled as an Int array.
+    define (id, value.asArrayInt());
+    break;
+  default:
+    throw AipsError ("RecordInterface::defineFromValueHolder - "
+                     "unknown data type");
+    break;
+  }
+}
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/casa/Containers/RecordInterface.cc
+++ b/casa/Containers/RecordInterface.cc
@@ -498,6 +498,8 @@ Int RecordInterface::asInt (const RecordFieldId& id) const
         break;
     case TpUInt:
 	return *(const uInt*)get_pointer (whichField, TpUInt);
+    case TpInt64:
+	return *(const Int64*)get_pointer (whichField, TpInt64);
     default:
 	throw (AipsError ("RecordInterface::asInt - invalid data type"));
     }
@@ -516,6 +518,8 @@ uInt RecordInterface::asuInt (const RecordFieldId& id) const
 	return *(const Int*)get_pointer (whichField, TpInt);
     case TpUInt:
 	break;
+    case TpInt64:
+	return *(const Int64*)get_pointer (whichField, TpInt64);
     default:
 	throw (AipsError ("RecordInterface::asuInt - invalid data type"));
     }

--- a/casa/Containers/RecordInterface.h
+++ b/casa/Containers/RecordInterface.h
@@ -43,6 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
 class RecordDesc;
+class ValueHolder;
 class IPosition;
 
 
@@ -288,6 +289,14 @@ public:
     // pointing to the removed field, but no other RecordFieldPtr's.
     // </note>
     virtual void removeField (const RecordFieldId&) = 0;
+
+    // Get or define the value as a ValueHolder.
+    // This is useful to pass around a value of any supported type.
+    // <group>
+    virtual ValueHolder asValueHolder (const RecordFieldId&) const;
+    virtual void defineFromValueHolder (const RecordFieldId&,
+                                        const ValueHolder&);
+    // </group>
 
     // Define a value for the given field.
     // Array conformance rules will not be applied for variable shaped arrays.

--- a/casa/Containers/ValueHolder.h
+++ b/casa/Containers/ValueHolder.h
@@ -101,7 +101,7 @@ public:
   explicit ValueHolder (const Record& value);
   // </group>
 
-  // Create an empty N-dim array.
+  // Create an empty N-dim array (gets type TpOther).
   ValueHolder (uInt ndim, Bool dummy);
 
   // Create a ValueHolder from a ValueHolderRep.

--- a/casa/Containers/ValueHolderRep.cc
+++ b/casa/Containers/ValueHolderRep.cc
@@ -32,6 +32,7 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/Utilities/ValType.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
 
@@ -134,10 +135,10 @@ ValueHolderRep::ValueHolderRep (const Array<Short>& value)
 
 ValueHolderRep::ValueHolderRep (const Array<uShort>& value)
   : itsNdim (value.ndim()),
-    itsType (TpArrayInt),
-    itsPtr  (new Array<Int>(value.shape()))
+    itsType (TpArrayUInt),
+    itsPtr  (new Array<uInt>(value.shape()))
 {
-  convertArray (*static_cast<Array<Int>*>(itsPtr), value);
+  convertArray (*static_cast<Array<uInt>*>(itsPtr), value);
 }
 
 ValueHolderRep::ValueHolderRep (const Array<Int>& value)
@@ -270,7 +271,8 @@ Bool ValueHolderRep::asBool() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asBool - invalid data type");
+  throw AipsError ("ValueHolderRep::asBool - invalid data type " +
+                   String::toString(itsType));
 }
 
 uChar ValueHolderRep::asuChar() const
@@ -293,7 +295,8 @@ uChar ValueHolderRep::asuChar() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asuChar - invalid data type");
+  throw AipsError ("ValueHolderRep::asuChar - invalid data type " +
+                   String::toString(itsType));
 }
 
 Short ValueHolderRep::asShort() const
@@ -316,7 +319,8 @@ Short ValueHolderRep::asShort() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asShort - invalid data type");
+  throw AipsError ("ValueHolderRep::asShort - invalid data type " +
+                   String::toString(itsType));
 }
 
 uShort ValueHolderRep::asuShort() const
@@ -339,7 +343,8 @@ uShort ValueHolderRep::asuShort() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asuShort - invalid data type");
+  throw AipsError ("ValueHolderRep::asuShort - invalid data type " +
+                   String::toString(itsType));
 }
 
 Int ValueHolderRep::asInt() const
@@ -359,7 +364,8 @@ Int ValueHolderRep::asInt() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asInt - invalid data type");
+  throw AipsError ("ValueHolderRep::asInt - invalid data type " +
+                   String::toString(itsType));
 }
 
 uInt ValueHolderRep::asuInt() const
@@ -382,7 +388,8 @@ uInt ValueHolderRep::asuInt() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asuInt - invalid data type");
+  throw AipsError ("ValueHolderRep::asuInt - invalid data type " +
+                   String::toString(itsType));
 }
 
 Int64 ValueHolderRep::asInt64() const
@@ -402,7 +409,8 @@ Int64 ValueHolderRep::asInt64() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asInt64 - invalid data type");
+  throw AipsError ("ValueHolderRep::asInt64 - invalid data type " +
+                   String::toString(itsType));
 }
 
 Float ValueHolderRep::asFloat() const
@@ -422,7 +430,8 @@ Float ValueHolderRep::asFloat() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asFloat - invalid data type");
+  throw AipsError ("ValueHolderRep::asFloat - invalid data type " +
+                   String::toString(itsType));
 }
 
 Double ValueHolderRep::asDouble() const
@@ -442,7 +451,8 @@ Double ValueHolderRep::asDouble() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asDouble - invalid data type");
+  throw AipsError ("ValueHolderRep::asDouble - invalid data type " +
+                   String::toString(itsType));
 }
 
 Complex ValueHolderRep::asComplex() const
@@ -467,7 +477,8 @@ Complex ValueHolderRep::asComplex() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asComplex - invalid data type");
+  throw AipsError ("ValueHolderRep::asComplex - invalid data type " +
+                   String::toString(itsType));
 }
 
 DComplex ValueHolderRep::asDComplex() const
@@ -491,7 +502,8 @@ DComplex ValueHolderRep::asDComplex() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asDComplex - invalid data type");
+  throw AipsError ("ValueHolderRep::asDComplex - invalid data type " +
+                   String::toString(itsType));
 }
 
 const String& ValueHolderRep::asString() const
@@ -502,7 +514,8 @@ const String& ValueHolderRep::asString() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asString - invalid data type");
+  throw AipsError ("ValueHolderRep::asString - invalid data type " +
+                   String::toString(itsType));
 }
 
 const Array<Bool> ValueHolderRep::asArrayBool() const
@@ -983,7 +996,8 @@ const Record& ValueHolderRep::asRecord() const
   default:
     ;
   }
-  throw AipsError ("ValueHolderRep::asRecord - invalid data type");
+  throw AipsError ("ValueHolderRep::asRecord - invalid data type " +
+                   String::toString(itsType));
 }
 
 
@@ -1130,7 +1144,8 @@ ValueHolderRep* ValueHolderRep::fromRecord (const Record& rec,
   default:
     break;
   }
-  throw AipsError ("ValueHolder::fromRecord - unknown data type");
+  throw AipsError ("ValueHolder::fromRecord - unknown data type " +
+                   String::toString(rec.dataType(id)));
 }
 
 ostream& ValueHolderRep::write (ostream& os) const
@@ -1187,7 +1202,8 @@ ostream& ValueHolderRep::write (ostream& os) const
     os << "Empty untyped array";
     break;
   default:
-    throw AipsError ("ValueHolder::write - unknown data type");
+    throw AipsError ("ValueHolder::write - unknown data type " +
+                     String::toString(itsType));
     break;
   }
   return os;
@@ -1213,7 +1229,8 @@ bool ValueHolderRep::operator< (const ValueHolderRep& right) const
   case TpString:
     return *static_cast<String*>(itsPtr) < *static_cast<String*>(right.itsPtr);
   default:
-    throw AipsError ("ValueHolder::operator< - unsupported data type");
+    throw AipsError ("ValueHolder::operator< - unsupported data type " +
+                     String::toString(itsType));
   }
 }
 

--- a/casa/Containers/test/tRecord.cc
+++ b/casa/Containers/test/tRecord.cc
@@ -27,6 +27,7 @@
 
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Containers/RecordField.h>
+#include <casacore/casa/Containers/ValueHolder.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Arrays/Array.h>
@@ -40,9 +41,8 @@
 
 #include <casacore/casa/namespace.h>
 // This program tests the Record and RecordRep classes.
-// Its expected output (which only consists of exception text)
-// is stored in tRecord.out and can be checked using assay.
-// This will also delete the temporary output file.
+// Its expected output is stored in tRecord.out and can be checked
+// using assay. This will also delete the temporary output file.
 // <p>
 // It can throw several exceptions, which may result in memory leaks.
 // To check if no real memory leaks occur, the program can be run
@@ -235,8 +235,14 @@ void doSubRecord (Bool doExcp, const RecordDesc& desc)
     AlwaysAssertExit (record.subRecord(subField1).asFloat(0) == 3);
     record.print (cout, 0, "  ");
     record.print (cout, -1, "  ");
-    record.print (cout, 1, "  ");
     cout << record;
+    // Test conversion to ValueHolder.
+    Record recin;
+    recin.defineRecord ("rec", record);
+    ValueHolder vh = recin.asValueHolder(0);
+    Record recout;
+    recout.defineFromValueHolder (0, vh);
+    recout.print (cout, 1);
 }
 
 void doIt (Bool doExcp)

--- a/casa/Containers/test/tRecord.out
+++ b/casa/Containers/test/tRecord.out
@@ -168,11 +168,12 @@ RecordInterface::asComplex - invalid data type
   TpDouble2a: Double 0
   TpComplex2a: Complex (0,0)
   TpDComplex2a: DComplex (0,0)
-  TpArrayString2a: String array with shape [3], first values:
-    []
+  TpArrayString2a: String array with shape [3]
+    [, , ]
   TpArrayString3a: String array with shape []
     []
   TpString2a: String ""
+*1: {
   TpBool: Bool 0
   TpUChar: uChar 0
   TpShort: Short 0
@@ -224,11 +225,12 @@ RecordInterface::asComplex - invalid data type
   TpDouble2a: Double 0
   TpComplex2a: Complex (0,0)
   TpDComplex2a: DComplex (0,0)
-  TpArrayString2a: String array with shape [3]
-    [, , ]
+  TpArrayString2a: String array with shape [3], first values:
+    []
   TpArrayString3a: String array with shape []
     []
   TpString2a: String ""
+}
 >>> Instance-specific assertion error message:
 (Record.cc : 281) Failed AlwaysAssertExit this != &other
 <<<

--- a/python/Converters/test/tConvert.out
+++ b/python/Converters/test/tConvert.out
@@ -78,7 +78,7 @@ Float -16
 Complex (-16,0)
 (-16+0j)
     testarrvh
-VH Array<Int>
+VH Array<uInt>
 [15 16]
 VH uShort
 15

--- a/tables/Tables/TableRecord.h
+++ b/tables/Tables/TableRecord.h
@@ -252,6 +252,25 @@ public:
     // Otherwise each individual field is copied.
     virtual void assign (const RecordInterface& that);
 
+    // Convert the TableRecord to a Record (recursively).
+    // A possible Table object is converted to a string containing
+    // the table name preceeded by 'Table: ' (as used by TableProxy).
+    Record toRecord() const;
+
+    // Fill the TableRecord from the given Record.
+    // The fields are appended to the TableRecord.
+    // It is the opposite of toRecord, so a String containg 'Table: '
+    // is handled as a Table (if it exists).
+    void fromRecord (const Record& rec);
+
+    // Get or define the value as a ValueHolder.
+    // This is useful to pass around a value of any supported type.
+    // <group>
+    virtual ValueHolder asValueHolder (const RecordFieldId&) const;
+    virtual void defineFromValueHolder (const RecordFieldId&,
+                                        const ValueHolder&);
+    // </group>
+
     // Get the comment for this field.
     virtual const String& comment (const RecordFieldId&) const;
 

--- a/tables/Tables/test/tTableRecord.cc
+++ b/tables/Tables/test/tTableRecord.cc
@@ -44,9 +44,8 @@
 
 #include <casacore/casa/namespace.h>
 // This program tests the TableRecord and TableRecordRep classes.
-// Its expected output (which only consists of exception text)
-// is stored in tTableRecord.out and can be checked using assay.
-// This will also delete the temporary output file.
+// Its expected output is stored in tTableRecord.out and can be checked
+// using assay. This will also delete the temporary output file.
 // <p>
 // It can throw several exceptions, which may result in memory leaks.
 // To check if no real memory leaks occur, the program can be run
@@ -226,6 +225,13 @@ void doSubRecord (Bool doExcp, const RecordDesc& desc)
     AlwaysAssertExit (record.subRecord(subField1).asfloat(0) == 4);
     record = record1;
     AlwaysAssertExit (record.subRecord(subField1).asfloat(0) == 3);
+    // Print the record.
+    cout << record;
+    // Convert to and from a Record.
+    Record srec = record.toRecord();
+    TableRecord trec;
+    trec.fromRecord (srec);
+    cout << trec;
 }
 
 void doIt (Bool doExcp)
@@ -796,6 +802,15 @@ void testTable (Bool doExcp)
     rec1.defineTable ("tab1a", t1);
     AlwaysAssertExit (rec1.conform(rec2));      // second table type is var.
     AlwaysAssertExit (! rec2.conform(rec1));    // second table type mismatches
+    // Convert to and from a Record.
+    // First flush, otherwise fromRecord won't find a table.
+    tab1.flush();
+    tab2.flush();
+    Record srec = rec1.toRecord();
+    cout << "Record" << endl << srec;
+    TableRecord trec;
+    trec.fromRecord (srec);
+    cout << "TableRecord" << endl << trec;
 
     // Constructor from RecordInterface
     // The first one should dynamic cast itself to a TableRecord,

--- a/tables/Tables/test/tTableRecord.out
+++ b/tables/Tables/test/tTableRecord.out
@@ -16,6 +16,116 @@ TableRecordRep::get_pointer - field SubRecord is not of type TableRecord
 >>> Instance-specific assertion error message:
 (/aips++/code/aips/implement/Tables/TableRecord.cc : 121) Failed AlwaysAssertExit conform (other)
 <<<
+  TpBool: Bool 0
+  TpUChar: uChar 0
+  TpShort: Short 0
+  TpInt: Int 0
+  TpUInt: uInt 0
+  TpFloat: Float 0
+  TpDouble: Double 0
+  TpComplex: Complex (0,0)
+  TpDComplex: DComplex (0,0)
+  TpString: String ""
+  TpArrayBool: Bool array with shape [1]
+    [0]
+  TpArrayUChar: uChar array with shape [1]
+    [0]
+  TpArrayShort: Short array with shape [1]
+    [0]
+  TpArrayInt: Int array with shape [1]
+    [0]
+  TpArrayUInt: uInt array with shape [1]
+    [0]
+  TpArrayFloat: Float array with shape [1]
+    [0]
+  TpArrayDouble: Double array with shape [1]
+    [0]
+  TpArrayComplex: Complex array with shape [1]
+    [(0,0)]
+  TpArrayDComplex: DComplex array with shape [1]
+    [(0,0)]
+  TpArrayString: String array with shape []
+    []
+  SubRecord1: {
+    fa: Float 3
+    ia: Int 2
+  }
+  SubRecord: {
+    SubFloat: Float 0
+    SubInt: Int 0
+  }
+  TpBool2a: Bool 0
+  TpUChar2a: uChar 0
+  TpShort2a: Short 0
+  TpInt2a: Int 0
+  TpUInt2a: uInt 0
+  TpFloat2a: Float 0
+  TpDouble2a: Double 0
+  TpComplex2a: Complex (0,0)
+  TpDComplex2a: DComplex (0,0)
+  TpArrayString2a: String array with shape [3]
+    [, , ]
+  TpArrayString3a: String array with shape []
+    []
+  TpString2a: String ""
+  TpBool: Bool 0
+  TpUChar: uChar 0
+  TpShort: Short 0
+  TpInt: Int 0
+  TpUInt: uInt 0
+  TpFloat: Float 0
+  TpDouble: Double 0
+  TpComplex: Complex (0,0)
+  TpDComplex: DComplex (0,0)
+  TpString: String ""
+  TpArrayBool: Bool array with shape [1]
+    [0]
+  TpArrayUChar: uChar array with shape [1]
+    [0]
+  TpArrayShort: Short array with shape [1]
+    [0]
+  TpArrayInt: Int array with shape [1]
+    [0]
+  TpArrayUInt: uInt array with shape [1]
+    [0]
+  TpArrayFloat: Float array with shape [1]
+    [0]
+  TpArrayDouble: Double array with shape [1]
+    [0]
+  TpArrayComplex: Complex array with shape [1]
+    [(0,0)]
+  TpArrayDComplex: DComplex array with shape [1]
+    [(0,0)]
+  TpArrayString: String array with shape []
+    []
+  SubRecord1: {
+    fa: Float 3
+    ia: Int 2
+  }
+  SubRecord: {
+    SubFloat: Float 0
+    SubInt: Int 0
+  }
+  TpBool2a: Bool 0
+  TpUChar2a: uChar 0
+  TpShort2a: Short 0
+  TpInt2a: Int 0
+  TpUInt2a: uInt 0
+  TpFloat2a: Float 0
+  TpDouble2a: Double 0
+  TpComplex2a: Complex (0,0)
+  TpDComplex2a: DComplex (0,0)
+  TpArrayString2a: String array with shape [3]
+    [, , ]
+  TpArrayString3a: String array with shape []
+    []
+  TpString2a: String ""
 TableKeyword::operator=; non-conforming table
 TableRecordRep::get_pointer - incorrect data type used for field tab1
+Record
+  tab1: String "Table: tTableRecord_tmp.tab1"
+  tab1a: String "Table: tTableRecord_tmp.tab1"
+TableRecord
+  tab1: Table tTableRecord_tmp.tab1
+  tab1a: Table tTableRecord_tmp.tab1
 OK


### PR DESCRIPTION
defineFromValueHoler and toValueHolder have been made virtual, so a TableRecord can also be converted to a ValueHolder. A Table in a TableRecord is kept as 'Table: <name>'
Close #361