### PR TITLE
Added check if column can be renamed

### DIFF
--- a/tables/DataMan/DataManager.cc
+++ b/tables/DataMan/DataManager.cc
@@ -252,6 +252,9 @@ Bool DataManager::canAddColumn() const
 Bool DataManager::canRemoveColumn() const
     { return False; }
 
+Bool DataManager::canRenameColumn() const
+    { return True; }
+
 void DataManager::addRow (uInt)
     { throw (DataManInvOper ("DataManager::addRow not allowed")); }
 

--- a/tables/DataMan/DataManager.h
+++ b/tables/DataMan/DataManager.h
@@ -337,6 +337,9 @@ public:
     // Does the data manager allow to delete columns? (default no)
     virtual Bool canRemoveColumn() const;
 
+    // Does the data manager allow to rename columns? (default yes)
+    virtual Bool canRenameColumn() const;
+
     // Set the maximum cache size (in bytes) to be used by a storage manager.
     // The default implementation does nothing.
     virtual void setMaximumCacheSize (uInt nbytes);

--- a/tables/Tables/ColumnSet.cc
+++ b/tables/Tables/ColumnSet.cc
@@ -271,8 +271,7 @@ Bool ColumnSet::canRenameColumn (const String& columnName) const
     if (! tdescPtr_p->isColumn (columnName)) {
 	return False;
     }
-    return True;
-    ////    return getColumn(columnName)->dataManager()->canRenameColumn();
+    return getColumn(columnName)->dataManager()->canRenameColumn();
 }
 
 


### PR DESCRIPTION
It must be possible for a data manager to forbid renaming a column.
Close #366