### PR TITLE
Use toArray instead of asArray

### DIFF
--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -480,7 +480,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayBool (name);
+                array(start, end) = coordValues.toArrayBool (name);
             }
         }
         break;
@@ -499,7 +499,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayInt (name);
+                array(start, end) = coordValues.toArrayInt (name);
             }
         }
         break;
@@ -518,7 +518,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayuInt (name);
+                array(start, end) = coordValues.toArrayuInt (name);
             }
         }
         break;
@@ -537,7 +537,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayfloat (name);
+                array(start, end) = coordValues.toArrayFloat (name);
             }
         }
         break;
@@ -556,7 +556,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArraydouble (name);
+                array(start, end) = coordValues.toArrayDouble (name);
             }
         }
         break;
@@ -575,7 +575,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayComplex (name);
+                array(start, end) = coordValues.toArrayComplex (name);
             }
         }
         break;
@@ -594,7 +594,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayDComplex (name);
+                array(start, end) = coordValues.toArrayDComplex (name);
             }
         }
         break;
@@ -613,7 +613,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
                 array.reference (newArray);
             }
             if (start(0) < Int(length)) {
-                array(start, end) = coordValues.asArrayString (name);
+                array(start, end) = coordValues.toArrayString (name);
             }
         }
         break;

--- a/tables/DataMan/TiledCellStMan.cc
+++ b/tables/DataMan/TiledCellStMan.cc
@@ -60,7 +60,7 @@ TiledCellStMan::TiledCellStMan (const String& hypercolumnName,
 : TiledStMan  (hypercolumnName, 0)
 {
     if (spec.isDefined ("DEFAULTTILESHAPE")) {
-        defaultTileShape_p = IPosition (spec.asArrayInt ("DEFAULTTILESHAPE"));
+        defaultTileShape_p = IPosition (spec.toArrayInt ("DEFAULTTILESHAPE"));
     }
     if (spec.isDefined ("MAXIMUMCACHESIZE")) {
         setPersMaxCacheSize (spec.asInt ("MAXIMUMCACHESIZE"));

--- a/tables/DataMan/TiledColumnStMan.cc
+++ b/tables/DataMan/TiledColumnStMan.cc
@@ -65,7 +65,7 @@ TiledColumnStMan::TiledColumnStMan (const String& hypercolumnName,
 : TiledStMan  (hypercolumnName, 0)
 {
     if (spec.isDefined ("DEFAULTTILESHAPE")) {
-        tileShape_p = IPosition (spec.asArrayInt ("DEFAULTTILESHAPE"));
+        tileShape_p = IPosition (spec.toArrayInt ("DEFAULTTILESHAPE"));
     }
     if (spec.isDefined ("MAXIMUMCACHESIZE")) {
         setPersMaxCacheSize (spec.asInt ("MAXIMUMCACHESIZE"));

--- a/tables/DataMan/TiledShapeStMan.cc
+++ b/tables/DataMan/TiledShapeStMan.cc
@@ -71,7 +71,7 @@ TiledShapeStMan::TiledShapeStMan (const String& hypercolumnName,
   lastHC_p       (-1)
 {
     if (spec.isDefined ("DEFAULTTILESHAPE")) {
-        defaultTileShape_p = IPosition (spec.asArrayInt ("DEFAULTTILESHAPE"));
+        defaultTileShape_p = IPosition (spec.toArrayInt ("DEFAULTTILESHAPE"));
     }
     if (spec.isDefined ("MAXIMUMCACHESIZE")) {
         setPersMaxCacheSize (spec.asInt ("MAXIMUMCACHESIZE"));


### PR DESCRIPTION
By using toArray in the TSM classes, the properties can be specified with other data types making it much easier to use from Python and TaQL.
Close #367 