### PR TITLE
Array functors derive from a base class

### DIFF
--- a/casa/Arrays/ArrayLogical.h
+++ b/casa/Arrays/ArrayLogical.h
@@ -32,6 +32,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/casa/Arrays/LogiArray.h>
+#include <casacore/casa/Arrays/ArrayMathBase.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -390,13 +391,18 @@ template<class T> Bool anyOR (const T &val, const Array<T> &array);
 inline Bool allTrue (const Array<Bool>& array)
   { return allEQ (array, True); }
 
-// Is any all element true?
+// Is any element true?
 inline Bool anyTrue (const Array<Bool>& array)
   { return anyEQ (array, True); }
 
-// 
+// The same functions as above, but for selected axes.
+Array<Bool> partialAllTrue (const Array<Bool>& array,
+                            const IPosition& collapseAxes);
+Array<Bool> partialAnyTrue (const Array<Bool>& array,
+                            const IPosition& collapseAxes);
+
 // Determine the number of true or false elements.
-// Note that is meant for Bool arrays, but can also be used for
+// Note: it is meant for Bool arrays, but can also be used for
 // e.g. Int arrays.
 // <group>
 
@@ -428,21 +434,24 @@ template<class T> Array<uInt> partialNFalse (const Array<T>& array,
 
 // Define logical Functors.
 // <group>
-class AllFunc {
+template<typename T> class AllFunc : public ArrayFunctorBase<T,Bool> {
 public:
-  Bool operator() (const Array<Bool>& arr) const { return allTrue(arr); }
+  virtual ~AllFunc() {}
+  virtual Bool operator() (const Array<T>& arr) const { return allTrue(arr); }
 };
-class AnyFunc {
+template<typename T> class AnyFunc : public ArrayFunctorBase<T,Bool> {
 public:
-  Bool operator() (const Array<Bool>& arr) const { return anyTrue(arr); }
+  virtual ~AnyFunc() {}
+  virtual Bool operator() (const Array<T>& arr) const { return anyTrue(arr); }
 };
-template<typename T> class NTrueFunc {
+
+template<typename T> class NTrueFunc : public ArrayFunctorBase<T,uInt> {
 public:
-  T operator() (const Array<T>& arr) const { return ntrue(arr); }
+  virtual uInt operator() (const Array<T>& arr) const { return ntrue(arr); }
 };
-template<typename T> class NFalseFunc {
+template<typename T> class NFalseFunc : public ArrayFunctorBase<T,uInt> {
 public:
-  T operator() (const Array<T>& arr) const { return nfalse(arr); }
+  virtual uInt operator() (const Array<T>& arr) const { return nfalse(arr); }
 };
 // </group>
 

--- a/casa/Arrays/ArrayMathBase.h
+++ b/casa/Arrays/ArrayMathBase.h
@@ -1,0 +1,67 @@
+//# ArrayMathBase.h: Basic functions and classes for math on Array objects
+//# Copyright (C) 2012
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: ArrayMathBase.h 21262 2012-09-07 12:38:36Z gervandiepen $
+
+#ifndef CASA_ARRAYMATHBASE_H
+#define CASA_ARRAYMATHBASE_H
+
+#include <casacore/casa/aips.h>
+
+namespace casacore {
+
+  //# Forward declarations.
+  template<typename T> class Array;
+
+
+  // <summary>
+  // Basic class for math on Array objects
+  // </summary>
+  //
+  // <reviewed reviewer="UNKNOWN" date="" tests="tArrayMath">
+  //
+  // <prerequisite>
+  //   <li> <linkto class=Array>Array</linkto>
+  // </prerequisite>
+  //
+  // <synopsis>
+  // The abstract base class ArrayFunctorBase is defined for functors to
+  // be used in functions like slidingXXX.
+  // Virtual functions instead of templated functions are used to avoid
+  // code bloat when used in functions like partialArrayMath. Because a
+  // reduction operation usually takes much more time than the call, using
+  // virtual functions hardly imposes a performance penalty.
+  // </synopsis>
+  template<typename T, typename RES=T> class ArrayFunctorBase {
+  public:
+    virtual ~ArrayFunctorBase() {}
+    virtual RES operator() (const Array<T>&) const = 0;
+  };
+
+  // </group>
+
+} //# end namespace
+
+#endif

--- a/casa/Arrays/ArrayPartMath.cc
+++ b/casa/Arrays/ArrayPartMath.cc
@@ -1,0 +1,81 @@
+//# ArrayPartMath.h: mathematics done on an array parts.
+//# Copyright (C) 1993,1994,1995,1996,1998,1999,2001,2003
+//# Associated Universities, Inc. Washington DC, USA.
+//# 
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//# 
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//# 
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//# 
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: ArrayPartMath.cc 21262 2012-09-07 12:38:36Z gervandiepen $
+
+#include <casacore/casa/Arrays/ArrayPartMath.h>
+
+namespace casacore {
+
+  void fillBoxedShape (const IPosition& shape, const IPosition& boxSize,
+                       IPosition& fullBoxSize, IPosition& resultShape)
+  {
+    uInt ndim = shape.size();
+    // Set missing axes to 1.
+    fullBoxSize.resize (ndim);
+    fullBoxSize = 1;
+    for (uInt i=0; i<min(ndim,boxSize.size()); ++i) {
+      // Set unspecified axes to full length.
+      if (boxSize[i] <= 0  ||  boxSize[i] > shape[i]) {
+        fullBoxSize[i] = shape[i];
+      } else {
+        fullBoxSize[i] = boxSize[i];
+      }
+    }
+    // Determine the output shape.
+    resultShape.resize (ndim);
+    for (uInt i=0; i<ndim; ++i) {
+      resultShape[i] = (shape[i] + fullBoxSize[i] - 1) / fullBoxSize[i];
+    }
+  }
+
+  Bool fillSlidingShape (const IPosition& shape, const IPosition& halfBoxSize,
+                         IPosition& boxEnd, IPosition& resultShape)
+  {
+    uInt ndim = shape.size();
+    // Set full box end (is size-1) and resize/fill as needed.
+    boxEnd.resize (halfBoxSize.size());
+    boxEnd = 2*halfBoxSize;
+    if (boxEnd.size() != ndim) {
+      uInt sz = boxEnd.size();
+      boxEnd.resize (ndim);
+      for (uInt i=sz; i<boxEnd.size(); ++i) {
+        boxEnd[i] = 0;
+      }
+    }
+    // Determine the output shape. See if anything has to be done.
+    Bool empty = False;
+    resultShape.resize (shape.size());
+    for (uInt i=0; i<ndim; ++i) {
+      resultShape[i] = shape[i] - boxEnd[i];
+      if (resultShape[i] <= 0) {
+        resultShape[i] = 0;
+        empty = True;
+      }
+    }
+    return empty;
+  }
+
+} //# end namespace

--- a/casa/Arrays/ArrayPartMath.h
+++ b/casa/Arrays/ArrayPartMath.h
@@ -23,13 +23,14 @@
 //#                        520 Edgemont Road
 //#                        Charlottesville, VA 22903-2475 USA
 //#
-//# $Id$
+//# $Id: ArrayPartMath.h 21262 2012-09-07 12:38:36Z gervandiepen $
 
 #ifndef CASA_ARRAYPARTMATH_H
 #define CASA_ARRAYPARTMATH_H
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/Arrays/ArrayMathBase.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -105,6 +106,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <group>
 template<class T> Array<T> partialSums (const Array<T>& array,
 					const IPosition& collapseAxes);
+template<class T> Array<T> partialSumSqrs (const Array<T>& array,
+                                           const IPosition& collapseAxes);
 template<class T> Array<T> partialProducts (const Array<T>& array,
 					    const IPosition& collapseAxes);
 template<class T> Array<T> partialMins (const Array<T>& array,
@@ -173,107 +176,150 @@ template<class T> Array<T> partialInterQuartileRanges (const Array<T>& array,
 
 
 
-template<typename T> class SumFunc {
-public:
-  T operator() (const Array<T>& arr) const { return sum(arr); }
-};
-template<typename T> class ProductFunc {
-public:
-  T operator() (const Array<T>& arr) const { return product(arr); }
-};
-template<typename T> class MinFunc {
-public:
-  T operator() (const Array<T>& arr) const { return min(arr); }
-};
-template<typename T> class MaxFunc {
-public:
-  T operator() (const Array<T>& arr) const { return max(arr); }
-};
-template<typename T> class MeanFunc {
-public:
-  T operator() (const Array<T>& arr) const { return mean(arr); }
-};
-template<typename T> class VarianceFunc {
-public:
-  T operator() (const Array<T>& arr) const { return variance(arr); }
-};
-template<typename T> class StddevFunc {
-public:
-  T operator() (const Array<T>& arr) const { return stddev(arr); }
-};
-template<typename T> class AvdevFunc {
-public:
-  T operator() (const Array<T>& arr) const { return avdev(arr); }
-};
-template<typename T> class RmsFunc {
-public:
-  T operator() (const Array<T>& arr) const { return rms(arr); }
-};
-template<typename T> class MedianFunc {
-public:
-  explicit MedianFunc (Bool sorted=False, Bool takeEvenMean=True,
-		       Bool inPlace = False)
-    : itsSorted(sorted), itsTakeEvenMean(takeEvenMean), itsInPlace(inPlace) {}
-  T operator() (const Array<T>& arr) const
-    { return median(arr, itsTmp, itsSorted, itsTakeEvenMean, itsInPlace); }
-private:
-  Bool     itsSorted;
-  Bool     itsTakeEvenMean;
-  Bool     itsInPlace;
-  mutable Block<T> itsTmp;
-};
-template<typename T> class MadfmFunc {
-public:
-  explicit MadfmFunc(Bool sorted = False, Bool takeEvenMean = True,
-                     Bool inPlace = False)
-    : itsSorted(sorted), itsTakeEvenMean(takeEvenMean), itsInPlace(inPlace) {}
-  T operator()(const Array<T>& arr) const
-    { return madfm(arr, itsTmp, itsSorted, itsTakeEvenMean, itsInPlace); }
-private:
+  // Define functors to perform a reduction function on an Array object.
+  // Use virtual functions instead of templates to avoid code bloat
+  // in partialArrayMath, etc.
+  template<typename T> class SumFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~SumFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return sum(arr); }
+  };
+  template<typename T> class SumSqrFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~SumSqrFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return sumsqr(arr); }
+  };
+  template<typename T> class ProductFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~ProductFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return product(arr); }
+  };
+  template<typename T> class MinFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~MinFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return min(arr); }
+  };
+  template<typename T> class MaxFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~MaxFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return max(arr); }
+  };
+  template<typename T> class MeanFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~MeanFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return mean(arr); }
+  };
+  template<typename T> class VarianceFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~VarianceFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return variance(arr); }
+  };
+  template<typename T> class StddevFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~StddevFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return stddev(arr); }
+  };
+  template<typename T> class AvdevFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~AvdevFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return avdev(arr); }
+  };
+  template<typename T> class RmsFunc : public ArrayFunctorBase<T> {
+  public:
+    virtual ~RmsFunc() {}
+    virtual T operator() (const Array<T>& arr) const { return rms(arr); }
+  };
+  template<typename T> class MedianFunc : public ArrayFunctorBase<T> {
+  public:
+    explicit MedianFunc (Bool sorted=False, Bool takeEvenMean=True,
+                          Bool inPlace = False)
+      : itsSorted(sorted), itsTakeEvenMean(takeEvenMean), itsInPlace(inPlace) {}
+    virtual ~MedianFunc() {}
+    virtual T operator() (const Array<T>& arr) const
+      { return median(arr, itsTmp, itsSorted, itsTakeEvenMean, itsInPlace); }
+  private:
+    Bool     itsSorted;
+    Bool     itsTakeEvenMean;
+    Bool     itsInPlace;
+    mutable Block<T> itsTmp;
+  };
+  template<typename T> class MadfmFunc {
+  public:
+    explicit MadfmFunc(Bool sorted = False, Bool takeEvenMean = True,
+                       Bool inPlace = False)
+      : itsSorted(sorted), itsTakeEvenMean(takeEvenMean), itsInPlace(inPlace) {}
+    virtual ~MadfmFunc() {}
+    virtual T operator()(const Array<T>& arr) const
+      { return madfm(arr, itsTmp, itsSorted, itsTakeEvenMean, itsInPlace); }
+  private:
     Bool     itsSorted;
     Bool     itsTakeEvenMean;
     Bool     itsInPlace;
     mutable Block<Float> itsTmp;
-};
-template<typename T> class FractileFunc {
-public:
-  explicit FractileFunc (Float fraction,
-			 Bool sorted = False, Bool inPlace = False)
-    : itsFraction(fraction), itsSorted(sorted), itsInPlace(inPlace) {}
-  T operator() (const Array<T>& arr) const
-    { return fractile(arr, itsTmp, itsFraction, itsSorted, itsInPlace); }
-private:
-  float    itsFraction;
-  Bool     itsSorted;
-  Bool     itsInPlace;
-  mutable Block<T> itsTmp;
-};
-template<typename T> class InterFractileRangeFunc {
-public:
-  explicit InterFractileRangeFunc(Float fraction,
-                                  Bool sorted = False, Bool inPlace = False)
-    : itsFraction(fraction), itsSorted(sorted), itsInPlace(inPlace) {}
-  T operator()(const Array<T>& arr) const
-    { return interFractileRange(arr, itsTmp, itsFraction,
-                                itsSorted, itsInPlace); }
-private:
-  float    itsFraction;
-  Bool     itsSorted;
-  Bool     itsInPlace;
-  mutable Block<Float> itsTmp;
-};
-template<typename T> class InterHexileRangeFunc: public InterFractileRangeFunc<T> {
-public:
-  explicit InterHexileRangeFunc(Bool sorted = False, Bool inPlace = False)
-    : InterFractileRangeFunc<T> (1./6., sorted, inPlace)
+  };
+  template<typename T> class FractileFunc : public ArrayFunctorBase<T> {
+  public:
+    explicit FractileFunc (Float fraction,
+                            Bool sorted = False, Bool inPlace = False)
+      : itsFraction(fraction), itsSorted(sorted), itsInPlace(inPlace) {}
+    virtual ~FractileFunc() {}
+    virtual T operator() (const Array<T>& arr) const
+      { return fractile(arr, itsTmp, itsFraction, itsSorted, itsInPlace); }
+  private:
+    float    itsFraction;
+    Bool     itsSorted;
+    Bool     itsInPlace;
+    mutable Block<T> itsTmp;
+  };
+  template<typename T> class InterFractileRangeFunc {
+  public:
+    explicit InterFractileRangeFunc(Float fraction,
+                                    Bool sorted = False, Bool inPlace = False)
+      : itsFraction(fraction), itsSorted(sorted), itsInPlace(inPlace) {}
+    virtual ~InterFractileRangeFunc() {}
+    virtual T operator()(const Array<T>& arr) const
+      { return interFractileRange(arr, itsTmp, itsFraction,
+                                  itsSorted, itsInPlace); }
+  private:
+    float    itsFraction;
+    Bool     itsSorted;
+    Bool     itsInPlace;
+    mutable Block<Float> itsTmp;
+  };
+  template<typename T> class InterHexileRangeFunc: public InterFractileRangeFunc<T> {
+  public:
+    explicit InterHexileRangeFunc(Bool sorted = False, Bool inPlace = False)
+      : InterFractileRangeFunc<T> (1./6., sorted, inPlace)
     {}
-};
-template<typename T> class InterQuartileRangeFunc: public InterFractileRangeFunc<T> {
-public:
-  explicit InterQuartileRangeFunc(Bool sorted = False, Bool inPlace = False)
-    : InterFractileRangeFunc<T> (0.25, sorted, inPlace)
-    {}
-};
+    virtual ~InterHexileRangeFunc() {}
+  };
+  template<typename T> class InterQuartileRangeFunc: public InterFractileRangeFunc<T> {
+  public:
+    explicit InterQuartileRangeFunc(Bool sorted = False, Bool inPlace = False)
+      : InterFractileRangeFunc<T> (0.25, sorted, inPlace)
+    {} 
+    virtual ~InterQuartileRangeFunc() {}
+  };
+
+
+
+  // Do partial reduction of an Array object. I.e., perform the operation
+  // on a subset of the array axes (the collapse axes).
+  template<typename T>
+  inline Array<T> partialArrayMath (const Array<T>& a,
+                                    const IPosition& collapseAxes,
+                                    const ArrayFunctorBase<T>& funcObj)
+  {
+    Array<T> res;
+    partialArrayMath (res, a, collapseAxes, funcObj);
+    return res;
+  }
+  template<typename T, typename RES>
+  void partialArrayMath (Array<RES>& res,
+                         const Array<T>& a,
+                         const IPosition& collapseAxes,
+                         const ArrayFunctorBase<T,RES>& funcObj);
+
 
 // Apply the given ArrayMath reduction function objects
 // to each box in the array.
@@ -287,10 +333,20 @@ public:
 // The dimensionality of the array can be larger than the box; in that
 // case the missing axes of the box are assumed to have length 1.
 // A box axis length <= 0 means the full array axis.
-template <typename T, typename FuncType>
-Array<T> boxedArrayMath (const Array<T>& array,
-			 const IPosition& boxSize,
-			 const FuncType& funcObj);
+  template<typename T>
+  inline Array<T> boxedArrayMath (const Array<T>& a,
+                                  const IPosition& boxSize,
+                                  const ArrayFunctorBase<T>& funcObj)
+  {
+    Array<T> res;
+    boxedArrayMath (res, a, boxSize, funcObj);
+    return res;
+  }
+  template<typename T, typename RES>
+  void boxedArrayMath (Array<RES>&,
+                       const Array<T>& array,
+                       const IPosition& boxSize,
+                       const ArrayFunctorBase<T,RES>& funcObj);
 
 // Apply for each element in the array the given ArrayMath reduction function
 // object to the box around that element. The full box is 2*halfBoxSize + 1.
@@ -316,19 +372,34 @@ Array<T> boxedArrayMath (const Array<T>& array,
 // as class <linkto class=MedianSlider>MedianSlider</linkto>, for a 2D array
 // it is much, much faster.
 // </note>
-//# Do not use this template definition, as it is stricter. It precludes use
-//# of double accumulators on float data.
-//# template <typename T, template <typename T> class FuncType>
-//# Array<T> slidingArrayMath (const Array<T>& array,
-//#			   const IPosition& halfBoxSize,
-//#			   const FuncType<T>& funcObj,
-//#			   Bool fillEdge=True);
-template <typename T, typename FuncType>
-Array<T> slidingArrayMath (const Array<T>& array,
-			   const IPosition& halfBoxSize,
-			   const FuncType& funcObj,
-			   Bool fillEdge=True);
+  template<typename T>
+  inline Array<T> slidingArrayMath (const Array<T>& a,
+                                    const IPosition& halfBoxSize,
+                                    const ArrayFunctorBase<T>& funcObj,
+                                    Bool fillEdge=True)
+  {
+    Array<T> res;
+    slidingArrayMath (res, a, halfBoxSize, funcObj, fillEdge);
+    return res;
+  }
+  template<typename T, typename RES>
+  void slidingArrayMath (Array<RES>& res,
+                         const Array<T>& array,
+                         const IPosition& halfBoxSize,
+                         const ArrayFunctorBase<T,RES>& funcObj,
+                         Bool fillEdge=True);
 
+// </group>
+
+// <group>
+// Helper functions for boxed and sliding functions.
+// Determine full box shape and shape of result for a boxed operation.
+void fillBoxedShape (const IPosition& shape, const IPosition& boxShape,
+                     IPosition& fullBoxShape, IPosition& resultShape);
+// Determine the box end and shape of result for a sliding operation.
+// It returns False if the result is empty.
+Bool fillSlidingShape (const IPosition& shape, const IPosition& halfBoxSize,
+                       IPosition& boxEnd, IPosition& resultShape);
 // </group>
 
 } //# NAMESPACE CASACORE - END

--- a/casa/BasicMath/test/tFunctors.cc
+++ b/casa/BasicMath/test/tFunctors.cc
@@ -27,6 +27,8 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/BasicMath/Functors.h>
+#include <casacore/casa/Arrays/Array.h>
+#include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/OS/Timer.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Utilities/Assert.h>
@@ -86,6 +88,34 @@ double sumsqr (double l, double r)
   { return l + r*r; }
 
 
+void testCompare()
+{
+  typedef Complex T;
+  IPosition shp(3,5,8,4);
+  Array<T> arr1(shp), arr2(shp);
+  Array<T> arr1s(arr1(IPosition(3,0,0,0), IPosition(3,3,7,3)));
+  Array<T> arr2s(arr2(IPosition(3,0,0,0), IPosition(3,3,7,3)));
+  indgen (arr1);
+  indgen (arr2);
+  AlwaysAssertExit (compareAll(arr1.begin(), arr1.end(),
+                               arr2.begin(), Near<T>()));
+  AlwaysAssertExit (compareAny(arr1.begin(), arr1.end(),
+                               arr2.begin(), Near<T>()));
+  AlwaysAssertExit (compareAll(arr1s.begin(), arr1s.end(),
+                               arr2s.begin(), Near<T>()));
+  AlwaysAssertExit (compareAny(arr1s.begin(), arr1s.end(),
+                               arr2s.begin(), Near<T>()));
+  arr1(IPosition(3,1,0,0)) -= 1;
+  AlwaysAssertExit (! compareAll(arr1.begin(), arr1.end(),
+                                 arr2.begin(), Near<T>()));
+  AlwaysAssertExit (compareAny(arr1.begin(), arr1.end(),
+                               arr2.begin(), Near<T>()));
+  AlwaysAssertExit (! compareAll(arr1s.begin(), arr1s.end(),
+                                 arr2s.begin(), Near<T>()));
+  AlwaysAssertExit (compareAny(arr1s.begin(), arr1s.end(),
+                               arr2s.begin(), Near<T>()));
+}
+
 int main()
 {
   try {
@@ -130,7 +160,8 @@ int main()
       for (uInt i=0; i<res.size(); ++i) {
         AlwaysAssertExit (near(res[i], v1[i] + (v2[i]-0.25)*(v2[i]-0.25)));
       }
-  }
+    }
+    testCompare();
   } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;

--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library (casa_casa
 Arrays/ArrayBase.cc
 Arrays/ArrayError.cc
 Arrays/ArrayOpsDiffShapes.cc
+Arrays/ArrayPartMath.cc
 Arrays/ArrayPosIter.cc
 Arrays/ArrayUtil2.cc
 Arrays/Array2.cc
@@ -244,6 +245,7 @@ Arrays/ArrayIter.h
 Arrays/ArrayIter.tcc
 Arrays/ArrayLogical.h
 Arrays/ArrayLogical.tcc
+Arrays/ArrayMathBase.h
 Arrays/ArrayMath.h
 Arrays/ArrayMath.tcc
 Arrays/ArrayOpsDiffShapes.h

--- a/casa/OS/Time.h
+++ b/casa/OS/Time.h
@@ -108,9 +108,9 @@ class Time {
      // Copy constructor
    Time (const Time& time);
 
-     // return the Julian day
+     // return the Julian day (unit day)
    double julianDay () const;
-     // return the modified Julian day
+     // return the modified Julian day (unit day)
    double modifiedJulianDay () const;
 
      // initialise the julian day data with Time class

--- a/tables/TaQL/ExprFuncNodeArray.cc
+++ b/tables/TaQL/ExprFuncNodeArray.cc
@@ -416,22 +416,22 @@ Array<Bool> TableExprFuncNodeArray::getArrayBool (const TableExprId& id)
     case TableExprFuncNode::runallFUNC:
       {
 	Array<Bool> arr (operands()[0]->getArrayBool(id));
-	return slidingArrayMath (arr, getArrayShape(id), AllFunc());
+        return slidingArrayMath (arr, getArrayShape(id), AllFunc<Bool>());
       }
     case TableExprFuncNode::runanyFUNC:
       {
 	Array<Bool> arr (operands()[0]->getArrayBool(id));
-	return slidingArrayMath (arr, getArrayShape(id), AnyFunc());
+	return slidingArrayMath (arr, getArrayShape(id), AnyFunc<Bool>());
       }
     case TableExprFuncNode::boxallFUNC:
       {
 	Array<Bool> arr (operands()[0]->getArrayBool(id));
-	return boxedArrayMath (arr, getArrayShape(id), AllFunc());
+	return boxedArrayMath (arr, getArrayShape(id), AllFunc<Bool>());
       }
     case TableExprFuncNode::boxanyFUNC:
       {
 	Array<Bool> arr (operands()[0]->getArrayBool(id));
-	return boxedArrayMath (arr, getArrayShape(id), AnyFunc());
+	return boxedArrayMath (arr, getArrayShape(id), AnyFunc<Bool>());
       }
     case TableExprFuncNode::arrayFUNC:
       {

--- a/tables/Tables/test/tArrayColumnCellSlices.cc
+++ b/tables/Tables/test/tArrayColumnCellSlices.cc
@@ -61,7 +61,7 @@ void createTable (
 
     // Now create a new table from the description.
 
-    SetupNewTable newtab("tArrayColumnSlices_tmp.data", td, Table::New);
+    SetupNewTable newtab("tArrayColumnCellSlices_tmp.data", td, Table::New);
     Table tab(newtab, nRows, False, Table::LocalEndian);
     ArrayColumn<Int> arrayColumn (tab, "testArrayColumn");
 
@@ -123,7 +123,7 @@ readAndCompareArray (ArrayColumn<Int> & arrayColumn)
 
 void readCellSlices()
 {
-  Table tab("tArrayColumnSlices_tmp.data");
+  Table tab("tArrayColumnCellSlices_tmp.data");
   ArrayColumn<Int> arrayColumn(tab, "testArrayColumn");
   {
       // Check ColumnSlicer validation logic
@@ -326,7 +326,7 @@ void readCellSlices()
 
 void writeCellSlices()
 {
-    Table tab("tArrayColumnSlices_tmp.data", Table::Update);
+    Table tab("tArrayColumnCellSlices_tmp.data", Table::Update);
     ArrayColumn<Int> arrayColumn(tab, "testArrayColumn");
   
   {

--- a/tables/Tables/test/tConcatTable3.cc
+++ b/tables/Tables/test/tConcatTable3.cc
@@ -69,7 +69,7 @@ void checkTable (Int stval, uInt nrow)
 ///void checkTable (const Table& tab, uInt nkey, uInt nsubrow, Int stval,
 ///		 Bool reorder=True, uInt nrow=10)
 {
-  Table tab("tConcatTable_tmp.conctab");
+  Table tab("tConcatTable3_tmp.conctab");
   AlwaysAssertExit (tab.nrow() == nrow);
   /*
   AlwaysAssertExit (tab.keywordSet().nfields() == nkey);
@@ -95,7 +95,7 @@ void concatTables()
   names[1] = "tConcatTable3_tmp.tab2";
   names[2] = "tConcatTable3_tmp.tab3";
   Table concTab (names, Block<String>(), Table::Old, TSMOption(), "SUBDIR");
-  concTab.rename ("tConcatTable_tmp.conctab", Table::New);
+  concTab.rename ("tConcatTable3_tmp.conctab", Table::New);
 }
 
 int main()


### PR DESCRIPTION
Array functors derive from a base class to reduce code bloat in arrayPartMath.
Furthermore, a few functors have been added.
Close #371