### PR TITLE
Added StorageOption argument to Table::copy

### DIFF
--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -402,14 +402,15 @@ void BaseTable::renameSubTables (const String&, const String&)
 {}
 
 void BaseTable::deepCopy (const String& newName,
-			  const Record& dataManagerInfo,
+                          const Record& dataManagerInfo,
+                          const StorageOption& stopt,
 			  int tableOption,
 			  Bool valueCopy,
 			  int endianFormat,
 			  Bool noRows) const
 {
     if (valueCopy  ||  dataManagerInfo.nfields() > 0  ||  noRows) {
-        trueDeepCopy (newName, dataManagerInfo, tableOption,
+      trueDeepCopy (newName, dataManagerInfo, stopt, tableOption,
 		      endianFormat, noRows);
     } else {
         copy (newName, tableOption);
@@ -418,6 +419,7 @@ void BaseTable::deepCopy (const String& newName,
 
 void BaseTable::trueDeepCopy (const String& newName,
 			      const Record& dataManagerInfo,
+                              const StorageOption& stopt,
 			      int tableOption,
 			      int endianFormat,
 			      Bool noRows) const
@@ -440,7 +442,8 @@ void BaseTable::trueDeepCopy (const String& newName,
     Table oldtab(ncThis);
     Table newtab = TableCopy::makeEmptyTable
                         (absNewName, dataManagerInfo, oldtab, Table::New,
-			 Table::EndianFormat(endianFormat), True, noRows);
+			 Table::EndianFormat(endianFormat), True, noRows,
+                         stopt);
     if (!noRows) {
       TableCopy::copyRows (newtab, oldtab);
     }
@@ -1014,7 +1017,9 @@ void BaseTable::showStructure (ostream& os, Bool showDataMans, Bool showColumns,
     os << " (" << info_p.subType() << ')';
   }
   os << endl;
-  os << nrow() << " rows, " << tdesc.ncolumn() << " columns (using "
+  os << nrow() << " rows, " << tdesc.ncolumn() << " columns in ";
+  os << (asBigEndian() ? "big" : "little") << " endian format";
+  os << " (using "
      << dminfo.nfields() << " data managers)" <<endl;
   const StorageOption& stopt = storageOption();
   if (stopt.option() == StorageOption::MultiFile) {

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -226,6 +226,7 @@ public:
     virtual void copy (const String& newName, int tableOption) const;
     virtual void deepCopy (const String& newName,
 			   const Record& dataManagerInfo,
+                           const StorageOption&,
 			   int tableOption,
 			   Bool valueCopy,
 			   int endianFormat,
@@ -498,6 +499,7 @@ protected:
     // Make a true deep copy of the table.
     void trueDeepCopy (const String& newName,
 		       const Record& dataManagerInfo,
+                       const StorageOption&,
 		       int tableOption,
 		       int endianFormat,
 		       Bool noRows) const;

--- a/tables/Tables/ConcatTable.cc
+++ b/tables/Tables/ConcatTable.cc
@@ -453,10 +453,11 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   void ConcatTable::deepCopy (const String& newName,
 			      const Record& dataManagerInfo,
+                              const StorageOption& stopt,
 			      int tableOption, Bool, int endianFormat,
 			      Bool noRows) const
   {
-    trueDeepCopy (newName, dataManagerInfo, tableOption,
+    trueDeepCopy (newName, dataManagerInfo, stopt, tableOption,
 		  endianFormat, noRows);
   }
 

--- a/tables/Tables/ConcatTable.h
+++ b/tables/Tables/ConcatTable.h
@@ -226,6 +226,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // It copies the contents of each row to get a real copy.
     virtual void deepCopy (const String& newName,
 			   const Record& dataManagerInfo,
+                           const StorageOption&,
 			   int tableOption, Bool, int endianFormat,
 			   Bool noRows) const;
 

--- a/tables/Tables/MemoryTable.cc
+++ b/tables/Tables/MemoryTable.cc
@@ -155,15 +155,18 @@ Bool MemoryTable::isWritable() const
 void MemoryTable::copy (const String& newName, int tableOption) const
 {
   Record dmInfo = colSetPtr_p->dataManagerInfo();
-  deepCopy (newName, dmInfo, tableOption, True, Table::AipsrcEndian, False);
+  deepCopy (newName, dmInfo, StorageOption(),
+            tableOption, True, Table::AipsrcEndian, False);
 }
 
 void MemoryTable::deepCopy (const String& newName,
 			    const Record& dataManagerInfo,
+                            const StorageOption& stopt,
 			    int tableOption, Bool, int endianFormat,
 			    Bool noRows) const
 {
-  trueDeepCopy (newName, dataManagerInfo, tableOption, endianFormat, noRows);
+  trueDeepCopy (newName, dataManagerInfo, stopt,
+                tableOption, endianFormat, noRows);
 }
 
 void MemoryTable::rename (const String& newName, int)

--- a/tables/Tables/MemoryTable.h
+++ b/tables/Tables/MemoryTable.h
@@ -142,6 +142,7 @@ public:
   virtual void copy (const String& newName, int tableOption) const;
   virtual void deepCopy (const String& newName,
 			 const Record& dataManagerInfo,
+                         const StorageOption&,
 			 int tableOption, Bool, int endianFormat,
 			 Bool noRows) const;
   // </group>

--- a/tables/Tables/NullTable.cc
+++ b/tables/Tables/NullTable.cc
@@ -122,7 +122,8 @@ Bool NullTable::isWritable() const
   return False;
 }
 
-void NullTable::deepCopy (const String&, const Record&, int, Bool,
+void NullTable::deepCopy (const String&, const Record&,
+                          const StorageOption&, int, Bool,
 			  int, Bool) const
 {
   throwError ("deepCopy");

--- a/tables/Tables/NullTable.h
+++ b/tables/Tables/NullTable.h
@@ -92,6 +92,7 @@ public:
   virtual Bool isWritable() const;
   virtual void deepCopy (const String& newName,
 			 const Record& dataManagerInfo,
+                         const StorageOption&,
 			 int tableOption,
 			 Bool valueCopy,
 			 int endianFormat,

--- a/tables/Tables/RefTable.cc
+++ b/tables/Tables/RefTable.cc
@@ -555,8 +555,8 @@ void RefTable::copy (const String& newName, int tableOption) const
 {
     // If a memory table, make a deep copy.
     if (tableType() == Table::Memory) {
-        deepCopy (newName, Record(), tableOption, True, Table::AipsrcEndian,
-                  False);
+      deepCopy (newName, Record(), StorageOption(), tableOption,
+                True, Table::AipsrcEndian, False);
         // If not persistent, make the copy by writing the table.
     } else if (!madeDir_p) {
         const_cast<RefTable*>(this)->copyRefTable (newName, tableOption);
@@ -567,10 +567,11 @@ void RefTable::copy (const String& newName, int tableOption) const
 
 void RefTable::deepCopy (const String& newName,
 			 const Record& dataManagerInfo,
+                         const StorageOption& stopt,
 			 int tableOption, Bool, int endianFormat,
 			 Bool noRows) const
 {
-    trueDeepCopy (newName, dataManagerInfo,
+    trueDeepCopy (newName, dataManagerInfo, stopt,
                   tableOption, endianFormat, noRows);
 }
 

--- a/tables/Tables/RefTable.h
+++ b/tables/Tables/RefTable.h
@@ -214,6 +214,7 @@ public:
     // It copies the contents of each row to get a real copy.
     virtual void deepCopy (const String& newName,
 			   const Record& dataManagerInfo,
+                           const StorageOption&,
 			   int tableOption, Bool, int endianFormat,
 			   Bool noRows) const;
 

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -545,6 +545,20 @@ public:
                         Bool showSubTables=False,
                         Bool sortColumns=False) const;
 
+    // Show the table and/or column keywords, possibly also of all subtables.
+    // Maximum <src>maxVal> values of Arrays will be shown.
+    void showKeywords (std::ostream&,
+                       Bool showSubTables=False,
+                       Bool showTabKey=True,
+                       Bool showColKey=False,
+                       Int maxVal=25) const;
+  
+    // Show the table and/or column keywords of this table.
+    // Maximum <src>maxVal> values of Arrays will be shown.
+    void showKeywordSets (std::ostream&,
+                          Bool showTabKey, Bool showColKey,
+                          Int maxVal) const;
+
     // Test if a table with the given name exists and is writable.
     static Bool isWritable (const String& tableName, bool throwIf=False);
 
@@ -678,6 +692,11 @@ public:
 		   EndianFormat=AipsrcEndian,
 		   Bool noRows=False) const;
     void deepCopy (const String& newName, const Record& dataManagerInfo,
+		   TableOption, Bool valueCopy=False,
+		   EndianFormat=AipsrcEndian,
+		   Bool noRows=False) const;
+    void deepCopy (const String& newName, const Record& dataManagerInfo,
+                   const StorageOption&,
 		   TableOption, Bool valueCopy=False,
 		   EndianFormat=AipsrcEndian,
 		   Bool noRows=False) const;
@@ -1135,7 +1154,18 @@ inline void Table::deepCopy (const String& newName,
 			     Bool valueCopy,
 			     EndianFormat endianFormat,
 			     Bool noRows) const
-    { baseTabPtr_p->deepCopy (newName, dataManagerInfo, option, valueCopy,
+    { baseTabPtr_p->deepCopy (newName, dataManagerInfo, StorageOption(),
+                              option, valueCopy,
+			      endianFormat, noRows); }
+inline void Table::deepCopy (const String& newName,
+			     const Record& dataManagerInfo,
+                             const StorageOption& stopt,
+			     TableOption option,
+			     Bool valueCopy,
+			     EndianFormat endianFormat,
+			     Bool noRows) const
+    { baseTabPtr_p->deepCopy (newName, dataManagerInfo, stopt,
+                              option, valueCopy,
 			      endianFormat, noRows); }
 inline void Table::markForDelete()
     { baseTabPtr_p->markForDelete (True, ""); }

--- a/tables/Tables/TableCopy.cc
+++ b/tables/Tables/TableCopy.cc
@@ -52,7 +52,8 @@ Table TableCopy::makeEmptyTable (const String& newName,
 				 Table::TableOption option,
 				 Table::EndianFormat endianFormat,
 				 Bool replaceTSM,
-				 Bool noRows)
+				 Bool noRows,
+                                 const StorageOption& stopt)
 {
   TableDesc tabDesc = tab.actualTableDesc();
   Record dminfo (dataManagerInfo);
@@ -71,7 +72,7 @@ Table TableCopy::makeEmptyTable (const String& newName,
   // Replace non-writable storage managers by StandardStMan.
   // This is for instance needed for LofarStMan.
   dminfo = DataManInfo::adjustStMan (dminfo, "StandardStMan", True);
-  SetupNewTable newtab (newName, tabDesc, option);
+  SetupNewTable newtab (newName, tabDesc, option, stopt);
   newtab.bindCreate (dminfo);
   return Table(newtab, (noRows ? 0 : tab.nrow()), False, endianFormat);
 }

--- a/tables/Tables/TableCopy.h
+++ b/tables/Tables/TableCopy.h
@@ -95,7 +95,8 @@ public:
 			       Table::TableOption option,
 			       Table::EndianFormat endianFormat,
 			       Bool replaceTSM = True,
-			       Bool noRows = False);
+			       Bool noRows = False,
+                               const StorageOption& = StorageOption());
 
   // Make an (empty) memory table with the same layout as the input one.
   // It has the same keywords and columns as the input one.

--- a/tables/apps/showtableinfo.cc
+++ b/tables/apps/showtableinfo.cc
@@ -41,42 +41,12 @@ using namespace casacore;
 using namespace std;
 
 
-void showKeys (const Table& table, Bool showtabkey, Bool showcolkey,
-               Int maxval)
-{
-  Bool shown = False;
-  if (showtabkey) {
-    if (table.keywordSet().size() > 0) {
-      cout << "  Table Keywords" << endl;
-      table.keywordSet().print (cout, maxval, "    ");
-      cout << endl;
-      shown = True;
-    }
-  }
-  if (showcolkey) {
-    Vector<String> colNames (table.tableDesc().columnNames());
-    for (uInt i=0; i<colNames.size(); ++i) {
-      TableRecord keys (TableColumn(table, colNames[i]).keywordSet());
-      if (keys.size() > 0) {
-        cout << "  Column " << colNames[i] << endl;
-        keys.print (cout, maxval, "    ");
-        cout << endl;
-        shown = True;
-      }
-    }
-  }
-  if (!shown) {
-    cout << endl;
-  }
-}
-
-
 int main (int argc, char* argv[])
 {
   try {
     // Read the input parameters.
     Input inputs(1);
-    inputs.version("2013Oct16GvD");
+    inputs.version("2016Feb17GvD");
     inputs.create("in", "", "Input table", "string");
     inputs.create("dm", "T", "Show data manager info?", "bool");
     inputs.create("col", "T", "Show column info?", "bool");
@@ -128,28 +98,7 @@ int main (int argc, char* argv[])
     }
     // Show the table structure.
     table.showStructure (cout, showdm, showcol, showsub, sortcol);
-    if (showtabkey || showcolkey) {
-      // Show table and/or column keywords.
-      cout << endl
-           << "Keywords of main table " << endl
-           << "----------------------" << endl;
-      showKeys (seltab, showtabkey, showcolkey, maxval);
-      if (showsub) {
-        // Also show them in the subtables.
-        TableRecord keyset (table.keywordSet());
-        for (uInt i=0; i<keyset.nfields(); ++i) {
-          if (keyset.dataType(i) == TpTable) {
-            Table tab(keyset.asTable(i));
-            // Do not show keywords if the subtable references the parent table.
-            if (! tab.isSameRoot (table)) {
-              cout << "Keywords of subtable " << keyset.name(i) << endl
-                   << "--------------------" << endl;
-              showKeys (keyset.asTable(i), showtabkey, showcolkey, maxval);
-            }
-          }
-        }
-      }
-    }
+    table.showKeywords (cout, showsub, showtabkey, showcolkey, maxval);
     if (browse) {
       // Need to make table persistent for casabrowser.
       String tmpName;
@@ -159,7 +108,7 @@ int main (int argc, char* argv[])
         char tmpnm[] = "/tmp/shtabXXXXXX";
         int fd = mkstemp(tmpnm);
         tmpName = tmpnm;
-        cout << "tmpnm="<<tmpName<<endl;
+        ///cout << "tmpnm="<<tmpName<<endl;
         // Close and delete the file.
         ::close(fd);
         ::unlink(tmpnm);
@@ -174,7 +123,7 @@ int main (int argc, char* argv[])
         clog << "Removing temporary table " << tmpName << endl;
         // Use Directory instead of Table::deleteTable because the
         // latter tests if the table is writable, which it is not if
-        // the underlying table is ot writable.
+        // the underlying table is not writable.
         Directory dir(tmpName);
         dir.removeRecursive();
       }


### PR DESCRIPTION
Copying an table can use the StorageOption argument.
showKeywords has been moved to class Table to be commonly available.
Close #374