### PR TITLE
Added the LD_LIBRARY_PATH to the run

### DIFF
--- a/derivedmscal/DerivedMC/test/tUDFMSCal.run
+++ b/derivedmscal/DerivedMC/test/tUDFMSCal.run
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Define the path to the library to be loaded dynamically
-LD_LIBRARY_PATH=../..
+LD_LIBRARY_PATH=../..:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH
 DYLD_LIBRARY_PATH=../..
 export DYLD_LIBRARY_PATH


### PR DESCRIPTION
This is needed to make this test pass if one uses a compiler that is not at the default location. Using this fix it can actually find the right libc++.