### PR TITLE
CAS-8511: Use subscan props in getNRowMap() if possible

### DIFF
--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -75,6 +75,8 @@ public:
     };
 
     struct SubScanProperties {
+        // number of auto-correlation rows
+        uInt acRows;
         std::set<Int> antennas;
         Double beginTime;
         std::set<uInt> ddIDs;


### PR DESCRIPTION
If _subScanProperties has been computed already, the necessary map can be gotten from that structure, avoiding a full table scan.