### PR TITLE
CAS-8497 implement modifications to uvfits AN read/write rules

### DIFF
--- a/msfits/MSFits/MSFitsInput.h
+++ b/msfits/MSFits/MSFitsInput.h
@@ -281,6 +281,16 @@ public:
   // 
   void readFitsFile(Int obsType = MSTileLayout::Standard);
 
+  // A simultaneous change to MSFitsOutput means that no longer are
+  // antenna positions being rotated when written to UVFITS. Calling
+  // this method with b=True will perform the reverse of a rotation
+  // when converting from uvfits to MS for relevant UVFITS files which
+  // were written prior to this change. Else no rotation of antenna
+  // positions is done.
+  void rotateAntennaPositions(Bool b) {
+      _rotateAnts = b;
+  }
+
 protected:
 
   // Check that the input is a UV fits file with required contents.
@@ -420,7 +430,7 @@ private:
 
   Matrix<Double> _restFreq; // used for UVFITS
   Matrix<Double> _sysVel;
-  Bool _msCreated;
+  Bool _msCreated, _rotateAnts;
 
   std::pair<Int, Int> _extractAntennas(Float baseline);
 

--- a/msfits/MSFits/test/tMSFITSInput.cc
+++ b/msfits/MSFits/test/tMSFITSInput.cc
@@ -29,8 +29,18 @@
 #include <casacore/casa/OS/Directory.h>
 #include <casacore/casa/OS/EnvVar.h>
 #include <casacore/msfits/MSFits/MSFitsInput.h>
+#include <casacore/ms/MSOper/MSMetaData.h>
+#include <casacore/casa/BasicSL/STLIO.h>
+#include <casacore/casa/Arrays/ArrayLogical.h>
 
 using namespace casacore;
+
+void removeIfNecessary(const String& msname) {
+    Directory d(msname);
+    if (d.exists()) {
+        d.removeRecursive();
+    }
+}
 
 int main() {
     try {
@@ -43,6 +53,7 @@ int main() {
             return 0;
         }
         String msfile = "myoutms.ms";
+        removeIfNecessary(msfile);
         MSFitsInput msfitsin(msfile, fitsfile);
         Bool thrown = False;
         try {
@@ -52,6 +63,56 @@ int main() {
             thrown = True;
         }
         AlwaysAssert(thrown, AipsError);
+        {
+            cout << "test rotating antenna positions" << endl;
+            fitsfile = datadir + "regression/unittest/uvfits/casa_4.6_vla.uvfits";
+            String msfile = "rotated_positions.ms";
+            removeIfNecessary(msfile);
+            SHARED_PTR<MSFitsInput> reader(new MSFitsInput(msfile, fitsfile));
+            reader->rotateAntennaPositions(True);
+            reader->readFitsFile();
+            MeasurementSet ms(msfile);
+            SHARED_PTR<MSMetaData> md(new MSMetaData(&ms, 50));
+            vector<MPosition> pos = md->getAntennaPositions(vector<uInt>(1, 0));
+            Vector<Double> expec(3);
+            expec[0] = -1601145.65187839;
+            expec[1] = -5041988.31653595;
+            expec[2] = 3554878.93106461;
+            AlwaysAssert(allNearAbs(pos[0].getValue().getValue(), expec, 1e-6), AipsError);
+
+            msfile = "nonrotated_positions.ms";
+            removeIfNecessary(msfile);
+            reader.reset(new MSFitsInput(msfile, fitsfile));
+            reader->readFitsFile();
+            ms = MeasurementSet(msfile);
+            md.reset(new MSMetaData(&ms, 50));
+            pos = md->getAntennaPositions(vector<uInt>(1, 0));
+            AlwaysAssert(! allNearAbs(pos[0].getValue().getValue(), expec, 1e-6), AipsError);
+
+            fitsfile = datadir + "regression/unittest/uvfits/casa_4.7_vla.uvfits";
+            msfile = "4_7.ms";
+            removeIfNecessary(msfile);
+            reader.reset(new MSFitsInput(msfile, fitsfile));
+            // This should have no effect on processing now, since in this uvfits
+            // file, the array position is at the ITRF origin
+            reader->rotateAntennaPositions(True);
+            reader->readFitsFile();
+            ms = MeasurementSet(msfile);
+            md.reset(new MSMetaData(&ms, 50));
+            pos = md->getAntennaPositions(vector<uInt>(1, 0));
+            AlwaysAssert(allNearAbs(pos[0].getValue().getValue(), expec, 1e-6), AipsError);
+
+            // and just check to make the default value of rotating antenna positions
+            // works as expected
+            removeIfNecessary(msfile);
+            reader.reset(new MSFitsInput(msfile, fitsfile));
+            reader->readFitsFile();
+            ms = MeasurementSet(msfile);
+            md.reset(new MSMetaData(&ms, 50));
+            pos = md->getAntennaPositions(vector<uInt>(1, 0));
+            AlwaysAssert(allNearAbs(pos[0].getValue().getValue(), expec, 1e-6), AipsError);
+
+        }
     }
     catch (const AipsError& x) {
         cerr << x.getMesg() << endl;


### PR DESCRIPTION
New UVFITS AN table writing rules:

1. Antenna positions are ITRF, with geocentric origin, no subtraction of a fiducial "array center" is done
   => Array position ARRAYX, ARRAYY, ARRAYZ are always written as 0.
2. Antenna coordinate systems are right-handed, => XYZHAND is always written as "RIGHT" 
   (which I believe is what AIPS hopes for if I've read the uvfits spec correctly). 

Reading rules:
Antenna positions are not implicitly rotated or inverted unless user explicitly specifies that they should be rotated and other conditions are met (the added configuration parameter allows for backward compatibility with UVFITS files written prior to this change). 