### PR TITLE
improve performance of MSSummary and MSMetaData

### DIFF
--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -227,6 +227,9 @@ public:
     // get a set of spectral windows corresponding to the specified field name
     std::set<uInt> getSpwsForField(const String& fieldName);
 
+    // get the values of the CODE column from the field table
+    vector<String> getFieldCodes() const;
+
     // get the set of field IDs corresponding to the specified spectral window.
     std::set<Int> getFieldIDsForSpw(const uInt spw);
 
@@ -652,7 +655,7 @@ private:
     mutable vector<std::set<ScanKey> > _spwToScansMap, _ddidToScansMap, _fieldToScansMap;
 
     mutable vector<String> _fieldNames, _antennaNames, _observatoryNames,
-        _stationNames, _observers, _projects, _sourceNames;
+        _stationNames, _observers, _projects, _sourceNames, _fieldCodes;
     mutable vector<vector<String> > _schedules;
     mutable vector<vector<Int> > _corrTypes;
     mutable vector<Array<Int> >_corrProds;

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2402,6 +2402,11 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(xc->find(key)->second == 316, AipsError);
         }
         {
+            cout << "*** test getFieldCodes()" << endl;
+            Vector<String> codes = Vector<String>(md.getFieldCodes());
+            AlwaysAssert(allEQ(codes, String("none")), AipsError);
+        }
+        {
 			cout << "*** cache size " << md.getCache() << endl;
 		}
 	}


### PR DESCRIPTION
1. create MSMetaData::getFieldCodes()
2. avoid unnecessary table scan in MSMetaData::_getSubScanKeys() if _subScanProperties data structure has previously been cached
3. avoid unnecessary table scan in MSMetaData::getUniqueFiedIDs() if _subScanProperties data structure has previously been cached 

Performance increase of 15-20% realized.