### PR TITLE
Mod to allow setting tile cache using hypercube number instead of row.

### DIFF
--- a/tables/DataMan/TiledStMan.cc
+++ b/tables/DataMan/TiledStMan.cc
@@ -466,6 +466,14 @@ void TiledStMan::setCacheSize (uInt rownr, uInt nbuckets, Bool forceSmaller)
     hypercube->setCacheSize (nbuckets, forceSmaller, True);
 }
 
+void TiledStMan::setHypercubeCacheSize (uInt hypercube, uInt nbuckets, Bool forceSmaller)
+{
+    // Set the cache size (in buckets) for the given hypercube.
+    TSMCube* tsmCube = getTSMCube (hypercube);
+    tsmCube->setCacheSize (nbuckets, forceSmaller, True);
+}
+
+
 Bool TiledStMan::userSetCache (uInt rownr) const
 {
     return getHypercube(rownr)->userSetCache();

--- a/tables/DataMan/TiledStMan.h
+++ b/tables/DataMan/TiledStMan.h
@@ -243,6 +243,9 @@ public:
     // <br>A flag is set indicating that the TSMDataColumn
     // access functions do not need to size the cache.
     void setCacheSize (uInt rownr, uInt nbuckets, Bool forceSmaller);
+
+    // Sets the cache size using the hypercube instead of the row number.
+    // Useful for iterating over all hypercubes.
     void setHypercubeCacheSize (uInt hypercube, uInt nbuckets, Bool forceSmaller);
 
     // Determine if the user set the cache size (using setCacheSize).

--- a/tables/DataMan/TiledStMan.h
+++ b/tables/DataMan/TiledStMan.h
@@ -243,6 +243,7 @@ public:
     // <br>A flag is set indicating that the TSMDataColumn
     // access functions do not need to size the cache.
     void setCacheSize (uInt rownr, uInt nbuckets, Bool forceSmaller);
+    void setHypercubeCacheSize (uInt hypercube, uInt nbuckets, Bool forceSmaller);
 
     // Determine if the user set the cache size (using setCacheSize).
     Bool userSetCache (uInt rownr) const;

--- a/tables/DataMan/TiledStManAccessor.cc
+++ b/tables/DataMan/TiledStManAccessor.cc
@@ -187,6 +187,12 @@ void ROTiledStManAccessor::setCacheSize (uInt rownr, uInt nbuckets,
     dataManPtr_p->setCacheSize (rownr, nbuckets, forceSmaller);
 }
 
+void ROTiledStManAccessor::setHypercubeCacheSize (uInt hypercube, uInt nbuckets,
+					 Bool forceSmaller)
+{
+    static_cast<TiledStMan *> (dataManPtr_p)->setHypercubeCacheSize (hypercube, nbuckets, forceSmaller);
+}
+
 void ROTiledStManAccessor::clearCaches()
 {
     dataManPtr_p->emptyCaches();

--- a/tables/DataMan/TiledStManAccessor.cc
+++ b/tables/DataMan/TiledStManAccessor.cc
@@ -190,7 +190,11 @@ void ROTiledStManAccessor::setCacheSize (uInt rownr, uInt nbuckets,
 void ROTiledStManAccessor::setHypercubeCacheSize (uInt hypercube, uInt nbuckets,
 					 Bool forceSmaller)
 {
-    static_cast<TiledStMan *> (dataManPtr_p)->setHypercubeCacheSize (hypercube, nbuckets, forceSmaller);
+    // Allow the cache to be sized only if the hypercube is not empty.
+
+    if (getBucketSize(hypercube) > 0){
+	static_cast<TiledStMan *> (dataManPtr_p)->setHypercubeCacheSize (hypercube, nbuckets, forceSmaller);
+    } 
 }
 
 void ROTiledStManAccessor::clearCaches()

--- a/tables/DataMan/TiledStManAccessor.h
+++ b/tables/DataMan/TiledStManAccessor.h
@@ -271,6 +271,9 @@ public:
     // <br>When forceSmaller is False, the cache is not resized when the
     // new size is smaller.
     void setCacheSize (uInt rownr, uInt nbuckets, Bool forceSmaller = True);
+
+    // This version allows setting the tile cache for a particular hypercube.  This
+    // is useful when iterating over the hypercubes in an StMan.
     void setHypercubeCacheSize (uInt hypercube, uInt nbuckets, Bool forceSmaller = True);
 
     // Clear the caches used by the hypercubes in this storage manager.

--- a/tables/DataMan/TiledStManAccessor.h
+++ b/tables/DataMan/TiledStManAccessor.h
@@ -271,6 +271,7 @@ public:
     // <br>When forceSmaller is False, the cache is not resized when the
     // new size is smaller.
     void setCacheSize (uInt rownr, uInt nbuckets, Bool forceSmaller = True);
+    void setHypercubeCacheSize (uInt hypercube, uInt nbuckets, Bool forceSmaller = True);
 
     // Clear the caches used by the hypercubes in this storage manager.
     // It will flush the caches as needed and remove all buckets from them

--- a/tables/DataMan/test/tTiledShapeStMan.cc
+++ b/tables/DataMan/test/tTiledShapeStMan.cc
@@ -33,6 +33,7 @@
 #include <casacore/tables/Tables/ScalarColumn.h>
 #include <casacore/tables/Tables/ArrayColumn.h>
 #include <casacore/tables/DataMan/TiledShapeStMan.h>
+#include <casacore/tables/DataMan/TiledStManAccessor.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
@@ -151,6 +152,43 @@ void writeFixed (const TSMOption& tsmOpt)
 	warray += float(200);
 	timeValue += 5;
     }
+}
+
+void testCacheSizing ()
+{
+    String result = "passed";
+    cout << "Testing cache sizing via accessor " << endl;
+
+    // Open the temporary table and establish a storage manager accessor.
+
+    Table table("tTiledShapeStMan_tmp.data", Table::Old, TSMOption::Aipsrc);
+    ROTiledStManAccessor accessor (table, "TSMExample", false);
+
+    // Set the cache sizes for the various hypercubes.
+
+    int nCubes = accessor.nhypercubes();
+    for (int cube = 0; cube < nCubes; cube ++){
+
+	if (accessor.getBucketSize(cube) != 0){
+	    int nBuckets = (cube + 1) * 3;
+	    accessor.setHypercubeCacheSize (cube, nBuckets);
+	}
+      
+    }
+
+    // Verify that the cache sizes are as expected.
+
+    for (int cube = 0; cube < nCubes; cube ++){
+
+	int nBuckets = accessor.getCacheSize (cube);
+	int nBucketsExpected = (cube + 1) * 3;
+	if (nBuckets != nBucketsExpected && accessor.getBucketSize(cube) != 0){
+	    cout << "Expected cache size of " << nBucketsExpected << "; got " << nBuckets << endl;
+	    result = "*FAILED*";
+	}
+    }
+
+    cout << "... completed testing cache sizing via accessor; status: " << result << endl;
 }
 
 void readTable (const IPosition& dwShape, const TSMOption& tsmOpt)
@@ -569,6 +607,7 @@ int main () {
         writeFixVar (TSMOption::Cache);
 	readTable (IPosition(2,16,25), TSMOption::MMap);
 	writeVarShaped (TSMOption::Default);
+        testCacheSizing ();
 	readTable (IPosition(), TSMOption::Aipsrc);
 	writeNoHyper (TSMOption::Aipsrc);
 	readTable (IPosition(2,16,25), TSMOption::Default);

--- a/tables/DataMan/test/tTiledShapeStMan.out
+++ b/tables/DataMan/test/tTiledShapeStMan.out
@@ -125,6 +125,8 @@ data.isDefined=0
 weig.isDefined=1
 freq.isDefined=1
 [16][10][16, 10][16, 10]
+Testing cache sizing via accessor 
+... completed testing cache sizing via accessor; status: passed
 Checking 10 rows
 WriteNoHyper ...
 Checking 101 rows


### PR DESCRIPTION
The tile cache for an StMan is set on a per hypercube basis.  The methods
available from the TiledStManAccessor class use a row number that the
StMan then uses to determine the appropriate hypercube.  For virtually
concatenated databases, it's handy to be able to walk through the
hypercubes without regard to the row number.  TiledStManAccessor already
provides the number of tiles, so the new feature allows looping over the
hypercubes in the StMan and setting each hypercube to have the appropriate
cache size.

I don't fell that this mod does not appear to significantly expose any
additional abstractions from the StMan beyond what TiledStManAccessor
already exposes.