### PR TITLE
CAS-8919 modify getRowStats() to use _subScanProps if it is cached

### DIFF
--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -85,12 +85,13 @@ public:
         // the subscan and that spwID
         map<uInt, Quantity> meanInterval;
         Quantity meanExposureTime;
-        uInt nrows;
         std::set<uInt> spws;
         // number of rows for each spectral window
         map<uInt, uInt> spwNRows;
         std::set<Int> stateIDs;
-        std::map<Double, TimeStampProperties> timeProps;
+        map<Double, TimeStampProperties> timeProps;
+        // number of cross-correlation rows.
+        uInt xcRows;
     };
 
     // construct an object which stores a pointer to the MS and queries the MS
@@ -551,8 +552,14 @@ public:
     // get polarization IDs for the specified scan and spwid
     std::set<uInt> getPolarizationIDs(uInt obsID, Int arrayID, Int scan, uInt spwid) const;
 
+    // DEPRECATED because of spelling error. Use getUniqueFieldIDs()
+    // instead.
+    inline std::set<Int> getUniqueFiedIDs() const {
+        return getUniqueFieldIDs();
+    }
+
     // get unique field IDs that exist in the main table.
-    std::set<Int> getUniqueFiedIDs() const;
+    std::set<Int> getUniqueFieldIDs() const;
 
     // get the pointing directions associated with antenna1 and antenna2 for
     // the specified row of the main MS table
@@ -646,7 +653,7 @@ private:
         _stateIDs, _dataDescIDs, _observationIDs, _arrayIDs;
     mutable SHARED_PTR<std::map<SubScanKey, uInt> > _subScanToNACRowsMap, _subScanToNXCRowsMap;
     mutable SHARED_PTR<QVD> _intervals;
-    mutable SHARED_PTR<vector<uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
+    mutable SHARED_PTR<map<Int, uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
     mutable std::map<ScanKey, std::set<String> > _scanToIntentsMap;
     mutable SHARED_PTR<const std::map<SubScanKey, std::set<String> > > _subScanToIntentsMap;
     mutable vector<std::set<String> > _stateToIntentsMap, _spwToIntentsMap, _fieldToIntentsMap;
@@ -859,18 +866,18 @@ private:
 
     void _getRowStats(
         uInt& nACRows, uInt& nXCRows,
-        std::map<SubScanKey, uInt>*& subScanToNACRowsMap,
-        std::map<SubScanKey, uInt>*& subScanToNXCRowsMap,
-        vector<uInt>*& fieldToNACRowsMap,
-        vector<uInt>*& fieldToNXCRowsMap
+        map<SubScanKey, uInt>*& subScanToNACRowsMap,
+        map<SubScanKey, uInt>*& subScanToNXCRowsMap,
+        map<Int, uInt>*& fieldToNACRowsMap,
+        map<Int, uInt>*& fieldToNXCRowsMap
     ) const;
 
     void _getRowStats(
         uInt& nACRows, uInt& nXCRows,
         SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
         SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
-        SHARED_PTR<vector<uInt> >& fieldToNACRowsMap,
-        SHARED_PTR<vector<uInt> >& fieldToNXCRowsMap
+        SHARED_PTR<map<Int, uInt> >& fieldToNACRowsMap,
+        SHARED_PTR<map<Int, uInt> >& fieldToNXCRowsMap
     ) const;
 
     // get the scan keys in the specified set that have the associated arrayKey

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -201,7 +201,7 @@ public:
 
     uInt nRows(CorrelationType cType);
 
-    SHARED_PTR<const map<SubScanKey, uInt> > getNRowMap(CorrelationType type) const;
+    SHARED_PTR<const std::map<SubScanKey, uInt> > getNRowMap(CorrelationType type) const;
 
     uInt nRows(
         CorrelationType cType, Int arrayID, Int observationID,
@@ -238,7 +238,7 @@ public:
     std::set<String> getFieldNamesForSpw(const uInt spw);
 
     // get rest frequencies from the SOURCE table
-    map<SourceKey, SHARED_PTR<vector<MFrequency> > > getRestFrequencies() const;
+    std::map<SourceKey, SHARED_PTR<vector<MFrequency> > > getRestFrequencies() const;
 
     // get the set of spectral windows for the specified scan.
     std::set<uInt> getSpwsForScan(const ScanKey& scan) const;
@@ -251,7 +251,7 @@ public:
 
     // get the transitions from the SOURCE table. If there are no transitions
     // for a particular key, the shared ptr contains the null ptr.
-    map<SourceKey, SHARED_PTR<vector<String> > > getTransitions() const;
+    std::map<SourceKey, SHARED_PTR<vector<String> > > getTransitions() const;
 
     // get the number of antennas in the ANTENNA table
     uInt nAntennas() const;
@@ -582,14 +582,14 @@ private:
     struct ScanProperties {
         // the key is the spwID, the value is the meanInterval for
         // the subscan and that spwID
-        map<uInt, Quantity> meanInterval;
+        std::map<uInt, Quantity> meanInterval;
         // number of rows for each spectral window
-        map<uInt, uInt> spwNRows;
+        std::map<uInt, uInt> spwNRows;
         // time range (which takes into account helf of the corresponding
         // interval, which is not accounted for in the SubScanProperties times
         std::pair<Double, Double> timeRange;
         // times for each spectral window
-        map<uInt, std::set<Double> > times;
+        std::map<uInt, std::set<Double> > times;
     };
 
     struct SpwProperties {
@@ -653,7 +653,7 @@ private:
         _stateIDs, _dataDescIDs, _observationIDs, _arrayIDs;
     mutable SHARED_PTR<std::map<SubScanKey, uInt> > _subScanToNACRowsMap, _subScanToNXCRowsMap;
     mutable SHARED_PTR<QVD> _intervals;
-    mutable SHARED_PTR<map<Int, uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
+    mutable SHARED_PTR<std::map<Int, uInt> > _fieldToNACRowsMap, _fieldToNXCRowsMap;
     mutable std::map<ScanKey, std::set<String> > _scanToIntentsMap;
     mutable SHARED_PTR<const std::map<SubScanKey, std::set<String> > > _subScanToIntentsMap;
     mutable vector<std::set<String> > _stateToIntentsMap, _spwToIntentsMap, _fieldToIntentsMap;
@@ -704,7 +704,7 @@ private:
 
     mutable vector<std::pair<Quantity, Quantity> > _properMotions;
 
-    mutable map<SourceKey, SourceProperties> _sourceInfo;
+    mutable std::map<SourceKey, SourceProperties> _sourceInfo;
 
     // disallow copy constructor and = operator
     MSMetaData(const MSMetaData&);
@@ -778,7 +778,7 @@ private:
     std::map<ArrayKey, std::set<SubScanKey> > _getArrayKeysToSubScanKeys() const;
 
     // Uses openmp for parallel processing
-    pair<map<ScanKey, ScanProperties>, map<SubScanKey, SubScanProperties> >
+    pair<std::map<ScanKey, ScanProperties>, std::map<SubScanKey, SubScanProperties> >
     _getChunkSubScanProperties(
         SHARED_PTR<const Vector<Int> > scans, SHARED_PTR<const Vector<Int> > fields,
         SHARED_PTR<const Vector<Int> > ddIDs, SHARED_PTR<const Vector<Int> > states,
@@ -866,18 +866,18 @@ private:
 
     void _getRowStats(
         uInt& nACRows, uInt& nXCRows,
-        map<SubScanKey, uInt>*& subScanToNACRowsMap,
-        map<SubScanKey, uInt>*& subScanToNXCRowsMap,
-        map<Int, uInt>*& fieldToNACRowsMap,
-        map<Int, uInt>*& fieldToNXCRowsMap
+        std::map<SubScanKey, uInt>*& subScanToNACRowsMap,
+        std::map<SubScanKey, uInt>*& subScanToNXCRowsMap,
+        std::map<Int, uInt>*& fieldToNACRowsMap,
+        std::map<Int, uInt>*& fieldToNXCRowsMap
     ) const;
 
     void _getRowStats(
         uInt& nACRows, uInt& nXCRows,
         SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNACRowsMap,
         SHARED_PTR<std::map<SubScanKey, uInt> >& scanToNXCRowsMap,
-        SHARED_PTR<map<Int, uInt> >& fieldToNACRowsMap,
-        SHARED_PTR<map<Int, uInt> >& fieldToNXCRowsMap
+        SHARED_PTR<std::map<Int, uInt> >& fieldToNACRowsMap,
+        SHARED_PTR<std::map<Int, uInt> >& fieldToNXCRowsMap
     ) const;
 
     // get the scan keys in the specified set that have the associated arrayKey
@@ -911,7 +911,7 @@ private:
 
     SHARED_PTR<std::map<ScanKey, std::set<Double> > > _getScanToTimesMap() const;
 
-    map<SourceKey, SourceProperties> _getSourceInfo() const;
+    std::map<SourceKey, SourceProperties> _getSourceInfo() const;
 
     vector<SpwProperties> _getSpwInfo(
         std::set<uInt>& avgSpw, std::set<uInt>& tdmSpw,

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -77,21 +77,21 @@ public:
     struct SubScanProperties {
         // number of auto-correlation rows
         uInt acRows;
+        // number of cross-correlation rows.
+        uInt xcRows;
         std::set<Int> antennas;
         Double beginTime;
         std::set<uInt> ddIDs;
         Double endTime;
         // the key is the spwID, the value is the meanInterval for
         // the subscan and that spwID
-        map<uInt, Quantity> meanInterval;
+        std::map<uInt, Quantity> meanInterval;
         Quantity meanExposureTime;
         std::set<uInt> spws;
         // number of rows for each spectral window
-        map<uInt, uInt> spwNRows;
+        std::map<uInt, uInt> spwNRows;
         std::set<Int> stateIDs;
-        map<Double, TimeStampProperties> timeProps;
-        // number of cross-correlation rows.
-        uInt xcRows;
+        std::map<Double, TimeStampProperties> timeProps;
     };
 
     // construct an object which stores a pointer to the MS and queries the MS

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -352,7 +352,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
         Int lastscan = 0;
         for (; siter != send; ++siter) {
             const MSMetaData::SubScanProperties& props = ssprops->find(*siter)->second;
-            Int nrow = props.nrows;
+            Int nrow = props.acRows + props.xcRows;
             Int thisscan = siter->scan;
             set<uInt> ddIDs = props.ddIDs;
             std::set<Int> stateIDs = props.stateIDs;
@@ -978,7 +978,7 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
     // Is source table present?
     Bool srcok=!(pMS->source().isNull() || pMS->source().nrow()<1);
     uInt nfields = _msmd->nFields();
-    std::set<Int> uniqueFields = _msmd->getUniqueFiedIDs();
+    std::set<Int> uniqueFields = _msmd->getUniqueFieldIDs();
     uInt nFieldsInMain = uniqueFields.size();
     if (nfields <= 0) {
         os << "The FIELD table is empty" << endl;
@@ -1017,9 +1017,9 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
             os.output().width(widthnVis);
             os << "nRows";
             if (_listUnflaggedRowCount) {
-                          os.output().width(widthNUnflaggedRows);
-                          os << "nUnflRows";
-                        }
+                os.output().width(widthNUnflaggedRows);
+                os << "nUnflRows";
+            }
         }
         os << endl;
         // loop through fields
@@ -1082,7 +1082,6 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
             } else {
                 os << "Field "<<fld<<" not found in FIELD table"<<endl;
             }
-
         }
     }
     os << endl << LogIO::POST;

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -1342,7 +1342,7 @@ void testIt(MSMetaData& md) {
 			for (Int i=0; i<6; ++i) {
 				expec.insert(i);
 			}
-			AlwaysAssert(md.getUniqueFiedIDs() == expec, AipsError);
+			AlwaysAssert(md.getUniqueFieldIDs() == expec, AipsError);
 		}
 		{
 			cout << "*** test getCenterFreqs()" << endl;
@@ -2159,10 +2159,13 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(thrown, AipsError);
             sskey.scan = 1;
             MSMetaData::SubScanProperties props = md.getSubScanProperties(sskey);
-            AlwaysAssert(props.nrows == 367, AipsError);
+            AlwaysAssert(props.acRows + props.xcRows == 367, AipsError);
             SHARED_PTR<const std::map<SubScanKey, MSMetaData::SubScanProperties> > allProps
                 = md.getSubScanProperties();
-            AlwaysAssert(allProps->find(sskey)->second.nrows == 367, AipsError);
+            AlwaysAssert(
+                allProps->find(sskey)->second.acRows + allProps->find(sskey)->second.xcRows == 367,
+                AipsError
+            );
             for (uInt i=0; i<9; ++i) {
                 Double expec = 0;
                 if (i == 0) {


### PR DESCRIPTION
Also add correct spelling of getUniqueFieldIDs() and deprecate getUniqueFiedIDs(). 