### PR TITLE
CAS-8526 improve effeciency of MSSummary::listAntenna()

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -4549,6 +4549,27 @@ Bool MSMetaData::_hasFieldID(const Int fieldID) const {
     return uniqueFields.find(fieldID) != uniqueFields.end();
 }
 
+const std::set<Int>& MSMetaData::getUniqueAntennaIDs() const {
+    // this method is responsible for setting _uniqueAntennas
+    if (_uniqueAntennaIDs.empty()) {
+        if (_subScanProperties) {
+            map<SubScanKey, SubScanProperties>::const_iterator iter = _subScanProperties->begin();
+            map<SubScanKey, SubScanProperties>::const_iterator end = _subScanProperties->end();
+            for (; iter!=end; ++iter) {
+                const std::set<Int>& ants = iter->second.antennas;
+                _uniqueAntennaIDs.insert(ants.begin(), ants.end());
+            }
+        }
+        else {
+            SHARED_PTR<Vector<Int> > ant1, ant2;
+            _getAntennas(ant1, ant2);
+            _uniqueAntennaIDs.insert(ant1->begin(), ant1->end());
+            _uniqueAntennaIDs.insert(ant2->begin(), ant2->end());
+        }
+    }    
+    return _uniqueAntennaIDs;
+}
+
 std::set<uInt> MSMetaData::getUniqueDataDescIDs() const {
     // this method is responsible for setting _uniqueDataDescIDs
     if (_uniqueDataDescIDs.empty()) {

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -122,7 +122,7 @@ public:
     ) const;
 
     // get the antenna stations for the specified antenna IDs
-    vector<String> getAntennaStations(const vector<uInt>& antennaIDs);
+    vector<String> getAntennaStations(const vector<uInt>& antennaIDs=vector<uInt>());
 
     // get the antenna stations for the specified antenna names
     vector<String> getAntennaStations(const vector<String>& antennaNames);
@@ -552,6 +552,10 @@ public:
     // get polarization IDs for the specified scan and spwid
     std::set<uInt> getPolarizationIDs(uInt obsID, Int arrayID, Int scan, uInt spwid) const;
 
+    // get the unique antennas (the union of the ANTENNA_1 and ANTENNA_2 columns) from
+    // the main table
+    const std::set<Int>& getUniqueAntennaIDs() const;
+
     // get unique data description IDs that exist in the main table
     std::set<uInt> getUniqueDataDescIDs() const;
 
@@ -650,7 +654,7 @@ private:
     mutable std::map<String, std::set<SubScanKey> > _intentToSubScansMap;
     mutable std::map<std::pair<ScanKey, uInt>, std::set<uInt> > _scanSpwToPolIDMap;
     mutable std::set<String> _uniqueIntents;
-    mutable std::set<Int>  _uniqueFieldIDs, _uniqueStateIDs;
+    mutable std::set<Int>  _uniqueFieldIDs, _uniqueStateIDs, _uniqueAntennaIDs;
     mutable std::set<uInt> _avgSpw, _tdmSpw, _fdmSpw, _wvrSpw, _sqldSpw, _uniqueDataDescIDs;
     mutable SHARED_PTR<Vector<Int> > _antenna1, _antenna2, _scans, _fieldIDs,
         _stateIDs, _dataDescIDs, _observationIDs, _arrayIDs;

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2410,12 +2410,24 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(allEQ(codes, String("none")), AipsError);
         }
         {
-            cout << "*** test uniqueDataDescIDs()" << endl;
+            cout << "*** test getUniqueDataDescIDs()" << endl;
             std::set<uInt> ddids = md.getUniqueDataDescIDs();
-            AlwaysAssert(ddids.size() == 25, AipsError);
             Vector<uInt> expec = indgen(25, (uInt)0, (uInt)1);
-            AlwaysAssert(allEQ(
-                Vector<uInt>(vector<uInt>(ddids.begin(), ddids.end())), expec), AipsError
+            AlwaysAssert(
+                allEQ(
+                    Vector<uInt>(vector<uInt>(ddids.begin(), ddids.end())), expec
+                ), AipsError
+            );
+        }
+        {
+            cout << "*** test getUniqueAntennaIDs()" << endl;
+            std::set<Int> ants = md.getUniqueAntennaIDs();
+            Int evals[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13};
+            Vector<Int> expec(vector<Int>(evals, evals+13));
+            AlwaysAssert(
+                allEQ(
+                    Vector<Int>(vector<Int>(ants.begin(), ants.end())), expec
+                ), AipsError
             );
         }
         {


### PR DESCRIPTION
add MSMetaData::getUniqueAntennaIDs() which uses subscan information if it exists rather than doing complete scans of two main table columns
add default parameter value to MSMetaData::getAntennaStations() to allow callers to retrieve all stations without having to provide cumbersome vector<uInt>() parameter.
rewrite portions of MSSummary::listAntenna() to use MSMetaData methods, along with minor style changes of existing code
add MSMetaData::getUniqueAntennaIDs() unit test to tMSMetaData
streamline MSMetaData::getUniqueDataDescIDs() unit test in tMSMetaData
