### PR TITLE
CAS-8529 improve performance of MSMetaData::_getExposureTimes()

### DIFF
--- a/measures/TableMeasures/ScalarQuantColumn.h
+++ b/measures/TableMeasures/ScalarQuantColumn.h
@@ -196,11 +196,10 @@ public:
 
   // get the column as a Quantum<Vector<T> >. If <src>unit</src> is
   // not empty, the returned Quantum will have that unit. Else if
-  // a unit was specified at construction of this object, the returned
-  // Quantum will have that unit. Else if the units are variable, the
-  // values in the returned Vector have been converted to the
-  // unit of the 0th row entry. Otherwise, the units of the returned
-  // Quantum are the units specified in the column descriptor.
+  // the units are variable, the values in the returned Vector
+  // have been converted to the unit of the 0th row entry. Otherwise,
+  // the units of the returned Quantum are the units specified in
+  // the column descriptor.
   SHARED_PTR<Quantum<Vector<T> > > getColumn(const Unit& unit="") const;
 
 protected:

--- a/measures/TableMeasures/ScalarQuantColumn.h
+++ b/measures/TableMeasures/ScalarQuantColumn.h
@@ -194,13 +194,14 @@ public:
   // Throw an exception if the object is null.
   void throwIfNull() const;
 
-  // get the column as a Quantum<Vector<T> >. If the units are variable, the
+  // get the column as a Quantum<Vector<T> >. If <src>unit</src> is
+  // not null, the returned Quantum will have that unit. Else if
+  // itsConv is True, the returned Quantum will have itsUnitOut as
+  // the unit. Else if the units are variable, the
   // values in the returned Vector have been converted to the
   // unit of the 0th row entry. Otherwise, the units of the returned
-  // Quantum are itsUnit (no conversion to itsUnitOut is attempted if
-  // itsConvOut is True, because of compile issues if the column type
-  // is Complex).
-  SHARED_PTR<Quantum<Vector<T> > > getColumn() const;
+  // Quantum are itsUnit.
+  SHARED_PTR<Quantum<Vector<T> > > getColumn(const Unit* unit=NULL) const;
 
 protected:
   //# Quantum column's units (if units not variable)

--- a/measures/TableMeasures/ScalarQuantColumn.h
+++ b/measures/TableMeasures/ScalarQuantColumn.h
@@ -195,13 +195,13 @@ public:
   void throwIfNull() const;
 
   // get the column as a Quantum<Vector<T> >. If <src>unit</src> is
-  // not null, the returned Quantum will have that unit. Else if
-  // itsConv is True, the returned Quantum will have itsUnitOut as
-  // the unit. Else if the units are variable, the
+  // not empty, the returned Quantum will have that unit. Else if
+  // a unit was specified at construction of this object, the returned
+  // Quantum will have that unit. Else if the units are variable, the
   // values in the returned Vector have been converted to the
   // unit of the 0th row entry. Otherwise, the units of the returned
-  // Quantum are itsUnit.
-  SHARED_PTR<Quantum<Vector<T> > > getColumn(const Unit* unit=NULL) const;
+  // Quantum are the units specified in the column descriptor.
+  SHARED_PTR<Quantum<Vector<T> > > getColumn(const Unit& unit="") const;
 
 protected:
   //# Quantum column's units (if units not variable)

--- a/measures/TableMeasures/ScalarQuantColumn.h
+++ b/measures/TableMeasures/ScalarQuantColumn.h
@@ -194,6 +194,14 @@ public:
   // Throw an exception if the object is null.
   void throwIfNull() const;
 
+  // get the column as a Quantum<Vector<T> >. If the units are variable, the
+  // values in the returned Vector have been converted to the
+  // unit of the 0th row entry. Otherwise, the units of the returned
+  // Quantum are itsUnit (no conversion to itsUnitOut is attempted if
+  // itsConvOut is True, because of compile issues if the column type
+  // is Complex).
+  SHARED_PTR<Quantum<Vector<T> > > getColumn() const;
+
 protected:
   //# Quantum column's units (if units not variable)
   Unit itsUnit;

--- a/measures/TableMeasures/ScalarQuantColumn.tcc
+++ b/measures/TableMeasures/ScalarQuantColumn.tcc
@@ -234,7 +234,34 @@ void ScalarQuantColumn<T>::put (uInt rownr, const Quantum<T>& q)
   }
 }
 
-} //# NAMESPACE CASACORE - END
+template<class T>
+SHARED_PTR<Quantum<Vector<T> > > ScalarQuantColumn<T>::getColumn() const {
+    SHARED_PTR<Quantum<Vector<T> > > qv;
+    if (itsUnitsCol) {
+        Vector<String> units = itsUnitsCol->getColumn();
+        Vector<String>::const_iterator uiter = units.begin();
+        const Unit unitOut = *uiter;
+        qv.reset(new Quantum<Vector<T> >(Vector<T>(), unitOut));
+        Vector<T>& val = qv->getValue();
+        itsDataCol->getColumn(val);
+        typename Vector<T>::iterator viter = val.begin();
+        typename Vector<T>::iterator vend = val.end();
+        Quantum<T> q;
+        for (; viter != vend; ++viter, ++uiter) {
+            q.setValue(*viter);
+            q.setUnit(*uiter);
+            q.convert(unitOut);
+            *viter = q.getValue();
+        }
+    }
+    else {
+        qv.reset(new Quantum<Vector<T> >(Vector<T>(), itsUnit));
+        Vector<T>& val = qv->getValue();
+        itsDataCol->getColumn(val);
+    }
+    return qv;
+}
 
+} //# NAMESPACE CASACORE - END
 
 #endif

--- a/measures/TableMeasures/ScalarQuantColumn.tcc
+++ b/measures/TableMeasures/ScalarQuantColumn.tcc
@@ -237,38 +237,27 @@ void ScalarQuantColumn<T>::put (uInt rownr, const Quantum<T>& q)
 template<class T>
 SHARED_PTR<Quantum<Vector<T> > > ScalarQuantColumn<T>::getColumn(const Unit& unit) const {
     SHARED_PTR<Quantum<Vector<T> > > qv;
-    Unit unitOut;
-    Bool convert = ! unit.empty() || itsConvOut;
-    if (convert) {
-        unitOut = unit.empty() ? itsUnitOut : unit;
-    }
-    if (itsUnitsCol) {
-        Vector<String> units = itsUnitsCol->getColumn();
-        Vector<String>::const_iterator uiter = units.begin();
-        if (! convert) {
-            unitOut = Unit(*uiter);
+    if ((itsUnitsCol && itsUnitsCol->nrow() > 0) || ! unit.empty()) {
+        Unit unitOut;
+        if (! unit.empty()) {
+            unitOut = unit;
+        }
+        else {
+            unitOut = itsUnitsCol->get(0);
         }
         qv.reset(new Quantum<Vector<T> >(Vector<T>(), unitOut));
         Vector<T>& val = qv->getValue();
         itsDataCol->getColumn(val);
-        typename Vector<T>::iterator viter = val.begin();
-        typename Vector<T>::iterator vend = val.end();
         Quantum<T> q;
-        for (; viter != vend; ++viter, ++uiter) {
-            q.setValue(*viter);
-            q.setUnit(*uiter);
-            *viter = q.getValue(unitOut);
+        for (uInt i = 0; i < val.size(); ++i) {
+            get(i, q, unitOut);
+            val[i] = q.getValue();
         }
     }
     else {
         qv.reset(new Quantum<Vector<T> >(Vector<T>(), itsUnit));
         Vector<T>& val = qv->getValue();
         itsDataCol->getColumn(val);
-        if (convert) {
-            qv->convert(unitOut);
-            //val = qv->getValue(unitOut);
-            //qv->setUnit(unitOut);
-        }
     }
     return qv;
 }

--- a/measures/TableMeasures/ScalarQuantColumn.tcc
+++ b/measures/TableMeasures/ScalarQuantColumn.tcc
@@ -250,8 +250,7 @@ SHARED_PTR<Quantum<Vector<T> > > ScalarQuantColumn<T>::getColumn() const {
         for (; viter != vend; ++viter, ++uiter) {
             q.setValue(*viter);
             q.setUnit(*uiter);
-            q.convert(unitOut);
-            *viter = q.getValue();
+            *viter = q.getValue(unitOut);
         }
     }
     else {

--- a/measures/TableMeasures/test/tTableQuantum.cc
+++ b/measures/TableMeasures/test/tTableQuantum.cc
@@ -503,6 +503,12 @@ int main (int argc, const char* argv[])
       cout << aqc4a.getUnits() << endl;
       cout << aqc4a(0) << endl;
     }
+    {
+        // test ScalarQuantColumn::getColumn()
+        ScalarQuantColumn<Double> col(qtab, "ScaQuantDouble"); 
+        SHARED_PTR<Quantum<Vector<Double> > > v = col.getColumn();
+        AlwaysAssert(v->getValue().size() == 5, AipsError);
+    }
 
   } catch (AipsError x) {
     cout << "Unexpected exception1: " << x.getMesg() << endl;

--- a/measures/TableMeasures/test/tTableQuantum.cc
+++ b/measures/TableMeasures/test/tTableQuantum.cc
@@ -518,6 +518,13 @@ int main (int argc, const char* argv[])
         }
         ScalarQuantColumn<Complex> ccol(qtab, "ScaQuantComplex");
         SHARED_PTR<Quantum<Vector<Complex> > > x = ccol.getColumn(); 
+        AlwaysAssert(x->getValue().size() == 5, AipsError);
+        SHARED_PTR<Quantum<Vector<Complex> > > y = ccol.getColumn("rad"); 
+        for (uInt i=0; i<5; ++i) {
+            AlwaysAssert(
+                near(y->getValue()[i], frac*x->getValue()[i]), AipsError
+            );
+        }
     }
 
   } catch (AipsError x) {

--- a/measures/TableMeasures/test/tTableQuantum.cc
+++ b/measures/TableMeasures/test/tTableQuantum.cc
@@ -508,8 +508,7 @@ int main (int argc, const char* argv[])
         ScalarQuantColumn<Double> col(qtab, "ScaQuantDouble"); 
         SHARED_PTR<Quantum<Vector<Double> > > v = col.getColumn();
         AlwaysAssert(v->getValue().size() == 5, AipsError);
-        Unit rad("rad");
-        SHARED_PTR<Quantum<Vector<Double> > > w = col.getColumn(&rad);
+        SHARED_PTR<Quantum<Vector<Double> > > w = col.getColumn("rad");
         AlwaysAssert(w->getValue().size() == 5, AipsError);
         Double frac = C::pi/180;
         for (uInt i=0; i<5; ++i) {
@@ -517,6 +516,8 @@ int main (int argc, const char* argv[])
                 near(w->getValue()[i], frac*v->getValue()[i]), AipsError
             );
         }
+        ScalarQuantColumn<Complex> ccol(qtab, "ScaQuantComplex");
+        SHARED_PTR<Quantum<Vector<Complex> > > x = ccol.getColumn(); 
     }
 
   } catch (AipsError x) {

--- a/measures/TableMeasures/test/tTableQuantum.cc
+++ b/measures/TableMeasures/test/tTableQuantum.cc
@@ -508,6 +508,15 @@ int main (int argc, const char* argv[])
         ScalarQuantColumn<Double> col(qtab, "ScaQuantDouble"); 
         SHARED_PTR<Quantum<Vector<Double> > > v = col.getColumn();
         AlwaysAssert(v->getValue().size() == 5, AipsError);
+        Unit rad("rad");
+        SHARED_PTR<Quantum<Vector<Double> > > w = col.getColumn(&rad);
+        AlwaysAssert(w->getValue().size() == 5, AipsError);
+        Double frac = C::pi/180;
+        for (uInt i=0; i<5; ++i) {
+            AlwaysAssert(
+                near(w->getValue()[i], frac*v->getValue()[i]), AipsError
+            );
+        }
     }
 
   } catch (AipsError x) {

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -2174,18 +2174,15 @@ SHARED_PTR<QVD> MSMetaData::_getExposureTimes() const {
     if (_exposures && ! _exposures->getValue().empty()) {
         return _exposures;
     }
-    ScalarQuantColumn<Double> exposure(
+    ScalarColumn<Double> col(
         *_ms, MeasurementSet::columnName(MSMainEnums::EXPOSURE)
     );
-    uInt nrow = _ms->nrow();
-    Vector<Double> v(nrow);
-    Vector<Double>::iterator iter = v.begin();
-    Vector<Double>::iterator end = v.end();
-    uInt i = 0;
-    for (; iter!=end; ++iter, ++i) {
-        *iter = exposure(i).getValue();
-    }
-    SHARED_PTR<QVD> ex(new QVD(v, exposure.getUnits()));
+    Unit units = ScalarQuantColumn<Double>(
+        *_ms, MeasurementSet::columnName(MSMainEnums::EXPOSURE)
+    ).getUnits();
+    SHARED_PTR<QVD> ex(new QVD(Vector<Double>(), units));
+    Vector<Double>& val = ex->getValue();
+    col.getColumn(val);
     if (_cacheUpdated((20 + sizeof(Double))*ex->getValue().size())) {
         _exposures = ex;
     }

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -1604,7 +1604,7 @@ vector<std::map<Int, Quantity> > MSMetaData::getFirstExposureTimeMap() {
     SHARED_PTR<Vector<Int> > scans = _getScans();
     SHARED_PTR<Vector<Int> > dataDescIDs = _getDataDescIDs();
     SHARED_PTR<Vector<Double> > times = _getTimes();
-    SHARED_PTR<QVD> exposureTimes = _getExposureTimes();
+    SHARED_PTR<Quantum<Vector<Double> > > exposureTimes = _getExposureTimes();
     vector<std::map<Int, Quantity> > firstExposureTimeMap(nDataDescIDs);
     vector<std::map<Int, Double> > tmap(nDataDescIDs);
     Vector<Int>::const_iterator siter = scans->begin();
@@ -2170,19 +2170,14 @@ SHARED_PTR<Vector<Double> > MSMetaData::_getTimes() const {
     return times;
 }
 
-SHARED_PTR<QVD> MSMetaData::_getExposureTimes() const {
+SHARED_PTR<Quantum<Vector<Double> > > MSMetaData::_getExposureTimes() const {
     if (_exposures && ! _exposures->getValue().empty()) {
         return _exposures;
     }
-    ScalarColumn<Double> col(
+    ScalarQuantColumn<Double> col(
         *_ms, MeasurementSet::columnName(MSMainEnums::EXPOSURE)
     );
-    Unit units = ScalarQuantColumn<Double>(
-        *_ms, MeasurementSet::columnName(MSMainEnums::EXPOSURE)
-    ).getUnits();
-    SHARED_PTR<QVD> ex(new QVD(Vector<Double>(), units));
-    Vector<Double>& val = ex->getValue();
-    col.getColumn(val);
+    SHARED_PTR<Quantum<Vector<Double> > > ex = col.getColumn();    
     if (_cacheUpdated((20 + sizeof(Double))*ex->getValue().size())) {
         _exposures = ex;
     }
@@ -3441,7 +3436,7 @@ void MSMetaData::_computeScanAndSubScanProperties(
     SHARED_PTR<Vector<Int> > arrays = _getArrayIDs();
     SHARED_PTR<Vector<Int> > observations = _getObservationIDs();
     SHARED_PTR<Vector<Int> > ant1, ant2;
-    SHARED_PTR<QVD> exposureTimes = _getExposureTimes();
+    SHARED_PTR<Quantum<Vector<Double> > > exposureTimes = _getExposureTimes();
     SHARED_PTR<QVD> intervalTimes = _getIntervals();
     vector<uInt> ddIDToSpw = getDataDescIDToSpwMap();
     _getAntennas(ant1, ant2);
@@ -3629,7 +3624,7 @@ MSMetaData::_getChunkSubScanProperties(
     SHARED_PTR<const Vector<Int> > ddIDs, SHARED_PTR<const Vector<Int> > states,
     SHARED_PTR<const Vector<Double> > times, SHARED_PTR<const Vector<Int> > arrays,
     SHARED_PTR<const Vector<Int> > observations, SHARED_PTR<const Vector<Int> > ant1,
-    SHARED_PTR<const Vector<Int> > ant2, SHARED_PTR<const QVD> exposureTimes,
+    SHARED_PTR<const Vector<Int> > ant2, SHARED_PTR<const Quantum<Vector<Double> > > exposureTimes,
     SHARED_PTR<const QVD> intervalTimes, const vector<uInt>& ddIDToSpw, uInt beginRow,
     uInt endRow
 ) const {

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -675,7 +675,7 @@ private:
     mutable vector<Array<Int> >_corrProds;
 
     mutable SHARED_PTR<Vector<Double> > _times;
-    mutable SHARED_PTR<QVD > _exposures;
+    mutable SHARED_PTR<Quantum<Vector<Double> > > _exposures;
     mutable SHARED_PTR<std::map<ScanKey, std::set<Double> > > _scanToTimesMap;
     std::map<String, std::set<uInt> > _intentToSpwsMap;
     mutable std::map<String, std::set<Double> > _intentToTimesMap;
@@ -791,14 +791,14 @@ private:
         SHARED_PTR<const Vector<Int> > ddIDs, SHARED_PTR<const Vector<Int> > states,
         SHARED_PTR<const Vector<Double> > times, SHARED_PTR<const Vector<Int> > arrays,
         SHARED_PTR<const Vector<Int> > observations, SHARED_PTR<const Vector<Int> > ant1,
-        SHARED_PTR<const Vector<Int> > ant2, SHARED_PTR<const QVD> exposureTimes,
+        SHARED_PTR<const Vector<Int> > ant2, SHARED_PTR<const Quantum<Vector<Double> > > exposureTimes,
         SHARED_PTR<const QVD> intervalTimes, const vector<uInt>& ddIDToSpw,
         uInt beginRow, uInt endRow
     ) const;
 
     SHARED_PTR<Vector<Int> > _getDataDescIDs() const;
 
-    SHARED_PTR<QVD > _getExposureTimes() const;
+    SHARED_PTR<Quantum<Vector<Double> > > _getExposureTimes() const;
 
     SHARED_PTR<Vector<Int> > _getFieldIDs() const;
 

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2431,6 +2431,46 @@ void testIt(MSMetaData& md) {
             );
         }
         {
+            cout << "*** test getFirstExposureTimeMap()" << endl;
+            vector<map<Int, Quantity> > mymap = md.getFirstExposureTimeMap();
+            AlwaysAssert(mymap.size() == 25, AipsError);
+            for (Int i=0; i<25; ++i) {
+                uInt expSize = 0;
+                Quantity expExposure(0, "s");
+                if (i == 0) {
+                    expSize = 32;
+                    expExposure.setValue(1.152);
+                }
+                else if (i == 1 || i == 3 || i == 5 || i == 7) {
+                    expSize = 3;
+                    expExposure.setValue(2.016);
+                }
+                else if (i == 2 || i == 4 || i == 6 || i == 8) {
+                    expSize = 3;
+                    expExposure.setValue(1.008);
+                }
+                else if (i == 9 || i == 11 || i == 13 || i == 15) {
+                    expSize = 14;
+                    expExposure.setValue(2.016);
+                }
+                else if (i == 10 || i == 12 || i == 14 || i == 16) {
+                    expSize = 14;
+                    expExposure.setValue(1.008);
+                }
+                else if (i == 17 || i == 19 || i == 21 || i == 23) {
+                    expSize = 15;
+                    expExposure.setValue(6.048);
+                }
+                else if (i == 18 || i == 20 || i == 22 || i == 24) {
+                    expSize = 15;
+                    expExposure.setValue(1.008);
+                }
+                AlwaysAssert(mymap[i].size() == expSize, AipsError);
+                AlwaysAssert(mymap[i].begin()->second == expExposure, AipsError);
+            }
+            
+        }
+        {
 			cout << "*** cache size " << md.getCache() << endl;
 		}
 	}


### PR DESCRIPTION
This decreases the run time of MSMetaData::_getExposureTimes()
    by a factor of 4 to 5 on large data sets.
Also, add a unit test for MSMetaData::getFirstExposureTimeMap()
    which verifies this change