### PR TITLE
Fixed update-like insert problem

### DIFF
--- a/tables/TaQL/TaQLNodeDer.cc
+++ b/tables/TaQL/TaQLNodeDer.cc
@@ -1359,15 +1359,17 @@ TaQLInsertNodeRep::TaQLInsertNodeRep (const TaQLMultiNode& tables,
     const TaQLUpdExprNodeRep* rep = dynamic_cast<const TaQLUpdExprNodeRep*>
       (nodes[i].getRep());
     AlwaysAssert (rep, AipsError);
-    if (rep->itsIndices1.isValid()) {
-      throw TableInvExpr ("Column indices cannot be given in an "
+    if (rep->itsIndices1.isValid()  ||  rep->itsIndices2.isValid()) {
+      throw TableInvExpr ("Column indices or masks cannot be given in an "
                           "INSERT command");
     }
     // Add the column name and value expression.
     itsColumns.add (new TaQLKeyColNodeRep (rep->itsName));
     values.add (rep->itsExpr);
   }
-  itsValues = values;
+  TaQLMultiNode valuesList(False);
+  valuesList.add (values);
+  itsValues = valuesList;
 }
 TaQLInsertNodeRep::~TaQLInsertNodeRep()
 {}

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -299,6 +299,9 @@ INSERT INTO tTaQLNode_tmp.tab VALUES [(1)+(2)],[8],[9],[10]
 insert limit 10 into tTaQLNode_tmp.tab values (1)
 INSERT LIMIT 10 INTO tTaQLNode_tmp.tab VALUES [1]
 
+insert into tTaQLNode_tmp.tab set ab1=1, ab2="str"
+INSERT INTO tTaQLNode_tmp.tab [ab1,ab2] VALUES [1,'str']
+
 count ab,ac+1 from tTaQLnode_tmp.tab
 COUNT  ab,(ac)+(1) FROM tTaQLnode_tmp.tab
 

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -163,6 +163,7 @@ $casa_checktool ./tTaQLNode 'insert into tTaQLNode_tmp.tab select from tTaQLNode
 $casa_checktool ./tTaQLNode 'insert into tTaQLNode_tmp.tab ((ab1,ab2),ac) values (1+2,3*ab + sum([select ab from tTaQLNode_tmp.tab]))'
 $casa_checktool ./tTaQLNode 'insert into tTaQLNode_tmp.tab values (1+2),(8),(9),(10)'
 $casa_checktool ./tTaQLNode 'insert limit 10 into tTaQLNode_tmp.tab values (1)'
+$casa_checktool ./tTaQLNode 'insert into tTaQLNode_tmp.tab set ab1=1, ab2="str"'
 
 $casa_checktool ./tTaQLNode 'count ab,ac+1 from tTaQLnode_tmp.tab'
 $casa_checktool ./tTaQLNode 'count min(ab),ac+1 from tTaQLnode_tmp.tab where ac>1'

--- a/tables/TaQL/test/tTableGram.out
+++ b/tables/TaQL/test/tTableGram.out
@@ -790,7 +790,7 @@ select ab from tTableGram_tmp.tab
  5
  7
  9
-insert into tTableGram_tmp.tab (ab,ac) values (1+2,3*ab + sum([select ab from tTableGram_tmp.tab]))
+insert into tTableGram_tmp.tab set ab=1+2, ac=3*ab + sum([select ab from tTableGram_tmp.tab])
     has been executed
     insert result of 1 rows
 2 selected columns:  ab ac

--- a/tables/TaQL/test/tTableGram.run
+++ b/tables/TaQL/test/tTableGram.run
@@ -202,7 +202,7 @@ $casa_checktool ./tTableGram 'select ab from tTableGram_tmp.tab'
 $casa_checktool ./tTableGram 'delete from tTableGram_tmp.tab where ab%2==0'
 $casa_checktool ./tTableGram 'select ab from tTableGram_tmp.tab'
 
-$casa_checktool ./tTableGram 'insert into tTableGram_tmp.tab (ab,ac) values (1+2,3*ab + sum([select ab from tTableGram_tmp.tab]))'
+$casa_checktool ./tTableGram 'insert into tTableGram_tmp.tab set ab=1+2, ac=3*ab + sum([select ab from tTableGram_tmp.tab])'
 $casa_checktool ./tTableGram 'select ab,ac from tTableGram_tmp.tab'
 
 $casa_checktool ./tTableGram 'insert into [createtable tTableGram_tmp.tab2 (ab I4, ac U2, ad I4)] values (10,11,1),(12,13,2),(14,15,4)'


### PR DESCRIPTION
The values had to be put in an extra TaQLMultiNode because INSERT now can have multiple value lists. Added some tests.
Close #418 