### PR TITLE
CAS-8645 improve MSSummary performance for MS with many fields

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -1093,7 +1093,6 @@ std::set<String> MSMetaData::getIntentsForField(Int fieldID) {
     return fieldToIntentsMap[fieldID];
 }
 
-
 uInt MSMetaData::nFields() const {
     if (_nFields > 0) {
         return _nFields;
@@ -1101,6 +1100,32 @@ uInt MSMetaData::nFields() const {
     uInt nFields = _ms->field().nrow();
     _nFields = nFields;
     return nFields;
+}
+
+SHARED_PTR<std::set<Int> > MSMetaData::_getEphemFieldIDs() const {
+    // responsible for setting _ephemFields
+    if (_ephemFields) {
+        return _ephemFields;
+    }
+    ROMSFieldColumns msfc(_ms->field());
+    ROScalarColumn<Int> ephemCol = msfc.ephemerisId();
+    _ephemFields.reset(new std::set<Int>());
+    if (ephemCol.isNull()) {
+        return _ephemFields;
+    }
+    Vector<Int> colData = ephemCol.getColumn();
+    if (! anyTrue(colData >= 0)) {
+        return _ephemFields;
+    }
+    Vector<Int>::const_iterator iter = colData.begin();
+    Vector<Int>::const_iterator end = colData.end();
+    uInt i = 0;
+    for (; iter!=end; ++iter, ++i) {
+        if (*iter >= 0) {
+            _ephemFields->insert(i);
+        }
+    }
+    return _ephemFields;
 }
 
 MDirection MSMetaData::phaseDirFromFieldIDAndTime(const uInt fieldID,  const MEpoch& ep) const {
@@ -3177,20 +3202,30 @@ MPosition MSMetaData::getObservatoryPosition(uInt which) const {
     return observatoryPositions[which];
 }
 
-vector<MDirection> MSMetaData::getPhaseDirs() const {
+vector<MDirection> MSMetaData::getPhaseDirs(const MEpoch& ep) const {
     // this method is responsible for setting _phaseDirs
-    if (! _phaseDirs.empty()) {
-        return _phaseDirs;
+    vector<MDirection> myDirs;
+    if (_phaseDirs.empty()) {
+        String name = MSField::columnName(MSFieldEnums::PHASE_DIR);
+        ScalarMeasColumn<MDirection> phaseDirCol(_ms->field(), name);
+        uInt nrows = nFields();
+        for (uInt i=0; i<nrows; ++i) {
+            myDirs.push_back(phaseDirCol(i));
+        }
+        if (_cacheUpdated(_sizeof(myDirs))) {
+            _phaseDirs = myDirs;
+        }
     }
-    String name = MSField::columnName(MSFieldEnums::PHASE_DIR);
-    ScalarMeasColumn<MDirection> phaseDirCol(_ms->field(), name);
-    uInt nrows = nFields();
-    vector<MDirection> myDirs(nrows);
-    for (uInt i=0; i<nrows; ++i) {
-        myDirs[i] = phaseDirCol(i);
+    else {
+        myDirs = _phaseDirs;
     }
-    if (_cacheUpdated(_sizeof(myDirs))) {
-        _phaseDirs = myDirs;
+    // get the correct directions for ephemeris objects and put them
+    // in the vector
+    SHARED_PTR<std::set<Int> > ephems = _getEphemFieldIDs();
+    std::set<Int>::const_iterator iter = ephems->begin();
+    std::set<Int>::const_iterator end = ephems->end();
+    for (; iter!=end; ++iter) {
+        myDirs[*iter] = phaseDirFromFieldIDAndTime(*iter, ep);
     }
     return myDirs;
 }

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -1114,9 +1114,6 @@ SHARED_PTR<std::set<Int> > MSMetaData::_getEphemFieldIDs() const {
         return _ephemFields;
     }
     Vector<Int> colData = ephemCol.getColumn();
-    if (! anyTrue(colData >= 0)) {
-        return _ephemFields;
-    }
     Vector<Int>::const_iterator iter = colData.begin();
     Vector<Int>::const_iterator end = colData.end();
     uInt i = 0;

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -395,8 +395,10 @@ public:
     // get the position of the specified telescope (observatory).
     MPosition getObservatoryPosition(uInt which) const;
 
-    // get the phase directions from the FIELD subtable
-    vector<MDirection> getPhaseDirs() const;
+    // get the phase directions from the FIELD subtable. The <src>ep</src> parameter
+    // specifies for which epoch to return the directions of any ephemeris objects
+    // in the data set. It is ignored for non-ephemeris objects.
+    vector<MDirection> getPhaseDirs(const MEpoch& ep=MEpoch(Quantity(0.0, Unit("s")))) const;
 
     // get all ScanKeys in the dataset
     std::set<ScanKey> getScanKeys() const;
@@ -711,6 +713,7 @@ private:
     mutable vector<std::pair<Quantity, Quantity> > _properMotions;
 
     mutable std::map<SourceKey, SourceProperties> _sourceInfo;
+    mutable SHARED_PTR<std::set<Int> > _ephemFields;
 
     // disallow copy constructor and = operator
     MSMetaData(const MSMetaData&);
@@ -796,6 +799,9 @@ private:
     ) const;
 
     SHARED_PTR<Vector<Int> > _getDataDescIDs() const;
+
+    // get the field IDs of ephemeris objects
+    SHARED_PTR<std::set<Int> > _getEphemFieldIDs() const;
 
     SHARED_PTR<Quantum<Vector<Double> > > _getExposureTimes() const;
 

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -1010,10 +1010,11 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
         std::set<Int>::const_iterator fend = uniqueFields.end();
         vector<Int> sourceIDs = _msmd->getFieldTableSourceIDs();
         static const MEpoch ezero(Quantity(0, "s"));
+        vector<MDirection> phaseDirs = _msmd->getPhaseDirs(ezero);
         for (; fiter!=fend; ++fiter) {
             Int fld = *fiter;
             if (fld >=0 && fld < (Int)nfields) {
-                MDirection mRaDec = _msmd->phaseDirFromFieldIDAndTime(fld, ezero);
+                MDirection mRaDec = phaseDirs[fld];
                 MVAngle mvRa = mRaDec.getAngle().getValue()(0);
                 MVAngle mvDec = mRaDec.getAngle().getValue()(1);
                 String name = fieldNames[fld];


### PR DESCRIPTION
Account for ephemeris objects in getPhaseDirs() and improve performance of MSSummary by retrieving entire phaseDir data structure in one go rather than making multiple calls to msmd method.