### PR TITLE
Add functionality to clone a table column

### DIFF
--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -256,6 +256,7 @@ Tables/TableAttr.h
 Tables/TableCache.h
 Tables/TableColumn.h
 Tables/TableCopy.h
+Tables/TableCopy.tcc
 Tables/TableDesc.h
 Tables/TableError.h
 Tables/TableIndexProxy.h

--- a/tables/DataMan/DataManager.cc
+++ b/tables/DataMan/DataManager.cc
@@ -384,6 +384,12 @@ IPosition DataManagerColumn::shape (uInt)
     return IPosition(0);
 }
 
+// The tile shape of the array in the given row.
+IPosition DataManagerColumn::tileShape (uInt)
+{
+    return IPosition(0);
+}
+
 Bool DataManagerColumn::canChangeShape() const
 {
     return False;

--- a/tables/DataMan/DataManager.h
+++ b/tables/DataMan/DataManager.h
@@ -683,6 +683,10 @@ public:
     // By default it returns a zero-length IPosition (for a scalar value).
     virtual IPosition shape (uInt rownr);
 
+    // Get the tile shape of the item in the given row.
+    // By default it returns a zero-length IPosition.
+    virtual IPosition tileShape (uInt rownr);
+
     // Can the data manager handle chaging the shape of an existing array?
     // Default is no.
     virtual Bool canChangeShape() const;

--- a/tables/DataMan/TSMDataColumn.cc
+++ b/tables/DataMan/TSMDataColumn.cc
@@ -118,7 +118,13 @@ void TSMDataColumn::setShapeTiled (uInt rownr, const IPosition& shape,
     if (cubeShape.nelements() == 0) {
 	stmanPtr_p->setShape (rownr, hypercube, shape, tileShape);
     }else{
-	if (! shape.isEqual(cubeShape)) {
+        Bool eq = True;
+        for (uInt i=0; i<shape.size(); ++i) {
+          if (shape[i] != cubeShape[i]) {
+            eq = False;
+          }
+        }
+	if (!eq) {
 	    if (! canChangeShape()) {
 		throw (TSMError
 		       ("Shape of data cells in same hypercube differs"));
@@ -162,6 +168,13 @@ IPosition TSMDataColumn::shape (uInt rownr)
 	shape(i) = cubeShape(i);
     }
     return shape;
+}
+
+IPosition TSMDataColumn::tileShape (uInt rownr)
+{
+    //# If no shape is defined, throw exception.
+    TSMCube* hypercube = stmanPtr_p->getHypercube (rownr);
+    return hypercube->tileShape();
 }
 
 

--- a/tables/DataMan/TSMDataColumn.h
+++ b/tables/DataMan/TSMDataColumn.h
@@ -150,6 +150,9 @@ public:
     // Get the shape of the item in the given row.
     IPosition shape (uInt rownr);
 
+    // Get the tile shape of the item in the given row.
+    IPosition tileShape (uInt rownr);
+
     // Get a scalar value in the given row.
     // The buffer pointed to by dataPtr has to have the correct length
     // (which is guaranteed by the Scalar/ArrayColumn get function).

--- a/tables/DataMan/VirtualTaQLColumn.cc
+++ b/tables/DataMan/VirtualTaQLColumn.cc
@@ -157,7 +157,7 @@ void VirtualTaQLColumn::prepare()
   TableColumn tabcol (table(), itsColumnName);
   itsExpr = tabcol.keywordSet().asString ("_VirtualTaQLEngine_CalcExpr");
   // Compile the expression.
-  TaQLResult res = tableCommand ("calc from $1 calc " + itsExpr, table());
+  TaQLResult res = tableCommand ("calc " + itsExpr + " from $1" , table());
   itsNode = new TableExprNode(res.node());
   // Check if the expression type matches the column type.
   if (itsNode->isScalar() == itsIsArray) {

--- a/tables/DataMan/VirtualTaQLColumn.cc
+++ b/tables/DataMan/VirtualTaQLColumn.cc
@@ -157,7 +157,7 @@ void VirtualTaQLColumn::prepare()
   TableColumn tabcol (table(), itsColumnName);
   itsExpr = tabcol.keywordSet().asString ("_VirtualTaQLEngine_CalcExpr");
   // Compile the expression.
-  TaQLResult res = tableCommand ("calc " + itsExpr + " from $1" , table());
+  TaQLResult res = tableCommand ("calc from $1 calc " + itsExpr, table());
   itsNode = new TableExprNode(res.node());
   // Check if the expression type matches the column type.
   if (itsNode->isScalar() == itsIsArray) {

--- a/tables/DataMan/test/tTiledShapeStMan.cc
+++ b/tables/DataMan/test/tTiledShapeStMan.cc
@@ -242,6 +242,9 @@ void readTable (const IPosition& dwShape, const TSMOption& tsmOpt)
 	    cout << "mismatch in time row " << i << endl;
 	}
 	timeValue += 5;
+        if (i < 10) {
+          cout << "tileshape=" << data.tileShape(i) << endl;
+        }
     }
 }
 

--- a/tables/DataMan/test/tTiledShapeStMan.out
+++ b/tables/DataMan/test/tTiledShapeStMan.out
@@ -1,5 +1,15 @@
 WriteFixed ...
 Checking 101 rows
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
 WriteVar ...
  pol.isDefined=0
  pol.isDefined=1
@@ -32,6 +42,11 @@ weig.isDefined=1
 freq.isDefined=1
 [16][25][16, 25][16, 25]
 Checking 5 rows
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
 WriteFixVar ...
  pol.isDefined=1
  pol.isDefined=1
@@ -64,6 +79,11 @@ weig.isDefined=1
 freq.isDefined=1
 [16][25][16, 25][16, 25]
 Checking 5 rows
+tileshape=[16, 25, 82]
+tileshape=[16, 25, 82]
+tileshape=[16, 25, 82]
+tileshape=[16, 25, 82]
+tileshape=[16, 25, 82]
 WriteVarShaped ...
  pol.isDefined=0
  pol.isDefined=1
@@ -128,5 +148,25 @@ freq.isDefined=1
 Testing cache sizing via accessor 
 ... completed testing cache sizing via accessor; status: passed
 Checking 10 rows
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
+tileshape=[12, 10, 273]
 WriteNoHyper ...
 Checking 101 rows
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]
+tileshape=[5, 6, 1092]

--- a/tables/Tables/ArrColData.h
+++ b/tables/Tables/ArrColData.h
@@ -150,6 +150,10 @@ public:
     // If the cell does not contain an array, an empty IPosition is returned.
     IPosition shape(uInt rownr) const;
 
+    // Get the tile shape of an array in a particular cell.
+    // If the cell does not contain an array, an empty IPosition is returned.
+    IPosition tileShape(uInt rownr) const;
+
     // Set dimensions of array in a particular cell.
     // <group>
     void setShape (uInt rownr, const IPosition& shape);

--- a/tables/Tables/ArrColData.tcc
+++ b/tables/Tables/ArrColData.tcc
@@ -148,6 +148,11 @@ IPosition ArrayColumnData<T>::shape (uInt rownr) const
 {
     return dataColPtr_p->shape(rownr);
 }
+template<class T>
+IPosition ArrayColumnData<T>::tileShape (uInt rownr) const
+{
+    return dataColPtr_p->tileShape(rownr);
+}
 
 
 template<class T>
@@ -377,17 +382,14 @@ template<class T>
 void ArrayColumnData<T>::checkShape (const IPosition& shape) const
 {
     if ((columnDesc().options() & ColumnDesc::FixedShape)
-	                               == ColumnDesc::FixedShape) {
-	throw (TableInvOper
-	     ("ArrayColumn::setShape only possible for non-FixedShape arrays"
-              " of column " + colDescPtr_p->name()));
-    }
-    if (columnDesc().ndim() > 0) {
+	                               != ColumnDesc::FixedShape) {
+      if (columnDesc().ndim() > 0) {
 	if (Int(shape.nelements()) != columnDesc().ndim()) {
 	    throw (TableInvOper
 		   ("ArrayColumn::setShape: mismatch in #dim of array"
                     " of column " + colDescPtr_p->name()));
 	}
+      }
     }
 }
 

--- a/tables/Tables/ArrayColumn.h
+++ b/tables/Tables/ArrayColumn.h
@@ -362,28 +362,18 @@ public:
     void put (uInt rownr, const Array<T>& array);
 
     // Copy the value of a cell of that column to a cell of this column.
-    // The data types of both columns must be the same, otherwise an
-    // exception is thrown.
-    // <group>
-    // Use the same row numbers for both cells.
-    void put (uInt rownr, const ArrayColumn<T>& that)
-	{ put (rownr, that, rownr); }
-    // Use possibly different row numbers for that (i.e. input) and
-    // and this (i.e. output) cell.
-    void put (uInt thisRownr, const ArrayColumn<T>& that, uInt thatRownr);
-    // </group>
-
-    // Copy the value of a cell of that column to a cell of this column.
     // This function uses a generic TableColumn object as input.
     // The data types of both columns must be the same, otherwise an
     // exception is thrown.
     // <group>
     // Use the same row numbers for both cells.
-    void put (uInt rownr, const TableColumn& that)
-	{ put (rownr, that, rownr); }
+    void put (uInt rownr, const TableColumn& that,
+              Bool preserveTileShape=False)
+      { put (rownr, that, rownr, preserveTileShape); }
     // Use possibly different row numbers for that (i.e. input) and
     // and this (i.e. output) cell.
-    void put (uInt thisRownr, const TableColumn& that, uInt thatRownr);
+    void put (uInt thisRownr, const TableColumn& that, uInt thatRownr,
+              Bool preserveTileShape=False);
     // </group>
 
     // Put into a slice of an N-dimensional array in a particular cell.

--- a/tables/Tables/ArrayColumn.tcc
+++ b/tables/Tables/ArrayColumn.tcc
@@ -878,9 +878,9 @@ ArrayColumn<T>::putColumnCells (const RefRows& rows,
 
 template<class T>
 void ArrayColumn<T>::put (uInt thisRownr, const TableColumn& that,
-			  uInt thatRownr)
+			  uInt thatRownr, Bool preserveTileShape)
 {
-    TableColumn::put (thisRownr, that, thatRownr);
+  TableColumn::put (thisRownr, that, thatRownr, preserveTileShape);
 }
 
 template<class T>
@@ -1116,13 +1116,6 @@ void ArrayColumn<T>::putColumnCells (const RefRows& rownrs,
     baseColPtr_p->putColumnSliceCells (rownrs, arraySection, &arr);
 }
 
-
-template<class T>
-void ArrayColumn<T>::put (uInt thisRownr, const ArrayColumn<T>& that,
-			  uInt thatRownr)
-{
-    put (thisRownr, that(thatRownr));
-}
 
 //# This is a very simple implementation.
 //# However, it does not need to be more fancy, since an array operation

--- a/tables/Tables/BaseColumn.cc
+++ b/tables/Tables/BaseColumn.cc
@@ -86,6 +86,12 @@ IPosition BaseColumn::shape (uInt) const
   return IPosition(0);
 }
 
+IPosition BaseColumn::tileShape (uInt) const
+{
+  throw (TableInvOper ("invalid tileShape() for column " + colDesc_p.name() +
+                       "; only valid for an array"));
+}
+
 
 Bool BaseColumn::canChangeShape() const
 {

--- a/tables/Tables/BaseColumn.h
+++ b/tables/Tables/BaseColumn.h
@@ -145,6 +145,9 @@ public:
     // Get the shape of an array in a particular cell.
     virtual IPosition shape (uInt rownr) const;
 
+    // Get the tile shape of an array in a particular cell.
+    virtual IPosition tileShape (uInt rownr) const;
+
     // Ask the data manager if the shape of an existing array can be changed.
     // Default is no.
     virtual Bool canChangeShape() const;

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -551,11 +551,13 @@ void BaseTable::addColumns (const TableDesc& desc, const Record& dmInfo,
   if (dmInfo.nfields() == 1  &&  dmInfo.dataType(0) == TpRecord) {
     rec = dmInfo.subRecord(0);
   }
-  if (rec.isDefined("TYPE")  &&  rec.isDefined("NAME")
-  &&  rec.isDefined("SPEC")) {
+  if (rec.isDefined("TYPE")  &&  rec.isDefined("NAME")) {
     String dmType = rec.asString ("TYPE");
     String dmGroup = rec.asString ("NAME");
-    const Record& sp = rec.subRecord ("SPEC");;
+    Record sp;
+    if (rec.isDefined("SPEC")) {
+      sp = rec.subRecord ("SPEC");
+    }
     DataManager* dataMan = DataManager::getCtor(dmType) (dmGroup, sp);
     addColumn (desc, *dataMan, addToParent);
     delete dataMan;

--- a/tables/Tables/ScalarColumn.h
+++ b/tables/Tables/ScalarColumn.h
@@ -216,11 +216,12 @@ public:
     // Otherwise an exception is thrown.
     // <group>
     // Use the same row numbers for both cells.
-    void put (uInt rownr, const TableColumn& that)
+    void put (uInt rownr, const TableColumn& that, Bool=False)
 	{ put (rownr, that, rownr); }
     // Use possibly different row numbers for that (i.e. input) and
     // and this (i.e. output) cell.
-    void put (uInt thisRownr, const TableColumn& that, uInt thatRownr);
+    void put (uInt thisRownr, const TableColumn& that, uInt thatRownr,
+              Bool=False);
     // </group>
 
     // Put the vector of all values in the column.

--- a/tables/Tables/ScalarColumn.tcc
+++ b/tables/Tables/ScalarColumn.tcc
@@ -215,7 +215,7 @@ void ScalarColumn<T>::put (uInt thisRownr, const ScalarColumn<T>& that,
 
 template<class T>
 void ScalarColumn<T>::put (uInt thisRownr, const TableColumn& that,
-			   uInt thatRownr)
+			   uInt thatRownr, Bool)
 {
     T value;
     that.getScalarValue (thatRownr, &value, columnDesc().dataTypeId());

--- a/tables/Tables/SetupNewTab.cc
+++ b/tables/Tables/SetupNewTab.cc
@@ -201,10 +201,13 @@ void SetupNewTableRep::bindCreate (const Record& spec)
     for (uInt i=0; i<spec.nfields(); i++) {
         const Record& rec = spec.subRecord(i);
 	if (rec.isDefined("TYPE")  &&  rec.isDefined("NAME")
-	&&  rec.isDefined("SPEC")  &&  rec.isDefined("COLUMNS")) {
+	&&  rec.isDefined("COLUMNS")) {
 	    String dmType = rec.asString ("TYPE");
 	    String dmGroup = rec.asString ("NAME");
-	    const Record& sp = rec.subRecord ("SPEC");;
+            Record sp;
+            if (rec.isDefined("SPEC")) {
+              sp = rec.subRecord ("SPEC");
+            }
 	    Vector<String> cols (rec.asArrayString ("COLUMNS"));
 	    DataManager* dataMan = DataManager::getCtor(dmType) (dmGroup, sp);
 	    // Bind the columns to this data manager.

--- a/tables/Tables/TableColumn.cc
+++ b/tables/Tables/TableColumn.cc
@@ -29,6 +29,7 @@
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/tables/Tables/TableError.h>
 #include <casacore/casa/Arrays/Array.h>
+#include <casacore/casa/Containers/ValueHolder.h>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -206,137 +207,226 @@ String TableColumn::asString (uInt rownr) const
 
 
 void TableColumn::put (uInt thisRownr, const TableColumn& that,
-		       uInt thatRownr)
+		       uInt thatRownr, Bool preserveTileShape)
 {
-    TABLECOLUMNCHECKROW(thisRownr);
-    checkWritable();
-    if (columnDesc().isScalar()) {
-	switch (columnDesc().dataType()) {
-	case TpBool:
-	    putScalar (thisRownr, that.asBool (thatRownr));
-	    return;
-	case TpUChar:
-	    putScalar (thisRownr, that.asuChar (thatRownr));
-	    return;
-	case TpShort:
-	    putScalar (thisRownr, that.asShort (thatRownr));
-	    return;
-	case TpUShort:
-	    putScalar (thisRownr, that.asuShort (thatRownr));
-	    return;
-	case TpInt:
-	    putScalar (thisRownr, that.asInt (thatRownr));
-	    return;
-	case TpUInt:
-	    putScalar (thisRownr, that.asuInt (thatRownr));
-	    return;
-	case TpFloat:
-	    putScalar (thisRownr, that.asfloat (thatRownr));
-	    return;
-	case TpDouble:
-	    putScalar (thisRownr, that.asdouble (thatRownr));
-	    return;
-	case TpComplex:
-	    putScalar (thisRownr, that.asComplex (thatRownr));
-	    return;
-	case TpDComplex:
-	    putScalar (thisRownr, that.asDComplex (thatRownr));
-	    return;
-	case TpString:
-	    putScalar (thisRownr, that.asString (thatRownr));
-	    return;
-	default:
-	    throw (TableInvDT ("TableColumn::put; invalid type promotion"));
-	}
-    }else{
-	if (columnDesc().isArray()) {
-	    if (columnDesc().dataType() != that.columnDesc().dataType()) {
-		throw (TableInvDT ("TableColumn::put; array types mismatch"));
-	    }
-	    if (that.isDefined (thatRownr)) {
-//#// If not defined, the this-value should be unset (if there is one).
-//#// However, this requires an undefine function, which is not there yet.
-		//# Get the shape and define it for non-FixedShape arrays.
-		//# Then get the data and put it depending on the type.
-		IPosition shape = that.shape (thatRownr);
-		if ((columnDesc().options() & ColumnDesc::FixedShape)
-		                                  != ColumnDesc::FixedShape) {
-		    baseColPtr_p->setShape (thisRownr, shape);
-		}
-		switch (columnDesc().dataType()) {
-		case TpBool:
-		    { Array<Bool> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpUChar:
-		    { Array<uChar> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpShort:
-		    { Array<Short> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpUShort:
-		    { Array<uShort> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpInt:
-		    { Array<Int> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpUInt:
-		    { Array<uInt> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpFloat:
-		    { Array<float> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpDouble:
-		    { Array<double> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpComplex:
-		    { Array<Complex> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpDComplex:
-		    { Array<DComplex> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-		      baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		case TpString:
-		    { Array<String> array(shape);
-		      baseColPtr(that)->get (thatRownr, &array);
-			  baseColPtr_p->put (thisRownr, &array);
-		    }
-		    return;
-		default:
-		    break;
-		}
-	    }
-	}
+  TABLECOLUMNCHECKROW(thisRownr);
+  checkWritable();
+  if (columnDesc().isScalar()) {
+    switch (columnDesc().dataType()) {
+    case TpBool:
+      putScalar (thisRownr, that.asBool (thatRownr));
+      break;
+    case TpUChar:
+      putScalar (thisRownr, that.asuChar (thatRownr));
+      break;
+    case TpShort:
+      putScalar (thisRownr, that.asShort (thatRownr));
+      break;
+    case TpUShort:
+      putScalar (thisRownr, that.asuShort (thatRownr));
+      break;
+    case TpInt:
+      putScalar (thisRownr, that.asInt (thatRownr));
+      break;
+    case TpUInt:
+      putScalar (thisRownr, that.asuInt (thatRownr));
+      break;
+    case TpFloat:
+      putScalar (thisRownr, that.asfloat (thatRownr));
+      break;
+    case TpDouble:
+      putScalar (thisRownr, that.asdouble (thatRownr));
+      break;
+    case TpComplex:
+      putScalar (thisRownr, that.asComplex (thatRownr));
+      break;
+    case TpDComplex:
+      putScalar (thisRownr, that.asDComplex (thatRownr));
+      break;
+    case TpString:
+      putScalar (thisRownr, that.asString (thatRownr));
+      break;
+    default:
+      throw (TableInvDT ("TableColumn::put; invalid type promotion"));
     }
-    throw (TableInvDT ("TableColumn::put"));
+  }else{
+    if (! columnDesc().isArray()) {
+      throw (TableInvDT ("TableColumn::put; no scalar or array"));
+    }
+    if (! that.columnDesc().isArray()) {
+      throw (TableInvDT ("TableColumn::put; array types mismatch"));
+    }
+    if (that.isDefined (thatRownr)) {
+      //#// If not defined, the this-value should be unset (if there is one).
+      //#// However, this requires an undefine function, which is not there yet.
+      //# Get the shape and define it for non-FixedShape arrays.
+      //# Then get the data and put it depending on the type.
+      IPosition shape = that.shape (thatRownr);
+      if (preserveTileShape) {
+        IPosition tileShape = that.tileShape (thatRownr);
+        if (tileShape.empty()) {
+          baseColPtr_p->setShape (thisRownr, shape);
+        } else {
+          baseColPtr_p->setShape (thisRownr, shape, tileShape);
+        }
+      } else if ((columnDesc().options() & ColumnDesc::FixedShape)
+                 != ColumnDesc::FixedShape) {
+        baseColPtr_p->setShape (thisRownr, shape);
+      }
+      ValueHolder vh;
+      switch (that.columnDesc().dataType()) {
+      case TpBool:
+        {
+          Array<Bool> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpUChar:
+        {
+          Array<uChar> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpShort:
+        {
+          Array<Short> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpUShort:
+        {
+          Array<uShort> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpInt:
+        {
+          Array<Int> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpUInt:
+        {
+          Array<uInt> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpFloat:
+        {
+          Array<float> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpDouble:
+        {
+          Array<double> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpComplex:
+        {
+          Array<Complex> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpDComplex:
+        {
+          Array<DComplex> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      case TpString:
+        {
+          Array<String> array(shape);
+          baseColPtr(that)->get (thatRownr, &array);
+          vh = ValueHolder (array);
+        }
+        break;
+      default:
+        throw (TableInvDT ("TableColumn::put of that column"));
+      }
+      switch (columnDesc().dataType()) {
+      case TpBool:
+        {
+          Array<Bool> arr (vh.asArrayBool());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpUChar:
+        {
+          Array<uChar> arr (vh.asArrayuChar());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpShort:
+        {
+          Array<Short> arr (vh.asArrayShort());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpUShort:
+        {
+          Array<uShort> arr (vh.asArrayuShort());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpInt:
+        {
+          Array<Int> arr (vh.asArrayInt());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpUInt:
+        {
+          Array<uInt> arr (vh.asArrayuInt());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpFloat:
+        {
+          Array<Float> arr (vh.asArrayFloat());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpDouble:
+        {
+          Array<Double> arr (vh.asArrayDouble());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpComplex:
+        {
+          Array<Complex> arr (vh.asArrayComplex());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpDComplex:
+        {
+          Array<DComplex> arr (vh.asArrayDComplex());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      case TpString:
+        {
+          Array<String> arr (vh.asArrayString());
+          baseColPtr_p->put (thisRownr, &arr);
+        }
+        break;
+      default:
+        throw (TableInvDT ("TableColumn::put of this column"));
+      }
+    }
+  }
 }
 
 

--- a/tables/Tables/TableColumn.h
+++ b/tables/Tables/TableColumn.h
@@ -231,6 +231,10 @@ public:
     IPosition shape (uInt rownr) const
 	{ TABLECOLUMNCHECKROW(rownr); return baseColPtr_p->shape (rownr); }
 
+    // Get the tile shape of an array in a particular cell.
+    IPosition tileShape (uInt rownr) const
+	{ TABLECOLUMNCHECKROW(rownr); return baseColPtr_p->tileShape (rownr); }
+
     // Get the value of a scalar in the given row.
     // Data type promotion is possible.
     // These functions only work for the standard data types.
@@ -317,12 +321,13 @@ public:
     // the data cannot be converted.
     // <group>
     // Use the same row numbers for both cells.
-    void put (uInt rownr, const TableColumn& that)
-	{ TABLECOLUMNCHECKROW(rownr); put (rownr, that, rownr); }
+    void put (uInt rownr, const TableColumn& that,
+              Bool preserveTileShape=False)
+      { put (rownr, that, rownr, preserveTileShape); }
     // Use possibly different row numbers for that (i.e. input) and
     // and this (i.e. output) cell.
     virtual void put (uInt thisRownr, const TableColumn& that,
-		      uInt thatRownr);
+		      uInt thatRownr, Bool preserveTileShape=False);
     // </group>
 
     // Copy the values of that column to this column.

--- a/tables/Tables/TableCopy.tcc
+++ b/tables/Tables/TableCopy.tcc
@@ -1,0 +1,119 @@
+//# TableCopy.tcc: Class with static functions for copying a table
+//# Copyright (C) 2016
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#ifndef TABLES_TABLECOPY_TCC
+#define TABLES_TABLECOPY_TCC
+
+//# Includes
+#include <casacore/tables/Tables/TableCopy.h>
+#include <casacore/tables/Tables/ScaColDesc.h>
+#include <casacore/tables/Tables/ArrColDesc.h>
+#include <casacore/tables/Tables/ScalarColumn.h>
+#include <casacore/tables/Tables/ArrayColumn.h>
+#include <casacore/tables/Tables/TableError.h>
+#include <casacore/casa/Utilities/Assert.h>
+
+namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+  template<typename T>
+  void TableCopy::cloneColumnTyped (const Table& fromTable,
+                                    const String& fromColumn,
+                                    Table& toTable, const String& newColumn,
+                                    const String& dataManagerName)
+  {
+    // Get existing column description.
+    ColumnDesc cd(fromTable.tableDesc()[fromColumn]);
+    if (cd.isScalar()) {
+      ScalarColumnDesc<T> scd(newColumn, cd.comment(), cd.dataManagerType(),
+                              cd.dataManagerGroup(), T(), cd.options());
+      cd = ColumnDesc(scd);
+    } else {
+      ArrayColumnDesc<T> acd(newColumn, cd.comment(), cd.dataManagerType(),
+                             cd.dataManagerGroup(),
+                             cd.shape(), cd.options(), cd.ndim());
+      cd = ColumnDesc(acd);
+    }
+    doCloneColumn (fromTable, fromColumn, toTable, cd, dataManagerName);
+  }
+
+  template<typename T>
+  void TableCopy::fillArrayColumn (Table& table, const String& column,
+                                   const Array<T>& value)
+  {
+    ArrayColumn<T> acol(table, column);
+    acol.fillColumn (value);
+  }
+
+  template<typename T>
+  void TableCopy::fillColumnData (Table& table, const String& column,
+                                  const T& value)
+  {
+    TableColumn col(table, column);
+    if (col.columnDesc().isScalar()) {
+      ScalarColumn<T> scol(col);
+      scol.fillColumn (value);
+    } else {
+      // Fill the array in each row with the value.
+      TableCopy::fillColumnData (table, column, value, table, column);
+    }
+  }
+
+  template<typename T>
+  void TableCopy::fillColumnData (Table& table, const String& column,
+                                  const T& value,
+                                  const Table& fromTable,
+                                  const String& fromColumn,
+                                  Bool preserveTileShape)
+  {
+    TableColumn fromCol(fromTable, fromColumn);
+    AlwaysAssert (fromCol.columnDesc().isArray(), AipsError);
+    Array<T> arr;
+    ArrayColumn<T> toCol(table, column);
+    for (uInt i=0; i<table.nrow(); ++i) {
+      // Only write if the source cell contains an array.
+      if (fromCol.isDefined(i)) {
+        IPosition shp(fromCol.shape(i));
+        if (! shp.isEqual (arr.shape())) {
+          if (shp.size() == arr.ndim()) {
+            // reformOrResize cannot change the dimensionality.
+            arr.reformOrResize (shp);
+          } else {
+            arr.resize (shp);
+          }
+          arr = value;
+          if (preserveTileShape) {
+            toCol.setShape (i, arr.shape(), fromCol.tileShape(i));
+          }
+        }
+        toCol.put (i, arr);
+      }
+    }
+  }
+
+} //# NAMESPACE CASACORE - END
+
+#endif

--- a/tables/Tables/TableRow.cc
+++ b/tables/Tables/TableRow.cc
@@ -626,7 +626,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayBool:
 	(*(ArrayColumn<Bool>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayBool (whichField));
+	                        (rownr, record.toArrayBool (whichField));
 	break;
     case TpUChar:
 	(*(ScalarColumn<uChar>*)(itsColumns[whichColumn])).put
@@ -634,7 +634,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayUChar:
 	(*(ArrayColumn<uChar>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayuChar (whichField));
+	                        (rownr, record.toArrayuChar (whichField));
 	break;
     case TpShort:
 	(*(ScalarColumn<Short>*)(itsColumns[whichColumn])).put
@@ -642,7 +642,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayShort:
 	(*(ArrayColumn<Short>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayShort (whichField));
+	                        (rownr, record.toArrayShort (whichField));
 	break;
     case TpInt:
 	(*(ScalarColumn<Int>*)(itsColumns[whichColumn])).put
@@ -650,7 +650,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayInt:
 	(*(ArrayColumn<Int>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayInt (whichField));
+	                        (rownr, record.toArrayInt (whichField));
 	break;
     case TpUInt:
 	(*(ScalarColumn<uInt>*)(itsColumns[whichColumn])).put
@@ -658,7 +658,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayUInt:
 	(*(ArrayColumn<uInt>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayuInt (whichField));
+	                        (rownr, record.toArrayuInt (whichField));
 	break;
     case TpFloat:
 	(*(ScalarColumn<Float>*)(itsColumns[whichColumn])).put
@@ -666,7 +666,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayFloat:
 	(*(ArrayColumn<Float>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayfloat (whichField));
+	                        (rownr, record.toArrayFloat (whichField));
 	break;
     case TpDouble:
 	(*(ScalarColumn<Double>*)(itsColumns[whichColumn])).put
@@ -674,7 +674,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayDouble:
 	(*(ArrayColumn<Double>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArraydouble (whichField));
+	                        (rownr, record.toArrayDouble (whichField));
 	break;
     case TpComplex:
 	(*(ScalarColumn<Complex>*)(itsColumns[whichColumn])).put
@@ -682,7 +682,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayComplex:
 	(*(ArrayColumn<Complex>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayComplex (whichField));
+	                        (rownr, record.toArrayComplex (whichField));
 	break;
     case TpDComplex:
 	(*(ScalarColumn<DComplex>*)(itsColumns[whichColumn])).put
@@ -690,7 +690,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayDComplex:
 	(*(ArrayColumn<DComplex>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayDComplex (whichField));
+	                        (rownr, record.toArrayDComplex (whichField));
 	break;
     case TpString:
 	(*(ScalarColumn<String>*)(itsColumns[whichColumn])).put
@@ -698,7 +698,7 @@ void ROTableRow::putField (uInt rownr, const TableRecord& record,
 	break;
     case TpArrayString:
 	(*(ArrayColumn<String>*)(itsColumns[whichColumn])).put
-	                        (rownr, record.asArrayString (whichField));
+	                        (rownr, record.toArrayString (whichField));
 	break;
     case TpRecord:
 	(*(ScalarColumn<TableRecord>*)(itsColumns[whichColumn])).put

--- a/tables/Tables/TableRow.h
+++ b/tables/Tables/TableRow.h
@@ -356,7 +356,7 @@ private:
 //      can be used to put some fields from the given TableRecord.
 //      Only fields having a corresponding name in the TableRow object
 //      will be put. Similar to the first way data type promotion will
-//      be applied for numeric scalars.
+//      be applied for numeric values.
 //      <br>E.g.: Suppose the TableRow object has columns A, C, and B,
 //      and the given TableRecord has fields B, D, and C. Only fields B and C
 //      will be put. As the example shows, the order of the fields is not
@@ -462,7 +462,7 @@ public:
     // in the given row.
     // The names and order of the fields in the TableRecord must conform
     // those of the description of the TableRow. The data types of numeric
-    // scalars do not need to conform exactly; they can be promoted
+    // values do not need to conform exactly; they can be promoted
     // (e.g. an Int value in the record may correspond to a float column).
     // If not conforming, an exception is thrown.
     // <note> For performance reasons it is optional to check
@@ -486,7 +486,7 @@ public:
     // <br>E.g.: If the TableRow contains columns A and B, and the
     // record contains fields B and C, only field B will be put.
     // <br>In principle the data types of the matching fields must match,
-    // but data type promotion of numeric scalars will be applied.
+    // but data type promotion of numeric values will be applied.
     void putMatchingFields (uInt rownr, const TableRecord& record);
 
 private:

--- a/tables/Tables/test/CMakeLists.txt
+++ b/tables/Tables/test/CMakeLists.txt
@@ -38,6 +38,7 @@ tScalarRecordColumn
 tTable
 tTableAccess
 tTableCopy
+tTableCopyPerf
 tTableDesc
 tTableDescHyper
 tTableInfo

--- a/tables/Tables/test/tTableCopy.out
+++ b/tables/Tables/test/tTableCopy.out
@@ -68,6 +68,528 @@ tTableCopy_tmp.newtbl/SUBTABLE
     }
   }
 
+testCloneColumn ...
+  *1: {
+    TYPE: String "StandardStMan"
+    NAME: String "SSM"
+    SEQNR: uInt 0
+    SPEC: {
+      ActualCacheSize: Int 2
+      BUCKETSIZE: Int 640
+      PERSCACHESIZE: Int 2
+      IndexLength: Int 0
+    }
+    COLUMNS: String array with shape [2]
+      [ARRAY, SCALAR]
+  }
+  *2: {
+    TYPE: String "TiledShapeStMan"
+    NAME: String "DATA_stm"
+    SEQNR: uInt 1
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [1, 1]
+          TileShape: Int array with shape [2]
+            [1, 4]
+          CellShape: Int array with shape [1]
+            [1]
+          BucketSize: Int 32
+          ID: {
+          }
+        }
+        *2: {
+          CubeShape: Int array with shape [2]
+            [11, 1]
+          TileShape: Int array with shape [2]
+            [4, 4]
+          CellShape: Int array with shape [1]
+            [11]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+        *3: {
+          CubeShape: Int array with shape [2]
+            [31, 1]
+          TileShape: Int array with shape [2]
+            [4, 4]
+          CellShape: Int array with shape [1]
+            [31]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 1
+      IndexSize: uInt 4
+    }
+    COLUMNS: String array with shape [1]
+      [DATA]
+  }
+  *3: {
+    TYPE: String "TiledShapeStMan"
+    NAME: String "DATA1"
+    SEQNR: uInt 2
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [1, 1]
+          TileShape: Int array with shape [2]
+            [1, 2]
+          CellShape: Int array with shape [1]
+            [1]
+          BucketSize: Int 16
+          ID: {
+          }
+        }
+        *2: {
+          CubeShape: Int array with shape [2]
+            [11, 1]
+          TileShape: Int array with shape [2]
+            [8, 2]
+          CellShape: Int array with shape [1]
+            [11]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+        *3: {
+          CubeShape: Int array with shape [2]
+            [31, 1]
+          TileShape: Int array with shape [2]
+            [8, 2]
+          CellShape: Int array with shape [1]
+            [31]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 2
+      IndexSize: uInt 4
+    }
+    COLUMNS: String array with shape [1]
+      [DATA1]
+  }
+  *4: {
+    TYPE: String "TiledShapeStMan"
+    NAME: String "Data2StMan"
+    SEQNR: uInt 3
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+      }
+      SEQNR: uInt 3
+      IndexSize: uInt 0
+    }
+    COLUMNS: String array with shape [1]
+      [DATA2]
+  }
+  *5: {
+    TYPE: String "TiledShapeStMan"
+    NAME: String "DATA3"
+    SEQNR: uInt 4
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [1, 1]
+          TileShape: Int array with shape [2]
+            [1, 4]
+          CellShape: Int array with shape [1]
+            [1]
+          BucketSize: Int 64
+          ID: {
+          }
+        }
+        *2: {
+          CubeShape: Int array with shape [2]
+            [11, 1]
+          TileShape: Int array with shape [2]
+            [4, 4]
+          CellShape: Int array with shape [1]
+            [11]
+          BucketSize: Int 256
+          ID: {
+          }
+        }
+        *3: {
+          CubeShape: Int array with shape [2]
+            [31, 1]
+          TileShape: Int array with shape [2]
+            [4, 4]
+          CellShape: Int array with shape [1]
+            [31]
+          BucketSize: Int 256
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 4
+      IndexSize: uInt 4
+    }
+    COLUMNS: String array with shape [1]
+      [DATA3]
+  }
+  *6: {
+    TYPE: String "StandardStMan"
+    NAME: String "SCALAR3"
+    SEQNR: uInt 5
+    SPEC: {
+      ActualCacheSize: Int 2
+      BUCKETSIZE: Int 640
+      PERSCACHESIZE: Int 2
+      IndexLength: Int 0
+    }
+    COLUMNS: String array with shape [1]
+      [SCALAR3]
+  }
+
+testCloneColumn ...
+  *1: {
+    TYPE: String "StandardStMan"
+    NAME: String "SSM"
+    SEQNR: uInt 0
+    SPEC: {
+      ActualCacheSize: Int 2
+      BUCKETSIZE: Int 640
+      PERSCACHESIZE: Int 2
+      IndexLength: Int 0
+    }
+    COLUMNS: String array with shape [2]
+      [ARRAY, SCALAR]
+  }
+  *2: {
+    TYPE: String "TiledCellStMan"
+    NAME: String "DATA_stm"
+    SEQNR: uInt 1
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [1]
+            [1]
+          TileShape: Int array with shape [1]
+            [1]
+          CellShape: Int array with shape [1]
+            [1]
+          BucketSize: Int 8
+          ID: {
+          }
+        }
+        *2: {
+          CubeShape: Int array with shape [1]
+            [11]
+          TileShape: Int array with shape [1]
+            [4]
+          CellShape: Int array with shape [1]
+            [11]
+          BucketSize: Int 32
+          ID: {
+          }
+        }
+        *3: {
+          CubeShape: Int array with shape [1]
+            [31]
+          TileShape: Int array with shape [1]
+            [4]
+          CellShape: Int array with shape [1]
+            [31]
+          BucketSize: Int 32
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 1
+    }
+    COLUMNS: String array with shape [1]
+      [DATA]
+  }
+  *3: {
+    TYPE: String "TiledCellStMan"
+    NAME: String "DATA1"
+    SEQNR: uInt 2
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [1]
+            [1]
+          TileShape: Int array with shape [1]
+            [1]
+          CellShape: Int array with shape [1]
+            [1]
+          BucketSize: Int 8
+          ID: {
+          }
+        }
+        *2: {
+          CubeShape: Int array with shape [1]
+            [11]
+          TileShape: Int array with shape [1]
+            [8]
+          CellShape: Int array with shape [1]
+            [11]
+          BucketSize: Int 64
+          ID: {
+          }
+        }
+        *3: {
+          CubeShape: Int array with shape [1]
+            [31]
+          TileShape: Int array with shape [1]
+            [8]
+          CellShape: Int array with shape [1]
+            [31]
+          BucketSize: Int 64
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 2
+    }
+    COLUMNS: String array with shape [1]
+      [DATA1]
+  }
+  *4: {
+    TYPE: String "TiledCellStMan"
+    NAME: String "Data2StMan"
+    SEQNR: uInt 3
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+      }
+      SEQNR: uInt 3
+    }
+    COLUMNS: String array with shape [1]
+      [DATA2]
+  }
+  *5: {
+    TYPE: String "TiledCellStMan"
+    NAME: String "DATA3"
+    SEQNR: uInt 4
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [1]
+            [1]
+          TileShape: Int array with shape [1]
+            [1]
+          CellShape: Int array with shape [1]
+            [1]
+          BucketSize: Int 16
+          ID: {
+          }
+        }
+        *2: {
+          CubeShape: Int array with shape [1]
+            [11]
+          TileShape: Int array with shape [1]
+            [4]
+          CellShape: Int array with shape [1]
+            [11]
+          BucketSize: Int 64
+          ID: {
+          }
+        }
+        *3: {
+          CubeShape: Int array with shape [1]
+            [31]
+          TileShape: Int array with shape [1]
+            [4]
+          CellShape: Int array with shape [1]
+            [31]
+          BucketSize: Int 64
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 4
+    }
+    COLUMNS: String array with shape [1]
+      [DATA3]
+  }
+  *6: {
+    TYPE: String "StandardStMan"
+    NAME: String "SCALAR3"
+    SEQNR: uInt 5
+    SPEC: {
+      ActualCacheSize: Int 2
+      BUCKETSIZE: Int 640
+      PERSCACHESIZE: Int 2
+      IndexLength: Int 0
+    }
+    COLUMNS: String array with shape [1]
+      [SCALAR3]
+  }
+
+testCloneColumn ...
+  *1: {
+    TYPE: String "StandardStMan"
+    NAME: String "SSM"
+    SEQNR: uInt 0
+    SPEC: {
+      ActualCacheSize: Int 2
+      BUCKETSIZE: Int 640
+      PERSCACHESIZE: Int 2
+      IndexLength: Int 0
+    }
+    COLUMNS: String array with shape [2]
+      [ARRAY, SCALAR]
+  }
+  *2: {
+    TYPE: String "TiledColumnStMan"
+    NAME: String "DATA_stm"
+    SEQNR: uInt 1
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [10, 4]
+          TileShape: Int array with shape [2]
+            [8, 2]
+          CellShape: Int array with shape [1]
+            [10]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 1
+    }
+    COLUMNS: String array with shape [1]
+      [DATA]
+  }
+  *3: {
+    TYPE: String "TiledColumnStMan"
+    NAME: String "DATA1"
+    SEQNR: uInt 2
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [10, 4]
+          TileShape: Int array with shape [2]
+            [8, 2]
+          CellShape: Int array with shape [1]
+            [10]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 2
+    }
+    COLUMNS: String array with shape [1]
+      [DATA1]
+  }
+  *4: {
+    TYPE: String "TiledColumnStMan"
+    NAME: String "Data2StMan"
+    SEQNR: uInt 3
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [10, 4]
+          TileShape: Int array with shape [2]
+            [8, 2]
+          CellShape: Int array with shape [1]
+            [10]
+          BucketSize: Int 128
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 3
+    }
+    COLUMNS: String array with shape [1]
+      [DATA2]
+  }
+  *5: {
+    TYPE: String "TiledColumnStMan"
+    NAME: String "DATA3"
+    SEQNR: uInt 4
+    SPEC: {
+      ActualMaxCacheSize: Int 0
+      DEFAULTTILESHAPE: Int array with shape [2]
+        [8, 2]
+      MAXIMUMCACHESIZE: Int 0
+      HYPERCUBES: {
+        *1: {
+          CubeShape: Int array with shape [2]
+            [10, 4]
+          TileShape: Int array with shape [2]
+            [8, 2]
+          CellShape: Int array with shape [1]
+            [10]
+          BucketSize: Int 256
+          ID: {
+          }
+        }
+      }
+      SEQNR: uInt 4
+    }
+    COLUMNS: String array with shape [1]
+      [DATA3]
+  }
+  *6: {
+    TYPE: String "StandardStMan"
+    NAME: String "SCALAR3"
+    SEQNR: uInt 5
+    SPEC: {
+      ActualCacheSize: Int 2
+      BUCKETSIZE: Int 640
+      PERSCACHESIZE: Int 2
+      IndexLength: Int 0
+    }
+    COLUMNS: String array with shape [1]
+      [SCALAR3]
+  }
+
 tTableCopy_tmp.tbl
 tTableCopy_tmp.tbl/SUBTABLE
 tTableCopy_tmp.newtbl

--- a/tables/Tables/test/tTableCopyPerf.cc
+++ b/tables/Tables/test/tTableCopyPerf.cc
@@ -1,0 +1,83 @@
+//# tTableCopy.cc: Test program for column copy performance
+//# Copyright (C) 2016
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/tables/Tables.h>
+#include <casacore/casa/OS/Timer.h>
+#include <stdexcept>
+#include <iostream>
+using namespace casacore;
+using namespace std;
+
+void testPerf (Int nrowPerf)
+{
+  cout << "testPerf with " << nrowPerf << " rows ..." << endl;
+  // First create a table.
+  TableDesc td;
+  td.addColumn (ArrayColumnDesc<Complex>("DATA", IPosition(2,4,256)));
+  td.addColumn (ScalarColumnDesc<Int>("SCALAR", 1));
+  SetupNewTable newtab("tTableCopyPerf_tmp.data", td, Table::New);
+  StandardStMan ssm;
+  TiledShapeStMan tsm("DATA_stm", IPosition(3,4,256,4));
+  newtab.bindAll (ssm);
+  newtab.bindColumn ("DATA", tsm);
+  Table tab(newtab, nrowPerf);
+  ArrayColumn<Complex> col(tab, "DATA");
+  Array<Complex> arr(IPosition(2,4,256));
+  indgen(arr);
+  Timer timer;
+  for (uInt row=0; row<tab.nrow(); ++row) {
+    col.put (row, arr);
+  }
+  timer.show ("put rows");
+  TableCopy::cloneColumn (tab, "DATA", tab, "DATA2");
+  timer.mark();
+  TableCopy::copyColumnData (tab, "DATA", tab, "DATA2");
+  timer.show ("copycol ");
+  TableCopy::cloneColumnTyped<DComplex> (tab, "DATA", tab, "DATA3");
+  timer.mark();
+  TableCopy::copyColumnData (tab, "DATA", tab, "DATA3");
+  timer.show ("copycold");
+  TableCopy::cloneColumnTyped<DComplex> (tab, "DATA", tab, "DATA4");
+  timer.mark();
+  tableCommand ("update $1 set DATA4=DATA", tab);
+  timer.show ("copytaql");
+}
+
+int main (int argc, const char* argv[])
+{
+  Int nrowPerf = 10;
+  if (argc > 1) {
+    nrowPerf = atoi(argv[1]);
+  }
+  try {
+    testPerf (nrowPerf);
+  } catch (const exception& x) {
+    cout << x.what() << endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
CASA needed functionality to clone a table column, which has been done by adding a few functions to class TableCopy.
- cloneColumn clones a column using the same description and data manager type
- cloneColumnTyped does the same, but can change the data type
- copyColumnData copies the data from the given column to another (e.g., the new one)
- fillArrayColumn fills an array column with the given array
- fillColumnData fills a column from another column or with a given value

The cloning/copying functionality can preserve the tile shape of the original column, for which a preserveTileShape argument has been added to some table functions.

Close #354 