### PR TITLE
Cas 8713

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -1421,6 +1421,13 @@ void MSMetaData::_getScansAndDDIDMaps(
     }
 }
 
+std::map<ScanKey, std::set<uInt> > MSMetaData::getScanToSpwsMap() const {
+    std::map<ScanKey, std::set<uInt> > scanToSpwMap;
+    vector<std::set<ScanKey> > spwToScanMap;
+    _getScansAndSpwMaps(scanToSpwMap, spwToScanMap);
+    return scanToSpwMap;
+}
+
 void MSMetaData::_getScansAndSpwMaps(
     std::map<ScanKey, std::set<uInt> >& scanToSpwMap,
     vector<std::set<ScanKey> >& spwToScanMap

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -1292,6 +1292,25 @@ MSMetaData::_generateScanPropsIfWanted() const {
     // we don't have it, and we aren't going to want it later
     return SHARED_PTR<const map<ScanKey, ScanProperties> >();
 }
+
+
+SHARED_PTR<const map<SubScanKey, MSMetaData::SubScanProperties> >
+MSMetaData::_generateSubScanPropsIfWanted() const {
+    if (_subScanProperties) {
+        // we already have it, just return it
+        return _subScanProperties;
+    }
+    if (_forceSubScanPropsToCache) {
+        // it hasn't been generated yet, but we will likely
+        // need it later, so just generate it now
+        SHARED_PTR<const map<ScanKey, ScanProperties> > scanProps;
+        SHARED_PTR<const map<SubScanKey, SubScanProperties> > subScanProps;
+        _getScanAndSubScanProperties(scanProps, subScanProps, False);
+        return subScanProps;
+    }
+    // we don't have it, and we aren't going to want it later
+    return SHARED_PTR<const map<SubScanKey, SubScanProperties> >();
+}
  
 std::set<ScanKey> MSMetaData::getScanKeys() const {
     if (! _scanKeys.empty()) {
@@ -1415,26 +1434,43 @@ void MSMetaData::_getScansAndSpwMaps(
     scanToSpwMap.clear();
     spwToScanMap.clear();
     spwToScanMap.resize(nSpw(True));
-    std::map<ScanKey, std::set<uInt> > scanToDDIDMap;
-    vector<std::set<ScanKey> > ddIDToScanMap;
-    _getScansAndDDIDMaps(scanToDDIDMap, ddIDToScanMap);
-    vector<uInt> ddToSpw = getDataDescIDToSpwMap();
-    std::map<ScanKey, std::set<uInt> >::const_iterator iter = scanToDDIDMap.begin();
-    std::map<ScanKey, std::set<uInt> >::const_iterator end = scanToDDIDMap.end();
-    std::set<uInt>::const_iterator dIter;
-    std::set<uInt>::const_iterator dEnd;
-    while (iter != end) {
-        ScanKey scanKey = iter->first;
-        std::set<uInt> ddids = scanToDDIDMap[scanKey];
-        dIter = ddids.begin();
-        dEnd = ddids.end();
-        while (dIter != dEnd) {
-            uInt spw = ddToSpw[*dIter];
-            scanToSpwMap[scanKey].insert(spw);
-            spwToScanMap[spw].insert(scanKey);
-            ++dIter;
+    SHARED_PTR<const map<SubScanKey, SubScanProperties> > subScanProps
+        = _generateSubScanPropsIfWanted();
+    if (subScanProps) {
+        map<SubScanKey, SubScanProperties>::const_iterator iter = subScanProps->begin();
+        map<SubScanKey, SubScanProperties>::const_iterator end = subScanProps->end();
+        for (; iter!=end; ++iter) {
+            ScanKey sk = scanKey(iter->first);
+            std::set<uInt> spws = iter->second.spws;
+            scanToSpwMap[sk].insert(spws.begin(), spws.end());
+            std::set<uInt>::const_iterator spwIter = spws.begin();
+            std::set<uInt>::const_iterator spwEnd = spws.end();
+            for (; spwIter!=spwEnd; ++spwIter) {
+                spwToScanMap[*spwIter].insert(sk);
+            }
         }
-        ++iter;
+    }
+    else {
+        // fastest way to generate what we want if we don't have _subScanProperties
+        std::map<ScanKey, std::set<uInt> > scanToDDIDMap;
+        vector<std::set<ScanKey> > ddIDToScanMap;
+        _getScansAndDDIDMaps(scanToDDIDMap, ddIDToScanMap);
+        vector<uInt> ddToSpw = getDataDescIDToSpwMap();
+        std::map<ScanKey, std::set<uInt> >::const_iterator iter = scanToDDIDMap.begin();
+        std::map<ScanKey, std::set<uInt> >::const_iterator end = scanToDDIDMap.end();
+        std::set<uInt>::const_iterator dIter;
+        std::set<uInt>::const_iterator dEnd;
+        for (; iter!=end; ++iter) {
+            ScanKey scanKey = iter->first;
+            std::set<uInt> ddids = scanToDDIDMap[scanKey];
+            dIter = ddids.begin();
+            dEnd = ddids.end();
+            for (; dIter!=dEnd; ++dIter) {
+                uInt spw = ddToSpw[*dIter];
+                scanToSpwMap[scanKey].insert(spw);
+                spwToScanMap[spw].insert(scanKey);
+            }
+        }
     }
     if (_cacheUpdated(_sizeof(scanToSpwMap)) + _sizeof(spwToScanMap)) {
         _scanToSpwsMap = scanToSpwMap;

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -785,6 +785,13 @@ private:
     // generate it. Otherwise, the returned object contains a null pointer.
     SHARED_PTR<const map<ScanKey, ScanProperties> > _generateScanPropsIfWanted() const;
 
+    // if _subScanProperties has been generated, just return it. If
+    // the caller has configured the object to generate _subScanPropertiess
+    // at some point, this call will generate it. Otherwise, the returned object
+    // contains a null pointer.
+    SHARED_PTR<const map<SubScanKey, SubScanProperties> >
+    _generateSubScanPropsIfWanted() const;
+
     vector<String> _getAntennaNames(
         std::map<String, uInt>& namesToIDsMap
     ) const;

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -255,6 +255,9 @@ public:
     // get the set of scan numbers for the specified spectral window.
     std::set<Int> getScansForSpw(uInt spw, Int obsID, Int arrayID) const;
 
+    // get the complete mapping of scans to spws
+    std::map<ScanKey, std::set<uInt> > getScanToSpwsMap() const;
+
     // get the transitions from the SOURCE table. If there are no transitions
     // for a particular key, the shared ptr contains the null ptr.
     std::map<SourceKey, SHARED_PTR<vector<String> > > getTransitions() const;

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -410,7 +410,8 @@ void testIt(MSMetaData& md) {
         cout << "nscans " << md.nScans() << endl;
         AlwaysAssert(md.nScans() == 32, AipsError);
         std::set<Int> scanNumbers = md.getScanNumbers(0, 0);
-        cout << "*** test getSpwsForScan() and getPolarizationIDs()" << endl;
+        cout << "*** test getSpwsForScan(), getScanToSpwsMap(), getPolarizationIDs()" << endl;
+        std::map<ScanKey, std::set<uInt> > mymap = md.getScanToSpwsMap();
         ScanKey scanKey;
         scanKey.obsID = 0;
         scanKey.arrayID = 0;
@@ -449,6 +450,7 @@ void testIt(MSMetaData& md) {
             }
             scanKey.scan = *scan;
             AlwaysAssert(md.getSpwsForScan(scanKey) == exp, AipsError);
+            AlwaysAssert(mymap[scanKey] == exp, AipsError);
             for (
                 std::set<uInt>::const_iterator spw=exp.begin();
                 spw!=exp.end(); ++spw


### PR DESCRIPTION
* Implemented MSMetaData::_generateSubScanPropsIfWanted() as analog to _generateScanPropsIfWanted()  and modified implementation of _getScansAndSpwMaps() to use it.
* Implemented MSMetaData::getScanToSpwsMap() to return complete scan -> spws map so callers do not have to call MSMetaData::getSpwsForScan() in a loop which is inefficient when the number of scans is large.