### PR TITLE
Show shape in C-order when needed

### DIFF
--- a/casa/BasicSL/STLMath.h
+++ b/casa/BasicSL/STLMath.h
@@ -69,6 +69,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
   }
 
+  // Reverse a Casacore container like IPosition, Block, or Vector.
+  template<typename CONTAINER>
+  inline CONTAINER reversedCasaContainer (const CONTAINER& in)
+  {
+    size_t sz = in.size();
+    CONTAINER out(sz);
+    for (size_t i=0; i<sz; ++i) {
+      out[i] = in[sz-i-1];
+    }
+    return out;
+  }
+
   // Add two std::vector objects.
   template<class T>
   std::vector<T> operator+ (const std::vector<T> &left,

--- a/tables/TaQL/TaQLShow.cc
+++ b/tables/TaQL/TaQLShow.cc
@@ -839,7 +839,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     String origType(type);
     type.downcase();
     if (cmd == "table") {
-      return showTable (parts);
+      return showTable (parts, style);
     } else if (cmd == "command"  ||  cmd == "commands") {
       return showCommand (type);
     } else if (cmd == "expr"  ||  cmd == "expression") {
@@ -870,7 +870,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     throw AipsError (cmd + " is an unknown SHOW command");
   }
 
-  String TaQLShow::showTable (const Vector<String>& parts)
+  String TaQLShow::showTable (const Vector<String>& parts,
+                              const TaQLStyle& style)
   {
     if (parts.size() < 2  ||  parts[1].empty()) {
       return getHelp (tableHelp);
@@ -911,7 +912,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     }
     std::ostringstream os;
-    table.showStructure (os, showdm, showcol, showsub, sortcol);
+    table.showStructure (os, showdm, showcol, showsub, sortcol,
+                         style.isCOrder());
     table.showKeywords (os, showsub, tabkey, colkey);
     return os.str();
   }

--- a/tables/TaQL/TaQLShow.h
+++ b/tables/TaQL/TaQLShow.h
@@ -74,7 +74,8 @@ class TaQLShow
 public:
   static String getInfo (const Vector<String>& parts,
                          const TaQLStyle& style);
-  static String showTable (const Vector<String>& parts);
+  static String showTable (const Vector<String>& parts,
+                           const TaQLStyle& style);
   static String showCommand (const String& cmd);
   static String showFuncs (const String& type,
                          const Vector<String>& parts,

--- a/tables/TaQL/TableGram.ll
+++ b/tables/TaQL/TableGram.ll
@@ -59,6 +59,7 @@
 */
 WHITE1    [ \t\n]
 WHITE     {WHITE1}*
+COMMENT   "#".*
 DIGIT     [0-9]
 INT       {DIGIT}+
 INT2      {DIGIT}{DIGIT}
@@ -175,20 +176,20 @@ NAMETAB   ([A-Za-z0-9_./+\-~$@:]|(\\.))+
 UDFLIBSYN {NAME}{WHITE}"="{WHITE}{NAME}
 REGEX1    m"/"[^/]+"/"
 REGEX2    m%[^%]+%
-REGEX3    m#[^#]+#
+REGEX3    m@[^@]+@
 REGEX     {REGEX1}|{REGEX2}|{REGEX3}
 FREGEX1   f"/"[^/]+"/"
 FREGEX2   f%[^%]+%
-FREGEX3   f#[^#]+#
+FREGEX3   f@[^@]+@
 FREGEX    {FREGEX1}|{FREGEX2}|{FREGEX3}
 PATT1     p\/[^/]+\/
 PATT2     p%[^%]+%
-PATT3     p#[^#]+#
+PATT3     p@[^@]+@
 PATT      {PATT1}|{PATT2}|{PATT3}
 PATTEX    ({REGEX}|{FREGEX}|{PATT})i?
 DIST1     d\/[^/]+\/
 DIST2     d%[^%]+%
-DIST3     d#[^#]+#
+DIST3     d@[^@]+@
 DISTOPT   [bi]*{INT}?[bi]*
 DISTEX    ({DIST1}|{DIST2}|{DIST3}){DISTOPT}
 OPERREX   "!"?"~"
@@ -451,6 +452,10 @@ PATTREX   {OPERREX}{WHITE}({PATTEX}|{DISTEX})
             BEGIN(EXPRstate);
             return RPAREN;
           }
+";"       {
+            tableGramPosition() += yyleng;
+            return SEMICOL;
+          }
 
  /* UDF libname synonym definition */
 <STYLEstate>{UDFLIBSYN} {
@@ -695,6 +700,9 @@ PATTREX   {OPERREX}{WHITE}({PATTEX}|{DISTEX})
 
  /* Whitespace is skipped */
 {WHITE}   { tableGramPosition() += yyleng; }
+
+ /* Comment is skipped */
+{COMMENT} { tableGramPosition() += yyleng; }
 
  /* An unterminated string is an error */
 {USTRING} { throw (TableInvExpr ("Unterminated string")); }

--- a/tables/TaQL/TableParse.cc
+++ b/tables/TaQL/TableParse.cc
@@ -1563,6 +1563,10 @@ void TableParseSelect::handleColSpec (const String& colName,
       if (ndim < 0) {
 	ndim = 0;
       }
+    } else if (name == "DIRECT") {
+      if (spec.asInt(i) == 1) {
+        options = 1;
+      }
     } else if (name == "DMTYPE") {
       dmType = spec.asString(i);
     } else if (name == "DMGROUP") {

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -1,13 +1,13 @@
 select 1*3
 SELECT (1)*(3)
 
-select 1*3 giving a.b
+select 1*3 giving a.b;
 SELECT (1)*(3) GIVING a.b
 
 select 1*3,5+7 into a.b where a>2 groupby c1,c2 having e1<0 and e2>3 orderby d1,d2 limit 2:5:2
 SELECT (1)*(3),(5)+(7) WHERE (a)>(2) GROUPBY c1,c2 HAVING ((e1)<(0))&&((e2)>(3)) ORDERBY d1,d2 LIMIT 2:5:2 GIVING a.b
 
-select from a.tab
+select from a.tab #comment
 SELECT FROM a.tab
 
 select from [a1.tab,a2.tab,[a3a.tab,a3b.tab]]
@@ -60,8 +60,8 @@ SELECT ab,ac,af FROM tTaQLNode_tmp.tab WHERE (af)<>(SQLPATTERN('_3%'))
 select from tTaQLNode_tmp.tab where af ~ d/abc/
 SELECT FROM tTaQLNode_tmp.tab WHERE (af)~d/abc/
 
-select from tTaQLNode_tmp.tab where af ~ d#abc#ib3
-SELECT FROM tTaQLNode_tmp.tab WHERE (af)~d#abc#ib3
+select from tTaQLNode_tmp.tab where af ~ d@abc@ib3
+SELECT FROM tTaQLNode_tmp.tab WHERE (af)~d@abc@ib3
 
 select from tTaQLNode_tmp.tab where af ~ d/abc/03bi
 SELECT FROM tTaQLNode_tmp.tab WHERE (af)~d/abc/ib3

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -7,10 +7,10 @@
 
 
 $casa_checktool ./tTaQLNode 'select 1*3'
-$casa_checktool ./tTaQLNode 'select 1*3 giving a.b'
+$casa_checktool ./tTaQLNode 'select 1*3 giving a.b;'
 $casa_checktool ./tTaQLNode 'select 1*3,5+7 into a.b where a>2 groupby c1,c2 having e1<0 and e2>3 orderby d1,d2 limit 2:5:2'
 
-$casa_checktool ./tTaQLNode 'select from a.tab'
+$casa_checktool ./tTaQLNode 'select from a.tab #comment'
 $casa_checktool ./tTaQLNode 'select from [a1.tab,a2.tab,[a3a.tab,a3b.tab]]'
 
 $casa_checktool ./tTaQLNode 'select ab,ac,ad,ae,af,ag into tTaQLNode_tmp.data2 from tTaQLNode_tmp.tab sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab'
@@ -36,7 +36,7 @@ $casa_checktool ./tTaQLNode 'select ab,ac,af from tTaQLNode_tmp.tab where af lik
 $casa_checktool ./tTaQLNode 'select ab,ac,af from tTaQLNode_tmp.tab where af not like "_3%"'
 
 $casa_checktool ./tTaQLNode 'select from tTaQLNode_tmp.tab where af ~ d/abc/'
-$casa_checktool ./tTaQLNode 'select from tTaQLNode_tmp.tab where af ~ d#abc#ib3'
+$casa_checktool ./tTaQLNode 'select from tTaQLNode_tmp.tab where af ~ d@abc@ib3'
 $casa_checktool ./tTaQLNode 'select from tTaQLNode_tmp.tab where af ~ d/abc/03bi'
 $casa_checktool ./tTaQLNode 'select from tTaQLNode_tmp.tab where af ~ d%abc%04'
 

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -39,6 +39,7 @@
 #include <casacore/tables/Tables/TableError.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/BasicSL/STLMath.h>
 #include <casacore/casa/BasicSL/STLIO.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Containers/Record.h>
@@ -1008,7 +1009,8 @@ void BaseTable::checkRowNumberThrow (uInt rownr) const
 }
 
 void BaseTable::showStructure (ostream& os, Bool showDataMans, Bool showColumns,
-                               Bool showSubTables, Bool sortColumns)
+                               Bool showSubTables, Bool sortColumns,
+                               Bool cOrder)
 {
   TableDesc tdesc = actualTableDesc();
   Record dminfo = dataManagerInfo();
@@ -1039,7 +1041,8 @@ void BaseTable::showStructure (ostream& os, Bool showDataMans, Bool showColumns,
   if (!showDataMans) {
     if (showColumns) {
       os << endl;
-      showColumnInfo (os, tdesc, maxl, tdesc.columnNames(), sortColumns);
+      showColumnInfo (os, tdesc, maxl, tdesc.columnNames(), sortColumns,
+                      cOrder);
     }
   } else {
     for (uInt i=0; i<dminfo.nfields(); ++i) {
@@ -1087,7 +1090,7 @@ void BaseTable::showStructure (ostream& os, Bool showDataMans, Bool showColumns,
       }
       if (showColumns) {
         showColumnInfo (os, tdesc, maxl, dm.asArrayString ("COLUMNS"),
-                        sortColumns);
+                        sortColumns, cOrder);
       }
     }
   }
@@ -1114,7 +1117,7 @@ void BaseTable::showStructure (ostream& os, Bool showDataMans, Bool showColumns,
              << " references the parent table!!" << endl;
         } else {
           tab.showStructure (os, showDataMans, showColumns,
-                             showSubTables, sortColumns);
+                             showSubTables, sortColumns, cOrder);
         }
       }
     }
@@ -1126,7 +1129,7 @@ void BaseTable::showStructureExtra (ostream&) const
 
 void BaseTable::showColumnInfo (ostream& os, const TableDesc& tdesc,
                                 uInt maxl, const Array<String>& columnNames,
-                                Bool sort) const
+                                Bool sort, Bool cOrder) const
 {
   Vector<String> columns(columnNames);
   if (sort) {
@@ -1145,7 +1148,11 @@ void BaseTable::showColumnInfo (ostream& os, const TableDesc& tdesc,
     } else if (cdesc.isArray()) {
       if (cdesc.options() & ColumnDesc::FixedShape) {
         os << " shape=";
-        showContainer (os, cdesc.shape());
+        if (cOrder) {
+          showContainer (os, reversedCasaContainer(cdesc.shape()));
+        } else {
+          showContainer (os, cdesc.shape());
+        }
       } else if (cdesc.ndim() > 0) {
         os << " ndim=" << cdesc.ndim();
       } else {

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -271,7 +271,8 @@ public:
                         Bool showDataMan,
                         Bool showColumns,
                         Bool showSubTables,
-                        Bool sortColumns);
+                        Bool sortColumns,
+                        Bool cOrder);
 
     // Get readonly access to the table keyword set.
     virtual TableRecord& keywordSet() = 0;
@@ -553,7 +554,8 @@ private:
     // Show the info of the given columns.
     // Sort the columns if needed.
     void showColumnInfo (ostream& os, const TableDesc&, uInt maxNameLength,
-                         const Array<String>& columnNames, Bool sort) const;
+                         const Array<String>& columnNames, Bool sort,
+                         Bool cOrder) const;
 
     // Throw an exception for checkRowNumber.
     void checkRowNumberThrow (uInt rownr) const;

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -543,7 +543,8 @@ public:
                         Bool showDataMans=True,
                         Bool showColumns=True,
                         Bool showSubTables=False,
-                        Bool sortColumns=False) const;
+                        Bool sortColumns=False,
+                        Bool cOrder=False) const;
 
     // Show the table and/or column keywords, possibly also of all subtables.
     // Maximum <src>maxVal> values of Arrays will be shown.
@@ -1245,9 +1246,10 @@ inline void Table::showStructure (std::ostream& os,
                                   Bool showDataMans,
                                   Bool showColumns,
                                   Bool showSubTables,
-                                  Bool sortColumns) const
+                                  Bool sortColumns,
+                                  Bool cOrder) const
     { baseTabPtr_p->showStructure (os, showDataMans, showColumns,
-                                   showSubTables, sortColumns); }
+                                   showSubTables, sortColumns, cOrder); }
 
 
 

--- a/tables/apps/showtableinfo.cc
+++ b/tables/apps/showtableinfo.cc
@@ -55,6 +55,7 @@ int main (int argc, char* argv[])
     inputs.create("maxval", "25", "Max nr of array values to show", "int");
     inputs.create("sub", "F", "Show info for all subtables?", "bool");
     inputs.create("sort", "F", "Sort columns in alphabetical order?", "bool");
+    inputs.create("corder", "F", "Show shapes in C-order?", "bool");
     inputs.create("browse", "F", "Browse contents of table?", "bool");
     inputs.create("selcol", "", "TaQL column selection string", "string");
     inputs.create("selrow", "", "TaQL row selection string", "string");
@@ -73,6 +74,7 @@ int main (int argc, char* argv[])
     Int  maxval     = inputs.getInt ("maxval");
     Bool showsub    = inputs.getBool("sub");
     Bool sortcol    = inputs.getBool("sort");
+    Bool cOrder     = inputs.getBool ("corder");
     Bool browse     = inputs.getBool("browse");
     String selcol  (inputs.getString("selcol"));
     String selrow  (inputs.getString("selrow"));
@@ -97,7 +99,7 @@ int main (int argc, char* argv[])
       seltab = tableCommand (command);
     }
     // Show the table structure.
-    table.showStructure (cout, showdm, showcol, showsub, sortcol);
+    table.showStructure (cout, showdm, showcol, showsub, sortcol, cOrder);
     table.showKeywords (cout, showsub, showtabkey, showcolkey, maxval);
     if (browse) {
       // Need to make table persistent for casabrowser.

--- a/tables/apps/taql.cc
+++ b/tables/apps/taql.cc
@@ -166,17 +166,7 @@ bool readLineSkip (String& line, const String& prompt)
 {
   bool fnd = false;
   while (!fnd  &&  readLine (line, prompt)) {
-    vector<String> parts = splitLine(line);
-    // Remove last part if empty.
-    if (! parts.empty()  &&  parts[parts.size()-1].empty()) {
-      parts.resize (parts.size() - 1);
-    }
-    if (parts.size() > 1) {
-      cerr << "A single TaQL command must be given" << endl;
-    } else if (! parts.empty()) {                            
-      line = parts[0];
-      fnd  = true;
-    }
+    fnd = !line.empty();
   }
 #ifdef HAVE_READLINE
   if (fnd) add_history (line.c_str());


### PR DESCRIPTION
TaQL now displays shapes in C-order when using that style.
The DIRECT option has been added for create table and add column commands.
close #428 
