### PR TITLE
TaQL: alias :: for outer table in subqueries

### DIFF
--- a/tables/TaQL/ExprFuncNode.cc
+++ b/tables/TaQL/ExprFuncNode.cc
@@ -420,7 +420,7 @@ Bool TableExprFuncNode::getBool (const TableExprId& id)
         String shand, columnName;
         Vector<String> fieldNames;
         TableParseSelect::splitName (shand, columnName, fieldNames,
-                                     name, True, True);
+                                     name, True, True, False);
         if (! shand.empty()) {
           return False;
         }

--- a/tables/TaQL/TableParse.h
+++ b/tables/TaQL/TableParse.h
@@ -615,9 +615,10 @@ public:
   // of the column (for the case where the column contains records).
   // If the name is invalid, an exception is thrown if checkError=True.
   // Otherwise the name is treated as a normal name without keyword.
+  // If allowEmtpy is True, :: is allowed, otherwise an error is thrown.
   static Bool splitName (String& shorthand, String& columnName,
                          Vector<String>& fieldNames, const String& name,
-                         Bool checkError, Bool isKeyword);
+                         Bool checkError, Bool isKeyword, Bool allowNoKey);
 
 private:
   // Test if groupby or aggregate functions are given.

--- a/tables/TaQL/test/tTableGram.out
+++ b/tables/TaQL/test/tTableGram.out
@@ -831,6 +831,11 @@ select ab,ac,ad from tTableGram_tmp.tab2
  4 14 5
  5 15 6
  6 16 7
+select [select ab from ::][rownr()] from tTableGram_tmp.tab limit 1
+    has been executed
+    select result of 1 rows
+1 selected columns:  Col_1
+ 1
 
 testing create ...
 create table tTableGram_tmp.tab2 (col1 i4 [shape=[2,3], unit="m", dmtype="IncrementalStMan"], col2 B) dminfo [TYPE="IncrementalStMan",NAME="ISM1",SPEC=[BUCKETSIZE=16384],COLUMNS=["col1"]]

--- a/tables/TaQL/test/tTableGram.run
+++ b/tables/TaQL/test/tTableGram.run
@@ -208,6 +208,7 @@ $casa_checktool ./tTableGram 'select ab,ac from tTableGram_tmp.tab'
 $casa_checktool ./tTableGram 'insert into [createtable tTableGram_tmp.tab2 (ab I4, ac U2, ad I4)] values (10,11,1),(12,13,2),(14,15,4)'
 $casa_checktool ./tTableGram 'insert top 4 into tTableGram_tmp.tab2 values (rowid(), ab+10, rownumber())'
 $casa_checktool ./tTableGram 'select ab,ac,ad from tTableGram_tmp.tab2'
+$casa_checktool ./tTableGram 'select [select ab from ::][rownr()] from tTableGram_tmp.tab limit 1'
 
 # Test create and insert with a unit.
 echo ""


### PR DESCRIPTION
This makes queries like the following possible:
```
taql 'select from L1235-2438143.MS where TIME in [SELECT DISTINCT TIME FROM :: LIMIT 5]'
```
Before this change, one had to type the name of the measurement set twice, or use an alias.