### PR TITLE
Use omp_get_max_threads to determine fftw thread number

### DIFF
--- a/scimath/Mathematics/FFTW.cc
+++ b/scimath/Mathematics/FFTW.cc
@@ -37,6 +37,9 @@
 #ifdef HAVE_FFTW3
 # include <fftw3.h>
 #endif
+#ifdef _OPENMP
+# include <omp.h>
+#endif
 
 #include <iostream>
 
@@ -96,7 +99,11 @@ namespace casacore {
     if (!is_initialized_fftw) {
       ScopedMutexLock lock(theirMutex);
       if (!is_initialized_fftw) {
+#ifdef _OPENMP
+        int numCPUs = omp_get_max_threads();
+#else
         int numCPUs = HostInfo::numCPUs();
+#endif
         int nthreads = 1;
         // cerr << "Number of threads is " << numCPUs << endl;
         if (numCPUs > 1) {


### PR DESCRIPTION
Allows controlling openmp based applications completely via the openmp
env variables.