### PR TITLE
CAS-8477 Ensure that receptor angles for specified spectral windows

### DIFF
--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -43,7 +43,7 @@
 
 #include <utility>
 
-#define _ORIGIN "MSMetaData::" + String(__FUNCTION__) + ": "
+#define _ORIGIN "MSMetaData::" + String(__func__) + ": "
 
 namespace casacore {
 
@@ -4684,6 +4684,18 @@ std::set<Int> MSMetaData::getUniqueFieldIDs() const {
         }
     }
     return _uniqueFieldIDs;
+}
+
+std::set<uInt> MSMetaData::getUniqueSpwIDs() const {
+    vector<uInt> ddToSpw = getDataDescIDToSpwMap();
+    std::set<uInt> uDDs = getUniqueDataDescIDs();
+    std::set<uInt> uSpws;
+    std::set<uInt>::const_iterator iter = uDDs.begin();
+    std::set<uInt>::const_iterator end = uDDs.end();
+    for (; iter!=end; ++iter) {
+        uSpws.insert(ddToSpw[*iter]);
+    }
+    return uSpws;
 }
 
 Bool MSMetaData::_hasStateID(const Int stateID) const {

--- a/ms/MSOper/MSMetaData.h
+++ b/ms/MSOper/MSMetaData.h
@@ -599,6 +599,10 @@ public:
     // Number of unique values from SOURCE.SOURCE_ID
     uInt nUniqueSourceIDsFromSourceTable() const;
 
+    // get the unique spectral window IDs represented by the data description
+    // IDs that appear in the main table
+    std::set<uInt> getUniqueSpwIDs() const;
+
     const MeasurementSet* getMS() const { return _ms; }
 
     void setShowProgress(Bool b) { _showProgress = b; }

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -2499,7 +2499,13 @@ void testIt(MSMetaData& md) {
                 AlwaysAssert(mymap[i].size() == expSize, AipsError);
                 AlwaysAssert(mymap[i].begin()->second == expExposure, AipsError);
             }
-            
+        }
+        {
+            cout << "*** test getUniqueSpwIDs()" << endl;
+            std::set<uInt> spws = md.getUniqueSpwIDs();
+            Vector<Int> expV = casa::indgen(25, 0, 1);
+            std::set<uInt> expec(expV.begin(), expV.end());
+            AlwaysAssert(spws == expec, AipsError);
         }
         {
             cout << "*** cache size " << md.getCache() << endl;

--- a/msfits/MSFits/MSFitsOutput.h
+++ b/msfits/MSFits/MSFitsOutput.h
@@ -29,6 +29,7 @@
 #define MS_MSFITSOUTPUT_H
 
 #include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/Quanta/Quantum.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 
 #include <casacore/casa/aips.h>
@@ -41,7 +42,6 @@ template<class T> class ScalarColumn;
 class Table;
 template<class T> class Block;
 template<class T> class Vector;
-
 
 // <summary>
 // Write a MeasurementSet to a random group uvfits file.
@@ -266,6 +266,10 @@ private:
         const ScalarColumn<Int>& ant2,
         const Bool asMultiSource,
         const ScalarColumn<Int>& fieldid
+    );
+
+    static void _checkReceptorAngles(
+        const Vector<Quantity>& ra0, Vector<Quantity>& ra1, Int antnum
     );
 };
 

--- a/msfits/MSFits/test/tMSFITSOutput.cc
+++ b/msfits/MSFits/test/tMSFITSOutput.cc
@@ -53,12 +53,17 @@ int main() {
             ), AipsError
         );
         // this should fail since overwrite is False
-        AlwaysAssert(
-            ! MSFitsOutput::writeFitsFile(
+        Bool thrown = False;
+        try {
+            MSFitsOutput::writeFitsFile(
                 fitsFile, ms, "DATA", 0, 1, 1, False,
                 False, False, False, 1.0, False, 1, 0, False
-            ), AipsError
-        );
+            );
+        }
+        catch (const AipsError&) {
+            thrown = True;
+        }
+        AlwaysAssert(thrown, AipsError);
         // this should succeed, since overwrite is True
         AlwaysAssert(
             MSFitsOutput::writeFitsFile(


### PR DESCRIPTION
do not vary on an antenna by antenna basis

implemented MSMetaData::getUniqueSpwIDs()

modify MSFitsOutput::writeFitsFile() not to consume thrown exception just to return False, but rather allow thrown exceptions to continue to propogate up the stack. Method return type remains Bool.