### PR TITLE
Remove table flush on destruction of PagedArray

### DIFF
--- a/lattices/Lattices/PagedArray.tcc
+++ b/lattices/Lattices/PagedArray.tcc
@@ -182,15 +182,6 @@ PagedArray<T>::~PagedArray()
   if (itsMarkDelete) {
     tempReopen();
   }
-  // Only need to do something if really constructed.
-  if (! itsTable.isNull()) {
-    // Table may not be written if ref count > 1 - here we force a write.
-    // (but only if it is not a scratch table).
-    if (! itsTable.isMarkedForDelete()) {
-      DebugAssert (ok(), AipsError);
-      itsTable.flush();
-    }
-  }
 }
 
 template<class T>

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -868,6 +868,9 @@ Table Table::operator! () const
 Bool Table::isReadable (const String& tableName, Bool throwIf)
 {
     String tabName = Path(tableName).absoluteName();
+    if (PlainTable::tableCache()(tabName)) {
+        return True;
+    }
     //# Check if the table directory exists.
     File dir(tabName);
     if (!dir.exists()) {

--- a/tables/Tables/TableCache.cc
+++ b/tables/Tables/TableCache.cc
@@ -170,9 +170,8 @@ void TableCache::flushTable (const String& name,
 PlainTable* TableCache::lookCache (const String& name, int tableOption,
                                    const TableLock& lockOptions)
 {
-    ScopedMutexLock sc(itsMutex);
     //# Exit if table is not in cache yet.
-    PlainTable* btp = getTable(name);
+    PlainTable* btp = this->operator()(name);
     if (btp == 0) {
 	return btp;
     }

--- a/tables/Tables/TableInfo.cc
+++ b/tables/Tables/TableInfo.cc
@@ -28,6 +28,7 @@
 
 //# Includes
 #include <casacore/tables/Tables/TableInfo.h>
+#include <casacore/tables/Tables/PlainTable.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/iostream.h>
@@ -43,10 +44,19 @@ TableInfo::TableInfo()
 TableInfo::TableInfo (const String& fileName)
 : writeIt_p (True)
 {
-    File file (Path(fileName).absoluteName());
+    String absName = Path(fileName).absoluteName();
+    // check cache first, table may not be flushed yet
+    PlainTable * tb = PlainTable::tableCache()(Path(absName).dirName());
+    if (tb) {
+        *this = tb->tableInfo();
+        return;
+    }
+
+    File file (absName);
     if (! file.exists()) {
 	return;
     }
+
     ifstream os(file.path().absoluteName().chars(), ios::in);
     char buf[1025];
     int  len;


### PR DESCRIPTION
The PagedArray destructor flushes its underlying Table which essentially
makes the write Tile cache useless as many short lived objects do
contain PagedArray objects. When iterating over a Lattice in an
order that does not match the tileshape it will flush the cache on
destructions of for example LatticeIterators, LatticeExpressions or
SubImages and it while thus constantly rewrite partially modified tiles.
In some CASA tasks this leads to unnecessary very large write
amplifications.

To remove the all code that explicitly looks at table files on disk must
be adapted to respect the TableCache as it the flush frequency is
massively reduced and the files might not exist on disk at the time the
functions try to read them.
This commit updates Table::isReadable and TableInfo which is enough to
make most of the CASA regression suite succeed.
This also requires removing an unnecessary lock from
TableCache::lookCache which is during the reopenRW call may otherwise
recursively lock the TableCache.

IsWritable is not changed as it does not appear necessary currently and
if would need additional logic to handle read-only tables in cache that
are supposed to be opened in write mode.

closes gh-453