### PR TITLE
remove unnecessary String constructions

### DIFF
--- a/tables/Tables/ArrayColumn.h
+++ b/tables/Tables/ArrayColumn.h
@@ -470,6 +470,9 @@ private:
     void checkShape (const IPosition& shp,
                      Array<T>& arr, Bool resize,
                      const String& where) const;
+    void checkShape (const IPosition& shp,
+                     Array<T>& arr, Bool resize,
+                     const char * where) const;
 
 protected:
     // A common function used by all functions that can get or put irregular

--- a/tables/Tables/ArrayColumn.tcc
+++ b/tables/Tables/ArrayColumn.tcc
@@ -145,7 +145,7 @@ void ArrayColumn<T>::checkDataType() const
 template<class T>
 void ArrayColumn<T>::checkShape (const IPosition& shp,
                                  Array<T>& arr, Bool resize,
-                                 const String& where) const
+                                 const char * where) const
 {
     if (! shp.isEqual (arr.shape())) {
 	if (resize  ||  arr.nelements() == 0) {
@@ -154,6 +154,14 @@ void ArrayColumn<T>::checkShape (const IPosition& shp,
           throw TableArrayConformanceError(where);
 	}
     }
+}
+
+template<class T>
+void ArrayColumn<T>::checkShape (const IPosition& shp,
+                                 Array<T>& arr, Bool resize,
+                                 const String& where) const
+{
+    checkShape (shp, arr, resize, where.c_str());
 }
 
 template<class T>
@@ -275,8 +283,8 @@ ArrayColumn<T>::getColumnCells (const RefRows & rows,
    IPosition destinationShape (columnSlicer.shape());
    destinationShape.append (IPosition (1, rows.nrows()));
 
-   static const String tag ("ArrayColumn::getColumnCells (rows, slicers, ...)");
-   checkShape (destinationShape, destination, resize, tag);
+   checkShape (destinationShape, destination, resize,
+               "ArrayColumn::getColumnCells (rows, slicers, ...)");
 
    // Fill the destination array one row at a time.
    // If rows is not sliced then rowNumbers is simply a vector of the relevant


### PR DESCRIPTION
the conversion from const char to String implies unnecessary memory
allocation in some relatively commonly called functions. Avoid this via
a const char interface