### PR TITLE
add some more extern templates

### DIFF
--- a/casa/Arrays/Array.h
+++ b/casa/Arrays/Array.h
@@ -934,6 +934,7 @@ protected:
 #ifdef AIPS_CXX11
   extern template class Array<Bool>;
   extern template class Array<Char>;
+  extern template class Array<uChar>;
   extern template class Array<Short>;
   extern template class Array<uShort>;
   extern template class Array<Int>;

--- a/casa/Arrays/Array_tmpl.cc
+++ b/casa/Arrays/Array_tmpl.cc
@@ -35,6 +35,7 @@
 namespace casacore {
   template class Array<Bool>;
   template class Array<Char>;
+  template class Array<uChar>;
   template class Array<Short>;
   template class Array<uShort>;
   template class Array<Int>;

--- a/casa/Arrays/Matrix.h
+++ b/casa/Arrays/Matrix.h
@@ -325,6 +325,15 @@ private:
     void makeIndexingConstants();
 };
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Matrix<Bool>;
+  extern template class Matrix<Float>;
+  extern template class Matrix<Double>;
+  extern template class Matrix<Complex>;
+  extern template class Matrix<DComplex>;
+#endif
+
 } //#End casa namespace
 #ifndef CASACORE_NO_AUTO_TEMPLATES
 #include <casacore/casa/Arrays/Matrix.tcc>

--- a/casa/Arrays/Matrix_tmpl.cc
+++ b/casa/Arrays/Matrix_tmpl.cc
@@ -1,0 +1,41 @@
+//# Array_tmpl.cc: Explicit Array template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Array.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/casa/Arrays/Matrix.h>
+#include <casacore/casa/Arrays/MatrixMath.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class Matrix<Bool>;
+  template class Matrix<Float>;
+  template class Matrix<Double>;
+  template class Matrix<Complex>;
+  template class Matrix<DComplex>;
+}
+#endif

--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -24,6 +24,7 @@ Arrays/IPosition.cc
 Arrays/IPosition2.cc
 Arrays/MaskArrMath2.cc
 Arrays/Matrix2Math.cc
+Arrays/Matrix_tmpl.cc
 Arrays/Slice.cc
 Arrays/Slicer.cc
 Arrays/Vector_tmpl.cc

--- a/casa/Quanta/Quantum.h
+++ b/casa/Quanta/Quantum.h
@@ -441,6 +441,11 @@ Bool readQuantity(Quantity &res, MUString &in);
 Bool readQuantity(Quantity &res, const String &in);
 // </group>
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Quantum<Double>;
+#endif
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/casa/Quanta/Quantum2.cc
+++ b/casa/Quanta/Quantum2.cc
@@ -34,6 +34,11 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
+//# Define extern templates for often used types.
+#ifdef AIPS_CXX11
+  template class Quantum<Double>;
+#endif
+
 istream &operator>> (istream &is, Quantity &ku)
 {
   String str;

--- a/casa/System/AipsrcValue.h
+++ b/casa/System/AipsrcValue.h
@@ -273,6 +273,13 @@ private:
 
 #undef AipsrcValue_Bool
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class AipsrcValue<Bool>;
+  extern template class AipsrcValue<Int>;
+  extern template class AipsrcValue<Double>;
+  extern template class AipsrcValue<String>;
+#endif
 
 } //# NAMESPACE CASACORE - END
 

--- a/casa/System/AipsrcValue2.cc
+++ b/casa/System/AipsrcValue2.cc
@@ -34,6 +34,14 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+    template class AipsrcValue<Bool>;
+    template class AipsrcValue<Int>;
+    template class AipsrcValue<Double>;
+    template class AipsrcValue<String>;
+#endif
+
 template <> 
 Bool AipsrcValue<String>::find(String &value,
 			       const String &keyword,

--- a/images/CMakeLists.txt
+++ b/images/CMakeLists.txt
@@ -35,6 +35,7 @@ Images/FITSImgParser.cc
 Images/FITSQualityImage.cc
 Images/FITSQualityMask.cc
 Images/HDF5Image2.cc
+Images/Image_tmpl.cc
 Images/ImageAttrGroup.cc
 Images/ImageAttrGroupCasa.cc
 Images/ImageAttrGroupHDF5.cc

--- a/images/Images/ImageInterface.h
+++ b/images/Images/ImageInterface.h
@@ -396,6 +396,12 @@ private:
 };
 
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class ImageInterface<Float>;
+  extern template class ImageInterface<Complex>;
+#endif
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/images/Images/ImageRegrid.h
+++ b/images/Images/ImageRegrid.h
@@ -379,7 +379,10 @@ public:
                const Array<Bool>& mask);
 };
 
- 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class ImageRegrid<Float>;
+#endif
 
 } //# NAMESPACE CASACORE - END
 

--- a/images/Images/ImageStatistics.h
+++ b/images/Images/ImageStatistics.h
@@ -242,6 +242,10 @@ public:
   using LatticeStatistics<T>::MAX;
 };
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class ImageStatistics<Float>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/images/Images/Image_tmpl.cc
+++ b/images/Images/Image_tmpl.cc
@@ -1,0 +1,49 @@
+//# Array_tmpl.cc: Explicit Array template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+
+//# Includes
+#include <casacore/images/Images/PagedImage.h>
+#include <casacore/images/Images/ImageStatistics.h>
+#include <casacore/images/Images/ImageRegrid.h>
+#include <casacore/images/Images/ImageInterface.h>
+#include <casacore/images/Images/TempImage.h>
+#include <casacore/images/Images/SubImage.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class PagedImage<Float>;
+  template class PagedImage<Complex>;
+  template class ImageStatistics<Float>;
+  template class ImageRegrid<Float>;
+  template class ImageInterface<Float>;
+  template class ImageInterface<Complex>;
+  template class TempImage<Float>;
+  template class TempImage<Complex>;
+  template class SubImage<Float>;
+  template class SubImage<Complex>;
+}
+#endif

--- a/images/Images/PagedImage.h
+++ b/images/Images/PagedImage.h
@@ -461,7 +461,11 @@ protected:
 // </group>
 
 
-
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class PagedImage<Float>;
+  extern template class PagedImage<Complex>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/images/Images/SubImage.h
+++ b/images/Images/SubImage.h
@@ -279,6 +279,11 @@ protected:
   using ImageInterface<T>::setCoordsMember;
 };
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class SubImage<Float>;
+  extern template class SubImage<Complex>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/images/Images/TempImage.h
+++ b/images/Images/TempImage.h
@@ -309,7 +309,11 @@ protected:
   using ImageInterface<T>::setCoordsMember;
 };
 
-
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class TempImage<Float>;
+  extern template class TempImage<Complex>;
+#endif
 
 } //# NAMESPACE CASACORE - END
 

--- a/lattices/CMakeLists.txt
+++ b/lattices/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 
 add_library (casa_lattices
+Lattices/Lattices_tmpl.cc
 Lattices/LatticeBase.cc
 Lattices/LatticeIndexer.cc
 Lattices/LatticeLocker.cc

--- a/lattices/LatticeMath/LatticeStatistics.h
+++ b/lattices/LatticeMath/LatticeStatistics.h
@@ -581,6 +581,12 @@ private:
    void _doStatsLoop(uInt nsets, CountedPtr<LattStatsProgress> progressMeter);
 };
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class LatticeStatistics<Float>;
+#endif
+
+
 } //# NAMESPACE CASA - END
 
 #ifndef CASACORE_NO_AUTO_TEMPLATES

--- a/lattices/Lattices/Lattice.h
+++ b/lattices/Lattices/Lattice.h
@@ -428,6 +428,11 @@ template<> inline
 void Lattice<Bool>::handleMathTo (Lattice<Bool>&, int) const
   { throwBoolMath(); }
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Lattice<Float>;
+  extern template class Lattice<Complex>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/lattices/Lattices/LatticeIterInterface.h
+++ b/lattices/Lattices/LatticeIterInterface.h
@@ -325,6 +325,10 @@ inline IPosition LatticeIterInterface<T>::cursorShape() const
   return itsNavPtr->cursorShape();
 }
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class LatticeIterInterface<Float>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/lattices/Lattices/Lattices_tmpl.cc
+++ b/lattices/Lattices/Lattices_tmpl.cc
@@ -1,0 +1,46 @@
+//# Array_tmpl.cc: Explicit Array template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+
+//# Includes
+#include <casacore/lattices/LatticeMath/LatticeStatistics.h>
+#include <casacore/lattices/Lattices/LatticeIterInterface.h>
+#include <casacore/lattices/Lattices/PagedArray.h>
+#include <casacore/lattices/Lattices/Lattice.h>
+#include <casacore/lattices/Lattices/SubLattice.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+  template class LatticeIterInterface<Float>;
+  template class LatticeStatistics<Float>;
+  template class Lattice<Float>;
+  template class Lattice<Complex>;
+  template class PagedArray<Float>;
+  template class PagedArray<Complex>;
+  template class SubLattice<Bool>;
+  template class SubLattice<Float>;
+}
+#endif

--- a/lattices/Lattices/PagedArray.h
+++ b/lattices/Lattices/PagedArray.h
@@ -667,6 +667,11 @@ void PagedArray<T>::doReopen() const
   }
 }
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class PagedArray<Float>;
+  extern template class PagedArray<Complex>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/lattices/Lattices/SubLattice.h
+++ b/lattices/Lattices/SubLattice.h
@@ -338,6 +338,11 @@ private:
   AxesMapping       itsAxesMap;
 };
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class SubLattice<Bool>;
+  extern template class SubLattice<Float>;
+#endif
 
 
 } //# NAMESPACE CASACORE - END

--- a/measures/CMakeLists.txt
+++ b/measures/CMakeLists.txt
@@ -60,6 +60,7 @@ Measures/SolarPos.cc
 Measures/Stokes.cc
 Measures/UVWMachine.cc
 Measures/VelocityMachine.cc
+TableMeasures/TableMeas_tmpl.cc
 TableMeasures/TableMeasColumn.cc
 TableMeasures/TableMeasDescBase.cc
 TableMeasures/TableMeasOffsetDesc.cc

--- a/measures/TableMeasures/ArrayQuantColumn.tcc
+++ b/measures/TableMeasures/ArrayQuantColumn.tcc
@@ -437,6 +437,11 @@ void ArrayQuantColumn<T>::put (uInt rownr, const Array<Quantum<T> >& q)
   q.freeStorage(q_p, deleteQuant);
 }
 
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class Array<Quantum<Double> >;
+#endif
+
 } //# NAMESPACE CASACORE - END
 
 

--- a/measures/TableMeasures/TableMeas_tmpl.cc
+++ b/measures/TableMeasures/TableMeas_tmpl.cc
@@ -1,0 +1,37 @@
+//# Array_tmpl.cc: Explicit Array template instantiations
+//# Copyright (C) 2015
+//# Associated Universities, Inc. Washington DC, USA,
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Array.h 21545 2015-01-22 19:36:35Z gervandiepen $
+
+//# Includes
+#include <casacore/measures/TableMeasures/ArrayQuantColumn.h>
+
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+namespace casacore {
+    template class Array<Quantum<Double > >;
+
+}
+#endif

--- a/ms/MeasurementSets/MSColumns.cc
+++ b/ms/MeasurementSets/MSColumns.cc
@@ -30,6 +30,15 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
+//# Instantiate extern templates for often used types.
+#ifdef AIPS_CXX11
+  template class ArrayMeasColumn<MDirection>;
+  template class ScalarMeasColumn<MPosition>;
+  template class ScalarMeasColumn<MEpoch>;
+  template class ArrayQuantColumn<Double>;
+  template class ScalarQuantColumn<Double>;
+#endif
+
 ROMSColumns::ROMSColumns(const MeasurementSet& ms):
   ROMSMainColumns(ms),
   antenna_p(ms.antenna()),

--- a/ms/MeasurementSets/MSColumns.h
+++ b/ms/MeasurementSets/MSColumns.h
@@ -31,6 +31,11 @@
 #include <casacore/casa/aips.h>
 #include <casacore/measures/Measures/MDirection.h>
 #include <casacore/measures/Measures/MEpoch.h>
+#include <casacore/measures/Measures/MCPosition.h>
+#include <casacore/measures/TableMeasures/ArrayMeasColumn.h>
+#include <casacore/measures/TableMeasures/ArrayQuantColumn.h>
+#include <casacore/measures/TableMeasures/ScalarMeasColumn.h>
+#include <casacore/measures/TableMeasures/ScalarQuantColumn.h>
 #include <casacore/ms/MeasurementSets/MSAntennaColumns.h>
 #include <casacore/ms/MeasurementSets/MSDataDescColumns.h>
 #include <casacore/ms/MeasurementSets/MSDopplerColumns.h>
@@ -310,6 +315,15 @@ private:
   MSSysCalColumns sysCal_p; //optional
   MSWeatherColumns weather_p; //optional
 };
+
+//# Declare extern templates for often used types.
+#ifdef AIPS_CXX11
+  extern template class ArrayMeasColumn<MDirection>;
+  extern template class ScalarMeasColumn<MPosition>;
+  extern template class ScalarMeasColumn<MEpoch>;
+  extern template class ArrayQuantColumn<Double>;
+  extern template class ScalarQuantColumn<Double>;
+#endif
 
 } //# NAMESPACE CASACORE - END
 


### PR DESCRIPTION
Add extern templates for types commonly used in CASA. Saves a bit of compilation time and disk space.