### PR TITLE
Measures data: reduce update frequency for IERS tables

### DIFF
--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -429,7 +429,7 @@ const tableProperties allProperties[] = {
 
   //**********************************************************************//
 
-  { "IERSeop97",		2.0,			4.0,
+  { "IERSeop97",		2.0,			34.0,
     False,			37664,			1.0,
     "geodetic/IERSeop97",  	"ftp",  		"ascii",
     &IERSeop97,			IERSeop97Col,		0,
@@ -441,7 +441,7 @@ const tableProperties allProperties[] = {
 
   //**********************************************************************//
 
-  { "IERSeop2000",		2.0,			4.0,
+  { "IERSeop2000",		2.0,			34.0,
     False,			37664,			1.0,
     "geodetic/IERSeop2000", 	"ftp",  		"ascii",
     &IERSeop2000,		IERSeop2000Col,		0,


### PR DESCRIPTION
The update frequency for IERS EOP-files was reduced in December 1 2011, see http://hpiers.obspm.fr/eop-pc/index.php?index=C04 . This has cause the script that generates the measures data tables to go into an infinite loop, downloading eopc04.16 , causing unnecessary load on the hpiers.obspm.fr server. 
The attached fix was implemented at ASTRON in december 2011 but apparently didn't make it upstream...