### PR TITLE
Justoagv aipsrc

### DIFF
--- a/casa/OS/HostInfo.cc
+++ b/casa/OS/HostInfo.cc
@@ -124,7 +124,9 @@ Int HostInfo::numCPUs(bool use_aipsrc)				\
     static const String keyword("system.resources.cores");	\
     if ( use_aipsrc ) {						\
 	String value;						\
-	if ( Aipsrc::find(value, keyword) ) {			\
+	if (resources_numCPUs > 0) {				\
+		return resources_numCPUs;			\
+	} else if ( Aipsrc::find(value, keyword) ) {			\
 	    int result;						\
 	    if ( sscanf( value.c_str( ), "%d", &result ) == 1 )	\
 		return (Int) result;				\
@@ -144,11 +146,15 @@ ptrdiff_t HostInfo::memoryTotal(bool use_aipsrc) 		\
     /** returns the memory in kilobytes...         **/		\
     if ( use_aipsrc ) {						\
 	String value;						\
-	if ( Aipsrc::find(value, memory) ) {			\
+    if (resources_memory > 0) {				\
+        return resources_memory;				\
+    } else if ( Aipsrc::find(value, memory) ) {		\
 	    int result;						\
 	    if ( sscanf( value.c_str( ), "%d", &result ) == 1 )	\
 		return (ptrdiff_t) result * 1024;		\
-	} else if ( Aipsrc::find(value,	fraction) ) {		\
+    } else if (resources_memfrac > 0) {			\
+        frac = resources_memfrac;				\
+    } else if ( Aipsrc::find(value,	fraction) ) {		\
 	    int result;						\
 	    if ( sscanf( value.c_str( ), "%d", &result ) == 1 )	\
 		frac = result;					\
@@ -200,6 +206,26 @@ ptrdiff_t HostInfo::swapFree( )					\
     if ( ! info ) info = new HostMachineInfo( );		\
     info->update_info( );					\
     return info->valid ? info->swap_free : -1;			\
+}								\
+								\
+ptrdiff_t HostInfo::setMemoryTotal(ptrdiff_t memory)		\
+{								\
+    ptrdiff_t old_memory = resources_memory;			\
+    resources_memory = 1024*memory;				\
+    return old_memory;						\
+}								\
+								\
+Int HostInfo::setMemoryFraction(Int memfrac)			\
+{								\
+    Int old_memfrac = resources_memfrac;			\
+    resources_memfrac = memfrac;				\
+    return old_memfrac;					\
+}								\
+Int HostInfo::setNumCPUs(Int numCPUs)				\
+{								\
+    Int old_numCPUs = resources_numCPUs;			\
+    resources_numCPUs = numCPUs;				\
+    return old_numCPUs;					\
 }
 
 
@@ -271,5 +297,8 @@ ptrdiff_t HostInfo::swapFree( )    { return -1; }
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 HostMachineInfo *HostInfo::info = 0;
+ptrdiff_t HostInfo::resources_memory = 0;
+Int HostInfo::resources_memfrac = 0;
+Int HostInfo::resources_numCPUs = 0;
 
 } //# NAMESPACE CASACORE - END

--- a/casa/OS/HostInfo.h
+++ b/casa/OS/HostInfo.h
@@ -131,12 +131,26 @@ public:
     static ptrdiff_t swapFree();
     // </group>
 
+    // Allows to set custom resource values overriding the
+    // existing .apisrc setting and/or system defaults
+    // Expected unit are KiB for memory total
+    // and percentage (%) for memory fraction
+    // Returns the value previously stored
+    // <group>
+    static ptrdiff_t setMemoryTotal(ptrdiff_t memory);
+    static Int setMemoryFraction(Int memfrac);
+    static Int setNumCPUs(Int numCPUs);
+    // </group>
+
 private:
     // we don't want folks creating these...
     HostInfo( );
     const HostInfo &operator=( const HostInfo & );
 
     static HostMachineInfo *info;
+    static ptrdiff_t resources_memory;
+    static Int resources_memfrac;
+    static Int resources_numCPUs;
 };
 
 


### PR DESCRIPTION
Prologue: I have not changed any existing functionality / interface, just added some new features.

Following requirements from the CASA HPC project (parallelization framework) I've added some set/gets to the casacore HostInfo class to override the aipsrc file values. In this way we can set different values per process for the memory/memoryFraction/numCores settings. 

When the custom memory/memoryFraction/numCores values are <= 0 they are ignored, so it is possible to set them to some custom value and then go back to the .aipsrc file defaults by setting them to 0.

See CAS-8159 and CAS-8158.