### PR TITLE
turn quicksort into introsort

### DIFF
--- a/casa/Utilities/GenSort.h
+++ b/casa/Utilities/GenSort.h
@@ -171,7 +171,7 @@ private:
                      uInt nparts);
 
     // Quicksort in ascending order.
-    static void quickSortAsc (T*, Int, Bool multiThread=False);
+    static void quickSortAsc (T*, Int, Bool multiThread=False, Int rec_lim=128);
 
     // Heapsort in ascending order.
     static void heapSortAsc (T*, Int);
@@ -268,7 +268,7 @@ private:
 
     // Quicksort in ascending order.
     static void quickSortAsc (uInt* inx, const T*, Int nr,
-                              Bool multiThread=False);
+                              Bool multiThread=False, Int rec_lim=128);
 
     // Heapsort in ascending order.
     static void heapSortAsc (uInt* inx, const T*, Int nr);

--- a/casa/Utilities/test/tGenSort.cc
+++ b/casa/Utilities/test/tGenSort.cc
@@ -138,6 +138,26 @@ int main(int argc, const char* argv[])
     delete [] a3;
     delete [] a4;
     delete [] a5;
+
+    // test N^2 quicksort input to check introsort fallback
+    // would crash due to large recursion without fallback
+    nr = 150000;
+    uInt * indx = new uInt[nr];
+    Int * data = new Int[nr];
+    for (uInt i=0; i < nr; i++) {
+        data[i] = 1;
+        indx[i] = i+1;
+    }
+    indx[nr - 1] = 0;
+    GenSortIndirect<Int>::quickSort (indx, data, nr, Sort::Ascending, 0);
+    for (uInt i=0; i < nr; i++) {
+        data[i] = i;
+    }
+    data[nr - 1] = -1;
+    GenSort<Int>::quickSort (data, nr, Sort::Ascending, 0);
+    delete [] indx;
+    delete [] data;
+
     return 0;                            // exit with success status
 }
 


### PR DESCRIPTION
limit worst case runtime to O(NlogN) by aborting to heapsort when the
recursion level goes above the expected depth of log2(len(data))

This avoids O(N^2) performance worst case and stack overflow on the not
so uncommon case where the median of 3 pivot selects the last element.
E.g. [1, 2, 3, 4, 5, 0] which can happen on indirect sorting of MS index
columns like SCAN_NUMBER.