### PR TITLE
For glibc systems, use the correct getrusage() declaration

### DIFF
--- a/casa/OS/Timer.cc
+++ b/casa/OS/Timer.cc
@@ -44,7 +44,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #if defined (DOS) || defined (MSDOS)
     usage0 = clock();
     ftime(&real0);
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     struct timezone tz;
     getrusage(0, &usage0);
@@ -75,7 +75,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     ms = ms * 0.001 + s;
     return (ms);
  
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     struct timeval now;
     struct timezone tz;
@@ -115,7 +115,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // error: Processor time not available
     return (0.0);
  
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     double dsec, dusec;
     rusage usage1;       // current rusage structure
@@ -145,7 +145,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #if defined (DOS) || defined (MSDOS)
     return(0L);
 
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     double dsec, dusec;
     rusage usage1;       // current rusage structure
@@ -180,7 +180,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // error: Processor time not available
     return (0.0);
  
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     double dsec, dusec;
     rusage usage1;       // current rusage structure
@@ -220,7 +220,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // error: Processor time not available
     return (0.0);
  
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     double dsec, dusec;
     rusage usage1;       // current rusage structure
@@ -251,7 +251,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #if defined (DOS) || defined (MSDOS)
     return(0.0);
 
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     double dsec, dusec;
     rusage usage1;       // current rusage structure
@@ -287,7 +287,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // error: Processor time not available
     return (0.0);
  
-#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined (AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
 # ifdef AIPS_CRAY_PGI
     double dsec, dusec;
     rusage usage1;       // current rusage structure

--- a/casa/OS/Timer.h
+++ b/casa/OS/Timer.h
@@ -41,7 +41,7 @@ extern "C" {
 #include <time.h>
 }
 
-#elif defined(AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined(AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
   #if defined(AIPS_CRAY_PGI)
     #include <sys/time.h>
     #include <sys/resource.h>
@@ -189,7 +189,7 @@ private:
 #if defined(DOS) || defined(MSDOS)
     clock_t usage0;
     timeb   real0;          //# elapsed real time at last mark
-#elif defined(AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD)
+#elif defined(AIPS_SOLARIS) || defined(AIPS_IRIX) || defined(AIPS_OSF) || defined(__hpux__) || defined(AIPS_LINUX) || defined(AIPS_DARWIN) || defined(AIPS_BSD) || defined(__GLIBC__)
   #if defined(AIPS_CRAY_PGI)
     //struct timeval usage0;
     rusage usage0;          //# rusage structure at last mark


### PR DESCRIPTION
There are some non-Linux systems using glibc as well, namely GNU HURD and kFreeBSD. For `getrusage()` they should be handled like the Linux systems.
This closes #463 by following the recommendation of the bug author Aaron M. Ucko amu@alum.mit.edu.
