### PR TITLE
Improve minMax performance

### DIFF
--- a/casa/Arrays/ArrayMath.tcc
+++ b/casa/Arrays/ArrayMath.tcc
@@ -764,7 +764,9 @@ template<class T> void minMax(T &minVal, T &maxVal, const Array<T> &array)
          iter!=iterEnd; ++iter) {
       if (*iter < minv) {
         minv = *iter;
-      } else if (*iter > maxv) {
+      }
+      // no else allows compiler to use branchless instructions
+      if (*iter > maxv) {
         maxv = *iter;
       }
     }
@@ -774,7 +776,8 @@ template<class T> void minMax(T &minVal, T &maxVal, const Array<T> &array)
          iter!=iterEnd; ++iter) {
       if (*iter < minv) {
         minv = *iter;
-      } else if (*iter > maxv) {
+      }
+      if (*iter > maxv) {
         maxv = *iter;
       }
     }


### PR DESCRIPTION
Removing the else allows the compiler to remove a branch by using the
branchless min and max instructions. It also allows vectorization.
Currently GCC does not vectorize the variation which also stores the
index so leave those unchanged.