### PR TITLE
Use IGRF12 instead of IGRF10 in measuresdata

### DIFF
--- a/measures/Measures/EarthField.h
+++ b/measures/Measures/EarthField.h
@@ -40,7 +40,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Constants
 // Length of P and Q arrays, half length of CL/SL arrays in IGRF model
-const Int PQ_LEN = 65;
+const Int PQ_LEN = 104;
 // Interval (m) for derivatives in IGRF model
 const Double DER_INTV = 10000;
 

--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -244,8 +244,8 @@ const String &IERSpredict2000Format = IERSpredictFormat;
 
 // IGRF
 const String IGRFFormat = String("") +
-"a1 x2 i3 i3 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9" +
-" f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9";  // 22 coefficients and SV
+"a1 i3 i3 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7" +
+" f7 f7 f7 f7 f7 f7 f7 f7 f7 f9 f10 f10 f9 f8"; // 24 coefficients and SV
 
 //*************************************************************************//
 
@@ -482,10 +482,10 @@ const tableProperties allProperties[] = {
     "geodetic/IGRF",		"http",  		"ascii",
     &IGRF,			IGRFCol,		0,
     vector<String>(),		vector<uInt>(),		vector<TableColumn*>(),
-    "IGRF10 reference magnetic field",			"earthField",
+    "IGRF12 reference magnetic field",			"earthField",
     False,			"",			vector<String>(),
     &IGRFFormat,		vector<formatDescr>(),
-    { "www.ngdc.noaa.gov", "IAGA/vmod", "igrf10coeffs.txt" } },
+    { "www.ngdc.noaa.gov", "IAGA/vmod", "igrf12coeffs.txt" } },
 
   //**********************************************************************//
 
@@ -1336,7 +1336,7 @@ Bool IGRF(tableProperties &tprop, inputValues &inVal) {
   vector<String> field;
   uInt expsize = tprop.fdesc.back().start +  tprop.fdesc.back().n; // Size
   for (uInt i=0; i<lines.size(); ++i) {
-    if (lines[i].size() > 80) {
+    if (lines[i].size() > 180) {
       if (lines[i].size() < expsize) lines[i].resize(expsize, ' ');
       field.resize(0);
       for (uInt j=0; j<tprop.fdesc.size(); ++j) {

--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -477,7 +477,7 @@ const tableProperties allProperties[] = {
 
   //**********************************************************************//
 
-  { "IGRF",			2.0,			180.0,
+  { "IGRF",			2.0,			0.0,
     True,			13193.75,		1826.25,
     "geodetic/IGRF",		"http",  		"ascii",
     &IGRF,			IGRFCol,		0,


### PR DESCRIPTION
IGRF12 has data for ten more years (until 2015 instead of 2005) and is the [latest IGRF model](http://www.ngdc.noaa.gov/IAGA/vmod/igrf.html).

Since the model is unchanged (for a change, a new model is created), it does not make sense to update the table from the same data again, so it makes sense to disable the update here.
