### PR TITLE
Added control of casa/casacore namespace via cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,17 @@ option (CASA_BUILD "Building the in the CASA (http://casa.nrao.edu) environment"
 
 set(CASA_DEFAULT_ALIGNMENT "32" CACHE STRING "Default alignment of casa::AlignedAllocator")
 
+if (UseCasacoreNamespace)
+
+    add_definitions (-DUseCasacoreNamespace)
+    message (STATUS "Using namespace casacore.")
+
+else ()
+
+    message (STATUS "Namespace casacore 'merged' into namespace casa.")
+
+endif ()
+
 # basic setup for building within CASA environment
 if( CASA_BUILD )
    if( NOT DATA_DIR )

--- a/casa/aipstype.h
+++ b/casa/aipstype.h
@@ -30,7 +30,10 @@
 
 // For temporary backward namespace compatibility, use casa as alias for casacore.
 //# Note: namespace casa = casacore; does not work for forward declarations.
-#define casacore casa
+
+#if ! defined (UseCasacoreNamespace)
+#   define casacore casa
+#endif
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 


### PR DESCRIPTION
Modified casa/aipstype.h to use an ifdef to enabled/disable the macro that
changes the "casacore" name to "casa".  Previously it was always defined but
with this mod it will only be defined when the symbol UseCasacoreNamespace
is not defined (i.e., ! defined (...)).

The CMakeLists.txt file was modified to define the C++ symbol
"UseCasacoreNamespace" by defining a similar vairable to make; for example

cmake .. -DUseCasacoreNamespace=1

The default behavior of the mod is to leave things the way they were so
that all "namespace casacore" are modified by the macro to be seen by
the compiler as "namespace casa", etc.   Only by defining the cmake
symbol will the new behavior be obtained.

Note: Any client project (e.g., CASA) that uses the new behavior will need
to define the same C++ symbol during that project's build.

Eventually, all of this functionality will be removed and casacore will
actually be in its own namespace all of the time.  When that will be is
currently an open question.