### PR TITLE
Making casacore namespace the norm for casa builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,17 +78,6 @@ option (CASA_BUILD "Building the in the CASA (http://casa.nrao.edu) environment"
 
 set(CASA_DEFAULT_ALIGNMENT "32" CACHE STRING "Default alignment of casa::AlignedAllocator")
 
-if (UseCasacoreNamespace)
-
-    add_definitions (-DUseCasacoreNamespace)
-    message (STATUS "Using namespace casacore.")
-
-else ()
-
-    message (STATUS "Namespace casacore 'merged' into namespace casa.")
-
-endif ()
-
 # basic setup for building within CASA environment
 if( CASA_BUILD )
    if( NOT DATA_DIR )
@@ -97,6 +86,7 @@ if( CASA_BUILD )
    set(USE_FFTW3 ON)
    set(USE_OPENMP ON)
    set(USE_THREADS ON)
+   set(UseCasacoreNamespace 1) # Force casacore routines to live in casacore rather than casa namespace
    ###
    ### after CASA switches from ASAP to libsakura, CASA will no longer
    ### use casacore's python module and it will no longer use boost...
@@ -155,6 +145,17 @@ if (ENABLE_SHARED)
 else()
     option (BUILD_SHARED_LIBS "" NO)
 endif (ENABLE_SHARED)
+
+if (UseCasacoreNamespace)
+
+    add_definitions (-DUseCasacoreNamespace)
+    message (STATUS "Using namespace casacore.")
+
+else ()
+
+    message (STATUS "Namespace casacore 'merged' into namespace casa.")
+
+endif ()
 
 # Define the compiler flags to be used.
 # Note: -Wshadow and -Wunreachable-code give (too) many warnings.


### PR DESCRIPTION

This will not affect builds where CASA_BUILD cmake variable is false.