### PR TITLE
Cas 8984 LatticeStats reimplement zero-ing out of quantile stats when they are not computed, et al.

### DIFF
--- a/lattices/LatticeMath/LatticeStatistics.tcc
+++ b/lattices/LatticeMath/LatticeStatistics.tcc
@@ -841,8 +841,10 @@ Bool LatticeStatistics<T>::generateStorageLattice() {
         _doStatsLoop(nsets, pProgressMeter);
     }
     pProgressMeter = NULL;
-    // Do robust statistics separately as required.
-    generateRobust();
+    if (doRobust_p) {
+        // Do robust statistics separately as required.
+        generateRobust();
+    }
     needStorageLattice_p = False;
     doneSomeGoodPoints_p = False;
     return True;
@@ -1034,9 +1036,6 @@ void LatticeStatistics<T>::_doStatsLoop(
 
 template <class T>
 void LatticeStatistics<T>::generateRobust () {
-    if (! doRobust_p) {
-        return;
-    }
     Bool showMsg = haveLogger_p && displayAxes_p.nelements()==0;
     if (showMsg) {
         os_p << LogIO::NORMAL << "Computing quantiles..." << LogIO::POST;

--- a/lattices/LatticeMath/StatsTiledCollapser.tcc
+++ b/lattices/LatticeMath/StatsTiledCollapser.tcc
@@ -232,6 +232,7 @@ void StatsTiledCollapser<T,U>::endAccumulator(
 	// we use to effectively mask it.
 
     result.resize(shape);
+    result.set(U(0));
     resultMask.resize(shape);
     resultMask.set(True);
 


### PR DESCRIPTION
CAS-8984 Reimplement inefficient method for zero-ing out quantile stats when they are not to be computed.
Catch noncontiguous array exceptions when old TiledApply method is used so that the new Stats framework method can be tried. Avoid that exception for smallish lattices by always using the new
framework method for them.