### PR TITLE
Unconditionally use `int` as data type for FitsLong.

### DIFF
--- a/casa/aipsxtype.h
+++ b/casa/aipsxtype.h
@@ -38,14 +38,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 typedef long long Int64;
 typedef unsigned long long uInt64;
 
-//# All FITS code seems to assume longs are 4 bytes. Take care of machines 
-//# for which this isn't true here by defining FitsLong to be the 4 byte int.
-//# Use FitsLong instead of long in the FITS code where it matters.
-#if (defined(AIPS_ALPHA) || defined(AIPS_SGI) || defined(__x86_64__))
-    typedef int FitsLong;
-#else
-    typedef long FitsLong;
-#endif 
+//# All FITS code seems to assume longs are 4 bytes. Currently
+//# this corresponds to an "int" on all useful platforms.
+typedef int FitsLong;
 
 } //# NAMESPACE CASACORE - END
 

--- a/fits/FITS/fits.h
+++ b/fits/FITS/fits.h
@@ -39,14 +39,9 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# All FITS code seems to assume longs are 4 bytes. To take care of machines 
-//# for which this isn't true use FitsLong instead of Long in the FITS code
-//# where it matters.
-# if (defined(__alpha) || defined(__sgi) || defined(__x86_64__))
+//# All FITS code seems to assume longs are 4 bytes. Currently
+//# this corresponds to an "int" on all useful platforms.
     typedef Int FitsLong;
-# else
-    typedef Long FitsLong;
-# endif 
 //# recovered by GYL
 
 //# Forward declarations


### PR DESCRIPTION
This is currently the case on all useful platforms. Cfitsio basically does the same in `fitsio.h`:
```
#define INT32BIT int  /* 32-bit integer datatype.  Currently this       */
                      /* datatype is an 'int' on all useful platforms   */
                      /* however, it is possible that that are cases    */
                      /* where 'int' is a 2-byte integer, in which case */
                      /* INT32BIT would need to be defined as 'long'.   */
```

This commit fixes some problems on some 64-bit architectures, namely arm64 and s390x which used the wrong typedef here because they were not explicitely listed. The test which failes was `images/Images/test/tFITSExtImage.cc`. Note, however, that there are still other tests failing, so this is just one step to get it running on non-x86 archs.

An alternative to the PR could be to use `#include <cstdint>` and then use `typedef int32_t FitsLong`; I am however afraid that this could create conflicts in some types (f.e. already `aipsxtype.h` creates some private `Int64` and `uInt64`). Consequently using standard C++11 types would be a good idea, however this seems to be a major effort :-)