### PR TITLE
In order to prevent segfault, replace all (illegally present) ...

### DIFF
--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -1942,12 +1942,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Parse the header
 
-	int nCards = strlen(pHeader) / 80;
-	int nReject;
-	::fitskey* keys;
-	int status = 0;
+	// sanitize to avoid segfaults in fitshdr
 	Bool crlfwarned = False;
-
 	for(uInt i=0; i<strlen(pHeader)-1; i++){
 	  uInt headerchar = pHeader[i];
 	  if( (headerchar==10) || (headerchar==13) ){
@@ -1959,7 +1955,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    pHeader[i] = 32;
 	  }
 	}
-	status = fitshdr (pHeader, nCards, nKeyIds, keyids, &nReject, &keys);
+
+	int nCards = strlen(pHeader) / 80;
+	int nReject;
+	::fitskey* keys;
+
+	int status = fitshdr (pHeader, nCards, nKeyIds, keyids, &nReject, &keys);
 	
 	if (status != 0) {
 	  throw(AipsError("Failed to extract non-coordinate cards from FITS header"));

--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -1945,15 +1945,15 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	// sanitize to avoid segfaults in fitshdr
 	Bool crlfwarned = False;
 	for(uInt i=0; i<strlen(pHeader)-1; i++){
-	  uInt headerchar = pHeader[i];
-	  if( (headerchar==10) || (headerchar==13) ){
-	    if( ! crlfwarned ){
-	      os << LogIO::WARN << "HEADER contains LF and/or CR characters!" << LogIO::POST;
-	      os << LogIO::WARN << "Will try to replace them by spaces ...." << LogIO::POST;
-	      crlfwarned = True;
+	    uInt headerchar = pHeader[i];
+	    if( (headerchar==10) || (headerchar==13) ){
+	        if( ! crlfwarned ){
+		    os << LogIO::WARN << "HEADER contains LF and/or CR characters!" << LogIO::POST;
+		    os << LogIO::WARN << "Will try to replace them by spaces ...." << LogIO::POST;
+		    crlfwarned = True;
+		}
+		pHeader[i] = 32;
 	    }
-	    pHeader[i] = 32;
-	  }
 	}
 
 	int nCards = strlen(pHeader) / 80;
@@ -1963,7 +1963,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	int status = fitshdr (pHeader, nCards, nKeyIds, keyids, &nReject, &keys);
 	
 	if (status != 0) {
-	  throw(AipsError("Failed to extract non-coordinate cards from FITS header"));
+	    throw(AipsError("Failed to extract non-coordinate cards from FITS header"));
 	}
 	
 //

--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -1945,10 +1945,26 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	int nCards = strlen(pHeader) / 80;
 	int nReject;
 	::fitskey* keys;
-	int status = fitshdr (pHeader, nCards, nKeyIds, keyids, &nReject, &keys);
-	if (status != 0) {
-	    throw(AipsError("Failed to extract non-coordinate cards from FITS header"));
+	int status = 0;
+	Bool crlfwarned = False;
+
+	for(uInt i=0; i<strlen(pHeader)-1; i++){
+	  uInt headerchar = pHeader[i];
+	  if( (headerchar==10) || (headerchar==13) ){
+	    if( ! crlfwarned ){
+	      os << LogIO::WARN << "HEADER contains LF and/or CR characters!" << LogIO::POST;
+	      os << LogIO::WARN << "Will try to replace them by spaces ...." << LogIO::POST;
+	      crlfwarned = True;
+	    }
+	    pHeader[i] = 32;
+	  }
 	}
+	status = fitshdr (pHeader, nCards, nKeyIds, keyids, &nReject, &keys);
+	
+	if (status != 0) {
+	  throw(AipsError("Failed to extract non-coordinate cards from FITS header"));
+	}
+	
 //
 	for (Int i=0; i<nCards; i++) {
 	    Record subRec;


### PR DESCRIPTION
... CRs and LFs by SPACEs in the header before calling fitshdr().