### PR TITLE
CMakeLists.txt mod to fix PR #506

### DIFF
--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -428,6 +428,13 @@ DESTINATION include/casacore/casa/Inputs
 )
 
 install (FILES
+Json/JsonOut.h
+Json/JsonValue.h
+Json/JsonParser.h
+DESTINATION include/casacore/casa/Json
+)
+
+install (FILES
 IO/AipsIOCarray.h
 IO/AipsIOCarray.tcc
 IO/AipsIO.h


### PR DESCRIPTION
The newly added Json*.h files weren't installed into the include directory
during build and would break casacore client builds.