### PR TITLE
Removed use of C++11 feature

### DIFF
--- a/lattices/LatticeMath/StatsTiledCollapser.tcc
+++ b/lattices/LatticeMath/StatsTiledCollapser.tcc
@@ -279,8 +279,9 @@ void StatsTiledCollapser<T,U>::_convertNPts(
     DComplex* storage = nptsComplex->storage();
     Double* realStorage = npts->storage();
     for (uInt64 i=0; i<_n1*_n3; ++i) {
-        storage[i].real(realStorage[i]);
-        storage[i].imag(0);
+         ///C++11 storage[i].real(realStorage[i]);
+         ///C++11 storage[i].imag(0);
+        storage[i] = DComplex(realStorage[i], 0);
     }
     nptsPtr = storage;
 }


### PR DESCRIPTION
Issue #516 
Removed use of complex function real and imag to set the complex values as it is only supported in C++11. Until we all agree, no C++11 features should be used (unless ifdef-ed).