### PR TITLE
Added functionality to create ITRF coordinates for an MS

### DIFF
--- a/derivedmscal/DerivedMC/DerivedColumn.cc
+++ b/derivedmscal/DerivedMC/DerivedColumn.cc
@@ -73,6 +73,17 @@ namespace casacore {
     itsEngine->getAzEl (itsAntNr, rowNr, data);
   }
 
+  ItrfColumn::~ItrfColumn()
+  {}
+  IPosition ItrfColumn::shape (uInt)
+  {
+    return IPosition(1,2);
+  }
+  void ItrfColumn::getArray (uInt rowNr, Array<Double>& data)
+  {
+    itsEngine->getItrf (itsAntNr, rowNr, data);
+  }
+
   UVWJ2000Column::~UVWJ2000Column()
   {}
   IPosition UVWJ2000Column::shape (uInt)

--- a/derivedmscal/DerivedMC/DerivedColumn.h
+++ b/derivedmscal/DerivedMC/DerivedColumn.h
@@ -125,6 +125,24 @@ namespace casacore {
   };
 
 
+  // <summary>Pointing ITRF coordinate derived from TIME, etc.</summary>
+  // <use visibility=local>
+  class ItrfColumn : public VirtualArrayColumn<Double>
+  {
+  public:
+    explicit ItrfColumn (MSCalEngine* engine, Int antnr)
+      : itsEngine (engine),
+        itsAntNr  (antnr)
+    {}
+    virtual ~ItrfColumn();
+    virtual IPosition shape (uInt rownr);
+    virtual void getArray (uInt rowNr, Array<Double>& data);
+  private:
+    MSCalEngine* itsEngine;
+    Int          itsAntNr;    //# 0=antenna1 1=antenna2
+  };
+
+
   // <summary>UVW J2000 derived from TIME, etc.</summary>
   // <use visibility=local>
   class UVWJ2000Column : public VirtualArrayColumn<Double>

--- a/derivedmscal/DerivedMC/DerivedMSCal.cc
+++ b/derivedmscal/DerivedMC/DerivedMSCal.cc
@@ -119,10 +119,14 @@ DataManagerColumn* DerivedMSCal::makeIndArrColumn (const String& name,
     col = new HaDecColumn(&itsEngine, 0);
   } else if (name == "HADEC2") {
     col = new HaDecColumn(&itsEngine, 1);
+  } else if (name == "AZEL") {
+    col = new AzElColumn(&itsEngine, -1);
   } else if (name == "AZEL1") {
     col = new AzElColumn(&itsEngine, 0);
   } else if (name == "AZEL2") {
     col = new AzElColumn(&itsEngine, 1);
+  } else if (name == "ITRF") {
+    col = new ItrfColumn(&itsEngine, -1);
   } else if (name == "UVW_J2000") {
     col = new UVWJ2000Column(&itsEngine);
   } else {

--- a/derivedmscal/DerivedMC/DerivedMSCal.h
+++ b/derivedmscal/DerivedMC/DerivedMSCal.h
@@ -59,21 +59,21 @@ namespace casacore {
 //
 // The following columns can be defined:
 // <ul>
-//  <li> HA is the hourangle of the array center (observatory position).
-//  <li> HA1 is the hourangle of ANTENNA1.
-//  <li> HA2 is the hourangle of ANTENNA2.
-//  <li> HADEC is the hourangle/DEC of the array center (observatory position).
-//  <li> HADEC1 is the hourangle/DEC of ANTENNA1.
-//  <li> HADEC2 is the hourangle/DEC of ANTENNA2.
-//  <li> LAST is the local sidereal time of the array center.
-//  <li> LAST1 is the local sidereal time of ANTENNA1.
-//  <li> LAST2 is the local sidereal time of ANTENNA2.
-//  <li> PA1 is the parallactic angle of ANTENNA1.
-//  <li> PA2 is the parallactic angle of ANTENNA2.
-//  <li> AZEL is the azimuth/elevation of the array center.
-//  <li> AZEL1 is the azimuth/elevation of ANTENNA1.
-//  <li> AZEL2 is the azimuth/elevation of ANTENNA2.
-//  <li> ITRF is the phase direction in (time-dependent) ITRF coordinates.
+//  <li> HA is the hourangle of the pointing from the array center (observatory position).
+//  <li> HA1 is the hourangle of the pointing from ANTENNA1.
+//  <li> HA2 is the hourangle of the pointing from ANTENNA2.
+//  <li> HADEC is the hourangle/DEC of the pointing from the array center (observatory position).
+//  <li> HADEC1 is the hourangle/DEC of the pointing from ANTENNA1.
+//  <li> HADEC2 is the hourangle/DEC of the pointing from ANTENNA2.
+//  <li> LAST is the local sidereal time of the pointing from the array center.
+//  <li> LAST1 is the local sidereal time of the pointing from ANTENNA1.
+//  <li> LAST2 is the local sidereal time of the pointing from ANTENNA2.
+//  <li> PA1 is the parallactic angle of the pointing from ANTENNA1.
+//  <li> PA2 is the parallactic angle of the pointing from ANTENNA2.
+//  <li> AZEL is the azimuth/elevation of the pointing from the array center.
+//  <li> AZEL1 is the azimuth/elevation of the pointing from ANTENNA1.
+//  <li> AZEL2 is the azimuth/elevation of the pointing from ANTENNA2.
+//  <li> ITRF is the pointing in (time-dependent) ITRF coordinates.
 //  <li> UVW_J2000 is the UVW coordinates in J2000 (in meters).
 // </ul>
 // All columns have data type double and unit radian (except UVW). The HADEC,

--- a/derivedmscal/DerivedMC/DerivedMSCal.h
+++ b/derivedmscal/DerivedMC/DerivedMSCal.h
@@ -70,12 +70,15 @@ namespace casacore {
 //  <li> LAST2 is the local sidereal time of ANTENNA2.
 //  <li> PA1 is the parallactic angle of ANTENNA1.
 //  <li> PA2 is the parallactic angle of ANTENNA2.
+//  <li> AZEL is the azimuth/elevation of the array center.
 //  <li> AZEL1 is the azimuth/elevation of ANTENNA1.
 //  <li> AZEL2 is the azimuth/elevation of ANTENNA2.
-//  <li> UVW_J2000 is the UVW coordinates in J2000 (in meters)
+//  <li> ITRF is the phase direction in (time-dependent) ITRF coordinates.
+//  <li> UVW_J2000 is the UVW coordinates in J2000 (in meters).
 // </ul>
 // All columns have data type double and unit radian (except UVW). The HADEC,
-// AZEL, and UVW columns are array columnns while the others are scalar columns.
+// AZEL, ITRF and UVW columns are array columnns while the others are
+// scalar columns.
 //
 // This engine is meant for a MeasurementSet, but can be used for any table
 // containing an ANTENNA and FIELD subtable and the relevant columns in the

--- a/derivedmscal/DerivedMC/MSCalEngine.cc
+++ b/derivedmscal/DerivedMC/MSCalEngine.cc
@@ -102,6 +102,12 @@ void MSCalEngine::getAzEl (Int antnr, uInt rownr, Array<double>& data)
   data = itsRADecToAzEl().getValue().get();
 }
 
+void MSCalEngine::getItrf (Int antnr, uInt rownr, Array<double>& data)
+{
+  setData (antnr, rownr);
+  data = itsRADecToItrf().getValue().get();
+}
+
 void MSCalEngine::getUVWJ2000 (uInt rownr, Array<double>& data)
 {
   setData (1, rownr);
@@ -216,6 +222,7 @@ Int MSCalEngine::setData (Int antnr, uInt rownr)
     } else {
       itsLastDirJ2000 = itsDirToJ2000();
       itsRADecToAzEl.setModel (itsLastDirJ2000);
+      itsRADecToItrf.setModel (itsLastDirJ2000);
       itsRADecToHADec.setModel(itsLastDirJ2000);
       itsFrame.resetDirection (itsLastDirJ2000);
     }
@@ -230,6 +237,7 @@ Int MSCalEngine::setData (Int antnr, uInt rownr)
     if (itsFieldDir[calInx][fieldId].isModel()) {
       itsLastDirJ2000 = itsDirToJ2000();
       itsRADecToAzEl.setModel (itsLastDirJ2000);
+      itsRADecToItrf.setModel (itsLastDirJ2000);
       itsRADecToHADec.setModel(itsLastDirJ2000);
       itsFrame.resetDirection (itsLastDirJ2000);
     }
@@ -316,6 +324,8 @@ void MSCalEngine::init()
   itsPoleToAzEl.set (mHADecPole, MDirection::Ref(MDirection::AZEL,itsFrame));
   // Set up the machine to convert RaDec to AzEl.
   itsRADecToAzEl.set (MDirection(), MDirection::Ref(MDirection::AZEL,itsFrame));
+  // Idem RaDec to ITRF.
+  itsRADecToItrf.set (MDirection(), MDirection::Ref(MDirection::ITRF,itsFrame));
   // Idem RaDec to HaDec.
   itsRADecToHADec.set (MDirection(), rHADec);
   // Idem direction to J2000.

--- a/derivedmscal/DerivedMC/MSCalEngine.h
+++ b/derivedmscal/DerivedMC/MSCalEngine.h
@@ -77,12 +77,14 @@ namespace casacore {
 //  <li> LAST2 is the local sidereal time of ANTENNA2.
 //  <li> PA1 is the parallactic angle of ANTENNA1.
 //  <li> PA2 is the parallactic angle of ANTENNA2.
+//  <li> AZEL is the azimuth/elevation of the array center.
 //  <li> AZEL1 is the azimuth/elevation of ANTENNA1.
 //  <li> AZEL2 is the azimuth/elevation of ANTENNA2.
-//  <li> UVW_J2000 is the UVW coordinates in J2000 (in meters)
+//  <li> ITRF is the direction in (time-dependent) ITRF coordinates.
+//  <li> UVW_J2000 is the UVW coordinates in J2000 (in meters).
 // </ul>
 // All values have data type double and unit radian (except UVW). The HADEC,
-// AZEL, and UVW cvalues are arrays while the others are scalars.
+// AZEL, ITRF and UVW cvalues are arrays while the others are scalars.
 //
 // This engine is meant for a MeasurementSet, but can be used for any table
 // containing an ANTENNA and FIELD subtable and the relevant columns in the
@@ -150,6 +152,9 @@ public:
   // Get the azimuth/elevation for the given row.
   void getAzEl (Int antnr, uInt rownr, Array<Double>&);
 
+  // Get the ITRF coordinates for the given row.
+  void getItrf (Int antnr, uInt rownr, Array<Double>&);
+
   // Get the UVW in J2000 for the given row.
   void getUVWJ2000 (uInt rownr, Array<Double>&);
 
@@ -208,6 +213,7 @@ private:
   MDirection::Convert         itsRADecToAzEl;  //# converter ra/dec to az/el
   MDirection::Convert         itsPoleToAzEl;   //# converter pole to az/el
   MDirection::Convert         itsRADecToHADec; //# converter ra/dec to ha/dec
+  MDirection::Convert         itsRADecToItrf;  //# converter ra/dec to itrf
   MDirection::Convert         itsDirToJ2000;   //# converter direction to J2000
   MEpoch::Convert             itsUTCToLAST;    //# converter UTC to LAST
   MBaseline::Convert          itsBLToJ2000;    //# convert ITRF to J2000

--- a/derivedmscal/DerivedMC/Register.cc
+++ b/derivedmscal/DerivedMC/Register.cc
@@ -58,6 +58,7 @@ void register_derivedmscal()
   UDFBase::registerUDF ("derivedmscal.AZEL",      UDFMSCal::makeAZEL);
   UDFBase::registerUDF ("derivedmscal.AZEL1",     UDFMSCal::makeAZEL1);
   UDFBase::registerUDF ("derivedmscal.AZEL2",     UDFMSCal::makeAZEL2);
+  UDFBase::registerUDF ("derivedmscal.ITRF",      UDFMSCal::makeITRF);
   UDFBase::registerUDF ("derivedmscal.UVWWVL",    UDFMSCal::makeUvwWvl);
   UDFBase::registerUDF ("derivedmscal.UVWWVLS",   UDFMSCal::makeUvwWvls);
   UDFBase::registerUDF ("derivedmscal.NEWUVW",    UDFMSCal::makeUVW);
@@ -93,7 +94,10 @@ namespace casacore {
 
   void HelpMsCalUDF::showFuncsDerived (ostream& os)
   {
-    os << "Derived values functions:" << endl;
+    os << "Derived direction coordinates functions" << endl;
+    os << "Direction can be given as the name of a FIELD subtable column," << endl;
+    os << "the name of a source, or a vector with source direction." << endl;
+    os << "If no direction argument is given, column PHASE_DIR is used." << endl;
     os << "  double MSCAL.HA()             "
       " hourangle of array center" << endl;
     os << "  double MSCAL.HA1()            "
@@ -112,6 +116,8 @@ namespace casacore {
       " azimuth/elevation of ANTENNA1" << endl;
     os << "  doublearray MSCAL.AZEL2()     "
       " azimuth/elevation of ANTENNA2" << endl;
+    os << "  doublearray MSCAL.ITRF()     "
+      " phase direction in ITRF coordinates" << endl;
     os << "  double MSCAL.LAST()           "
       " local sidereal time of array center" << endl;
     os << "  double MSCAL.LAST1()          "

--- a/derivedmscal/DerivedMC/UDFMSCal.cc
+++ b/derivedmscal/DerivedMC/UDFMSCal.cc
@@ -104,6 +104,8 @@ namespace casacore {
     { return new UDFMSCal (AZEL, 0); }
   UDFBase* UDFMSCal::makeAZEL2 (const String&)
     { return new UDFMSCal (AZEL, 1); }
+  UDFBase* UDFMSCal::makeITRF (const String&)
+    { return new UDFMSCal (ITRF, -1); }
   UDFBase* UDFMSCal::makeUVW (const String&)
     { return new UDFMSCal (NEWUVW, -1); }
   UDFBase* UDFMSCal::makeWvl (const String&)
@@ -189,6 +191,7 @@ namespace casacore {
       break;
     case HADEC:
     case AZEL:
+    case ITRF:
       setShape (IPosition(1,2));
       itsTmpVector.resize (2);
       setUnit ("rad");
@@ -830,6 +833,9 @@ namespace casacore {
       return MArray<Double>(itsTmpVector);
     case AZEL:
       itsEngine.getAzEl (itsArg, id.rownr(), itsTmpVector);
+      return MArray<Double>(itsTmpVector);
+    case ITRF:
+      itsEngine.getItrf (itsArg, id.rownr(), itsTmpVector);
       return MArray<Double>(itsTmpVector);
     case NEWUVW:
       itsEngine.getUVWJ2000 (id.rownr(), itsTmpVector);

--- a/derivedmscal/DerivedMC/UDFMSCal.h
+++ b/derivedmscal/DerivedMC/UDFMSCal.h
@@ -73,6 +73,7 @@ namespace casacore {
 //  <li> PA2 is the parallactic angle of ANTENNA2.
 //  <li> AZEL1 is the azimuth/elevation of ANTENNA1.
 //  <li> AZEL2 is the azimuth/elevation of ANTENNA2.
+//  <li> ITRF is the PHASE_DIR in ITRF coordinates (depends on TIME only).
 //  <li> UVW_J2000 is the UVW coordinates in J2000 (in meters)
 //  <li> STOKES makes it possible to convert Stokes of data, flag, or weight.
 //  <li> BASELINE is baseline selection using CASA syntax.
@@ -117,7 +118,7 @@ namespace casacore {
   {
   public:
     // Define the possible 'column' types.
-    enum ColType {HA, HADEC, PA, LAST, AZEL, NEWUVW,
+    enum ColType {HA, HADEC, PA, LAST, AZEL, ITRF, NEWUVW,
                   UVWWVL, UVWWVLS, NEWUVWWVL, NEWUVWWVLS,
                   STOKES, SELECTION, GETVALUE};
     // Define the possible selection types.
@@ -151,6 +152,7 @@ namespace casacore {
     static UDFBase* makeAZEL     (const String&);
     static UDFBase* makeAZEL1    (const String&);
     static UDFBase* makeAZEL2    (const String&);
+    static UDFBase* makeITRF     (const String&);
     static UDFBase* makeUVW      (const String&);
     static UDFBase* makeWvl      (const String&);
     static UDFBase* makeWvls     (const String&);

--- a/meas/MeasUDF/DirectionEngine.h
+++ b/meas/MeasUDF/DirectionEngine.h
@@ -184,7 +184,7 @@ namespace casacore {
     Unit                            itsUnit;
     MeasFrame                       itsFrame;       //# frame used by converter
     MDirection::Convert             itsConverter;
-    Vector<MDirection>              itsConstants;
+    Array<MDirection>               itsConstants;
     Vector<Double>                  itsH;           //# diff for sun or moon
     MDirection::Types               itsRefType;
     TableExprNode                   itsExprNode;


### PR DESCRIPTION
Added functionality to derivedmscal to get the ITRF coordinates for the PHASE_DIR (or another FIELD column or another direction) using the TaQL UDF mscal.itrf or as a derived column that can be added to the MS.