### PR TITLE
Cas 8875 MSFITSOutput now writes antenna diameters...

### DIFF
--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -1853,38 +1853,42 @@ void MSFitsInput::fillAntennaTable(BinaryTable& bt) {
 
     //If it has a column called DIAMETER ...make use of it if
     // any of the values are valid
+    Bool positiveDiamsFound = False;
     if (anTab.tableDesc().isColumn("DIAMETER")) {
         Vector<Float> tmpDiams = ROScalarColumn<Float>(anTab, "DIAMETER").getColumn();
         if (anyGT(tmpDiams, 0.0f)) {
             antDiams = tmpDiams;
+            positiveDiamsFound = True;
         }
     }
-    else if (_array == "OVRO" || _array == "CARMA") {
-        for (Int i = 0; i < nAnt; ++i) {
-            //Crystal Brogan has guaranteed that it is always this order
-            if (id(i) <= 6) {
-                antDiams(i) = 10.4;
-            }
-            else {
-                antDiams(i) = 6.1;
+    if (! positiveDiamsFound) {
+        if (_array == "OVRO" || _array == "CARMA") {
+            for (Int i = 0; i < nAnt; ++i) {
+                //Crystal Brogan has guaranteed that it is always this order
+                if (id(i) <= 6) {
+                    antDiams(i) = 10.4;
+                }
+                else {
+                    antDiams(i) = 6.1;
+                }
             }
         }
-    }
-    else if (_array == "ALMA") {
-        // CAS-8875, algorithm from Jen Meyer
-        for (Int i = 0; i < nAnt; ++i) {
-            String myName = name(i);
-            if (myName.startsWith("CM")) {
-                antDiams[i] = 7.0;
-            }
-            else if (
-                myName.startsWith("DA") || myName.startsWith("DV")
-                || myName.startsWith("PM")
-            ) {
-                antDiams[i] = 12.0;
-            }
-            else {
-                antDiams[i] = diameter;
+        else if (_array == "ALMA") {
+            // CAS-8875, algorithm from Jen Meyer
+            for (Int i = 0; i < nAnt; ++i) {
+                String myName = name(i);
+                if (myName.startsWith("CM")) {
+                    antDiams[i] = 7.0;
+                }
+                else if (
+                    myName.startsWith("DA") || myName.startsWith("DV")
+                    || myName.startsWith("PM")
+                ) {
+                    antDiams[i] = 12.0;
+                }
+                else {
+                    antDiams[i] = diameter;
+                }
             }
         }
     }

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -1865,18 +1865,13 @@ void MSFitsInput::fillAntennaTable(BinaryTable& bt) {
         if (_array == "OVRO" || _array == "CARMA") {
             for (Int i = 0; i < nAnt; ++i) {
                 //Crystal Brogan has guaranteed that it is always this order
-                if (id(i) <= 6) {
-                    antDiams(i) = 10.4;
-                }
-                else {
-                    antDiams(i) = 6.1;
-                }
+                antDiams[i] = id(i) <= 6 ? 10.4 : 6.1;
             }
         }
         else if (_array == "ALMA") {
             // CAS-8875, algorithm from Jen Meyer
             for (Int i = 0; i < nAnt; ++i) {
-                String myName = name(i);
+                const String& myName = name(i);
                 if (myName.startsWith("CM")) {
                     antDiams[i] = 7.0;
                 }

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -237,8 +237,9 @@ void MSPrimaryTableHolder::detach() {
 //------------------------------------------------------------
 MSFitsInput::MSFitsInput(const String& msFile, const String& fitsFile,
         const Bool useNewStyle) :
-    _infile(0), _msc(0), _uniqueAnts(), _nAntRow(0), _restfreq(0), _addSourceTable(False), _log(LogOrigin(
-            "MSFitsInput", "MSFitsInput")), _newNameStyle(useNewStyle), _msCreated(False) {
+    _infile(0), _msc(0), _uniqueAnts(), _nAntRow(0), _restfreq(0),
+    _addSourceTable(False), _log(LogOrigin("MSFitsInput", "MSFitsInput")),
+    _newNameStyle(useNewStyle), _msCreated(False), _rotateAnts(False) {
     // First, lets verify that fitsfile exists and that it appears to be a
     // FITS file.
     File f(fitsFile);
@@ -1859,7 +1860,7 @@ void MSFitsInput::fillAntennaTable(BinaryTable& bt) {
         }
     }
     else if (_array == "OVRO" || _array == "CARMA") {
-        for (Int i = 0; i < nAnt; i++) {
+        for (Int i = 0; i < nAnt; ++i) {
             //Crystal Brogan has guaranteed that it is always this order
             if (id(i) <= 6) {
                 antDiams(i) = 10.4;
@@ -1871,7 +1872,7 @@ void MSFitsInput::fillAntennaTable(BinaryTable& bt) {
     }
     else if (_array == "ALMA") {
         // CAS-8875, algorithm from Jen Meyer
-        for (Int i = 0; i < nAnt; i++) {
+        for (Int i = 0; i < nAnt; ++i) {
             String myName = name(i);
             if (myName.startsWith("CM")) {
                 antDiams[i] = 7.0;

--- a/msfits/MSFits/MSFitsOutput.cc
+++ b/msfits/MSFits/MSFitsOutput.cc
@@ -1678,7 +1678,7 @@ Bool MSFitsOutput::writeAN(FitsOutput *output, const MeasurementSet &ms,
         ///    desc.addField("POLCALB", TpArrayFloat,           // POLCALB
         ///          IPosition(1,0));
         desc.addField("POLCALB", TpFloat); // POLCALB
-
+        desc.addField("DIAMETER", TpFloat);
         MSAntenna antennaTable = ms.antenna();
         ROMSAntennaColumns antennaCols(antennaTable);
 
@@ -1714,12 +1714,11 @@ Bool MSFitsOutput::writeAN(FitsOutput *output, const MeasurementSet &ms,
         RecordFieldPtr<Float> staxof(writer.row(), "STAXOF");
         RecordFieldPtr<String> poltya(writer.row(), "POLTYA");
         RecordFieldPtr<Float> polaa(writer.row(), "POLAA");
-        ///    RecordFieldPtr< Array<Float> > polcala(writer.row(), "POLCALA");
         RecordFieldPtr<Float> polcala(writer.row(), "POLCALA");
         RecordFieldPtr<String> poltyb(writer.row(), "POLTYB");
         RecordFieldPtr<Float> polab(writer.row(), "POLAB");
-        ///    RecordFieldPtr< Array<Float> > polcalb(writer.row(), "POLCALB");
         RecordFieldPtr<Float> polcalb(writer.row(), "POLCALB");
+        RecordFieldPtr<Float> diam(writer.row(), "DIAMETER");
 
         // Set the ones we're not going to change once
         *orbparm = 0.0;
@@ -1739,6 +1738,7 @@ Bool MSFitsOutput::writeAN(FitsOutput *output, const MeasurementSet &ms,
         // Also: if writeStation==True use station names instead of antenna names
         // for the output fits file (input fits file tends to have this).
         Vector<String> anames = antid.getColumn();
+        Vector<Double> antDiams = msmd.getAntennaDiameters().getValue("m");
         if (anames.nelements() > 0) {
             if (writeStation || allEQ(anames, anames(0))) {
                 Vector<String> stations = inantname.getColumn();
@@ -1825,6 +1825,7 @@ Bool MSFitsOutput::writeAN(FitsOutput *output, const MeasurementSet &ms,
                         << "Could not find polarization types for antenna "
                         << antnum << LogIO::POST;
             }
+            *diam = antDiams[antnum];
             writer.write();
         }
     }


### PR DESCRIPTION
MSFITSInput now uses algorithm supplied by Jen Meyer to write ALMA antenna diameters if no ant diameters are supplied in the uvfits file.
Changed a couple ++ operators from postfix to prefix as loop incrementers
Initialized a object field that wasn't being initialized that was causing a unit test to fail under some circumstances. 