### PR TITLE
Fix minor issue in JsonKVMap.h

### DIFF
--- a/casa/Json/JsonKVMap.h
+++ b/casa/Json/JsonKVMap.h
@@ -69,8 +69,8 @@ namespace casacore {
   class JsonKVMap: public std::map<String, JsonValue>
   {
   public:
-    typedef map<String,JsonValue>::const_iterator const_iterator;
-    typedef map<String,JsonValue>::iterator iterator;
+    typedef std::map<String,JsonValue>::const_iterator const_iterator;
+    typedef std::map<String,JsonValue>::iterator iterator;
 
     JsonKVMap();
       


### PR DESCRIPTION
In JsonKVMap.h, the namespace was not added to `map`. Not sure why this is allowed in new compilers, but GCC 4.4.3 complains about it, and I agree with it.