### PR TITLE
Cas 8482 fix unwrap bug in GaussianBeam and refactor that code into own method

### DIFF
--- a/images/Images/ImageBeamSet.cc
+++ b/images/Images/ImageBeamSet.cc
@@ -512,7 +512,7 @@ Record ImageBeamSet::toRecord() const {
     return perPlaneBeams;
 }
 
-void ImageBeamSet::rotate(const Quantity& angle) {
+void ImageBeamSet::rotate(const Quantity& angle, Bool unwrap) {
     ThrowIf(
         ! angle.isConform("rad"),
         "Quantity is not an angle"
@@ -520,11 +520,11 @@ void ImageBeamSet::rotate(const Quantity& angle) {
     Matrix<GaussianBeam>::iterator iter = _beams.begin();
     Matrix<GaussianBeam>::iterator end = _beams.end();
     while(iter != end) {
-        iter->setPA(iter->getPA(True) + angle);
+        iter->setPA(iter->getPA(True) + angle, unwrap);
         ++iter;
     }
-    _minBeam.setPA(_minBeam.getPA() + angle);
-    _maxBeam.setPA(_maxBeam.getPA() + angle);
+    _minBeam.setPA(_minBeam.getPA() + angle, unwrap);
+    _maxBeam.setPA(_maxBeam.getPA() + angle, unwrap);
 }
 
 void ImageBeamSet::summarize(

--- a/images/Images/ImageBeamSet.h
+++ b/images/Images/ImageBeamSet.h
@@ -265,7 +265,9 @@ public:
     void summarize(LogIO& log, Bool verbose, const CoordinateSystem& csys) const;
 
     // Modify the beam set by rotating all beams counterclockwise through the specified angle.
-    void rotate(const Quantity& angle);
+    // If unwrap=True, unwrap the new position angle(s) so that it falls in the range -90 to
+    // 90 degrees before setting it.
+    void rotate(const Quantity& angle, Bool unwrap=False);
 
 private:
 

--- a/scimath/Mathematics/GaussianBeam.h
+++ b/scimath/Mathematics/GaussianBeam.h
@@ -136,7 +136,9 @@ public:
 
     void setMajorMinor(const Quantity& majAx, const Quantity& minAx);
 
-    void setPA(const Quantity& pa);
+    // if unwrap=True, unwrap pa so its value lies in the range
+    // -90 to 90 degrees before setting it.
+    void setPA(const Quantity& pa, Bool unwrap=False);
 
     static GaussianBeam fromRecord(const Record& rec);
 
@@ -151,6 +153,9 @@ public:
 
 protected:
     Quantity _major, _minor, _pa;
+
+private:
+    static Quantity _unwrap(const Quantity& pa);
 
 };
 

--- a/scimath/Mathematics/test/tGaussianBeam.cc
+++ b/scimath/Mathematics/test/tGaussianBeam.cc
@@ -129,6 +129,20 @@ int main() {
         v = beam.toVector();
         GaussianBeam beam4(v);
         AlwaysAssert(beam4 == beam3, AipsError);
+        {
+            cout << "Test  setPA() and getPA() using unwrapping" << endl;
+            Double u = 60;
+            for (Double d=-660; d<=660; d+=30, u+=30) {
+                if (u > 90) {
+                    u -= 180;
+                }
+                beam.setPA(Quantity(d, "deg"), False);
+                AlwaysAssert(beam.getPA(False).getValue("deg") == d, AipsError);
+                AlwaysAssert(beam.getPA(True).getValue("deg") == u, AipsError);
+                beam.setPA(Quantity(d, "deg"), True);
+                AlwaysAssert(beam.getPA(False).getValue("deg") == u, AipsError);
+            }
+        }
     }
     catch (AipsError x) {
         cout << x.getMesg() << endl;


### PR DESCRIPTION
Add optional unwrap parameter to GaussianBeam::setPA()
Add tests to test unwrap parameter in GaussianBeam::getPA()/setPA()
Add optional unwrap parameter to ImageBeamSet::rotate().