### PR TITLE
Make TableProxy Record to TableDesc static methods public

### DIFF
--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -1696,7 +1696,7 @@ Bool TableProxy::makeHC (const Record& gdesc, TableDesc& tabdesc,
 Bool TableProxy::makeTableDesc (const Record& gdesc, TableDesc& tabdesc,
 				String& message)
 {
-    for(uInt nrdone=0; nrdone < gdesc.nfields(); ++nrdone)
+    for(uInt nrdone=0, nrcols=0; nrdone < gdesc.nfields(); ++nrdone)
     {
         String name = gdesc.name(nrdone);
         const Record& cold (gdesc.asRecord(nrdone));
@@ -1821,13 +1821,15 @@ Bool TableProxy::makeTableDesc (const Record& gdesc, TableDesc& tabdesc,
         }
         // Set maximum string length.
         if (maxlen > 0) {
-            tabdesc.rwColumnDesc(nrdone).setMaxLength (maxlen);
+            tabdesc.rwColumnDesc(nrcols).setMaxLength (maxlen);
         }
         // Define the keywords if needed.
         if (cold.isDefined ("keywords")) {
-            TableRecord& keySet (tabdesc.rwColumnDesc(nrdone).rwKeywordSet());
+            TableRecord& keySet (tabdesc.rwColumnDesc(nrcols).rwKeywordSet());
             keySet.fromRecord (cold.asRecord("keywords"));
         }
+
+        ++nrcols;
     }
 
     if (gdesc.isDefined ("_define_hypercolumn_"))

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -1696,36 +1696,26 @@ Bool TableProxy::makeHC (const Record& gdesc, TableDesc& tabdesc,
 Bool TableProxy::makeTableDesc (const Record& gdesc, TableDesc& tabdesc,
 				String& message)
 {
-    for(uInt nrdone=0, nrcols=0; nrdone < gdesc.nfields(); ++nrdone)
-    {
+    for(uInt nrdone=0, nrcols=0; nrdone < gdesc.nfields(); ++nrdone) {
         String name = gdesc.name(nrdone);
         const Record& cold (gdesc.asRecord(nrdone));
 
         // Avoid special records for now
-        if(name == "_define_hypercolumn_")
-        {
+        if(name == "_define_hypercolumn_") {
             // Ignore, for now, handled later
             continue;
-        }
-        else if(name == "_define_dminfo_")
-        {
+        } else if(name == "_define_dminfo_") {
             // Ignore, this is obsolete
             continue;
-        }
-        else if(name == "_keywords_")
-        {
+        } else if(name == "_keywords_") {
             // Unpack keywords into TableDesc
             tabdesc.rwKeywordSet().fromRecord(cold);
             continue;
-        }
-        else if(name == "_private_keywords_")
-        {
+        } else if(name == "_private_keywords_") {
             // Ignore, private keywords are not
             // publicly accessable on TableDesc
             continue;
-        }
-        else if(!cold.isDefined("valueType"))
-        {
+        } else if(!cold.isDefined("valueType")) {
             // Assume it is a column and complain as
             // no value type exists to describe it
             message = "No value type for column " + name;
@@ -1832,10 +1822,8 @@ Bool TableProxy::makeTableDesc (const Record& gdesc, TableDesc& tabdesc,
         ++nrcols;
     }
 
-    if (gdesc.isDefined ("_define_hypercolumn_"))
-    {
-        if (! makeHC (gdesc.asRecord("_define_hypercolumn_"), tabdesc, message))
-        {
+    if (gdesc.isDefined ("_define_hypercolumn_"))  {
+        if (! makeHC (gdesc.asRecord("_define_hypercolumn_"), tabdesc, message))  {
             return False;
         }
     }

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -908,23 +908,33 @@ void TableProxy::setProperties (const String& name, Bool byColumn,
 Record TableProxy::getTableDescription (Bool actual, Bool cOrder)
 {
   // Get the table description.
-  TableDesc* tableDescPtr;
+  const TableDesc* tableDescPtr;
   if (actual) {
     tableDescPtr = new TableDesc(table_p.actualTableDesc());
   } else {
     tableDescPtr = new TableDesc(table_p.tableDesc());
   }
-  // Return the table description as a record.
-  Record rec;
-  for (uInt i=0; i<tableDescPtr->ncolumn(); i++) {
-    const ColumnDesc& columnDescription = tableDescPtr->columnDesc(i);
-    rec.defineRecord (columnDescription.name(), 
-		      recordColumnDesc (columnDescription, cOrder));
-  }
-  rec.defineRecord ("_define_hypercolumn_", recordHCDesc (*tableDescPtr));
+  Record rec = getTableDesc(*tableDescPtr, cOrder);
+
   delete tableDescPtr;
   return rec;
 }
+
+Record TableProxy::getTableDesc(const TableDesc & tabdesc, Bool cOrder)
+{
+    Record rec;
+
+    for (uInt i=0; i<tabdesc.ncolumn(); i++) {
+      const ColumnDesc& columnDescription = tabdesc.columnDesc(i);
+      rec.defineRecord (columnDescription.name(),
+                recordColumnDesc (columnDescription, cOrder));
+    }
+
+    rec.defineRecord ("_define_hypercolumn_", recordHCDesc (tabdesc));
+
+    return rec;
+}
+
 
 Record TableProxy::getColumnDescription (const String& columnName,
 					 Bool actual, Bool cOrder)

--- a/tables/Tables/test/tTableRecord.cc
+++ b/tables/Tables/test/tTableRecord.cc
@@ -834,6 +834,10 @@ void testTable (Bool doExcp)
     td3.addColumn (ScalarColumnDesc<float> ("col1"));
     td3.addColumn (ScalarColumnDesc<double> ("col2"));
 
+
+    uInt keyvalue1 = 10;
+    td3.rwKeywordSet().define("key1", keyvalue1);
+
     // Add a hypercolumn
     Vector<String> dcnames(2);
     dcnames[0] = "dcol1";
@@ -878,6 +882,11 @@ void testTable (Bool doExcp)
         AlwaysAssertExit (icnames[i] == icresult[i]);
 
     }
+
+    // Check that the keyword matches the original value
+    keyvalue1 = 20;
+    td4.keywordSet().get("key1", keyvalue1);
+    AlwaysAssertExit (keyvalue1 == 10);
 }
 
 void testTable2 (Bool)


### PR DESCRIPTION
Previously, much of the functionality for constructing a TableDesc
object from the more generic (and python convertible) Record object class was
static private. This meant that it was only possible to perform this
conversion within TableProxy methods.

By contrast, the functionality for constructing a Record
from the internal TableDesc (via TableProxy.getTableDescription) is public.

This commit changes many of the static private methods for constructing
a TableDesc from a Record public. By doing so, it becomes possible to
create more flexible C++ functions for creating various types of tables
from python-casacore. In particular, this makes it possible to create
default MeasurementSet tables from python while supplying additional table
description parameters. For example:

```cpp
TableProxy makems(const String & name, const Record & tabdesc)
{
    TableDesc required_td = MeasurementSet::requiredTableDesc();
    TableDesc user_td;
    String message;

    TableProxy::makeTableDesc(tabdesc, user_td, message);
    required_td.add(user_td);

    SetupNewTable new_table(name, required_td, Table::New);
    MeasurementSet ms(new_table);
    ms.createDefaultSubtables(Table::New);
    return TableProxy(ms);
}
```

It may be better at some point to abstract the Record to/from TableDesc
functionality out of TableProxy at some point, but this simple change at
least makes the functionality accessible.

See also: https://github.com/casacore/python-casacore/issues/61