### PR TITLE
Disable travis test on OSX, until #503 is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: ccache
 
 os:
   - linux
-  - osx
+#  - osx
 
 compiler:
   - clang


### PR DESCRIPTION
Solving issue #503 and #507 takes some time. In the meantime we could limit the testing to linux.