### PR TITLE
Removing message that may be put for developer testing.

### DIFF
--- a/casa/Arrays/Cube.tcc
+++ b/casa/Arrays/Cube.tcc
@@ -327,7 +327,6 @@ template<class T> const Matrix<T> Cube<T>::xzPlane(size_t which) const
     Cube<T> *This = const_cast<Cube<T>*>(this);
     // Cast away constness, but the return type is a const Matrix<T>, so
     // this should still be safe.
-    cout << "test" << endl;
     return This->xzPlane(which);
 }
 


### PR DESCRIPTION
I found that Cube<T>::xzPlane(size_t) const outputs a message "test" to stdout. Since this is completely meaningless from the user's point of view, I guess it is temporary message for development that supposed to be removed finally. 

This request is just to remove the message. No functional change is made.