### PR TITLE
Remove use of assert() in Error.h

### DIFF
--- a/casa/Exceptions/Error.h
+++ b/casa/Exceptions/Error.h
@@ -53,7 +53,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // NDEBUG is not defined (release build) then a throw is used to report the error.
 
 #ifdef NDEBUG
-#define AssertCc(c) {assert (c); }
+#define AssertCc(c) ((void)0)
 #else
 #define AssertCc(c) { if (! (c)) {casacore::AipsError::throwIf (casacore::True, "Assertion failed: " #c, __FILE__, __LINE__, __PRETTY_FUNCTION__); }}
 #endif
@@ -69,7 +69,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Asserts when in debug build and issues a warning message to the log in release.
 #if defined (NDEBUG)
-#define AssertOrWarn(c,m) {assert (c);}
+#define AssertOrWarn(c,m) ((void)0)
 #else
 #define AssertOrWarn(c,m)\
 { if (! (c)) {\


### PR DESCRIPTION
CASA Assert* macro definitions are dependent on whether NDEBUG is defined or
not, such that when NDEBUG is defined, the CASA macros are defined in terms of
the standard assert() macro. However, when NDEBUG is defined, the assert() macro
is effectively a no-op. The drawback of maintaining the inclusion of the
assert() macro is that it requires the assert.h header file, which is actually
missing from the Error.h file. Rather than include the header file so that
compilation works in the case of NDEBUG being defined, removing the use of
assert() in that case, in which it becomes a no-op, is the better solution.