### PR TITLE
Issue #572 Properly copy "valid" when Convolver object is copied.

### DIFF
--- a/scimath/Mathematics/Convolver.tcc
+++ b/scimath/Mathematics/Convolver.tcc
@@ -62,6 +62,7 @@ Convolver(const Convolver<FType>& other){
   thePsf = other.thePsf;
   theFFT = other.theFFT;
   theIFFT = other.theIFFT;
+  valid = other.valid;
   doFast_p=False;
 }
 
@@ -78,6 +79,7 @@ Convolver<FType>::operator=(const Convolver<FType> & other){
     thePsf = other.thePsf;
     theFFT = other.theFFT;
     theIFFT = other.theIFFT;
+    valid = other.valid;
     doFast_p=False;
   }
   return *this;


### PR DESCRIPTION
This is a possible fix for the issue #572. Please merge it if appropriate.