### PR TITLE
Travis: re-run failed test with verbose output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
   - ccache -s
   - ccache -z
   - make -j2
-  - make test
+  - env CTEST_OUTPUT_ON_FAILURE=1 make test
   - make install
   - ccache -s
 


### PR DESCRIPTION
This change re-runs all failed tests on Travis. This should make it easier to spot why a test failed.