### PR TITLE
Only skip over a subtable if it actually contains data

### DIFF
--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -328,7 +328,8 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 	  }
 	}
 	else{ // ignore this subtable
-	  infits.skip_all(FITS::BinaryTableHDU);
+	  if (infits.datasize() > 0)
+	    infits.skip_all(FITS::BinaryTableHDU);
 	}
       }
     }


### PR DESCRIPTION
This fixes importing FITS-IDI files produced by DiFX, which produces
empty subtables if certain metadata is missing for all stations.