### PR TITLE
Fixed ImageConcat problem with ImageInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,19 +254,21 @@ endif()
 #
 #This has measurable impact on e.g. applycal where the cpu performance improves
 #by about 20%.
-check_cxx_compiler_flag(-fcx-fortran-rules HAS_GXX_FORTRAN_RULES)
-check_c_compiler_flag(-fcx-fortran-rules HAS_GCC_FORTRAN_RULES)
-# added before cmake flags so it can be disabled with
-# -fno-cx-fortran-rules for testing
-if (HAS_GXX_FORTRAN_RULES)
-    set(CMAKE_CXX_FLAGS "-fcx-fortran-rules ${CMAKE_CXX_FLAGS}")
-endif()
-if (HAS_GCC_FORTRAN_RULES)
-    set(CMAKE_C_FLAGS "-fcx-fortran-rules ${CMAKE_C_FLAGS}")
-endif()
-
-# Ensure clang is not complaining about unused arguments.
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+# For one reason or another the check on the compiler flag has no
+# effect; it still adds the option which fails for clang.
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    check_cxx_compiler_flag(-fcx-fortran-rules HAS_GXX_FORTRAN_RULES)
+    check_c_compiler_flag(-fcx-fortran-rules HAS_GCC_FORTRAN_RULES)
+    # added before cmake flags so it can be disabled with
+    # -fno-cx-fortran-rules for testing
+    if (HAS_GXX_FORTRAN_RULES)
+        set(CMAKE_CXX_FLAGS "-fcx-fortran-rules ${CMAKE_CXX_FLAGS}")
+    endif()
+    if (HAS_GCC_FORTRAN_RULES)
+        set(CMAKE_C_FLAGS "-fcx-fortran-rules ${CMAKE_C_FLAGS}")
+    endif()
+else()
+    # Ensure clang is not complaining about unused arguments.
     set(CMAKE_CXX_FLAGS "-Qunused-arguments ${CMAKE_CXX_FLAGS}")    
     set(CMAKE_C_FLAGS "-Qunused-arguments ${CMAKE_C_FLAGS}")    
 endif()

--- a/images/Images/ImageConcat.tcc
+++ b/images/Images/ImageConcat.tcc
@@ -292,10 +292,12 @@ void ImageConcat<T>::setImage (ImageInterface<T>& image, Bool relax)
     this->setImageInfo (image.imageInfo());
     this->setMiscInfoMember (image.miscInfo());
     this->setCoordinates();
-  } else if (combineMiscInfo_p) {
-    TableRecord rec = miscInfo();
-    rec.merge (image.miscInfo(), RecordInterface::RenameDuplicates);
-    this->setMiscInfoMember (rec);
+  } else {
+    if (combineMiscInfo_p) {
+      TableRecord rec = miscInfo();
+      rec.merge (image.miscInfo(), RecordInterface::RenameDuplicates);
+      this->setMiscInfoMember (rec);
+    }
 
     // Combine the beams if possible.
     // Should be done before the coordinates are merged.

--- a/images/Images/test/tFITSImage.run
+++ b/images/Images/test/tFITSImage.run
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-$casa_checktool ./tFITSImage | fold -w 80 | sed 's/DATE    =\(.*written\)   /DATE =>>>\1<<</' | sed 's/ORIGIN  = \x27casacore-\([^ ]*\)\x27/ORIGIN  = \x27casacore->>>\1<<<\x27/'
+# Make output independent of date and version.
+$casa_checktool ./tFITSImage | fold -w 80 | sed 's/DATE    =\(.*written\)   /DATE =>>>\1<<</' | sed "s/ORIGIN  = 'casacore-\(.*\)'/ORIGIN  = 'casacore->>>\1<<<'/"


### PR DESCRIPTION
The CAS-9605 was not fully correct, because the ImageInfo (beam info) was not always combined.

It also appeared that the sed command in tFITSIMage did not always work properly, so it has been fixed.
