### PR TITLE
Handle FITS-IDI that uses the WEIGHT random parameter

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -298,10 +298,10 @@ protected:
   Bool weather_hasWater_p;
   Bool weather_hasElectron_p;
   Bool uv_data_hasWeights_p;
-  Bool weightKwPresent_p;
   Bool weightypKwPresent_p;
   String weightyp_p;
-  Matrix<Float> weightsFromKW_p;
+  Int nStokes_p;
+  Int nBand_p;
   static SimpleOrderedMap<Int,Int> antIdFromNo;
 
   //


### PR DESCRIPTION
FITS-IDI generated by the DiFX software correlator has weights encoded in
the WEIGHT random parameter instead of encoding it along the COMPLEX axis.
This replaces the no-working/unused code that looked for a WEIGHT keyword
which doesn't exist in FITS-IDI.

Tested with both GMVA data (DiFX data that uses the WEIGHT random parameter)
and EVN data (SFXC data that stores weights along the COMPLEX axis).
