### PR TITLE
Implement digital corrections for DiFX/VLBA

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -121,7 +121,7 @@ public:
   // The only constructor is from a FitsInput.
   //
 
-  FITSIDItoMS1(FitsInput& in, const Int& obsType=0, const Bool& initFirstMain=True);
+  FITSIDItoMS1(FitsInput& in, const String& correlat, const Int& obsType=0, const Bool& initFirstMain=True);
 
   ~FITSIDItoMS1();
   
@@ -290,6 +290,7 @@ protected:
   Double startTime_p;
   Double lastTime_p;
   Int itsObsType;
+  String itsCorrelat;
   MeasurementSet ms_p;
   MSColumns* msc_p;
   static Bool firstMain;
@@ -303,6 +304,7 @@ protected:
   Int nStokes_p;
   Int nBand_p;
   static SimpleOrderedMap<Int,Int> antIdFromNo;
+  static SimpleOrderedMap<Int,Int> digiLevels;
 
   //
   //# Member Functions

--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -288,10 +288,23 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
   Vector<String> subTableName;
   Int subTableNr = -1;
   Table maintab;
-  
+
+  // Correlator
+  String correlat;
+
   // Loop over all HDU in the FITS-IDI file
   Bool initFirstMain = True;
   while (infits.err() == FitsIO::OK && !infits.eof()) {
+
+    // Fetch correlator name from the primary HDU
+    if (infits.hdutype() == FITS::PrimaryArrayHDU) {
+      BytePrimaryArray tab(infits);
+      if (tab.kw("CORRELAT")) {
+	correlat = tab.kw("CORRELAT")->asString();
+	correlat.trim();
+	os << LogIO::NORMAL << "Correlator: " << correlat << LogIO::POST;
+      }
+    }
 
     // Skip non-binary table HDU's
     if (infits.hdutype() != FITS::BinaryTableHDU) {
@@ -304,7 +317,7 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 
     } else {
       // Process the FITS-IDI input from the position of this binary table
-      FITSIDItoMS1 bintab(infits, itsObsType, initFirstMain);
+      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain);
       initFirstMain = False;
       String hduName = bintab.extname();
       hduName = hduName.before(trailing);


### PR DESCRIPTION
Data correlated with the DiFX correlator needs to have quantization
corrections applied.  Since these corrections are different for auto
correlations and cross correlations it is easiest to apply them while
importing the data.  This implementation matches what the AIPS FITLD task
does and what is described in VLBA Correlator Memo 75 and VLBA Scientific
Memo 12.