### PR TITLE
Properly initialize weights when importing FITS-IDI

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -312,6 +312,7 @@ protected:
   Int nBand_p;
   static SimpleOrderedMap<Int,Int> antIdFromNo;
   static SimpleOrderedMap<Int,Int> digiLevels;
+  static Vector<Double> effChBw;
 
   //
   //# Member Functions


### PR DESCRIPTION
Initialize the WEIGHT/WEIGHT_SPECTRUM and SIGMA/SIGMA_SPECTRUM columns
in a way that is compatible with the conventions used by CASA 4.4 an later.
This uses the correlator weights to calculate the effective integration time
that is used in the caclulation of the expected per-channel noise.
This should make is possible to combine data with different integration
times and channel widths.