### PR TITLE
Fix transpose problem of FITS PC matrix found in CAS-9993

### DIFF
--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -485,7 +485,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    while (cunit(i).length() < 8) cunit(i) += " ";
 	}
 //
-	pc = cSys.linearTransform();
+	Matrix<Double> imageLT = cSys.linearTransform();
+	pc = imageLT;
+	// need to transpose to conform with FITSKeywordUtil
+	for(uInt i=0; i<imageLT.nrow(); i++){
+	  for(uInt j=0; j<imageLT.ncolumn(); j++){
+	    pc(i,j) = imageLT(j,i);
+	  }
+	}
 
 	return True;
     }

--- a/fits/FITS/FITSKeywordUtil.cc
+++ b/fits/FITS/FITSKeywordUtil.cc
@@ -340,7 +340,7 @@ Bool FITSKeywordUtil::addKeywords(FitsKeywordList &out,
  			Int ii = k % nrow + 1;
  			Int jj = k / nrow + 1;
 			ostringstream ostr;
-			if(nrow>9){
+			if(nrow>9){ // i.e. the indices have more than one digit
 			  ostr << setfill('0') << setw(2) << ii
 			       << "_"
 			       << setfill('0') << setw(2) << jj;


### PR DESCRIPTION
This is part 2 of 2 of the fix for CAS-9993 / CAS-10342 (the latter ticket needed to be filed for technical reasons as a continuation of CAS-9993). The problem solved here is that the PC matrix written by FITSKeywordUtil.cc is transposed w.r.t. its proper value. However, FITSKeywordUtil.cc is self-consistent in its read/write behaviour. The problem is therefore solved at the transition from the image representation of the linear image coordinates transformation to the PC matrix, i.e. in FITSCoordinateUtil.cc where the pc matrix is retrieved from the CASA image.
Comprehensive tests were performed to verify that the change (a) solves the problem within the CASA framework and (b) does not damage anything else in casacore.
As promised in pull 606, I also added the comment explaining the magic number 9 in FITSCoordinateUtil.cc .