### PR TITLE
Cas 10358 add clone() method, allow user to set max number of threads

### DIFF
--- a/scimath/Mathematics/ChauvenetCriterionStatistics.h
+++ b/scimath/Mathematics/ChauvenetCriterionStatistics.h
@@ -64,6 +64,9 @@ public:
         const ChauvenetCriterionStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+ 
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::CHAUVENETCRITERION;

--- a/scimath/Mathematics/ChauvenetCriterionStatistics.tcc
+++ b/scimath/Mathematics/ChauvenetCriterionStatistics.tcc
@@ -61,6 +61,11 @@ ChauvenetCriterionStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* ChauvenetCriterionStatistics<CASA_STATP>::clone() const {
+    return new ChauvenetCriterionStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 void ChauvenetCriterionStatistics<CASA_STATP>::reset() {
     ConstrainedRangeStatistics<CASA_STATP>::reset();
     _rangeIsSet = False;

--- a/scimath/Mathematics/ClassicalStatistics.h
+++ b/scimath/Mathematics/ClassicalStatistics.h
@@ -58,19 +58,19 @@ template <class T> class PtrHolder;
 
 template <class AccumType, class DataIterator, class MaskIterator=const Bool*, class WeightsIterator=DataIterator> 
 class ClassicalStatistics
-    : public StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator> {
+    : public StatisticsAlgorithm<CASA_STATP> {
 public:
 
     ClassicalStatistics();
 
     // copy semantics
-    ClassicalStatistics(const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& cs);
+    ClassicalStatistics(const ClassicalStatistics<CASA_STATP>& cs);
 
     virtual ~ClassicalStatistics();
 
     // copy semantics
-    ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
-        const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
+    ClassicalStatistics<CASA_STATP>& operator=(
+        const ClassicalStatistics<CASA_STATP>& other
     );
 
     // Clone this instance
@@ -195,7 +195,13 @@ public:
     virtual void setCalculateAsAdded(Bool c);
 
     // An exception will be thrown if setCalculateAsAdded(True) has been called.
-    void setDataProvider(StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider);
+    void setDataProvider(StatsDataProvider<CASA_STATP> *dataProvider);
+
+    // set the maximum number of threads. If 0, the object decides. This is useful if
+    // the calling from a parallelized loop to force only one thread to execute in
+    // the called method, because otherwise unexpected results may occur. If not compiled
+    // with openmp support, this has no effect; a single thread is always used.
+    void setMaxThreads(uInt nThreadsMax);
 
     void setStatsToCalculate(std::set<StatisticsData::STATS>& stats);
 
@@ -657,6 +663,7 @@ private:
     Int64 _idataset;
     Bool _calculateAsAdded, _doMaxMin, _doMedAbsDevMed, _mustAccumulate,
         _hasData;
+    uInt _nThreadsMax;
 
     // mutables, used to mitigate repeated code
     mutable typename vector<DataIterator>::const_iterator _dend, _diter;
@@ -811,8 +818,6 @@ private:
     // _npts will be used if it has been previously calculated. If not, the data sets will
     // be scanned to determine npts.
     std::set<uInt64> _medianIndices(CountedPtr<uInt64> knownNpts);
-
-    uInt _nThreadsMax() const;
 
     uInt _threadIdx() const;
 

--- a/scimath/Mathematics/ClassicalStatistics.h
+++ b/scimath/Mathematics/ClassicalStatistics.h
@@ -73,6 +73,9 @@ public:
         const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
     );
 
+    // Clone this instance
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+    
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::CLASSICAL;

--- a/scimath/Mathematics/ClassicalStatistics.tcc
+++ b/scimath/Mathematics/ClassicalStatistics.tcc
@@ -55,6 +55,7 @@ ClassicalStatistics<CASA_STATP>::ClassicalStatistics()
       _idataset(0), _calculateAsAdded(False), _doMaxMin(True),
       _doMedAbsDevMed(False), _mustAccumulate(False) {
     reset();
+    setMaxThreads(0);
 }
 
 CASA_STATD
@@ -67,7 +68,7 @@ ClassicalStatistics<CASA_STATP>::ClassicalStatistics(
     _statsData(cs._statsData),
     _idataset(cs._idataset),_calculateAsAdded(cs._calculateAsAdded),
     _doMaxMin(cs._doMaxMin), _doMedAbsDevMed(cs._doMedAbsDevMed), _mustAccumulate(cs._mustAccumulate),
-    _hasData(cs._hasData) {
+    _hasData(cs._hasData), _nThreadsMax(cs._nThreadsMax) {
 }
 
 CASA_STATD
@@ -86,6 +87,7 @@ ClassicalStatistics<CASA_STATP>::operator=(
     _doMedAbsDevMed = other._doMedAbsDevMed;
     _mustAccumulate = other._mustAccumulate;
     _hasData = other._hasData;
+    _nThreadsMax = other._nThreadsMax;
     return *this;
 }
 
@@ -480,11 +482,10 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
         return copy(stats);
     }
     _initIterators();
-    uInt nThreadsMax = _nThreadsMax();
     PtrHolder<StatsData<AccumType> > tStats(
-        new StatsData<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new StatsData<AccumType>[CACHE_PADDING*_nThreadsMax], True
     );
-    for (uInt i=0; i<nThreadsMax; ++i) {
+    for (uInt i=0; i<_nThreadsMax; ++i) {
         uInt idx8 = CACHE_PADDING*i;
         tStats[idx8] = _getInitialStats();
         // set nominal max and mins so accumulate
@@ -502,7 +503,7 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
         PtrHolder<uInt64> offset;
         _initThreadVars(
             nBlocks, extra, nthreads, dataIter,
-            maskIter, weightsIter, offset, nThreadsMax
+            maskIter, weightsIter, offset, _nThreadsMax
         );
         if (_hasWeights) {
             stats.weighted = True;
@@ -535,8 +536,8 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
             break;
         }
     }
-    vector<StatsData<AccumType> > xstats;
-    for (uInt i=0; i<nThreadsMax; ++i) {
+    std::vector<StatsData<AccumType> > xstats;
+    for (uInt i=0; i<_nThreadsMax; ++i) {
         // in case no max/min was set, clear the nominal values
         // set above
         StatsData<AccumType>& s = tStats[CACHE_PADDING*i];
@@ -906,11 +907,11 @@ void ClassicalStatistics<CASA_STATP>::_accumulate(
 }
 
 CASA_STATD
-uInt ClassicalStatistics<CASA_STATP>::_nThreadsMax() const {
+void ClassicalStatistics<CASA_STATP>::setMaxThreads(uInt nThreadsMax) {
 #ifdef _OPENMP
-    return omp_get_max_threads();
+    _nThreadsMax = nThreadsMax == 0 ? omp_get_max_threads() : nThreadsMax;
 #else
-    return 1;
+    _nThreadsMax = 1;
 #endif
 }
 
@@ -946,7 +947,7 @@ vector<vector<uInt64> > ClassicalStatistics<CASA_STATP>::_binCounts(
             ++iDesc;
         }
     }
-    vector<Bool> allSame(binDesc.size(), True);
+    std::vector<Bool> allSame(binDesc.size(), True);
     vector<vector<uInt64> > bins(binDesc.size());
     iDesc = bDesc;
     vector<vector<uInt64> >::iterator bBins = bins.begin();
@@ -969,17 +970,16 @@ vector<vector<uInt64> > ClassicalStatistics<CASA_STATP>::_binCounts(
         ++iDesc;
     }
     _initIterators();
-    uInt nThreadsMax = _nThreadsMax();
-    PtrHolder<vector<vector<uInt64> > > tBins(
-        new vector<vector<uInt64> >[CACHE_PADDING*nThreadsMax], True
+    PtrHolder<std::vector<std::vector<uInt64> > > tBins(
+        new std::vector<std::vector<uInt64> >[CACHE_PADDING*_nThreadsMax], True
     );
-    PtrHolder<vector<CountedPtr<AccumType> > > tSameVal(
-        new vector<CountedPtr<AccumType> >[CACHE_PADDING*nThreadsMax], True
+    PtrHolder<std::vector<CountedPtr<AccumType> > > tSameVal(
+        new std::vector<CountedPtr<AccumType> >[CACHE_PADDING*_nThreadsMax], True
     );
     PtrHolder<vector<Bool> > tAllSame(
-        new vector<Bool>[CACHE_PADDING*nThreadsMax], True
+        new std::vector<Bool>[CACHE_PADDING*_nThreadsMax], True
     );
-    for (uInt tid=0; tid<nThreadsMax; ++tid) {
+    for (uInt tid=0; tid<_nThreadsMax; ++tid) {
         uInt idx8 = CACHE_PADDING*tid;
         tBins[idx8] = bins;
         tSameVal[idx8] = sameVal;
@@ -995,7 +995,7 @@ vector<vector<uInt64> > ClassicalStatistics<CASA_STATP>::_binCounts(
         PtrHolder<uInt64> offset;
         _initThreadVars(
             nBlocks, extra, nthreads, dataIter,
-            maskIter, weightsIter, offset, nThreadsMax
+            maskIter, weightsIter, offset, _nThreadsMax
         );
 #pragma omp parallel for num_threads(nthreads)
         for (uInt i=0; i<nBlocks; ++i) {
@@ -1015,7 +1015,7 @@ vector<vector<uInt64> > ClassicalStatistics<CASA_STATP>::_binCounts(
         }
     }
     _mergeResults(
-        bins, sameVal, allSame, tBins, tSameVal, tAllSame, nThreadsMax
+        bins, sameVal, allSame, tBins, tSameVal, tAllSame, _nThreadsMax
     );
     return bins;
 }
@@ -1156,12 +1156,11 @@ void ClassicalStatistics<CASA_STATP>::_computeBins(
 
 CASA_STATD
 void ClassicalStatistics<CASA_STATP>::_createDataArray(
-    vector<AccumType>& ary
+    std::vector<AccumType>& ary
 ) {
     _initIterators();
-    uInt nThreadsMax = _nThreadsMax();
-    PtrHolder<vector<AccumType> > tAry(
-        new vector<AccumType>[CACHE_PADDING*nThreadsMax], True
+    PtrHolder<std::vector<AccumType> > tAry(
+        new std::vector<AccumType>[CACHE_PADDING*_nThreadsMax], True
     );
     while (True) {
         _initLoopVars();
@@ -1173,7 +1172,7 @@ void ClassicalStatistics<CASA_STATP>::_createDataArray(
         PtrHolder<uInt64> offset;
         _initThreadVars(
             nBlocks, extra, nthreads, dataIter,
-            maskIter, weightsIter, offset, nThreadsMax
+            maskIter, weightsIter, offset, _nThreadsMax
         );
 #pragma omp parallel for num_threads(nthreads)
         for (uInt i=0; i<nBlocks; ++i) {
@@ -1193,8 +1192,8 @@ void ClassicalStatistics<CASA_STATP>::_createDataArray(
         }
     }
     // merge the per-thread arrays
-    for (uInt tid=0; tid<nThreadsMax; ++tid) {
-        const vector<AccumType>& v = tAry[CACHE_PADDING*tid];
+    for (uInt tid=0; tid<_nThreadsMax; ++tid) {
+        const std::vector<AccumType>& v = tAry[CACHE_PADDING*tid];
         ary.insert(ary.end(), v.begin(), v.end());
     }
 }
@@ -1266,12 +1265,13 @@ void ClassicalStatistics<CASA_STATP>::_computeDataArray(
 
 CASA_STATD
 void ClassicalStatistics<CASA_STATP>::_createDataArrays(
-    vector<vector<AccumType> >& arys, const vector<std::pair<AccumType, AccumType> >& includeLimits,
+    std::vector<std::vector<AccumType> >& arys,
+    const std::vector<std::pair<AccumType, AccumType> >& includeLimits,
     uInt64 maxCount
 ) {
-    typename vector<std::pair<AccumType, AccumType> >::const_iterator bLimits = includeLimits.begin();
-    typename vector<std::pair<AccumType, AccumType> >::const_iterator iLimits = bLimits;
-    typename vector<std::pair<AccumType, AccumType> >::const_iterator eLimits = includeLimits.end();
+    typename std::vector<std::pair<AccumType, AccumType> >::const_iterator bLimits = includeLimits.begin();
+    typename std::vector<std::pair<AccumType, AccumType> >::const_iterator iLimits = bLimits;
+    typename std::vector<std::pair<AccumType, AccumType> >::const_iterator eLimits = includeLimits.end();
     std::pair<AccumType, AccumType> prevLimits;
     while(iLimits != eLimits) {
         // sanity checks
@@ -1294,14 +1294,13 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
         ++iLimits;
     }
     _initIterators();
-    uInt nThreadsMax = _nThreadsMax();
-    PtrHolder<vector<vector<AccumType> > > tArys(
-        new vector<vector<AccumType> >[CACHE_PADDING*nThreadsMax], True
+    PtrHolder<std::vector<std::vector<AccumType> > > tArys(
+        new std::vector<std::vector<AccumType> >[CACHE_PADDING*_nThreadsMax], True
     );
     PtrHolder<uInt64> tCurrentCount(
-        new uInt64[CACHE_PADDING*nThreadsMax], True
+        new uInt64[CACHE_PADDING*_nThreadsMax], True
     );
-    for (uInt tid=0; tid<nThreadsMax; ++tid) {
+    for (uInt tid=0; tid<_nThreadsMax; ++tid) {
         uInt idx8 = CACHE_PADDING*tid;
         tArys[idx8] = arys;
     }
@@ -1316,9 +1315,9 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
         PtrHolder<uInt64> offset;
         _initThreadVars(
             nBlocks, extra, nthreads, dataIter,
-            maskIter, weightsIter, offset, nThreadsMax
+            maskIter, weightsIter, offset, _nThreadsMax
         );
-        for (uInt tid=0; tid<nThreadsMax; ++tid) {
+        for (uInt tid=0; tid<_nThreadsMax; ++tid) {
             uInt idx8 = CACHE_PADDING*tid;
             tCurrentCount[idx8] = currentCount;
         }
@@ -1341,7 +1340,7 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
         // loop seems a reasonable trade off between possibly short
         // circuiting earlier vs performance hits if that does not happen
         uInt64 prevCount = currentCount;
-        for (uInt tid=0; tid<nThreadsMax; ++tid) {
+        for (uInt tid=0; tid<_nThreadsMax; ++tid) {
             uInt idx8 = CACHE_PADDING*tid;
             currentCount += (tCurrentCount[idx8] - prevCount);
         }
@@ -1351,7 +1350,7 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
     }
     AlwaysAssert(currentCount == maxCount, AipsError);
     // merge the per-thread arrays
-    for (uInt tid=0; tid<nThreadsMax; ++tid) {
+    for (uInt tid=0; tid<_nThreadsMax; ++tid) {
         uInt idx8 = CACHE_PADDING*tid;
         typename vector<vector<AccumType> >::iterator iter = arys.begin();
         typename vector<vector<AccumType> >::iterator end = arys.end();
@@ -1653,12 +1652,11 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
     AccumType& datamin, AccumType& datamax
 ) {
     _initIterators();
-    uInt nThreadsMax = _nThreadsMax();
     PtrHolder<CountedPtr<AccumType> > tmin(
-        new CountedPtr<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new CountedPtr<AccumType>[CACHE_PADDING*_nThreadsMax], True
     );
     PtrHolder<CountedPtr<AccumType> > tmax(
-        new CountedPtr<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new CountedPtr<AccumType>[CACHE_PADDING*_nThreadsMax], True
     );
     while (True) {
         _initLoopVars();
@@ -1670,7 +1668,7 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
         PtrHolder<uInt64> offset;
         _initThreadVars(
             nBlocks, extra, nthreads, dataIter,
-            maskIter, weightsIter, offset, nThreadsMax
+            maskIter, weightsIter, offset, _nThreadsMax
         );
 #pragma omp parallel for num_threads(nthreads)
         for (uInt i=0; i<nBlocks; ++i) {
@@ -1691,7 +1689,7 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
     }
     CountedPtr<AccumType> mymax;
     CountedPtr<AccumType> mymin;
-    for (uInt i=0; i<nThreadsMax; ++i) {
+    for (uInt i=0; i<_nThreadsMax; ++i) {
         uInt idx8 = i * CACHE_PADDING;
         if (! tmin[idx8].null()) {
             if (mymin.null() || *tmin[idx8] < *mymin) {

--- a/scimath/Mathematics/ClassicalStatistics.tcc
+++ b/scimath/Mathematics/ClassicalStatistics.tcc
@@ -90,6 +90,11 @@ ClassicalStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* ClassicalStatistics<CASA_STATP>::clone() const {
+    return new ClassicalStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 AccumType ClassicalStatistics<CASA_STATP>::getMedian(
     CountedPtr<uInt64> knownNpts, CountedPtr<AccumType> knownMin,
     CountedPtr<AccumType> knownMax, uInt binningThreshholdSizeBytes,

--- a/scimath/Mathematics/FitToHalfStatistics.h
+++ b/scimath/Mathematics/FitToHalfStatistics.h
@@ -64,6 +64,9 @@ public:
         const FitToHalfStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance. Caller is responsible for deleting the returned pointer.
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::FITTOHALF;

--- a/scimath/Mathematics/FitToHalfStatistics.tcc
+++ b/scimath/Mathematics/FitToHalfStatistics.tcc
@@ -76,6 +76,11 @@ FitToHalfStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* FitToHalfStatistics<CASA_STATP>::clone() const {
+    return new FitToHalfStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 AccumType FitToHalfStatistics<CASA_STATP>::getMedian(
     CountedPtr<uInt64> , CountedPtr<AccumType> ,
     CountedPtr<AccumType> , uInt , Bool , uInt64

--- a/scimath/Mathematics/HingesFencesStatistics.h
+++ b/scimath/Mathematics/HingesFencesStatistics.h
@@ -58,6 +58,9 @@ public:
         const HingesFencesStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance. Caller is responsible for deleting the returned pointer.
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+    
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::HINGESFENCES;

--- a/scimath/Mathematics/HingesFencesStatistics.tcc
+++ b/scimath/Mathematics/HingesFencesStatistics.tcc
@@ -65,6 +65,11 @@ HingesFencesStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* HingesFencesStatistics<CASA_STATP>::clone() const {
+    return new HingesFencesStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 void HingesFencesStatistics<CASA_STATP>::reset() {
     _rangeIsSet = False;
     _hasRange = False;

--- a/scimath/Mathematics/StatisticsAlgorithm.h
+++ b/scimath/Mathematics/StatisticsAlgorithm.h
@@ -108,6 +108,9 @@ public:
 
     virtual ~StatisticsAlgorithm();
 
+    // Clone this instance
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const = 0;
+
     // <group>
     // Add a dataset to an existing set of datasets on which statistics are
     // to be calculated. nr is the number of points to be considered.

--- a/scimath/Mathematics/test/tChauvenetCriterionStatistics.cc
+++ b/scimath/Mathematics/test/tChauvenetCriterionStatistics.cc
@@ -90,6 +90,19 @@ int main() {
             StatsData<Double> sd = cs.getStatistics();
             AlwaysAssert(sd.npts == 104, AipsError);
             AlwaysAssert(*sd.max == 6, AipsError);
+            // test cloning gives same results
+            SHARED_PTR<
+                ChauvenetCriterionStatistics<
+                    Double, Double*, Bool*
+                >
+            > cs1(
+                dynamic_cast<
+                    ChauvenetCriterionStatistics<Double, Double*, Bool*>*
+                >(cs.clone())
+            ); 
+            StatsData<Double> sd1 = cs1->getStatistics();
+            AlwaysAssert(sd1.npts == 104, AipsError);
+            AlwaysAssert(*sd1.max == 6, AipsError);
         }
         {
             // zscore=3.5, iterate until converged

--- a/scimath/Mathematics/test/tClassicalStatistics.cc
+++ b/scimath/Mathematics/test/tClassicalStatistics.cc
@@ -370,6 +370,37 @@ int main() {
             AlwaysAssert(sd.sum == 13.5, AipsError);
             AlwaysAssert(sd.sumsq == 79.25, AipsError);
             AlwaysAssert(near(sd.variance, variance), AipsError);
+
+            // test cloning gives same results
+            SHARED_PTR<
+                ClassicalStatistics<
+                    Double, std::vector<Double>::const_iterator,
+                    std::vector<Bool>::const_iterator
+                >
+            > cs1(
+                dynamic_cast<
+                    ClassicalStatistics<
+                        Double, std::vector<Double>::const_iterator,
+                        std::vector<Bool>::const_iterator
+                    >*
+                >(cs.clone())
+            );
+            StatsData<Double> sd1 = cs1->getStatistics();
+            AlwaysAssert(sd1.masked, AipsError);
+            AlwaysAssert(! sd1.weighted, AipsError);
+            AlwaysAssert(*sd1.max == *sd.max, AipsError);
+            AlwaysAssert(sd1.maxpos.first == sd.maxpos.first , AipsError);
+            AlwaysAssert(sd1.maxpos.second == sd.maxpos.second, AipsError);
+            AlwaysAssert(sd1.mean == sd.mean, AipsError);
+            AlwaysAssert(*sd1.min == *sd.min, AipsError);
+            AlwaysAssert(sd1.minpos.first == sd.minpos.first, AipsError);
+            AlwaysAssert(sd1.minpos.second == sd.minpos.second, AipsError);
+            AlwaysAssert(sd1.npts == sd.npts, AipsError);
+            AlwaysAssert(sd1.rms == sd.rms, AipsError);
+            AlwaysAssert(sd1.stddev == sd.stddev, AipsError);
+            AlwaysAssert(sd1.sum == sd.sum, AipsError);
+            AlwaysAssert(sd1.sumsq == sd.sumsq, AipsError);
+            AlwaysAssert(sd1.variance == sd.variance, AipsError);
         }
         {
             // mask and ranges

--- a/scimath/Mathematics/test/tFitToHalfStatistics.cc
+++ b/scimath/Mathematics/test/tFitToHalfStatistics.cc
@@ -553,6 +553,56 @@ int main() {
                     sqrt(sumsq/npts)
                 ), AipsError
             );
+
+            // test cloning gives same results
+            SHARED_PTR<
+                FitToHalfStatistics<
+                    Double, std::vector<Double>::const_iterator,
+                    std::vector<Bool>::const_iterator
+                >
+            > fh1(
+                dynamic_cast<
+                    FitToHalfStatistics<
+                        Double, std::vector<Double>::const_iterator,
+                        std::vector<Bool>::const_iterator
+                    >*
+                >(fh.clone())
+            );
+            StatsData<Double> sd1 = fh1->getStatistics();
+            AlwaysAssert(sd1.masked == sd.masked, AipsError);
+            AlwaysAssert(sd1.weighted == sd.weighted, AipsError);
+            AlwaysAssert(*sd1.max == *sd.max, AipsError);
+            AlwaysAssert(sd1.maxpos.first == sd.maxpos.first, AipsError);
+            AlwaysAssert(sd1.maxpos.second == sd.maxpos.second, AipsError);
+            AlwaysAssert(sd1.mean == sd.mean, AipsError);
+            AlwaysAssert(*sd1.min == *sd.min, AipsError);
+            AlwaysAssert(sd1.minpos.first == sd.minpos.first, AipsError);
+            AlwaysAssert(sd1.minpos.second == sd.minpos.second, AipsError);
+            AlwaysAssert(sd1.npts == sd.npts, AipsError);
+            AlwaysAssert(sd1.rms == sd.rms, AipsError);
+            AlwaysAssert(sd1.stddev == sd.stddev, AipsError);
+            AlwaysAssert(sd1.sum == sd.sum, AipsError);
+            AlwaysAssert(sd1.sumsq == sd.sumsq, AipsError);
+            AlwaysAssert(sd1.variance == sd.variance, AipsError);
+            AlwaysAssert(
+                fh1->getStatisticIndex(StatisticsData::MAX)
+                == std::pair<Int64 COMMA Int64>(-1, -1),
+                AipsError
+            );
+            AlwaysAssert(
+                fh1->getStatisticIndex(StatisticsData::MIN)
+                == std::pair<Int64 COMMA Int64>(0, 4),
+                AipsError
+            );
+            AlwaysAssert(fh1->getStatistic(
+                StatisticsData::NPTS) == npts, AipsError
+            );
+            AlwaysAssert(
+                near(
+                    fh1->getStatistic(StatisticsData::RMS),
+                    sqrt(sumsq/npts)
+                ), AipsError
+            );
         }
         {
             // mask

--- a/scimath/Mathematics/test/tHingesFencesStatistics.cc
+++ b/scimath/Mathematics/test/tHingesFencesStatistics.cc
@@ -496,6 +496,38 @@ int main() {
             AlwaysAssert(sd.sumweights == 11.0, AipsError);
             AlwaysAssert(sd.sumsq == 195.25, AipsError);
             AlwaysAssert(near(sd.variance, variance), AipsError);
+
+            // test cloning gives same results
+            SHARED_PTR<
+                HingesFencesStatistics<
+                    Double, std::vector<Double>::const_iterator,
+                    std::vector<Bool>::const_iterator
+                >
+            > cs1(
+                dynamic_cast<
+                    HingesFencesStatistics<
+                        Double, std::vector<Double>::const_iterator,
+                        std::vector<Bool>::const_iterator
+                    >*
+                >(cs.clone())
+            );
+            StatsData<Double> sd1 = cs1->getStatistics();
+            AlwaysAssert(sd1.masked == sd.masked, AipsError);
+            AlwaysAssert(sd1.weighted == sd.weighted, AipsError);
+            AlwaysAssert(*sd1.max == *sd.max, AipsError);
+            AlwaysAssert(sd1.maxpos.first == sd.maxpos.first, AipsError);
+            AlwaysAssert(sd1.maxpos.second == sd.maxpos.second, AipsError);
+            AlwaysAssert(sd1.mean == sd.mean, AipsError);
+            AlwaysAssert(*sd1.min == *sd.min, AipsError);
+            AlwaysAssert(sd1.minpos.first == sd.minpos.first, AipsError);
+            AlwaysAssert(sd1.minpos.second == sd.minpos.second, AipsError);
+            AlwaysAssert(sd1.npts == sd.npts, AipsError);
+            AlwaysAssert(sd1.rms == sd.rms, AipsError);
+            AlwaysAssert(sd1.stddev == sd.stddev, AipsError);
+            AlwaysAssert(sd1.sum == sd.sum, AipsError);
+            AlwaysAssert(sd1.sumweights == sd.sumweights, AipsError);
+            AlwaysAssert(sd1.sumsq == sd.sumsq, AipsError);
+            AlwaysAssert(sd1.variance == sd.variance, AipsError);
         }
         {
             // integer weights and ranges


### PR DESCRIPTION
Implemented clone() method to all stats classes, added tests
Implemented ClassicalStatistics::setMaxThreads() to allow caller to set max threads used.
Substituted macros in some places.
Made more eclipse-friendly by fully qualifying certain classes with namesspace (eg vector -> std::vector)