### PR TITLE
CAS-10358 implement clone() method, do not parallelize if called from a parallelized block

### DIFF
--- a/scimath/Mathematics/ChauvenetCriterionStatistics.h
+++ b/scimath/Mathematics/ChauvenetCriterionStatistics.h
@@ -64,6 +64,9 @@ public:
         const ChauvenetCriterionStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+ 
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::CHAUVENETCRITERION;

--- a/scimath/Mathematics/ChauvenetCriterionStatistics.tcc
+++ b/scimath/Mathematics/ChauvenetCriterionStatistics.tcc
@@ -61,6 +61,11 @@ ChauvenetCriterionStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* ChauvenetCriterionStatistics<CASA_STATP>::clone() const {
+    return new ChauvenetCriterionStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 void ChauvenetCriterionStatistics<CASA_STATP>::reset() {
     ConstrainedRangeStatistics<CASA_STATP>::reset();
     _rangeIsSet = False;

--- a/scimath/Mathematics/ClassicalStatistics.h
+++ b/scimath/Mathematics/ClassicalStatistics.h
@@ -58,21 +58,24 @@ template <class T> class PtrHolder;
 
 template <class AccumType, class DataIterator, class MaskIterator=const Bool*, class WeightsIterator=DataIterator> 
 class ClassicalStatistics
-    : public StatisticsAlgorithm<AccumType, DataIterator, MaskIterator, WeightsIterator> {
+    : public StatisticsAlgorithm<CASA_STATP> {
 public:
 
     ClassicalStatistics();
 
     // copy semantics
-    ClassicalStatistics(const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& cs);
+    ClassicalStatistics(const ClassicalStatistics<CASA_STATP>& cs);
 
     virtual ~ClassicalStatistics();
 
     // copy semantics
-    ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& operator=(
-        const ClassicalStatistics<AccumType, DataIterator, MaskIterator, WeightsIterator>& other
+    ClassicalStatistics<CASA_STATP>& operator=(
+        const ClassicalStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+    
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::CLASSICAL;
@@ -192,7 +195,7 @@ public:
     virtual void setCalculateAsAdded(Bool c);
 
     // An exception will be thrown if setCalculateAsAdded(True) has been called.
-    void setDataProvider(StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator> *dataProvider);
+    void setDataProvider(StatsDataProvider<CASA_STATP> *dataProvider);
 
     void setStatsToCalculate(std::set<StatisticsData::STATS>& stats);
 

--- a/scimath/Mathematics/FitToHalfStatistics.h
+++ b/scimath/Mathematics/FitToHalfStatistics.h
@@ -64,6 +64,9 @@ public:
         const FitToHalfStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance. Caller is responsible for deleting the returned pointer.
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::FITTOHALF;

--- a/scimath/Mathematics/FitToHalfStatistics.tcc
+++ b/scimath/Mathematics/FitToHalfStatistics.tcc
@@ -76,6 +76,11 @@ FitToHalfStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* FitToHalfStatistics<CASA_STATP>::clone() const {
+    return new FitToHalfStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 AccumType FitToHalfStatistics<CASA_STATP>::getMedian(
     CountedPtr<uInt64> , CountedPtr<AccumType> ,
     CountedPtr<AccumType> , uInt , Bool , uInt64

--- a/scimath/Mathematics/HingesFencesStatistics.h
+++ b/scimath/Mathematics/HingesFencesStatistics.h
@@ -58,6 +58,9 @@ public:
         const HingesFencesStatistics<CASA_STATP>& other
     );
 
+    // Clone this instance. Caller is responsible for deleting the returned pointer.
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const;
+    
     // get the algorithm that this object uses for computing stats
     virtual StatisticsData::ALGORITHM algorithm() const {
         return StatisticsData::HINGESFENCES;

--- a/scimath/Mathematics/HingesFencesStatistics.tcc
+++ b/scimath/Mathematics/HingesFencesStatistics.tcc
@@ -65,6 +65,11 @@ HingesFencesStatistics<CASA_STATP>::operator=(
 }
 
 CASA_STATD
+StatisticsAlgorithm<CASA_STATP>* HingesFencesStatistics<CASA_STATP>::clone() const {
+    return new HingesFencesStatistics<CASA_STATP>(*this);
+}
+
+CASA_STATD
 void HingesFencesStatistics<CASA_STATP>::reset() {
     _rangeIsSet = False;
     _hasRange = False;

--- a/scimath/Mathematics/StatisticsAlgorithm.h
+++ b/scimath/Mathematics/StatisticsAlgorithm.h
@@ -108,6 +108,9 @@ public:
 
     virtual ~StatisticsAlgorithm();
 
+    // Clone this instance
+    virtual StatisticsAlgorithm<CASA_STATP>* clone() const = 0;
+
     // <group>
     // Add a dataset to an existing set of datasets on which statistics are
     // to be calculated. nr is the number of points to be considered.

--- a/scimath/Mathematics/test/tChauvenetCriterionStatistics.cc
+++ b/scimath/Mathematics/test/tChauvenetCriterionStatistics.cc
@@ -90,6 +90,19 @@ int main() {
             StatsData<Double> sd = cs.getStatistics();
             AlwaysAssert(sd.npts == 104, AipsError);
             AlwaysAssert(*sd.max == 6, AipsError);
+            // test cloning gives same results
+            SHARED_PTR<
+                ChauvenetCriterionStatistics<
+                    Double, Double*, Bool*
+                >
+            > cs1(
+                dynamic_cast<
+                    ChauvenetCriterionStatistics<Double, Double*, Bool*>*
+                >(cs.clone())
+            ); 
+            StatsData<Double> sd1 = cs1->getStatistics();
+            AlwaysAssert(sd1.npts == 104, AipsError);
+            AlwaysAssert(*sd1.max == 6, AipsError);
         }
         {
             // zscore=3.5, iterate until converged

--- a/scimath/Mathematics/test/tClassicalStatistics.cc
+++ b/scimath/Mathematics/test/tClassicalStatistics.cc
@@ -370,6 +370,37 @@ int main() {
             AlwaysAssert(sd.sum == 13.5, AipsError);
             AlwaysAssert(sd.sumsq == 79.25, AipsError);
             AlwaysAssert(near(sd.variance, variance), AipsError);
+
+            // test cloning gives same results
+            SHARED_PTR<
+                ClassicalStatistics<
+                    Double, std::vector<Double>::const_iterator,
+                    std::vector<Bool>::const_iterator
+                >
+            > cs1(
+                dynamic_cast<
+                    ClassicalStatistics<
+                        Double, std::vector<Double>::const_iterator,
+                        std::vector<Bool>::const_iterator
+                    >*
+                >(cs.clone())
+            );
+            StatsData<Double> sd1 = cs1->getStatistics();
+            AlwaysAssert(sd1.masked, AipsError);
+            AlwaysAssert(! sd1.weighted, AipsError);
+            AlwaysAssert(*sd1.max == *sd.max, AipsError);
+            AlwaysAssert(sd1.maxpos.first == sd.maxpos.first , AipsError);
+            AlwaysAssert(sd1.maxpos.second == sd.maxpos.second, AipsError);
+            AlwaysAssert(sd1.mean == sd.mean, AipsError);
+            AlwaysAssert(*sd1.min == *sd.min, AipsError);
+            AlwaysAssert(sd1.minpos.first == sd.minpos.first, AipsError);
+            AlwaysAssert(sd1.minpos.second == sd.minpos.second, AipsError);
+            AlwaysAssert(sd1.npts == sd.npts, AipsError);
+            AlwaysAssert(sd1.rms == sd.rms, AipsError);
+            AlwaysAssert(sd1.stddev == sd.stddev, AipsError);
+            AlwaysAssert(sd1.sum == sd.sum, AipsError);
+            AlwaysAssert(sd1.sumsq == sd.sumsq, AipsError);
+            AlwaysAssert(sd1.variance == sd.variance, AipsError);
         }
         {
             // mask and ranges

--- a/scimath/Mathematics/test/tFitToHalfStatistics.cc
+++ b/scimath/Mathematics/test/tFitToHalfStatistics.cc
@@ -553,6 +553,56 @@ int main() {
                     sqrt(sumsq/npts)
                 ), AipsError
             );
+
+            // test cloning gives same results
+            SHARED_PTR<
+                FitToHalfStatistics<
+                    Double, std::vector<Double>::const_iterator,
+                    std::vector<Bool>::const_iterator
+                >
+            > fh1(
+                dynamic_cast<
+                    FitToHalfStatistics<
+                        Double, std::vector<Double>::const_iterator,
+                        std::vector<Bool>::const_iterator
+                    >*
+                >(fh.clone())
+            );
+            StatsData<Double> sd1 = fh1->getStatistics();
+            AlwaysAssert(sd1.masked == sd.masked, AipsError);
+            AlwaysAssert(sd1.weighted == sd.weighted, AipsError);
+            AlwaysAssert(*sd1.max == *sd.max, AipsError);
+            AlwaysAssert(sd1.maxpos.first == sd.maxpos.first, AipsError);
+            AlwaysAssert(sd1.maxpos.second == sd.maxpos.second, AipsError);
+            AlwaysAssert(sd1.mean == sd.mean, AipsError);
+            AlwaysAssert(*sd1.min == *sd.min, AipsError);
+            AlwaysAssert(sd1.minpos.first == sd.minpos.first, AipsError);
+            AlwaysAssert(sd1.minpos.second == sd.minpos.second, AipsError);
+            AlwaysAssert(sd1.npts == sd.npts, AipsError);
+            AlwaysAssert(sd1.rms == sd.rms, AipsError);
+            AlwaysAssert(sd1.stddev == sd.stddev, AipsError);
+            AlwaysAssert(sd1.sum == sd.sum, AipsError);
+            AlwaysAssert(sd1.sumsq == sd.sumsq, AipsError);
+            AlwaysAssert(sd1.variance == sd.variance, AipsError);
+            AlwaysAssert(
+                fh1->getStatisticIndex(StatisticsData::MAX)
+                == std::pair<Int64 COMMA Int64>(-1, -1),
+                AipsError
+            );
+            AlwaysAssert(
+                fh1->getStatisticIndex(StatisticsData::MIN)
+                == std::pair<Int64 COMMA Int64>(0, 4),
+                AipsError
+            );
+            AlwaysAssert(fh1->getStatistic(
+                StatisticsData::NPTS) == npts, AipsError
+            );
+            AlwaysAssert(
+                near(
+                    fh1->getStatistic(StatisticsData::RMS),
+                    sqrt(sumsq/npts)
+                ), AipsError
+            );
         }
         {
             // mask

--- a/scimath/Mathematics/test/tHingesFencesStatistics.cc
+++ b/scimath/Mathematics/test/tHingesFencesStatistics.cc
@@ -496,6 +496,38 @@ int main() {
             AlwaysAssert(sd.sumweights == 11.0, AipsError);
             AlwaysAssert(sd.sumsq == 195.25, AipsError);
             AlwaysAssert(near(sd.variance, variance), AipsError);
+
+            // test cloning gives same results
+            SHARED_PTR<
+                HingesFencesStatistics<
+                    Double, std::vector<Double>::const_iterator,
+                    std::vector<Bool>::const_iterator
+                >
+            > cs1(
+                dynamic_cast<
+                    HingesFencesStatistics<
+                        Double, std::vector<Double>::const_iterator,
+                        std::vector<Bool>::const_iterator
+                    >*
+                >(cs.clone())
+            );
+            StatsData<Double> sd1 = cs1->getStatistics();
+            AlwaysAssert(sd1.masked == sd.masked, AipsError);
+            AlwaysAssert(sd1.weighted == sd.weighted, AipsError);
+            AlwaysAssert(*sd1.max == *sd.max, AipsError);
+            AlwaysAssert(sd1.maxpos.first == sd.maxpos.first, AipsError);
+            AlwaysAssert(sd1.maxpos.second == sd.maxpos.second, AipsError);
+            AlwaysAssert(sd1.mean == sd.mean, AipsError);
+            AlwaysAssert(*sd1.min == *sd.min, AipsError);
+            AlwaysAssert(sd1.minpos.first == sd.minpos.first, AipsError);
+            AlwaysAssert(sd1.minpos.second == sd.minpos.second, AipsError);
+            AlwaysAssert(sd1.npts == sd.npts, AipsError);
+            AlwaysAssert(sd1.rms == sd.rms, AipsError);
+            AlwaysAssert(sd1.stddev == sd.stddev, AipsError);
+            AlwaysAssert(sd1.sum == sd.sum, AipsError);
+            AlwaysAssert(sd1.sumweights == sd.sumweights, AipsError);
+            AlwaysAssert(sd1.sumsq == sd.sumsq, AipsError);
+            AlwaysAssert(sd1.variance == sd.variance, AipsError);
         }
         {
             // integer weights and ranges


### PR DESCRIPTION
Implemented clone() method and added tests
If being called from a parallelized block, don't parallelize stats computations
Substituted macros in some places
Made more eclipse-friendly in some places (eg vector -> std::vector)
