### PR TITLE
Use antenna name as station name when provided

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2547,17 +2547,17 @@ void FITSIDItoMS1::fillAntennaTable()
      }
      if(name(i)==""){
        ant.name().put(row,String("ANT")+temps);
+       ant.station().put(row,arrnam+":"+temps);     
      }
      else{
        ant.name().put(row, name(i));
+       ant.station().put(row,name(i));
      }
      Vector<Float> tempf=offset(i);
      Vector<Double> tempd(3);
      for (Int j=0; j<3; j++) tempd[j]=tempf[j];
      ant.offset().put(row,tempd);
 
-     //ant.station().put(row,name(i));
-     ant.station().put(row,arrnam+":"+temps);     
      ant.type().put(row,"GROUND-BASED");
 
      // Do UVFITS-dependent position corrections:


### PR DESCRIPTION
The current approach of using ARRAYNAME:NUMBER as the station name breaks
concatenating imported FITS-IDI files that have different sets of antennas.
This results in differences in station names for the same antenna which
the concatenation code interprets as moving the antenna.