### PR TITLE
Fixed parsing of date/time

### DIFF
--- a/casa/OS/Time.cc
+++ b/casa/OS/Time.cc
@@ -399,31 +399,29 @@ double Time::age() {
 
 uInt Time::seconds() {
   // return integral seconds after the minute [0,59]
-  return (uInt)(dseconds());
+  // accuracy of Time seconds is about 2e-5, so add a bit.
+  return (uInt)(dseconds() + 2e-5);
 }
 
 double Time::dseconds() {
   // return seconds after the minute [0,59]
-  double hour,min;
-
-  hour= mJulianDayfrac*24.0;
-  min= (hour-(int)hour)*60.0;
-
-  return ((min-(int)min)*60.0);
+  double hour = mJulianDayfrac*24.0;
+  double sec = (hour - hours()) * 3600. - minutes() * 60.;
+  return sec;
 }
 
 uInt Time::minutes() {
   // return minutes after the hour [0,59]
-  double hour;
-
-  hour= mJulianDayfrac*24.0;
-  return (uInt)((hour-(int)hour)*60.0);
+  double hour = mJulianDayfrac*24.0;
+  double min  = (hour - hours()) * 60.0;
+  // accuracy of Time second is about 2e-5, so add a bit.
+  return uInt(min + 2e-5/60.);
 }
 
 uInt Time::hours() {
   // return hours after the day [0,23]
-
-  return (uInt)(mJulianDayfrac*24.0);
+  // accuracy of Time second is 2e-5, so add a bit.
+  return uInt(mJulianDayfrac*24.0 + 2e-5/3600.);
 }
 
 uInt Time::dayOfMonth() {

--- a/casa/Quanta/MVAngle.h
+++ b/casa/Quanta/MVAngle.h
@@ -334,12 +334,21 @@ class MVAngle {
   const MVAngle &binorm(Double norm);
   // Check if String unit
   static Bool unitString(UnitVal &uv, String &us, MUString &in);
+
   // Make res angle Quantity from string in angle/time-like format. In the
-  // case of String input, also quantities are recognised. chk checks eos
-  // <group> 
+  // case of String input, also quantities are recognised.
+  // chk=True means that the entire string should be consumed.
+  // throwExcp=True means that an exception is thrown in case of an error.
+  // <group>
   static Bool read(Quantity &res, const String &in, Bool chk=True);
   static Bool read(Quantity &res, MUString &in, Bool chk=True);
+  static Bool read(Quantity &res, const String &in, Bool chk, Bool throwExcp);
+  static Bool read(Quantity &res, MUString &in, Bool chk, Bool throwExcp);
   // </group>
+  // Handle a read error. An exception is thrown if indicated so.
+  // Otherwise in.pop() is called and False is returned.
+  static Bool handleReadError(MUString& in, Bool throwExcp);
+
   // Make co-angle (e.g. zenith distance from elevation)
   MVAngle coAngle() const;
   // Get value in given unit

--- a/casa/Quanta/MVTime.h
+++ b/casa/Quanta/MVTime.h
@@ -361,10 +361,14 @@ class MVTime {
 
 //# General member functions
   // Make res time Quantity from string. The String version will accept
-  // a time/angle Quantity as well. The chk checks for eos
+  // a time/angle Quantity as well. It returns False in case of an error.
+  // chk=True means that the entire string should be consumed.
+  // throwExcp=True means that an exception is thrown in case of an error.
   // <group>
   static Bool read(Quantity &res, const String &in, Bool chk=True);
   static Bool read(Quantity &res, MUString &in, Bool chk=True);
+  static Bool read(Quantity &res, const String &in, Bool chk, Bool throwExcp);
+  static Bool read(Quantity &res, MUString &in, Bool chk, Bool throwExcp);
   // </group>
 // Get value of date/time (MJD) in given units
 // <group>

--- a/casa/Quanta/test/tMVTime.out
+++ b/casa/Quanta/test/tMVTime.out
@@ -1,3 +1,6 @@
+Expected exception: Invalid date/time '2017-Jul-1x/11:57:0.0', invalid char about pos 10
+Expected exception: Invalid date/time 'x', invalid char about pos 1
+Expected exception: Invalid date/time '2017-Jul-1/11:57:0.0  x', invalid char about pos 11
 +206.23.12.281
 +.23.12.281
 +..12.281


### PR DESCRIPTION
In some cases it was not checked if the entire date/time was processed when parsed. It has been fixed.
Furthermore, an argument has been added (in an ABI-compliant way) to tell if an exception has to be thrown in case of an error.
Finally, it appeared that Time had rounding problems when returning hours, minutes or seconds. It has been improved.

Close #614 