### PR TITLE
Pin travis Linux OS at "precise"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 cache: ccache
+dist: precise
 
 os:
   - linux


### PR DESCRIPTION
The default travis Linux OS has become Ubuntu "trusty". To continue using Ubuntu "precise" on travis, this configuration value is required. Note that a build of the branch for #615 was failing until I tried out this change (which has been reverted on that branch). Long term, I suggest we move to "trusty", in which case pinning the version at "precise" may be considered a workaround.