### PR TITLE
Parallactic angle calculation for Nasmyth mounts

### DIFF
--- a/ms/MSOper/MSDerivedValues.cc
+++ b/ms/MSOper/MSDerivedValues.cc
@@ -194,8 +194,12 @@ MSDerivedValues& MSDerivedValues::setAntennaMount(const Vector<String>& mount)
         mount_p(i)=2;
       } else if (mount(i)=="orbiting" || mount(i)=="ORBITING") {
         mount_p(i)=3;
+      } else if (mount(i)=="nasmyth-right" || mount(i)=="NASMYTH-RIGHT") {
+	mount_p(i)=4;
+      } else if (mount(i)=="nasmyth-left" || mount(i)=="NASMYTH-LEFT") {
+	mount_p(i)=5;
       } else {
-        mount_p(i)=4;
+        mount_p(i)=6;
       }
     }
   }
@@ -264,7 +268,8 @@ Double MSDerivedValues::parAngle()
   // all antennas & times since we just change the Frame
   Double pa=0;
 
-  if (mount_p(antenna_p)==0) {
+  if (mount_p(antenna_p)==0 || mount_p(antenna_p)==4 ||
+      mount_p(antenna_p)== 5) {
     // Now we can do the conversions using the machines
     mRADecInAzEl_p     = cRADecToAzEl_p();
     mHADecPoleInAzEl_p = cHADecToAzEl_p();
@@ -272,6 +277,14 @@ Double MSDerivedValues::parAngle()
     // Get the parallactic angle
     pa = mRADecInAzEl_p.getValue().
       positionAngle(mHADecPoleInAzEl_p.getValue());
+
+    if (mount_p(antenna_p)==4) {
+      // Right-handed Nasmyth
+      pa += mRADecInAzEl_p.getAngle().getValue()[1];
+    } else if (mount_p(antenna_p)==5) {
+      // Left-handed Nasmyth
+      pa -= mRADecInAzEl_p.getAngle().getValue()[1];
+    }
 
     // pa_p(iant)+= receptorAngle_p(iant);
     //#if (iant==0) 
@@ -287,6 +300,7 @@ Double MSDerivedValues::parAngle()
     message.priority(LogMessage::WARN);
     logSink.post(message);
   }
+
   return pa;
 }
 

--- a/ms/MSOper/MSDerivedValues.cc
+++ b/ms/MSOper/MSDerivedValues.cc
@@ -194,9 +194,9 @@ MSDerivedValues& MSDerivedValues::setAntennaMount(const Vector<String>& mount)
         mount_p(i)=2;
       } else if (mount(i)=="orbiting" || mount(i)=="ORBITING") {
         mount_p(i)=3;
-      } else if (mount(i)=="nasmyth-right" || mount(i)=="NASMYTH-RIGHT") {
+      } else if (mount(i)=="alt-az+nasmyth-r" || mount(i)=="ALT-AZ+NASMYTH-R") {
 	mount_p(i)=4;
-      } else if (mount(i)=="nasmyth-left" || mount(i)=="NASMYTH-LEFT") {
+      } else if (mount(i)=="alt-az+nasmyth-l" || mount(i)=="ALT-AZ+NASMYTH-L") {
 	mount_p(i)=5;
       } else {
         mount_p(i)=6;
@@ -300,7 +300,6 @@ Double MSDerivedValues::parAngle()
     message.priority(LogMessage::WARN);
     logSink.post(message);
   }
-
   return pa;
 }
 

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2536,7 +2536,8 @@ void FITSIDItoMS1::fillAntennaTable()
      case 1: mount="EQUATORIAL"; break;
      case 2: mount="X-Y"; break;
      case 3: mount="ORBITING"; break;
-     case 4: mount="BIZARRE"; break;
+     case 4: mount="NASMYTH-RIGHT"; break;
+     case 5: mount="NASMYTH-LEFT"; break;
      default: mount="UNKNOWN"; break;
      }
      ant.flagRow().put(row,False);

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2536,8 +2536,8 @@ void FITSIDItoMS1::fillAntennaTable()
      case 1: mount="EQUATORIAL"; break;
      case 2: mount="X-Y"; break;
      case 3: mount="ORBITING"; break;
-     case 4: mount="NASMYTH-RIGHT"; break;
-     case 5: mount="NASMYTH-LEFT"; break;
+     case 4: mount="ALT-AZ+NASMYTH-R"; break;
+     case 5: mount="ALT-AZ+NASMYTH-L"; break;
      default: mount="UNKNOWN"; break;
      }
      ant.flagRow().put(row,False);


### PR DESCRIPTION
This introduces new mount types "NASMYTH-LEFT" and "NASMYTH-RIGHT"
for left-handed and right-handed Nasmyth mounts found on EVN, GMVA
and EHT antennas.  This change also makes the FITS-IDI import code
recognize these mount types, which are described in the update
FITS-IDI standard (AIPS Memo 114).