### PR TITLE
Enable dT[T0~T1] syntax and return dT via MSSelection:getTimeList()

### DIFF
--- a/coordinates/Coordinates/SpectralCoordinate.cc
+++ b/coordinates/Coordinates/SpectralCoordinate.cc
@@ -1293,10 +1293,11 @@ Bool SpectralCoordinate::near(const Coordinate& other,
          }
       }
    }
-
 // LinearXForm components
-
-   {
+//Tabular spectral coordinates with 1 channel has increment 0. by definition in TabularCoordinates !
+//so linear transform test is bound to fail so skip for that case
+   if( !(_tabular.ptr() && (_tabular->pixelValues()).nelements()==1))
+     {
       LinearXform thisVal(referencePixel(), increment(), linearTransform());
       LinearXform thatVal(sCoord.referencePixel(), sCoord.increment(), sCoord.linearTransform());
       if (!(thisVal.near(thatVal, excludeAxes))) {

--- a/ms/MSOper/MSDerivedValues.cc
+++ b/ms/MSOper/MSDerivedValues.cc
@@ -194,8 +194,12 @@ MSDerivedValues& MSDerivedValues::setAntennaMount(const Vector<String>& mount)
         mount_p(i)=2;
       } else if (mount(i)=="orbiting" || mount(i)=="ORBITING") {
         mount_p(i)=3;
+      } else if (mount(i)=="alt-az+nasmyth-r" || mount(i)=="ALT-AZ+NASMYTH-R") {
+	mount_p(i)=4;
+      } else if (mount(i)=="alt-az+nasmyth-l" || mount(i)=="ALT-AZ+NASMYTH-L") {
+	mount_p(i)=5;
       } else {
-        mount_p(i)=4;
+        mount_p(i)=6;
       }
     }
   }
@@ -264,7 +268,8 @@ Double MSDerivedValues::parAngle()
   // all antennas & times since we just change the Frame
   Double pa=0;
 
-  if (mount_p(antenna_p)==0) {
+  if (mount_p(antenna_p)==0 || mount_p(antenna_p)==4 ||
+      mount_p(antenna_p)== 5) {
     // Now we can do the conversions using the machines
     mRADecInAzEl_p     = cRADecToAzEl_p();
     mHADecPoleInAzEl_p = cHADecToAzEl_p();
@@ -272,6 +277,14 @@ Double MSDerivedValues::parAngle()
     // Get the parallactic angle
     pa = mRADecInAzEl_p.getValue().
       positionAngle(mHADecPoleInAzEl_p.getValue());
+
+    if (mount_p(antenna_p)==4) {
+      // Right-handed Nasmyth
+      pa += mRADecInAzEl_p.getAngle().getValue()[1];
+    } else if (mount_p(antenna_p)==5) {
+      // Left-handed Nasmyth
+      pa -= mRADecInAzEl_p.getAngle().getValue()[1];
+    }
 
     // pa_p(iant)+= receptorAngle_p(iant);
     //#if (iant==0) 

--- a/ms/MSSel/MSSelection.cc
+++ b/ms/MSSel/MSSelection.cc
@@ -738,7 +738,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	// generated so far to find the first logical row to use to get
 	// value of the wild-card fields in the time expression. 
 	//
-	selectedTimesList_p.resize(2,0);
+	selectedTimesList_p.resize(3,0);
 
 	const TableExprNode *timeNode = 0x0;
 	TableExprNode colAsTEN = msLike->col(msLike->columnName(MS::TIME));

--- a/ms/MSSel/MSTimeParse.cc
+++ b/ms/MSSel/MSTimeParse.cc
@@ -259,7 +259,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       throw(MSSelectionTimeError("lower bound > upper bound"));
     }
     TableExprNode condition;
-    Float edgeWidth_l = (edgeWidth < 0.0) ? defaultExposure/2.0 : edgeWidth;
+    Float edgeWidth_l = (edgeWidth < 0.0) ? (edgeInclusive==True ? defaultExposure/2.0 : 0.0) : edgeWidth;
     if (!edgeInclusive) {
       condition = (columnAsTEN_p >= lowerBound &&
 		   (columnAsTEN_p <= upperBound));
@@ -433,7 +433,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     timeList.resize(newShape,True);
     timeList(0,n0) = t0;//-4.68193e+09;
     timeList(1,n0) = t1;//-4.68193e+09;
-    if (dT > 0) timeList(2,n0) = dT;
+    if (dT >= 0) timeList(2,n0) = dT;
     else timeList(2,n0) = defaultExposure;
   }
 } //# NAMESPACE CASACORE - END

--- a/ms/MSSel/MSTimeParse.cc
+++ b/ms/MSSel/MSTimeParse.cc
@@ -46,7 +46,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   MeasurementSet*  MSTimeParse::ms_p        = 0x0;
   TableExprNode*   MSTimeParse::otherTens_p = 0x0;
   Bool             MSTimeParse::defaultTimeComputed=False;
-  Matrix<Double>   MSTimeParse::timeList(2,0);
+  Matrix<Double>   MSTimeParse::timeList(3,0);
   TableExprNode MSTimeParse::columnAsTEN_p;
   MSSelectableMainColumn *MSTimeParse::mainColumn_p=0x0;
 
@@ -209,7 +209,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     TableExprNode condition = (abs(columnAsTEN_p - timeInSec) <= dT);
 
     //    TableExprNode condition = (abs(columnAsTEN_p - timeInSec) <= dT);
-    accumulateTimeList(timeInSec,timeInSec);
+    accumulateTimeList(timeInSec,timeInSec,dT);
 
     return addCondition(condition);
   }
@@ -259,15 +259,15 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       throw(MSSelectionTimeError("lower bound > upper bound"));
     }
     TableExprNode condition;
+    Float edgeWidth_l = (edgeWidth < 0.0) ? defaultExposure/2.0 : edgeWidth;
     if (!edgeInclusive) {
       condition = (columnAsTEN_p >= lowerBound &&
 		   (columnAsTEN_p <= upperBound));
     } else {
-      Float edgeWidth_l = (edgeWidth < 0.0) ? defaultExposure/2.0 : edgeWidth;
       condition = (((columnAsTEN_p > lowerBound) || (abs(columnAsTEN_p - lowerBound) < edgeWidth_l)) &&
 		   ((columnAsTEN_p < upperBound) || (abs(columnAsTEN_p - upperBound) < edgeWidth_l)));
     }
-    accumulateTimeList(lowerBound, upperBound);
+    accumulateTimeList(lowerBound, upperBound, edgeWidth_l);
 
     return addCondition(condition);
   }
@@ -424,7 +424,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   //
   //-------------------------------------------------------------------
   //  
-  void MSTimeParse::accumulateTimeList(const Double t0, const Double t1)
+  void MSTimeParse::accumulateTimeList(const Double t0, const Double t1,
+				       const Double dT)
   {
     Int n0=timeList.shape()(1);
     IPosition newShape(timeList.shape());
@@ -432,5 +433,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     timeList.resize(newShape,True);
     timeList(0,n0) = t0;//-4.68193e+09;
     timeList(1,n0) = t1;//-4.68193e+09;
+    if (dT > 0) timeList(2,n0) = dT;
+    else timeList(2,n0) = defaultExposure;
   }
 } //# NAMESPACE CASACORE - END

--- a/ms/MSSel/MSTimeParse.cc
+++ b/ms/MSSel/MSTimeParse.cc
@@ -259,6 +259,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       throw(MSSelectionTimeError("lower bound > upper bound"));
     }
     TableExprNode condition;
+    // edgeWidth < 0, edgeInclusive=F ==> T0~T1 syntax
+    // edgeWidth < 0, edgeInclusive=T ==> [T0~T1] syntax
+    // edgeWidth = N, edgeInclusive=T ==> N[T0~T1] syntax
     Float edgeWidth_l = (edgeWidth < 0.0) ? (edgeInclusive==True ? defaultExposure/2.0 : 0.0) : edgeWidth;
     if (!edgeInclusive) {
       condition = (columnAsTEN_p >= lowerBound &&

--- a/ms/MSSel/MSTimeParse.h
+++ b/ms/MSSel/MSTimeParse.h
@@ -148,7 +148,7 @@ public:
   Double defaultInteg() {return defaultExposure;}
 
   static void validate(const TimeFields& tf);
-  static void reset(){timeList.resize(2,0);}
+  static void reset(){timeList.resize(3,0);}
   static void cleanup() {if (node_p) delete node_p;node_p=0x0;}
 
   static TableExprNode* node_p;
@@ -167,7 +167,7 @@ public:
   const String colName;
   Bool honourRowFlags_p;
   static Matrix<Double> timeList;
-  void accumulateTimeList(const Double t0, const Double t1);
+  void accumulateTimeList(const Double t0, const Double t1,const Double dT=-1);
   static MSTimeParse *thisMSTParser;
   static TableExprNode columnAsTEN_p;
   static MSSelectableMainColumn *mainColumn_p;

--- a/ms/MSSel/test/tMSSelection.out
+++ b/ms/MSSel/test/tMSSelection.out
@@ -17,7 +17,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -52,7 +52,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -88,7 +88,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -123,7 +123,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -159,7 +159,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -195,7 +195,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -230,7 +230,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -266,7 +266,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -301,7 +301,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -336,7 +336,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -372,7 +372,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -408,7 +408,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -444,7 +444,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -479,7 +479,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -514,7 +514,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -549,7 +549,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -590,7 +590,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -630,7 +630,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -670,7 +670,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -710,7 +710,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -754,7 +754,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -793,7 +793,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -838,7 +838,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -893,7 +893,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -936,7 +936,7 @@ StE: STATE Expr=
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -979,7 +979,7 @@ StE: STATE Expr=*PHASE*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -1022,7 +1022,7 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=
-	TE: Time         = Axis Lengths: [2, 0] []
+	TE: Time         = Axis Lengths: [3, 0] []
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
 	UVE: UV in meters = []
@@ -1065,9 +1065,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=
 	UVE: UVRange      = Axis Lengths: [2, 0] []
@@ -1111,9 +1112,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1160,9 +1162,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1205,9 +1208,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1250,9 +1254,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1301,9 +1306,10 @@ StE: STATE Expr=*OFF*,*JUNK*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1346,9 +1352,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1391,9 +1398,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1436,9 +1444,10 @@ StE: STATE Expr=0,100
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1484,9 +1493,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1529,9 +1539,10 @@ StE: STATE Expr=*OFF*
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1574,9 +1585,10 @@ StE: STATE Expr=0,100
 AE: Array Expr=
 	AE: Array        = []
 TE: Time Expr=*+0:0:1
-	TE: Time         = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
 [4.91793e+09
- 4.91793e+09]
+ 4.91793e+09
+ 0]
 
 UVE: UVRange Expr=>1000m:50%
 	UVE: UVRange      = Axis Lengths: [2, 1]  (NB: Matrix in Row/Column order)
@@ -1600,4 +1612,133 @@ Number of selected rows: 0
 ###MSSelectionError: Spw Expression: No match found for 100, 
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ###MSSelectionError: No match found for the antenna specificion [ID(s): [500]] 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+BE: Baseline Expr=DA41&DV14
+	BE: Ant1         = [0]
+	BE: Ant2         = [9]
+	Baselines = 0 
+	            9 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=1
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 0, 63, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62903e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=
+	StE: StateObsMode = []
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=2014/09/20/10:38:0.9~2014/09/20/10:38:03.88
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09
+ 0]
+
+UVE: UVRange Expr=
+	UVE: UVRange      = Axis Lengths: [2, 0] []
+	UVE: UV in meters = []
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=
+	PE: PolMap       = 
+	PE: CorrMap      = 
+
+===========================================================
+DDIDs(Poln)  = []
+DDIDs(SPW)   = [1]
+StateList    = []
+Number of selected rows: 2
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+BE: Baseline Expr=DA41&DV14
+	BE: Ant1         = [0]
+	BE: Ant2         = [9]
+	Baselines = 0 
+	            9 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=1
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 0, 63, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62903e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=
+	StE: StateObsMode = []
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=[2014/09/20/10:38:1.1~2014/09/20/10:38:03.88]
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09
+ 0.96]
+
+UVE: UVRange Expr=
+	UVE: UVRange      = Axis Lengths: [2, 0] []
+	UVE: UV in meters = []
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=
+	PE: PolMap       = 
+	PE: CorrMap      = 
+
+===========================================================
+DDIDs(Poln)  = []
+DDIDs(SPW)   = [1]
+StateList    = []
+Number of selected rows: 2
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+BE: Baseline Expr=DA41&DV14
+	BE: Ant1         = [0]
+	BE: Ant2         = [9]
+	Baselines = 0 
+	            9 
+	            
+FE: Field Expr=
+	FE: Field        = []
+SE: SPW Expr=1
+	SE: SPW          = [1]
+	SE: Chan         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 0, 63, 1]
+
+	SE: Freq         = Axis Lengths: [1, 4]  (NB: Matrix in Row/Column order)
+[1, 8.62903e+10, 8.43216e+10, -3.125e+07]
+
+ScE: Scan Expr=
+	ScE: tScan         = []
+StE: STATE Expr=
+	StE: StateObsMode = []
+AE: Array Expr=
+	AE: Array        = []
+TE: Time Expr=0.04[2014/09/20/10:38:1.1~2014/09/20/10:38:03.88]
+	TE: Time         = Axis Lengths: [3, 1]  (NB: Matrix in Row/Column order)
+[4.91793e+09
+ 4.91793e+09
+ 0.04]
+
+UVE: UVRange Expr=
+	UVE: UVRange      = Axis Lengths: [2, 0] []
+	UVE: UV in meters = []
+OE: Observation Expr=
+	OE: ObservationIDList    = []
+PE: Poln Expr=
+	PE: PolMap       = 
+	PE: CorrMap      = 
+
+===========================================================
+DDIDs(Poln)  = []
+DDIDs(SPW)   = [1]
+StateList    = []
+Number of selected rows: 1
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/ms/MSSel/test/tMSSelection.run
+++ b/ms/MSSel/test/tMSSelection.run
@@ -90,6 +90,13 @@
   runCmd 40 "$casa_checktool" " ./tMSSelection ms=$MS baseline='(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11' stateobsmode='*OFF*' spw='0,1,100' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'";
   runCmd 41 "$casa_checktool" " ./tMSSelection ms=$MS baseline='0,1,2;500' stateobsmode='*OFF*' spw='ALMA*FULL*:85290~86290.305MHz' time='*+0:0:1' uvdist='>1000m:50%' poln='XX,YX' installeh='0'";
 
+  runCmd 42 "$casa_checktool" " ./tMSSelection ms=$MS baseline='DA41&DV14' spw='1' time='2014/09/20/10:38:0.9~2014/09/20/10:38:03.88' installeh='0'";
+  runCmd 43 "$casa_checktool" " ./tMSSelection ms=$MS baseline='DA41&DV14' spw='1' time='[2014/09/20/10:38:1.1~2014/09/20/10:38:03.88]' installeh='0'";
+  runCmd 44 "$casa_checktool" " ./tMSSelection ms=$MS baseline='DA41&DV14' spw='1' time='0.04[2014/09/20/10:38:1.1~2014/09/20/10:38:03.88]' installeh='0'";
+#Time Expr=2014/09/20/10:38:0.9~2014/09/20/10:38:03.88
+#Time Expr=[2014/09/20/10:38:1.10~2014/09/20/10:38:03.88]
+#Time Expr=0.04[2014/09/20/10:38:1.10~2014/09/20/10:38:03.88]
+
   #
   # Remove the test MS and any other cleanup required.
   #

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2536,7 +2536,8 @@ void FITSIDItoMS1::fillAntennaTable()
      case 1: mount="EQUATORIAL"; break;
      case 2: mount="X-Y"; break;
      case 3: mount="ORBITING"; break;
-     case 4: mount="BIZARRE"; break;
+     case 4: mount="ALT-AZ+NASMYTH-R"; break;
+     case 5: mount="ALT-AZ+NASMYTH-L"; break;
      default: mount="UNKNOWN"; break;
      }
      ant.flagRow().put(row,False);

--- a/scimath/Mathematics/StatisticsAlgorithm.tcc
+++ b/scimath/Mathematics/StatisticsAlgorithm.tcc
@@ -26,11 +26,11 @@
 
 #ifndef SCIMATH_STATISTICSALGORITHM_TCC
 #define SCIMATH_STATISTICSALGORITHM_TCC
- 
+
 #include <casacore/scimath/Mathematics/StatisticsAlgorithm.h>
- 
+
 #include <casacore/casa/BasicSL/STLIO.h>
-#include <casa/Utilities/GenSort.h>
+#include <casacore/casa/Utilities/GenSort.h>
 
 namespace casacore {
 

--- a/scimath/Mathematics/StatisticsAlgorithmFactory.h
+++ b/scimath/Mathematics/StatisticsAlgorithmFactory.h
@@ -26,11 +26,11 @@
 #ifndef SCIMATH_STATSALGORITHMFACTORY_H
 #define SCIMATH_STATSALGORITHMFACTORY_H
 
-#include <casa/Utilities/CountedPtr.h>
-#include <scimath/Mathematics/FitToHalfStatisticsData.h>
-#include <scimath/Mathematics/NumericTraits.h>
-#include <scimath/Mathematics/StatisticsAlgorithm.h>
-#include <scimath/Mathematics/StatisticsData.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
+#include <casacore/scimath/Mathematics/FitToHalfStatisticsData.h>
+#include <casacore/scimath/Mathematics/NumericTraits.h>
+#include <casacore/scimath/Mathematics/StatisticsAlgorithm.h>
+#include <casacore/scimath/Mathematics/StatisticsData.h>
 
 namespace casacore {
 
@@ -81,7 +81,7 @@ public:
     StatisticsData::ALGORITHM algorithm() const { return _algorithm; }
 
     // Throws an exception if the current configuration is not relevant
-    // to the Chauvenet/zscore algorithm 
+    // to the Chauvenet/zscore algorithm
     ChauvenetData chauvenetData() const;
 
     // Throws an exception if the current configuration is not relevant

--- a/scimath/Mathematics/StatisticsAlgorithmFactory.tcc
+++ b/scimath/Mathematics/StatisticsAlgorithmFactory.tcc
@@ -26,10 +26,10 @@
 
 #ifndef SCIMATH_STATISTICSALGORITHMFACTORY_TCC
 #define SCIMATH_STATISTICSALGORITHMFACTORY_TCC
- 
+
 #include <casacore/scimath/Mathematics/StatisticsAlgorithmFactory.h>
 
-#include <casa/Utilities/CountedPtr.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/scimath/Mathematics/ChauvenetCriterionStatistics.h>
 #include <casacore/scimath/Mathematics/ClassicalStatistics.h>
 #include <casacore/scimath/Mathematics/FitToHalfStatistics.h>


### PR DESCRIPTION
Time selection syntax of the type `dT[ T0~T1]` where the supplied `dT` is used to determine the boundaries for the given range was not enabled (accidentally).  With this merge, it would be enabled.

`MSSelection::getTimeList()` would return a 3xN matrix with the third element of each row containing the value for `dT `used.  Currently a 2xN matrix is return.  

Changes are in the following files:

```
> git diff --name-only origin
ms/MSSel/MSSelection.cc
ms/MSSel/MSTimeGram.yy
ms/MSSel/MSTimeParse.cc
ms/MSSel/MSTimeParse.h
ms/MSSel/test/tMSSelection.out
ms/MSSel/test/tMSSelection.run
```
