### PR TITLE
Correct the header paths.

### DIFF
--- a/scimath/Mathematics/StatisticsAlgorithm.tcc
+++ b/scimath/Mathematics/StatisticsAlgorithm.tcc
@@ -26,11 +26,11 @@
 
 #ifndef SCIMATH_STATISTICSALGORITHM_TCC
 #define SCIMATH_STATISTICSALGORITHM_TCC
- 
+
 #include <casacore/scimath/Mathematics/StatisticsAlgorithm.h>
- 
+
 #include <casacore/casa/BasicSL/STLIO.h>
-#include <casa/Utilities/GenSort.h>
+#include <casacore/casa/Utilities/GenSort.h>
 
 namespace casacore {
 

--- a/scimath/Mathematics/StatisticsAlgorithmFactory.h
+++ b/scimath/Mathematics/StatisticsAlgorithmFactory.h
@@ -26,11 +26,11 @@
 #ifndef SCIMATH_STATSALGORITHMFACTORY_H
 #define SCIMATH_STATSALGORITHMFACTORY_H
 
-#include <casa/Utilities/CountedPtr.h>
-#include <scimath/Mathematics/FitToHalfStatisticsData.h>
-#include <scimath/Mathematics/NumericTraits.h>
-#include <scimath/Mathematics/StatisticsAlgorithm.h>
-#include <scimath/Mathematics/StatisticsData.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
+#include <casacore/scimath/Mathematics/FitToHalfStatisticsData.h>
+#include <casacore/scimath/Mathematics/NumericTraits.h>
+#include <casacore/scimath/Mathematics/StatisticsAlgorithm.h>
+#include <casacore/scimath/Mathematics/StatisticsData.h>
 
 namespace casacore {
 
@@ -81,7 +81,7 @@ public:
     StatisticsData::ALGORITHM algorithm() const { return _algorithm; }
 
     // Throws an exception if the current configuration is not relevant
-    // to the Chauvenet/zscore algorithm 
+    // to the Chauvenet/zscore algorithm
     ChauvenetData chauvenetData() const;
 
     // Throws an exception if the current configuration is not relevant

--- a/scimath/Mathematics/StatisticsAlgorithmFactory.tcc
+++ b/scimath/Mathematics/StatisticsAlgorithmFactory.tcc
@@ -26,10 +26,10 @@
 
 #ifndef SCIMATH_STATISTICSALGORITHMFACTORY_TCC
 #define SCIMATH_STATISTICSALGORITHMFACTORY_TCC
- 
+
 #include <casacore/scimath/Mathematics/StatisticsAlgorithmFactory.h>
 
-#include <casa/Utilities/CountedPtr.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/scimath/Mathematics/ChauvenetCriterionStatistics.h>
 #include <casacore/scimath/Mathematics/ClassicalStatistics.h>
 #include <casacore/scimath/Mathematics/FitToHalfStatistics.h>


### PR DESCRIPTION
Grimmer noticed that some of the header paths were incorrect. This went undetected by the Casa build system but caused trouble if Carta.