### PR TITLE
Remove travis Linux OS version pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 cache: ccache
-dist: precise
 
 os:
   - linux


### PR DESCRIPTION
Allow build under Ubuntu trusty.
I don't expect the travis build for this PR to succeed. As I'm unsure why the travis build under Ubuntu trusty is failing, and I don't have an Ubuntu trusty system to do my own testing, I am using this pull request for build testing.