### PR TITLE
LogSink.theirMutex may not be initialized when createGlobalSink( ) is…

### DIFF
--- a/casa/Logging/LogSink.cc
+++ b/casa/Logging/LogSink.cc
@@ -42,7 +42,6 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 CountedPtr<LogSink::LsiIntermediate> *LogSink::global_sink_p = 0;
-Mutex LogSink::theirMutex;
 
 
 String LogSink::localId( ) {
@@ -318,11 +317,16 @@ void LogSink::flush (Bool global)
 
 void LogSink::createGlobalSink()
 {
-    ScopedMutexLock lock(theirMutex);
+    ScopedMutexLock lock(theirMutex( ));
     if ( ! LogSink::global_sink_p ) {
         LogSink::global_sink_p = new CountedPtr<LsiIntermediate> ();
         (* global_sink_p) = new LsiIntermediate (new StreamLogSink(LogMessage::NORMAL, &cerr));
     }
+}
+
+Mutex &LogSink::theirMutex( ) {
+    static Mutex mutex;
+    return mutex;
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/Logging/LogSink.h
+++ b/casa/Logging/LogSink.h
@@ -305,7 +305,7 @@ private:
   //# Data members.
   CountedPtr<LogSinkInterface> local_sink_p;
   static CountedPtr<LsiIntermediate> * global_sink_p;
-  static Mutex theirMutex;
+  static Mutex &theirMutex( );
 
   // The following is a reference to the global sink. It is created to
   // ensure that the global sink is not destroyed before the last local


### PR DESCRIPTION
… called from a separate translation unit. While working on alternative library packaging for CASA, I encountered problems during library loading. This turned out to be due to the fact that LogSink does not proper ensure the initialization of theirMutex when createGlobalSink( ) is called from a different translation unit.

This proposed merge is just one solution. It is probably also possible to use a helper class with a static object defined within LogSink.h to ensure that the Mutex variable is initialized. However, with this approach one needs to worry about destruction and avoiding multiple initialization (when this static is initialized in its own time).

The error etc. that I received is below:

-bash-4.2$ LD_DEBUG=reloc LD_LIBRARY_PATH=/opt/casa/02/lib:/opt/casa/02/lib/libsakura/default/lib /opt/casa/02/bin/python -c 'import utils'
     19228:	
     19228:	relocation processing: /lib64/libc.so.6
     19228:	
     19228:	relocation processing: /lib64/libm.so.6 (lazy)
     19228:	
     19228:	relocation processing: /lib64/libutil.so.1 (lazy)
     19228:	
     19228:	relocation processing: /lib64/libtinfo.so.5 (lazy)
     19228:	
     19228:	relocation processing: /lib64/libdl.so.2 (lazy)
     19228:	
     19228:	relocation processing: /lib64/libpthread.so.0 (lazy)
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/libpython2.7.so.1.0 (lazy)
     19228:	
     19228:	relocation processing: /opt/casa/02/bin/python (lazy)
     19228:	
     19228:	relocation processing: /lib64/ld-linux-x86-64.so.2
     19228:	
     19228:	calling init: /lib64/libpthread.so.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libc.so.6
     19228:	
     19228:	
     19228:	calling init: /lib64/libm.so.6
     19228:	
     19228:	
     19228:	calling init: /lib64/libutil.so.1
     19228:	
     19228:	
     19228:	calling init: /lib64/libtinfo.so.5
     19228:	
     19228:	
     19228:	calling init: /lib64/libdl.so.2
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/libpython2.7.so.1.0
     19228:	
     19228:	
     19228:	initialize program: /opt/casa/02/bin/python
     19228:	
     19228:	
     19228:	transferring control: /opt/casa/02/bin/python
     19228:	
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/python2.7/lib-dynload/_locale.so
     19228:	
     19228:	calling init: /opt/casa/02/lib/python2.7/lib-dynload/_locale.so
     19228:	
     19228:	
     19228:	relocation processing: /lib64/libquadmath.so.0
     19228:	
     19228:	relocation processing: /lib64/libnsl.so.1
     19228:	
     19228:	relocation processing: /lib64/liblzma.so.5
     19228:	
     19228:	relocation processing: /lib64/libz.so.1
     19228:	
     19228:	relocation processing: /lib64/libicudata.so.50
     19228:	
     19228:	relocation processing: /lib64/libgcc_s.so.1
     19228:	
     19228:	relocation processing: /lib64/libstdc++.so.6
     19228:	
     19228:	relocation processing: /lib64/libicuuc.so.50
     19228:	
     19228:	relocation processing: /lib64/libicui18n.so.50
     19228:	
     19228:	relocation processing: /lib64/librt.so.1
     19228:	
     19228:	relocation processing: /lib64/libgfortran.so.3
     19228:	
     19228:	relocation processing: /lib64/libreadline.so.6
     19228:	
     19228:	relocation processing: /lib64/libblas.so.3
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/librpfits.so.2.23
     19228:	
     19228:	relocation processing: /lib64/libcfitsio.so.2
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/libwcs.so.5
     19228:	
     19228:	relocation processing: /lib64/liblapack.so.3
     19228:	
     19228:	relocation processing: /lib64/libfftw3.so.3
     19228:	
     19228:	relocation processing: /lib64/libfftw3_threads.so.3
     19228:	
     19228:	relocation processing: /lib64/libfftw3f.so.3
     19228:	
     19228:	relocation processing: /lib64/libfftw3f_threads.so.3
     19228:	
     19228:	relocation processing: /lib64/libgomp.so.1
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/libgslcblas.so.0
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/libgsl.so.19
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/libsakura/default/lib/libsakura.so.3
     19228:	
     19228:	relocation processing: /lib64/libxerces-c-3.1.so
     19228:	
     19228:	relocation processing: /lib64/libxml2.so.2
     19228:	
     19228:	relocation processing: /lib64/libxslt.so.1
     19228:	
     19228:	relocation processing: /lib64/libsqlite3.so.0
     19228:	
     19228:	relocation processing: /lib64/libdbus-1.so.3
     19228:	
     19228:	relocation processing: /opt/casa/02/lib/libcasa-dbus-cpp.so.0.1
     19228:	
     19228:	relocation processing: /lib64/libboost_system-mt.so.1.53.0
     19228:	
     19228:	relocation processing: /lib64/libboost_thread-mt.so.1.53.0
     19228:	
     19228:	relocation processing: /lib64/libboost_filesystem-mt.so.1.53.0
     19228:	
     19228:	relocation processing: /lib64/libboost_regex-mt.so.1.53.0
     19228:	
     19228:	relocation processing: /lib64/libboost_python-mt.so.1.53.0
     19228:	
     19228:	relocation processing: /home/hypnos/dschieb/casa/python-setup/src/build/lib.linux-x86_64-2.7/CASAtools/casac/lib/libCASAtools.so
     19228:	
     19228:	relocation processing: /home/hypnos/dschieb/casa/python-setup/src/build/lib.linux-x86_64-2.7/CASAtools/casac/_utils.so
     19228:	
     19228:	calling init: /lib64/libquadmath.so.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libnsl.so.1
     19228:	
     19228:	
     19228:	calling init: /lib64/liblzma.so.5
     19228:	
     19228:	
     19228:	calling init: /lib64/libz.so.1
     19228:	
     19228:	
     19228:	calling init: /lib64/libicudata.so.50
     19228:	
     19228:	
     19228:	calling init: /lib64/libgcc_s.so.1
     19228:	
     19228:	
     19228:	calling init: /lib64/libstdc++.so.6
     19228:	
     19228:	
     19228:	calling init: /lib64/libicuuc.so.50
     19228:	
     19228:	
     19228:	calling init: /lib64/libicui18n.so.50
     19228:	
     19228:	
     19228:	calling init: /lib64/librt.so.1
     19228:	
     19228:	
     19228:	calling init: /lib64/libgfortran.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libreadline.so.6
     19228:	
     19228:	
     19228:	calling init: /lib64/libblas.so.3
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/librpfits.so.2.23
     19228:	
     19228:	
     19228:	calling init: /lib64/libcfitsio.so.2
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/libwcs.so.5
     19228:	
     19228:	
     19228:	calling init: /lib64/liblapack.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libfftw3.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libfftw3_threads.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libfftw3f.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libfftw3f_threads.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libgomp.so.1
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/libgslcblas.so.0
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/libgsl.so.19
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/libsakura/default/lib/libsakura.so.3
     19228:	
     19228:	
     19228:	calling init: /lib64/libxerces-c-3.1.so
     19228:	
     19228:	
     19228:	calling init: /lib64/libxml2.so.2
     19228:	
     19228:	
     19228:	calling init: /lib64/libxslt.so.1
     19228:	
     19228:	
     19228:	calling init: /lib64/libsqlite3.so.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libdbus-1.so.3
     19228:	
     19228:	
     19228:	calling init: /opt/casa/02/lib/libcasa-dbus-cpp.so.0.1
     19228:	
     19228:	
     19228:	calling init: /lib64/libboost_system-mt.so.1.53.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libboost_thread-mt.so.1.53.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libboost_filesystem-mt.so.1.53.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libboost_regex-mt.so.1.53.0
     19228:	
     19228:	
     19228:	calling init: /lib64/libboost_python-mt.so.1.53.0
     19228:	
     19228:	
     19228:	calling init: /home/hypnos/dschieb/casa/python-setup/src/build/lib.linux-x86_64-2.7/CASAtools/casac/lib/libCASAtools.so
     19228:	
Segmentation fault (core dumped)
-bash-4.2$ LD_DEBUG=reloc LD_LIBRARY_PATH=/opt/casa/02/lib:/opt/casa/02/lib/libsakura/default/lib valgrind /opt/casa/02/bin/python -c 'import utils'
     19312:	
     19312:	relocation processing: /lib64/libc.so.6
     19312:	
     19312:	relocation processing: valgrind (lazy)
     19312:	
     19312:	relocation processing: /lib64/ld-linux-x86-64.so.2
     19312:	
     19312:	calling init: /lib64/libc.so.6
     19312:	
     19312:	
     19312:	initialize program: valgrind
     19312:	
     19312:	
     19312:	transferring control: valgrind
     19312:	
==19312== Memcheck, a memory error detector
==19312== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==19312== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==19312== Command: /opt/casa/02/bin/python -c import\ utils
==19312== 
     19312:	
     19312:	relocation processing: /lib64/libc.so.6
     19312:	
     19312:	relocation processing: /lib64/libm.so.6 (lazy)
     19312:	
     19312:	relocation processing: /lib64/libutil.so.1 (lazy)
     19312:	
     19312:	relocation processing: /lib64/libtinfo.so.5 (lazy)
     19312:	
     19312:	relocation processing: /lib64/libdl.so.2 (lazy)
     19312:	
     19312:	relocation processing: /lib64/libpthread.so.0 (lazy)
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/libpython2.7.so.1.0 (lazy)
     19312:	
     19312:	relocation processing: /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so (lazy)
     19312:	
     19312:	relocation processing: /usr/lib64/valgrind/vgpreload_core-amd64-linux.so (lazy)
     19312:	
     19312:	relocation processing: /opt/casa/02/bin/python (lazy)
     19312:	
     19312:	relocation processing: /lib64/ld-linux-x86-64.so.2
     19312:	
     19312:	calling init: /lib64/libpthread.so.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libc.so.6
     19312:	
     19312:	
     19312:	calling init: /lib64/libm.so.6
     19312:	
     19312:	
     19312:	calling init: /lib64/libutil.so.1
     19312:	
     19312:	
     19312:	calling init: /lib64/libtinfo.so.5
     19312:	
     19312:	
     19312:	calling init: /lib64/libdl.so.2
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/libpython2.7.so.1.0
     19312:	
     19312:	
     19312:	calling init: /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so
     19312:	
     19312:	
     19312:	calling init: /usr/lib64/valgrind/vgpreload_core-amd64-linux.so
     19312:	
     19312:	
     19312:	initialize program: /opt/casa/02/bin/python
     19312:	
     19312:	
     19312:	transferring control: /opt/casa/02/bin/python
     19312:	
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4ED1D42: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92DDA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E47F: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Address 0x61dd020 is 384 bytes inside a block of size 568 free'd
==19312==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==19312==    by 0x5DD0C14: fclose@@GLIBC_2.2.5 (in /usr/lib64/libc-2.17.so)
==19312==    by 0x4F2E420: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E3A8: PyEval_EvalCode (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Block was alloc'd at
==19312==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==19312==    by 0x5DD158C: __fopen_internal (in /usr/lib64/libc-2.17.so)
==19312==    by 0x4F2E3C4: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E3A8: PyEval_EvalCode (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312== 
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92D6A: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E47F: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E3A8: PyEval_EvalCode (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Address 0x6234020 is 2,576 bytes inside a block of size 2,767 free'd
==19312==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==19312==    by 0x4F33D50: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Block was alloc'd at
==19312==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==19312==    by 0x4F33D11: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312== 
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92D6A: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4ED1D29: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92DEA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E47F: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Address 0x6222020 is 464 bytes inside a block of size 576 free'd
==19312==    at 0x4C2BB78: realloc (vg_replace_malloc.c:785)
==19312==    by 0x4EAAC07: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4EABCF5: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F323B6: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31EBA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31EBA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33C77: PyMarshal_ReadObjectFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33D45: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Block was alloc'd at
==19312==    at 0x4C2BB78: realloc (vg_replace_malloc.c:785)
==19312==    by 0x4EAAC07: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4EABCF5: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F323B6: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31ED0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31EBA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33C77: PyMarshal_ReadObjectFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33D45: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312== 
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4ED1D42: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92DEA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E47F: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Address 0x61d2020 is 9,472 bytes inside a block of size 11,558 free'd
==19312==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==19312==    by 0x4F33D50: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Block was alloc'd at
==19312==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==19312==    by 0x4F33D11: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312== 
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92D40: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E47F: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E3A8: PyEval_EvalCode (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Address 0x61d5020 is 224 bytes inside a block of size 1,384 free'd
==19312==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==19312==    by 0x4EABABC: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33C93: PyMarshal_ReadObjectFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33D45: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Block was alloc'd at
==19312==    at 0x4C2BB78: realloc (vg_replace_malloc.c:785)
==19312==    by 0x4EAAC07: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4EABCF5: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F323B6: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31EE4: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31EBA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33C77: PyMarshal_ReadObjectFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33D45: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312== 
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/python2.7/lib-dynload/_locale.so
     19312:	
     19312:	calling init: /opt/casa/02/lib/python2.7/lib-dynload/_locale.so
     19312:	
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E92D7A: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E47F: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F19094: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1C84E: PyEval_EvalFrameEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F1E28B: PyEval_EvalCodeEx (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Address 0x6329020 is 2,256 bytes inside a block of size 4,784 free'd
==19312==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==19312==    by 0x4EABABC: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33C93: PyMarshal_ReadObjectFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33D45: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2FD5C: PyImport_ImportModuleLevel (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F12727: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E82552: PyObject_Call (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F14346: PyEval_CallObjectWithKeywords (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==  Block was alloc'd at
==19312==    at 0x4C2BB78: realloc (vg_replace_malloc.c:785)
==19312==    by 0x4EAAC07: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4EABCF5: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F323B6: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31B9E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F31EBA: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33C77: PyMarshal_ReadObjectFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F33D45: PyMarshal_ReadLastObjectFromFile (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2CAE0: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2E415: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F0EF: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F2F37E: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312== 
==19312== Conditional jump or move depends on uninitialised value(s)
==19312==    at 0x4EC0A1C: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E781EB: PyGrammar_AddAccelerators (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E78C8C: PyParser_New (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E79144: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F388E4: PyParser_ASTFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F389D3: PyRun_StringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F3A30A: PyRun_SimpleStringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F4B85F: Py_Main (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x5D87C04: (below main) (in /usr/lib64/libc-2.17.so)
==19312== 
==19312== Use of uninitialised value of size 8
==19312==    at 0x4EC0A34: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E781EB: PyGrammar_AddAccelerators (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E78C8C: PyParser_New (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E79144: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F388E4: PyParser_ASTFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F389D3: PyRun_StringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F3A30A: PyRun_SimpleStringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F4B85F: Py_Main (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x5D87C04: (below main) (in /usr/lib64/libc-2.17.so)
==19312== 
==19312== Invalid read of size 4
==19312==    at 0x4EC0A13: PyObject_Free (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E781EB: PyGrammar_AddAccelerators (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E78C8C: PyParser_New (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E79144: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F388E4: PyParser_ASTFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F389D3: PyRun_StringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F3A30A: PyRun_SimpleStringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F4B85F: Py_Main (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x5D87C04: (below main) (in /usr/lib64/libc-2.17.so)
==19312==  Address 0x63be020 is 544 bytes inside a block of size 676 free'd
==19312==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==19312==    by 0x4E781EB: PyGrammar_AddAccelerators (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E78C8C: PyParser_New (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E79144: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F388E4: PyParser_ASTFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F389D3: PyRun_StringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F3A30A: PyRun_SimpleStringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F4B85F: Py_Main (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x5D87C04: (below main) (in /usr/lib64/libc-2.17.so)
==19312==  Block was alloc'd at
==19312==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==19312==    by 0x4E780D7: PyGrammar_AddAccelerators (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E78C8C: PyParser_New (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4E79144: ??? (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F388E4: PyParser_ASTFromString (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F389D3: PyRun_StringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F3A30A: PyRun_SimpleStringFlags (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x4F4B85F: Py_Main (in /opt/casa/02/lib/libpython2.7.so.1.0)
==19312==    by 0x5D87C04: (below main) (in /usr/lib64/libc-2.17.so)
==19312== 
     19312:	
     19312:	relocation processing: /lib64/libquadmath.so.0
     19312:	
     19312:	relocation processing: /lib64/libnsl.so.1
     19312:	
     19312:	relocation processing: /lib64/liblzma.so.5
     19312:	
     19312:	relocation processing: /lib64/libz.so.1
     19312:	
     19312:	relocation processing: /lib64/libicudata.so.50
     19312:	
     19312:	relocation processing: /lib64/libgcc_s.so.1
     19312:	
     19312:	relocation processing: /lib64/libstdc++.so.6
     19312:	
     19312:	relocation processing: /lib64/libicuuc.so.50
     19312:	
     19312:	relocation processing: /lib64/libicui18n.so.50
     19312:	
     19312:	relocation processing: /lib64/librt.so.1
     19312:	
     19312:	relocation processing: /lib64/libgfortran.so.3
     19312:	
     19312:	relocation processing: /lib64/libreadline.so.6
     19312:	
     19312:	relocation processing: /lib64/libblas.so.3
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/librpfits.so.2.23
     19312:	
     19312:	relocation processing: /lib64/libcfitsio.so.2
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/libwcs.so.5
     19312:	
     19312:	relocation processing: /lib64/liblapack.so.3
     19312:	
     19312:	relocation processing: /lib64/libfftw3.so.3
     19312:	
     19312:	relocation processing: /lib64/libfftw3_threads.so.3
     19312:	
     19312:	relocation processing: /lib64/libfftw3f.so.3
     19312:	
     19312:	relocation processing: /lib64/libfftw3f_threads.so.3
     19312:	
     19312:	relocation processing: /lib64/libgomp.so.1
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/libgslcblas.so.0
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/libgsl.so.19
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/libsakura/default/lib/libsakura.so.3
     19312:	
     19312:	relocation processing: /lib64/libxerces-c-3.1.so
     19312:	
     19312:	relocation processing: /lib64/libxml2.so.2
     19312:	
     19312:	relocation processing: /lib64/libxslt.so.1
     19312:	
     19312:	relocation processing: /lib64/libsqlite3.so.0
     19312:	
     19312:	relocation processing: /lib64/libdbus-1.so.3
     19312:	
     19312:	relocation processing: /opt/casa/02/lib/libcasa-dbus-cpp.so.0.1
     19312:	
     19312:	relocation processing: /lib64/libboost_system-mt.so.1.53.0
     19312:	
     19312:	relocation processing: /lib64/libboost_thread-mt.so.1.53.0
     19312:	
     19312:	relocation processing: /lib64/libboost_filesystem-mt.so.1.53.0
     19312:	
     19312:	relocation processing: /lib64/libboost_regex-mt.so.1.53.0
     19312:	
     19312:	relocation processing: /lib64/libboost_python-mt.so.1.53.0
     19312:	
     19312:	relocation processing: /home/hypnos/dschieb/casa/python-setup/src/build/lib.linux-x86_64-2.7/CASAtools/casac/lib/libCASAtools.so
     19312:	
     19312:	relocation processing: /home/hypnos/dschieb/casa/python-setup/src/build/lib.linux-x86_64-2.7/CASAtools/casac/_utils.so
     19312:	
     19312:	calling init: /lib64/libquadmath.so.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libnsl.so.1
     19312:	
     19312:	
     19312:	calling init: /lib64/liblzma.so.5
     19312:	
     19312:	
     19312:	calling init: /lib64/libz.so.1
     19312:	
     19312:	
     19312:	calling init: /lib64/libicudata.so.50
     19312:	
     19312:	
     19312:	calling init: /lib64/libgcc_s.so.1
     19312:	
     19312:	
     19312:	calling init: /lib64/libstdc++.so.6
     19312:	
     19312:	
     19312:	calling init: /lib64/libicuuc.so.50
     19312:	
     19312:	
     19312:	calling init: /lib64/libicui18n.so.50
     19312:	
     19312:	
     19312:	calling init: /lib64/librt.so.1
     19312:	
     19312:	
     19312:	calling init: /lib64/libgfortran.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libreadline.so.6
     19312:	
     19312:	
     19312:	calling init: /lib64/libblas.so.3
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/librpfits.so.2.23
     19312:	
     19312:	
     19312:	calling init: /lib64/libcfitsio.so.2
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/libwcs.so.5
     19312:	
     19312:	
     19312:	calling init: /lib64/liblapack.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libfftw3.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libfftw3_threads.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libfftw3f.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libfftw3f_threads.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libgomp.so.1
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/libgslcblas.so.0
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/libgsl.so.19
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/libsakura/default/lib/libsakura.so.3
     19312:	
     19312:	
     19312:	calling init: /lib64/libxerces-c-3.1.so
     19312:	
     19312:	
     19312:	calling init: /lib64/libxml2.so.2
     19312:	
     19312:	
     19312:	calling init: /lib64/libxslt.so.1
     19312:	
     19312:	
     19312:	calling init: /lib64/libsqlite3.so.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libdbus-1.so.3
     19312:	
     19312:	
     19312:	calling init: /opt/casa/02/lib/libcasa-dbus-cpp.so.0.1
     19312:	
     19312:	
     19312:	calling init: /lib64/libboost_system-mt.so.1.53.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libboost_thread-mt.so.1.53.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libboost_filesystem-mt.so.1.53.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libboost_regex-mt.so.1.53.0
     19312:	
     19312:	
     19312:	calling init: /lib64/libboost_python-mt.so.1.53.0
     19312:	
     19312:	
     19312:	calling init: /home/hypnos/dschieb/casa/python-setup/src/build/lib.linux-x86_64-2.7/CASAtools/casac/lib/libCASAtools.so
     19312:	
==19312== Invalid read of size 4
==19312==    at 0x5220C30: pthread_mutex_lock (in /usr/lib64/libpthread-2.17.so)
==19312==    by 0x127139E0: casacore::Mutex::lock() (Mutex.cc:92)
==19312==    by 0xFB5BE85: casacore::ScopedMutexLock::ScopedMutexLock(casacore::Mutex&) (Mutex.h:103)
==19312==    by 0x1270A663: casacore::LogSink::createGlobalSink() (LogSink.cc:321)
==19312==    by 0x127090F9: casacore::LogSink::LogSink(casacore::LogMessage::Priority, bool) (LogSink.cc:61)
==19312==    by 0x127080D4: casacore::LogIO::LogIO(casacore::LogOrigin const&) (LogIO.cc:47)
==19312==    by 0xFF36046: __static_initialization_and_destruction_0(int, int) (RFFlagCube.cc:66)
==19312==    by 0xFF3668E: _GLOBAL__sub_I_RFFlagCube.cc (RFFlagCube.cc:711)
==19312==    by 0x400F502: _dl_init (in /usr/lib64/ld-2.17.so)
==19312==    by 0x4013C15: dl_open_worker (in /usr/lib64/ld-2.17.so)
==19312==    by 0x400F313: _dl_catch_error (in /usr/lib64/ld-2.17.so)
==19312==    by 0x401330A: _dl_open (in /usr/lib64/ld-2.17.so)
==19312==  Address 0x10 is not stack'd, malloc'd or (recently) free'd
==19312== 
==19312== 
==19312== Process terminating with default action of signal 11 (SIGSEGV)
==19312==  Access not within mapped region at address 0x10
==19312==    at 0x5220C30: pthread_mutex_lock (in /usr/lib64/libpthread-2.17.so)
==19312==    by 0x127139E0: casacore::Mutex::lock() (Mutex.cc:92)
==19312==    by 0xFB5BE85: casacore::ScopedMutexLock::ScopedMutexLock(casacore::Mutex&) (Mutex.h:103)
==19312==    by 0x1270A663: casacore::LogSink::createGlobalSink() (LogSink.cc:321)
==19312==    by 0x127090F9: casacore::LogSink::LogSink(casacore::LogMessage::Priority, bool) (LogSink.cc:61)
==19312==    by 0x127080D4: casacore::LogIO::LogIO(casacore::LogOrigin const&) (LogIO.cc:47)
==19312==    by 0xFF36046: __static_initialization_and_destruction_0(int, int) (RFFlagCube.cc:66)
==19312==    by 0xFF3668E: _GLOBAL__sub_I_RFFlagCube.cc (RFFlagCube.cc:711)
==19312==    by 0x400F502: _dl_init (in /usr/lib64/ld-2.17.so)
==19312==    by 0x4013C15: dl_open_worker (in /usr/lib64/ld-2.17.so)
==19312==    by 0x400F313: _dl_catch_error (in /usr/lib64/ld-2.17.so)
==19312==    by 0x401330A: _dl_open (in /usr/lib64/ld-2.17.so)
==19312==  If you believe this happened as a result of a stack
==19312==  overflow in your program's main thread (unlikely but
==19312==  possible), you can try to increase the size of the
==19312==  main thread stack using the --main-stacksize= flag.
==19312==  The main thread stack size used in this run was 8388608.
==19312== 
==19312== HEAP SUMMARY:
==19312==     in use at exit: 1,178,334 bytes in 1,545 blocks
==19312==   total heap usage: 5,914 allocs, 4,369 frees, 3,560,807 bytes allocated
==19312== 
==19312== LEAK SUMMARY:
==19312==    definitely lost: 0 bytes in 0 blocks
==19312==    indirectly lost: 0 bytes in 0 blocks
==19312==      possibly lost: 5,736 bytes in 10 blocks
==19312==    still reachable: 1,172,598 bytes in 1,535 blocks
==19312==                       of which reachable via heuristic:
==19312==                         stdstring          : 16,952 bytes in 539 blocks
==19312==         suppressed: 0 bytes in 0 blocks
==19312== Rerun with --leak-check=full to see details of leaked memory
==19312== 
==19312== For counts of detected and suppressed errors, rerun with: -v
==19312== Use --track-origins=yes to see where uninitialised values come from
==19312== ERROR SUMMARY: 328 errors from 10 contexts (suppressed: 0 from 0)
Segmentation fault (core dumped)
-bash-4.2$ 
