### PR TITLE
 	CAS-7309 add support to ImageOpener for componentlist images

### DIFF
--- a/casa/Arrays/IPosition.cc
+++ b/casa/Arrays/IPosition.cc
@@ -1162,5 +1162,24 @@ void IPosition::throwIndexError() const
     throw(AipsError("IPosition::operator() - index error"));
 }
 
+bool IPositionComparator::operator ()(const IPosition& lhs, const IPosition& rhs) const {
+    size_t lhsSize = lhs.size_p;
+    size_t rhsSize = rhs.size_p;
+    if (lhsSize == rhsSize) {
+        ssize_t *lp = lhs.data_p;
+        ssize_t *rp = rhs.data_p;
+        for (uInt i=0; i<lhsSize; ++i, ++lp, ++rp) {
+            if (*lp != *rp) {
+                return *lp < *rp;
+            }
+        }
+    }
+    else {
+        return lhsSize < rhsSize;
+    }
+    // same size and all elements equal, return False
+    return False;
+}
+
 } //# NAMESPACE CASACORE - END
 

--- a/casa/Arrays/IPosition.h
+++ b/casa/Arrays/IPosition.h
@@ -118,6 +118,7 @@ template<class T> class Vector;
 
 class IPosition
 {
+    friend class IPositionComparator;
 public:
     enum {MIN_INT = -2147483647};
     // A zero-length IPosition.
@@ -413,6 +414,17 @@ private:
     // When the iposition is length BufferSize or less data is just buffer_p,
     // avoiding calls to new and delete.
     ssize_t *data_p;
+};
+
+class IPositionComparator : public std::binary_function<IPosition, IPosition, bool> {
+    // allows a way for IPosition to be used as keys in a std::map
+public:
+    // if sizes aren't equal, returns True if lhs.size() < rhs.size(), false
+    // otherwise. If sizes are equal, does an element by element comparison. The first
+    // corresponding elements that are not equal, returns True if the rhs element is
+    // less than the lhs element, False otherwise. Returns False if all elements are
+    // equal.
+    bool operator()(const IPosition& lhs, const IPosition& rhs) const;
 };
 
 // <summary>Arithmetic Operations for IPosition's</summary>

--- a/casa/Arrays/test/tIPosition.cc
+++ b/casa/Arrays/test/tIPosition.cc
@@ -40,6 +40,7 @@
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <vector>
+#include <map>
 
 #include <casacore/casa/namespace.h>
 
@@ -460,6 +461,39 @@ int main()
   IPosition ipos(4,11,12,13,14);
   AlwaysAssertExit(ipos(IPosition(4, 0,2,1,3)) == IPosition(4, 11,13,12,14));
   AlwaysAssertExit(ipos(IPosition(3, 2,2,1)) == IPosition(3, 13,13,12));
+  {
+      // test IPOsitionComparator
+      IPosition ip0(2, 0);
+      IPosition ip1(2, 1);
+      IPosition ip2(3, 1);
+      IPosition ip3(2, 0, 1);
+      IPosition ip4(2, 1, 0);
+      // creating a map with IPosition keys without the comparator
+      // doesn't work as we would like
+      std::map<IPosition, Int> mymap;
+      mymap[ip0] = 0;
+      mymap[ip1] = 1;
+      Bool thrown = False;
+      try {
+          // throws exception because size not equal
+          mymap[ip2] = 2;
+      } catch (const AipsError& x) {
+          thrown = True;
+      }
+      AlwaysAssertExit(thrown);
+      mymap[ip3] = 3;
+      mymap[ip4] = 4;
+      // one would think the map now has four elements, but no, it only has two
+      AlwaysAssertExit(mymap.size() != 4);
+      // so use the comparator and things make sense
+      std::map<IPosition, Int, IPositionComparator> goodmap;
+      goodmap[ip0] = 0;
+      goodmap[ip1] = 1;
+      goodmap[ip2] = 2;
+      goodmap[ip3] = 3;
+      goodmap[ip4] = 4;
+      AlwaysAssertExit(goodmap.size() == 5);
+  }
   
   cout << "OK\n";
   return 0;

--- a/images/Images/ImageOpener.cc
+++ b/images/Images/ImageOpener.cc
@@ -80,6 +80,13 @@ ImageOpener::ImageTypes ImageOpener::imageType (const String& name)
       if (info.type() == TableInfo::type(TableInfo::PAGEDIMAGE)) {
 	return AIPSPP;
       }
+      else if (info.type() == TableInfo::type(TableInfo::COMPONENTLIST)) {
+          TableDesc tableDesc;
+          Table::getLayout(tableDesc, name);
+          if (tableDesc.keywordSet().isDefined("coords")) {
+              return COMPLISTIMAGE;
+          }
+      }
     } else {
       if (File(name + "/header").isRegular()  &&
 	  File(name + "/image").isRegular()) {

--- a/images/Images/ImageOpener.h
+++ b/images/Images/ImageOpener.h
@@ -85,6 +85,8 @@ public:
     IMAGECONCAT,
     // ImageExpr
     IMAGEEXPR,
+    // ComponentListImage, CASA
+    COMPLISTIMAGE,
     // Unknown
     UNKNOWN
    };


### PR DESCRIPTION
Added COMPLISTIMAGE to ImageOpener::ImageTypes enum
Added logic to ImageOpener::imageType() for case when to return the new enum.
Added IPositionComparator class as part of IPosition files to allow std::map to be created using IPositions as keys. Added tests for that to tIPostion.cc