### PR TITLE
CAS-10760 bug fix for FitToHalfStatistics::setStatsToCalculate()

### DIFF
--- a/scimath/Mathematics/FitToHalfStatistics.h
+++ b/scimath/Mathematics/FitToHalfStatistics.h
@@ -146,13 +146,17 @@ public:
     uInt64 getNPts();
 
     // reset object to initial state. Clears all private fields including data,
-    // accumulators, global range. It does not affect the fence factor (_f), which was
-    // set at object construction.
+    // accumulators, global range. It does not affect the center type, center value,
+    // or which "side" to use which were set at construction.
     virtual void reset();
 
     // This class does not allow statistics to be calculated as datasets are added, so
     // an exception will be thrown if <src>c</src> is True.
     void setCalculateAsAdded(Bool c);
+
+    // Override base class method by requiring mean to be computed in addition to what is
+    // added in stats if the requested center value is CMEAN.
+    void setStatsToCalculate(std::set<StatisticsData::STATS>& stats);
 
 protected:
 
@@ -195,7 +199,6 @@ protected:
     void _updateDataProviderMaxMin(
         const StatsData<AccumType>& threadStats
     );  
-
     
     // <group>
     // has weights, but no mask, no ranges

--- a/scimath/Mathematics/FitToHalfStatistics.tcc
+++ b/scimath/Mathematics/FitToHalfStatistics.tcc
@@ -338,6 +338,16 @@ void FitToHalfStatistics<CASA_STATP>::reset() {
 }
 
 CASA_STATD
+void FitToHalfStatistics<CASA_STATP>::setStatsToCalculate(
+    std::set<StatisticsData::STATS>& stats
+) {
+    if (! stats.empty() && _centerType == FitToHalfStatisticsData::CMEAN) {
+        stats.insert(StatisticsData::MEAN);
+    }
+    ClassicalStatistics<CASA_STATP>::setStatsToCalculate(stats);
+}
+
+CASA_STATD
 StatsData<AccumType> FitToHalfStatistics<CASA_STATP>::_getInitialStats() const {
     StatsData<AccumType> stats = initializeStatsData<AccumType>();
     stats.mean = _centerValue;

--- a/scimath/Mathematics/test/tFitToHalfStatistics.cc
+++ b/scimath/Mathematics/test/tFitToHalfStatistics.cc
@@ -38,7 +38,7 @@
 
 int main() {
     try {
-        vector<Double> v0(5);
+        std::vector<Double> v0(5);
         v0[0] = 2;
         v0[1] = 1;
         v0[2] = 1.5;
@@ -88,6 +88,28 @@ int main() {
             AlwaysAssert(fh.getStatistic(
                 StatisticsData::RMS) == sqrt(sumsq/npts), AipsError
             );
+        }
+        {
+            // CAS-10760, test that setStatsToCalculate() works correctly
+            FitToHalfStatistics<
+                Double, std::vector<Double>::const_iterator,
+                std::vector<Bool>::const_iterator
+            > fh(
+                FitToHalfStatisticsData::CMEAN, FitToHalfStatisticsData::LE_CENTER
+            );
+            fh.setData(v0.begin(), v0.size());
+            std::set<StatisticsData::STATS> x;
+            x.insert(StatisticsData::VARIANCE);
+            fh.setStatsToCalculate(x);
+            StatsData<Double> sd = fh.getStatistics();
+            AlwaysAssert(! sd.masked, AipsError);
+            AlwaysAssert(! sd.weighted, AipsError);
+            Double variance = fh.getStatistic(StatisticsData::VARIANCE);
+            Double npts = 6;
+            Double nvariance = 3.94;
+            AlwaysAssert(near(variance, nvariance/(npts - 1)), AipsError);
+            Double mean = fh.getStatistic(StatisticsData::MEAN);
+            AlwaysAssert(near(mean, 13.2/6), AipsError);
         }
         {
             FitToHalfStatistics<Double, vector<Double>::const_iterator, vector<Bool>::const_iterator> fh(


### PR DESCRIPTION
to always include MEAN if centerType is CMEAN.