### PR TITLE
Do not set default diameter for VLBA to 25m

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2491,7 +2491,6 @@ void FITSIDItoMS1::fillAntennaTable()
    }
    else{
      if (arrnam=="ATCA") diameter=22.;
-     if (arrnam=="VLBA") diameter=25.;
      if (arrnam=="SMA")  diameter=6.;
      *itsLog << LogIO::WARN 
 	     << "ARRAY_GEOMETRY input table does not contain dish DIAMETER column.\n Will assume default diameter for TELESCOPE " 


### PR DESCRIPTION
While the VLBA dishes themselves have a diameter of 25m, VLBA
observations regularly include Green Bank or (phased) VLA.
On top of that, other VLBI arrays that use the DiFX correlator
often set the array name in their FITS-IDI file for compatibility
with (older versions of) AIPS.  Setting the dish diameter to 25m
for these arrays is simply wrong.  Instead, rely on the diameters
set in the FITS-IDI file for the VLBA.