### PR TITLE
Avoid incrementing TableIterator in copy assignment

### DIFF
--- a/tables/Tables/TableIter.cc
+++ b/tables/Tables/TableIter.cc
@@ -99,10 +99,10 @@ TableIterator& TableIterator::operator= (const TableIterator& iter)
 {
     delete tabIterPtr_p;
     tabIterPtr_p = 0;
-    subTable_p   = Table();
+    subTable_p = Table();
     if (iter.tabIterPtr_p != 0) {
         tabIterPtr_p = iter.tabIterPtr_p->clone();
-        next();                        // get first subtable
+        subTable_p = iter.table();
     }
     return *this;
 }


### PR DESCRIPTION
Replace the call to TableIterator::next(), which initializes the subTable_p
member, in the TableIterator copy assignment operator with a copy assignment of
the subTable_p member. This is intended for the copy to have the same state as
the copied instance.