### PR TITLE
CAS-9007 allow data provider to control max number of threads

### DIFF
--- a/images/Images/ImageRegrid.tcc
+++ b/images/Images/ImageRegrid.tcc
@@ -33,6 +33,7 @@
 
 #include <casacore/casa/Arrays/ArrayAccessor.h>
 #include <casacore/casa/Exceptions/Error.h>
+#include <casacore/casa/OS/Timer.h>
 #include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/coordinates/Coordinates/LinearCoordinate.h>
 #include <casacore/coordinates/Coordinates/SpectralCoordinate.h>

--- a/lattices/LatticeMath/LatticeStatistics.tcc
+++ b/lattices/LatticeMath/LatticeStatistics.tcc
@@ -69,8 +69,6 @@
 #include <casacore/casa/stdlib.h>
 #include <casacore/casa/sstream.h>
 
-#include <casacore/casa/OS/Timer.h>
-
 #include <casacore/scimath/Mathematics/ChauvenetCriterionStatistics.h>
 #include <casacore/scimath/Mathematics/FitToHalfStatistics.h>
 #include <casacore/scimath/Mathematics/HingesFencesStatistics.h>
@@ -122,7 +120,6 @@ LatticeStatistics<T>::LatticeStatistics (const MaskedLattice<T>& lattice,
    }
 }
 
-
 template <class T>
 LatticeStatistics<T>::LatticeStatistics (const MaskedLattice<T>& lattice,
                                          Bool showProgress,
@@ -167,7 +164,6 @@ LatticeStatistics<T>::LatticeStatistics (const MaskedLattice<T>& lattice,
    }
 }
 
-
 template <class T>
 LatticeStatistics<T>::LatticeStatistics(const LatticeStatistics<T> &other) 
 : pInLattice_p(0), pStoreLattice_p(0),
@@ -179,7 +175,6 @@ LatticeStatistics<T>::LatticeStatistics(const LatticeStatistics<T> &other)
 {
    operator=(other);
 }
-
 
 template <class T>
 LatticeStatistics<T> &LatticeStatistics<T>::operator=(const LatticeStatistics<T> &other)
@@ -805,13 +800,11 @@ Bool LatticeStatistics<T>::generateStorageLattice() {
         timeNew = nsets*(_aNew + _bNew*nel);
         tryOldMethod = timeOld < timeNew;
     }
-    //Timer timer;
     Bool ranOldMethod = False;
     uInt ndim = shape.nelements();
     if (tryOldMethod) {
         // use older method for higher performance in the large loop count
         // regime
-        //timer.mark();
         minPos_p.resize(ndim);
         maxPos_p.resize(ndim);
         StatsTiledCollapser<T,AccumType> collapser(

--- a/lattices/LatticeMath/LatticeStatsDataProvider.h
+++ b/lattices/LatticeMath/LatticeStatsDataProvider.h
@@ -85,6 +85,9 @@ public:
 	// Get the associated mask of the current dataset. Only called if hasMask() returns True;
 	const Bool* getMask();
 
+	// returns something reasonable based on the lattice size.
+	uInt getNMaxThreads() const;
+
 	// Does the current data set have an associated mask?
 	Bool hasMask() const;
 
@@ -119,6 +122,7 @@ private:
 	Array<T> _currentSlice;
 	const T* _currentPtr;
 	Bool _delData, _atEnd;
+	uInt _nMaxThreads;
 
 	void _freeStorage();
 

--- a/lattices/LatticeMath/MaskedLatticeStatsDataProvider.h
+++ b/lattices/LatticeMath/MaskedLatticeStatsDataProvider.h
@@ -86,6 +86,9 @@ public:
 	// Get the associated mask of the current dataset. Only called if hasMask() returns True;
 	const Bool* getMask();
 
+	// returns something reasonable based on the lattice size.
+	uInt getNMaxThreads() const;
+
 	// Does the current data set have an associated mask?
 	Bool hasMask() const;
 
@@ -121,6 +124,7 @@ private:
 	const T* _currentPtr;
 	const Bool* _currentMaskPtr;
 	Bool _delData, _delMask, _atEnd;
+	uInt _nMaxThreads;
 
 	void _freeStorage();
 

--- a/lattices/LatticeMath/MaskedLatticeStatsDataProvider.tcc
+++ b/lattices/LatticeMath/MaskedLatticeStatsDataProvider.tcc
@@ -35,7 +35,8 @@ template <class T>
 MaskedLatticeStatsDataProvider<T>::MaskedLatticeStatsDataProvider()
 	: LatticeStatsDataProviderBase<T>(),
 	_iter(), /* _ary(), _mask(), */ _currentSlice(), _currentMaskSlice(),
-	_currentPtr(0), _currentMaskPtr(0), _delData(False), _delMask(False), _atEnd(False) {}
+	_currentPtr(0), _currentMaskPtr(0), _delData(False), _delMask(False),
+	_atEnd(False), _nMaxThreads(0) {}
 
 template <class T>
 MaskedLatticeStatsDataProvider<T>::MaskedLatticeStatsDataProvider(
@@ -126,6 +127,15 @@ const Bool* MaskedLatticeStatsDataProvider<T>::getMask() {
 }
 
 template <class T>
+uInt MaskedLatticeStatsDataProvider<T>::getNMaxThreads() const {
+#ifdef _OPENMP
+    return _nMaxThreads;
+#else
+    return 0;
+#endif
+}
+
+template <class T>
 Bool MaskedLatticeStatsDataProvider<T>::hasMask() const {
 	return True;
 }
@@ -157,6 +167,12 @@ void MaskedLatticeStatsDataProvider<T>::setLattice(
 		_currentMaskSlice.assign(lattice.getMask());
 		_atEnd = False;
 	}
+#ifdef _OPENMP
+    _nMaxThreads = min(
+        omp_get_max_threads(),
+        lattice.size()/ClassicalStatisticsData::BLOCK_SIZE + 1
+    );
+#endif
 }
 
 

--- a/scimath/CMakeLists.txt
+++ b/scimath/CMakeLists.txt
@@ -13,6 +13,7 @@ Functionals/FuncExprData.cc
 Functionals/FunctionFactoryErrors.cc
 Functionals/FunctionalProxy.cc
 Functionals/SerialHelper.cc
+Mathematics/ClassicalStatisticsData.cc
 Mathematics/Combinatorics.cc
 Mathematics/FFTPack.cc
 Mathematics/FFTServer.cc
@@ -233,6 +234,7 @@ Mathematics/ChauvenetCriterionStatistics.h
 Mathematics/ChauvenetCriterionStatistics.tcc
 Mathematics/ClassicalStatistics.h
 Mathematics/ClassicalStatistics.tcc
+Mathematics/ClassicalStatisticsData.h
 Mathematics/Combinatorics.h
 Mathematics/ConstrainedRangeStatistics.h
 Mathematics/ConstrainedRangeStatistics.tcc

--- a/scimath/Mathematics/ClassicalStatistics.h
+++ b/scimath/Mathematics/ClassicalStatistics.h
@@ -675,9 +675,6 @@ private:
     mutable uInt _dataCount, _myStride;
     mutable uInt64 _myCount;
 
-    static const uInt CACHE_PADDING;
-    static const uInt BLOCK_SIZE;
-
     // tally the number of data points that fall into each bin provided by <src>binDesc</src>
     // Any points that are less than binDesc.minLimit or greater than
     // binDesc.minLimit + binDesc.nBins*binDesc.binWidth are not included in the counts. A data

--- a/scimath/Mathematics/ClassicalStatistics.tcc
+++ b/scimath/Mathematics/ClassicalStatistics.tcc
@@ -29,6 +29,7 @@
 
 #include <casacore/scimath/Mathematics/ClassicalStatistics.h>
 
+#include <casacore/scimath/Mathematics/ClassicalStatisticsData.h>
 #include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/scimath/Mathematics/StatisticsIncrementer.h>
 #include <casacore/scimath/Mathematics/StatisticsUtilities.h>
@@ -40,12 +41,6 @@
 #endif
 
 namespace casacore {
-
-CASA_STATD
-const uInt ClassicalStatistics<CASA_STATP>::CACHE_PADDING = 8;
-
-CASA_STATD
-const uInt ClassicalStatistics<CASA_STATP>::BLOCK_SIZE = 4000;
 
 // min > max indicates that these quantities have not be calculated
 CASA_STATD
@@ -482,10 +477,12 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
     _initIterators();
     uInt nThreadsMax = _nThreadsMax();
     PtrHolder<StatsData<AccumType> > tStats(
-        new StatsData<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new StatsData<AccumType>[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     for (uInt i=0; i<nThreadsMax; ++i) {
-        uInt idx8 = CACHE_PADDING*i;
+        uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*i;
         tStats[idx8] = _getInitialStats();
         // set nominal max and mins so accumulate
         // doesn't segfault
@@ -510,11 +507,14 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
         if (_hasMask) {
             stats.masked = True;
         }
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(nthreads)
+#endif
         for (uInt i=0; i<nBlocks; ++i) {
             uInt64 ngood = 0;
             uInt idx8 = _threadIdx();
-            uInt64 dataCount = _myCount - offset[idx8] < BLOCK_SIZE ? extra : BLOCK_SIZE;
+            uInt64 dataCount = _myCount - offset[idx8] < ClassicalStatisticsData::BLOCK_SIZE
+                ? extra : ClassicalStatisticsData::BLOCK_SIZE;
             LocationType location(_idataset, offset[idx8]);
             _computeStats(
                 tStats[idx8], ngood, location, dataIter[idx8], maskIter[idx8],
@@ -528,7 +528,7 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
         for (uInt tid=0; tid<nthreads; ++tid) {
             // LattStatsDataProvider relies on min and max
             // being updated after each increment of the data provider
-            uInt idx8 = CACHE_PADDING*tid;
+            uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
             _updateDataProviderMaxMin(tStats[idx8]);
         }
         if (_increment(True)) {
@@ -539,7 +539,8 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
     for (uInt i=0; i<nThreadsMax; ++i) {
         // in case no max/min was set, clear the nominal values
         // set above
-        StatsData<AccumType>& s = tStats[CACHE_PADDING*i];
+        StatsData<AccumType>& s 
+            = tStats[ClassicalStatisticsData::CACHE_PADDING*i];
         if (s.minpos.first < 0) {
             s.min.reset();
         }
@@ -580,7 +581,7 @@ void ClassicalStatistics<CASA_STATP>::_incrementThreadIters(
     DataIterator& dataIter, MaskIterator& maskIter,
     WeightsIterator& weightsIter, uInt64& offset, uInt nthreads
 ) const {
-    uInt increment = nthreads*BLOCK_SIZE*_myStride;
+    uInt increment = nthreads*ClassicalStatisticsData::BLOCK_SIZE*_myStride;
     if (offset+increment >= _myCount*_myStride) {
         // necessary because in some cases std::advance will segfault
         // if advanced past the end of the data structure
@@ -591,7 +592,7 @@ void ClassicalStatistics<CASA_STATP>::_incrementThreadIters(
         std::advance(weightsIter, increment);
     }
     if (_hasMask) {
-        std::advance(maskIter, nthreads*BLOCK_SIZE*_maskStride);
+        std::advance(maskIter, nthreads*ClassicalStatisticsData::BLOCK_SIZE*_maskStride);
     }
     offset += increment;
 }
@@ -913,11 +914,16 @@ uInt ClassicalStatistics<CASA_STATP>::_nThreadsMax() const {
         // so we should not parallelize
         return 1;
     }
-    else {
-        // we are being called from a single threaded block of code,
-        // so parallelize
-        return omp_get_max_threads();
+    // we are being called from a single threaded block of code,
+    // so parallelize
+    const StatsDataProvider<CASA_STATP> *dataProvider = this->_getDataProvider();
+    if (dataProvider) {
+        uInt n = dataProvider->getNMaxThreads();
+        if (n > 0) {
+            return n;
+        }
     }
+    return omp_get_max_threads();
 #else
     return 1;
 #endif
@@ -930,7 +936,7 @@ uInt ClassicalStatistics<CASA_STATP>::_threadIdx() const {
 #else
     uInt tid = 0;
 #endif
-    return tid * CACHE_PADDING;
+    return tid * ClassicalStatisticsData::CACHE_PADDING;
 }
 
 CASA_STATD
@@ -980,16 +986,22 @@ vector<vector<uInt64> > ClassicalStatistics<CASA_STATP>::_binCounts(
     _initIterators();
     const uInt nThreadsMax = _nThreadsMax();
     PtrHolder<std::vector<std::vector<uInt64> > > tBins(
-        new std::vector<std::vector<uInt64> >[CACHE_PADDING*nThreadsMax], True
+        new std::vector<std::vector<uInt64> >[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     PtrHolder<std::vector<CountedPtr<AccumType> > > tSameVal(
-        new std::vector<CountedPtr<AccumType> >[CACHE_PADDING*nThreadsMax], True
+        new std::vector<CountedPtr<AccumType> >[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     PtrHolder<vector<Bool> > tAllSame(
-        new std::vector<Bool>[CACHE_PADDING*nThreadsMax], True
+        new std::vector<Bool>[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
-        uInt idx8 = CACHE_PADDING*tid;
+        uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
         tBins[idx8] = bins;
         tSameVal[idx8] = sameVal;
         tAllSame[idx8] = allSame;
@@ -1006,10 +1018,13 @@ vector<vector<uInt64> > ClassicalStatistics<CASA_STATP>::_binCounts(
             nBlocks, extra, nthreads, dataIter,
             maskIter, weightsIter, offset, nThreadsMax
         );
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(nthreads)
+#endif
         for (uInt i=0; i<nBlocks; ++i) {
             uInt idx8 = _threadIdx();
-            uInt64 dataCount = _myCount - offset[idx8] < BLOCK_SIZE ? extra : BLOCK_SIZE;
+            uInt64 dataCount = _myCount - offset[idx8] < ClassicalStatisticsData::BLOCK_SIZE
+                ? extra : ClassicalStatisticsData::BLOCK_SIZE;
             _computeBins(
                 tBins[idx8], tSameVal[idx8], tAllSame[idx8], dataIter[idx8],
                 maskIter[idx8], weightsIter[idx8], dataCount, binDesc, maxLimit
@@ -1044,7 +1059,7 @@ void ClassicalStatistics<CASA_STATP>::_mergeResults(
         typename vector<CountedPtr<AccumType> >::iterator siter;
         typename vector<CountedPtr<AccumType> >::iterator send = sameVal.end();
         vector<Bool>::iterator aiter;
-        uInt idx8 = CACHE_PADDING*tid;
+        uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
         vector<vector<uInt64> >::const_iterator titer = tBins[idx8].begin();
         for (iter=bins.begin(); iter!=end; ++iter, ++titer) {
             std::transform(
@@ -1170,7 +1185,9 @@ void ClassicalStatistics<CASA_STATP>::_createDataArray(
     _initIterators();
     const uInt nThreadsMax = _nThreadsMax();
     PtrHolder<std::vector<AccumType> > tAry(
-        new std::vector<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new std::vector<AccumType>[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     while (True) {
         _initLoopVars();
@@ -1184,10 +1201,13 @@ void ClassicalStatistics<CASA_STATP>::_createDataArray(
             nBlocks, extra, nthreads, dataIter,
             maskIter, weightsIter, offset, nThreadsMax
         );
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(nthreads)
+#endif
         for (uInt i=0; i<nBlocks; ++i) {
             uInt idx8 = _threadIdx();
-            uInt64 dataCount = _myCount - offset[idx8] < BLOCK_SIZE ? extra : BLOCK_SIZE;
+            uInt64 dataCount = _myCount - offset[idx8] < ClassicalStatisticsData::BLOCK_SIZE
+                ? extra : ClassicalStatisticsData::BLOCK_SIZE;
             _computeDataArray(
                 tAry[idx8], dataIter[idx8], maskIter[idx8],
                 weightsIter[idx8], dataCount
@@ -1203,7 +1223,7 @@ void ClassicalStatistics<CASA_STATP>::_createDataArray(
     }
     // merge the per-thread arrays
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
-        const std::vector<AccumType>& v = tAry[CACHE_PADDING*tid];
+        const std::vector<AccumType>& v = tAry[ClassicalStatisticsData::CACHE_PADDING*tid];
         ary.insert(ary.end(), v.begin(), v.end());
     }
 }
@@ -1306,13 +1326,17 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
     _initIterators();
     const uInt nThreadsMax = _nThreadsMax();
     PtrHolder<std::vector<std::vector<AccumType> > > tArys(
-        new std::vector<std::vector<AccumType> >[CACHE_PADDING*nThreadsMax], True
+        new std::vector<std::vector<AccumType> >[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     PtrHolder<uInt64> tCurrentCount(
-        new uInt64[CACHE_PADDING*nThreadsMax], True
+        new uInt64[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
-        uInt idx8 = CACHE_PADDING*tid;
+        uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
         tArys[idx8] = arys;
     }
     uInt64 currentCount = 0;
@@ -1329,13 +1353,16 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
             maskIter, weightsIter, offset, nThreadsMax
         );
         for (uInt tid=0; tid<nThreadsMax; ++tid) {
-            uInt idx8 = CACHE_PADDING*tid;
+            uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
             tCurrentCount[idx8] = currentCount;
         }
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(nthreads)
+#endif
         for (uInt i=0; i<nBlocks; ++i) {
             uInt idx8 = _threadIdx();
-            uInt64 dataCount = _myCount - offset[idx8] < BLOCK_SIZE ? extra : BLOCK_SIZE;
+            uInt64 dataCount = _myCount - offset[idx8] < ClassicalStatisticsData::BLOCK_SIZE
+                ? extra : ClassicalStatisticsData::BLOCK_SIZE;
             _computeDataArrays(
                 tArys[idx8], tCurrentCount[idx8], dataIter[idx8], maskIter[idx8],
                 weightsIter[idx8], dataCount, includeLimits, maxCount
@@ -1352,7 +1379,7 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
         // circuiting earlier vs performance hits if that does not happen
         uInt64 prevCount = currentCount;
         for (uInt tid=0; tid<nThreadsMax; ++tid) {
-            uInt idx8 = CACHE_PADDING*tid;
+            uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
             currentCount += (tCurrentCount[idx8] - prevCount);
         }
         if (_increment(False)) {
@@ -1362,7 +1389,7 @@ void ClassicalStatistics<CASA_STATP>::_createDataArrays(
     AlwaysAssert(currentCount == maxCount, AipsError);
     // merge the per-thread arrays
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
-        uInt idx8 = CACHE_PADDING*tid;
+        uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
         typename vector<vector<AccumType> >::iterator iter = arys.begin();
         typename vector<vector<AccumType> >::iterator end = arys.end();
         typename vector<vector<AccumType> >::const_iterator titer = tArys[idx8].begin();
@@ -1665,10 +1692,14 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
     _initIterators();
     const uInt nThreadsMax = _nThreadsMax();
     PtrHolder<CountedPtr<AccumType> > tmin(
-        new CountedPtr<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new CountedPtr<AccumType>[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     PtrHolder<CountedPtr<AccumType> > tmax(
-        new CountedPtr<AccumType>[CACHE_PADDING*nThreadsMax], True
+        new CountedPtr<AccumType>[
+            ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
+        ], True
     );
     while (True) {
         _initLoopVars();
@@ -1682,10 +1713,13 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
             nBlocks, extra, nthreads, dataIter,
             maskIter, weightsIter, offset, nThreadsMax
         );
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(nthreads)
+#endif
         for (uInt i=0; i<nBlocks; ++i) {
             uInt idx8 = _threadIdx();
-            uInt64 dataCount = _myCount - offset[idx8] < BLOCK_SIZE ? extra : BLOCK_SIZE;
+            uInt64 dataCount = _myCount - offset[idx8] < ClassicalStatisticsData::BLOCK_SIZE
+                ? extra : ClassicalStatisticsData::BLOCK_SIZE;
             _computeMinMax(
                 tmax[idx8], tmin[idx8], dataIter[idx8], maskIter[idx8],
                 weightsIter[idx8], dataCount
@@ -1702,7 +1736,7 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
     CountedPtr<AccumType> mymax;
     CountedPtr<AccumType> mymin;
     for (uInt i=0; i<nThreadsMax; ++i) {
-        uInt idx8 = i * CACHE_PADDING;
+        uInt idx8 = i * ClassicalStatisticsData::CACHE_PADDING;
         if (! tmin[idx8].null()) {
             if (mymin.null() || *tmin[idx8] < *mymin) {
                 mymin = tmin[idx8];
@@ -2310,13 +2344,13 @@ void ClassicalStatistics<CASA_STATP>::_initThreadVars(
     PtrHolder<MaskIterator>& maskIter, PtrHolder<WeightsIterator>& weightsIter,
     PtrHolder<uInt64>& offset, uInt nThreadsMax
 ) const {
-    uInt n = CACHE_PADDING*nThreadsMax;
+    uInt n = ClassicalStatisticsData::CACHE_PADDING*nThreadsMax;
     dataIter.set(new DataIterator[n], True);
     maskIter.set(new MaskIterator[n], True);
     weightsIter.set(new WeightsIterator[n], True);
     offset.set(new uInt64[n], True);
-    nBlocks = _myCount/BLOCK_SIZE;
-    extra = _myCount % BLOCK_SIZE;
+    nBlocks = _myCount/ClassicalStatisticsData::BLOCK_SIZE;
+    extra = _myCount % ClassicalStatisticsData::BLOCK_SIZE;
     if (extra > 0) {
         ++nBlocks;
     }
@@ -2324,9 +2358,9 @@ void ClassicalStatistics<CASA_STATP>::_initThreadVars(
     for (uInt tid=0; tid<nthreads; ++tid) {
         // advance the per-thread iterators to their correct starting
         // locations
-        uInt idx8 = CACHE_PADDING*tid;
+        uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
         dataIter[idx8] = _myData;
-        offset[idx8] = tid*BLOCK_SIZE*_myStride;
+        offset[idx8] = tid*ClassicalStatisticsData::BLOCK_SIZE*_myStride;
         std::advance(dataIter[idx8], offset[idx8]);
         if (_hasWeights) {
             weightsIter[idx8] = _myWeights;
@@ -2334,7 +2368,7 @@ void ClassicalStatistics<CASA_STATP>::_initThreadVars(
         }
         if (_hasMask) {
             maskIter[idx8] = _myMask;
-            std::advance(maskIter[idx8], tid*BLOCK_SIZE*_maskStride);
+            std::advance(maskIter[idx8], tid*ClassicalStatisticsData::BLOCK_SIZE*_maskStride);
         }
     }
 }

--- a/scimath/Mathematics/ClassicalStatisticsData.cc
+++ b/scimath/Mathematics/ClassicalStatisticsData.cc
@@ -1,4 +1,4 @@
-//# Copyright (C) 2014
+//# Copyright (C) 2000,2001
 //# Associated Universities, Inc. Washington DC, USA.
 //#
 //# This library is free software; you can redistribute it and/or modify it
@@ -22,26 +22,15 @@
 //#                        520 Edgemont Road
 //#                        Charlottesville, VA 22903-2475 USA
 //#
-//# $Id: Array.h 21545 2015-01-22 19:36:35Z gervandiepen $
 
-#ifndef SCIMATH_STATSDATAPROVIDER_TCC
-#define SCIMATH_STATSDATAPROVIDER_TCC
 
-#include <casacore/scimath/Mathematics/StatsDataProvider.h>
+#include <casacore/scimath/Mathematics/ClassicalStatisticsData.h>
 
 namespace casacore {
 
-template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
-StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::StatsDataProvider() {}
+const uInt ClassicalStatisticsData::CACHE_PADDING = 8;
 
-template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
-StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::~StatsDataProvider() {}
-
-template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
-uInt StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNMaxThreads() const {
-    return 0;
-}
+const uInt ClassicalStatisticsData::BLOCK_SIZE = 4000;
 
 }
 
-#endif

--- a/scimath/Mathematics/ClassicalStatisticsData.h
+++ b/scimath/Mathematics/ClassicalStatisticsData.h
@@ -1,4 +1,4 @@
-//# Copyright (C) 2014
+//# Copyright (C) 2000,2001
 //# Associated Universities, Inc. Washington DC, USA.
 //#
 //# This library is free software; you can redistribute it and/or modify it
@@ -22,25 +22,31 @@
 //#                        520 Edgemont Road
 //#                        Charlottesville, VA 22903-2475 USA
 //#
-//# $Id: Array.h 21545 2015-01-22 19:36:35Z gervandiepen $
 
-#ifndef SCIMATH_STATSDATAPROVIDER_TCC
-#define SCIMATH_STATSDATAPROVIDER_TCC
+#ifndef SCIMATH_CLASSICALSTATSDATA_H
+#define SCIMATH_CLASSICALSTATSDATA_H
 
-#include <casacore/scimath/Mathematics/StatsDataProvider.h>
+#include <casacore/casa/aips.h>
 
 namespace casacore {
 
-template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
-StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::StatsDataProvider() {}
+// Non-templated data related to ClassicalStatistics class 
 
-template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
-StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::~StatsDataProvider() {}
+class ClassicalStatisticsData {
+public:
+    static const uInt CACHE_PADDING;
 
-template <class AccumType, class DataIterator, class MaskIterator, class WeightsIterator>
-uInt StatsDataProvider<AccumType, DataIterator, MaskIterator, WeightsIterator>::getNMaxThreads() const {
-    return 0;
-}
+    static const uInt BLOCK_SIZE;
+
+    ~ClassicalStatisticsData() {}
+
+private:
+    // disable default constructors 
+    ClassicalStatisticsData() {}
+    
+    ClassicalStatisticsData(const ClassicalStatisticsData& ) {}
+
+};
 
 }
 

--- a/scimath/Mathematics/StatisticsAlgorithm.h
+++ b/scimath/Mathematics/StatisticsAlgorithm.h
@@ -317,6 +317,10 @@ protected:
         return _dataProvider;
     }
 
+    const StatsDataProvider<CASA_STATP>* _getDataProvider() const {
+        return _dataProvider;
+    }
+
     const vector<uInt>& _getDataStrides() const { return _dataStrides; }
 
     const std::map<uInt, Bool>& _getIsIncludeRanges() const { return _isIncludeRanges; }

--- a/scimath/Mathematics/StatsDataProvider.h
+++ b/scimath/Mathematics/StatsDataProvider.h
@@ -66,6 +66,14 @@ public:
 	// Get the stride for the current mask (only called if hasMask() returns True).
 	virtual uInt getMaskStride() = 0;
 
+	// If OpenMP is enabled and statistics methods are not being called in a multi-threaded
+	// context, get maximum number of threads that should be used. If zero is returned,
+	// the statistics classes will use the maximum number of threads available to openmp.
+	// Returning less than that helps to decrease overhead used by statistics methods when the
+    // maximum number of threads available to openmp are unnecessary. The base class
+	// implmentation returns 0.
+	virtual uInt getNMaxThreads() const;
+
 	// Get the associated range(s) of the current dataset. Only called if hasRanges() returns True;
 	virtual DataRanges getRanges() = 0;
 


### PR DESCRIPTION
decreases overhead and increases performance when less than the number of maximum threads available to openmp can be used.
improves run time of one of my image stats test cases by almost a factor of 2