### PR TITLE
Issue #638 Fixed HDF-1.10 problem with 64-bit hid_t

### DIFF
--- a/casa/HDF5/HDF5DataSet.cc
+++ b/casa/HDF5/HDF5DataSet.cc
@@ -27,6 +27,7 @@
 
 #include <casacore/casa/HDF5/HDF5DataSet.h>
 #include <casacore/casa/HDF5/HDF5Error.h>
+#include <casacore/casa/Arrays/ArrayBase.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Containers/BlockIO.h>
 #include <casacore/casa/BasicMath/Primes.h>
@@ -302,6 +303,24 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     return HDF5DataType::getDataType (dtid);
   }
 
+  void HDF5DataSet::get (const Slicer& section, ArrayBase& arr, Bool resize)
+  {
+    const IPosition& shp = section.length();
+    if (! shp.isEqual (arr.shape())) {
+      if (resize  ||  arr.nelements() == 0) {
+        arr.resize (shp);
+      } else {
+        throw HDF5Error("Shape of slicer " + shp.toString() +
+                        " and array " + arr.shape().toString() +
+                        " mismatch in get of dataset " + getName());
+      }
+    }
+    Bool deleteIt;
+    void* buf = arr.getVStorage (deleteIt);
+    get (section, buf);
+    arr.putVStorage (buf, deleteIt);
+  }
+  
   void HDF5DataSet::get (const Slicer& section, void* buf)
   {
     // Define the data set selection.
@@ -310,7 +329,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Block<hsize_t> stride = fromShape(section.stride());
     if (H5Sselect_hyperslab (itsDSid, H5S_SELECT_SET, offset.storage(),
 			     stride.storage(), count.storage(), NULL) < 0) {
-      throw HDF5Error("invalid data set array selection");
+      throw HDF5Error("invalid array get selection for dataset " + getName());
     }
     // Define a data space for the memory buffer.
     HDF5HidDataSpace memspace (H5Screate_simple (count.size(),
@@ -319,15 +338,29 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     offset = 0;
     if (H5Sselect_hyperslab (memspace, H5S_SELECT_SET, offset.storage(),
 			     NULL, count.storage(), NULL) < 0) {
-      throw HDF5Error("setting slab of memory buffer");
+      throw HDF5Error("setting slab of memory buffer for dataset " + getName());
     }
     // Read the data.
     if (H5Dread (getHid(), itsDataType.getHidMem(), memspace, itsDSid,
 		 H5P_DEFAULT, buf) < 0) {
-      throw HDF5Error("reading slab from data set array");
+      throw HDF5Error("reading slab from data set array " + getName());
     }
   }
 
+  void HDF5DataSet::put (const Slicer& section, const ArrayBase& arr)
+  {
+    const IPosition& shp = section.length();
+    if (! shp.isEqual (arr.shape())) {
+      throw HDF5Error("Shape of slicer " + shp.toString() +
+                      " and array " + arr.shape().toString() +
+                      " mismatch in put of dataset " + getName());
+    }
+    Bool deleteIt;
+    const void* buf = arr.getVStorage (deleteIt);
+    put (section, buf);
+    arr.freeVStorage (buf, deleteIt);
+  }
+  
   void HDF5DataSet::put (const Slicer& section, const void* buf)
   {
     // Define the data set selection.
@@ -336,7 +369,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Block<hsize_t> stride = fromShape(section.stride());
     if (H5Sselect_hyperslab (itsDSid, H5S_SELECT_SET, offset.storage(),
 			     stride.storage(), count.storage(), NULL) < 0) {
-      throw HDF5Error("invalid data set array selection");
+      throw HDF5Error("invalid array put selection for datset " + getName());
     }
     // Define a data space for the memory buffer.
     HDF5HidDataSpace memspace (H5Screate_simple (count.size(),
@@ -345,12 +378,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     offset = 0;
     if (H5Sselect_hyperslab (memspace, H5S_SELECT_SET, offset.storage(),
 			     NULL, count.storage(), NULL) < 0) {
-      throw HDF5Error("setting slab of memory buffer");
+      throw HDF5Error("setting slab of memory buffer for dataset " + getName());
     }
     // Write the data.
     if (H5Dwrite (getHid(), itsDataType.getHidMem(), memspace, itsDSid,
 		  H5P_DEFAULT, buf) < 0) {
-      throw HDF5Error("writing slab into data set array");
+      throw HDF5Error("writing slab into data set array " + getName());
     }
   }
 
@@ -369,7 +402,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (ext) {
       Block<hsize_t> ls = fromShape (newShape);
       if (H5Dset_extent (getHid(), ls.storage()) < 0) {
-        throw HDF5Error("Could not extend data set");
+        throw HDF5Error("Could not extend data set " + getName());
       }
       itsShape = newShape;
       // The DataSpace has to be refreshed.

--- a/casa/HDF5/HDF5DataSet.cc
+++ b/casa/HDF5/HDF5DataSet.cc
@@ -448,9 +448,15 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   DataType HDF5DataSet::getDataType (hid_t, const String&)
     { return TpOther; }
 
+  void HDF5DataSet::get (const Slicer&, ArrayBase&, Bool)
+  {}
+    
   void HDF5DataSet::get (const Slicer&, void*)
   {}
 
+  void HDF5DataSet::put (const Slicer&, const ArrayBase&)
+  {}
+  
   void HDF5DataSet::put (const Slicer&, const void*)
   {}
 

--- a/casa/HDF5/HDF5DataSet.h
+++ b/casa/HDF5/HDF5DataSet.h
@@ -40,6 +40,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   //# Forward Declarations
+  class ArrayBase;
   template<typename T> class Block;
 
   // <summary>
@@ -140,11 +141,23 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     const IPosition& tileShape() const
       { return itsTileShape; }
 
+    // Get a section of data into the array.
+    // The array is resized if its shape does not match the slicer's shape.
+    // This is only possible if the array is empty or if resize=True.
+    // It is not checked if the data type of array and HDF5DataSet match.
+    void get (const Slicer&, ArrayBase& buf, Bool resize=False);
+    
     // Get a section of data.
     // The buffer must be large enough to hold the section.
     void get (const Slicer&, void* buf);
 
     // Put a section of data.
+    // The shape of the array and slicer must match.
+    // It is not checked if the data type of array and HDF5DataSet match.
+    void put (const Slicer&, const ArrayBase& buf);
+
+    // Put a section of data.
+    // The buffer must be large enough to hold the section.
     void put (const Slicer&, const void* buf);
 
     // Extend the dataset if an axis in the new shape is larger.

--- a/casa/HDF5/HDF5Object.h
+++ b/casa/HDF5/HDF5Object.h
@@ -38,24 +38,12 @@
 #ifdef HAVE_HDF5
 # include <hdf5.h>
 #else 
-  typedef int                hid_t;
-  typedef unsigned long long hsize_t;
+  typedef Int64 hid_t;
+  typedef uInt64 hsize_t;
 #endif
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
-
-  // Define 2 functions to check that hid_t and hsize_t are mapped correctly.
-  // They are called by the constructor, so the compiler will scream if
-  // incorrect.
-  // <group>
-  void throwInvHDF5();
-  inline void check_hid_t (int) {}
-  template<typename T> inline void check_hid_t (T) {throwInvHDF5();}
-  inline void check_hsize_t (unsigned long long) {}
-  template<typename T> inline void check_hsize_t (T) {throwInvHDF5();}
-  // </group>
-
 
   // <summary>
   // An abstract base class representing an HDF5 object
@@ -84,11 +72,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   public: 
     // Default constructor sets to invalid hid.
     HDF5Object()
-    : itsHid(-1)
-    {
-      check_hid_t   (hid_t(0));
-      check_hsize_t (hsize_t(0));
-    }
+      : itsHid(-1)
+    {}
 
     // The destructor in a derived class should close the hid appropriately.
     virtual ~HDF5Object();
@@ -133,7 +118,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   private:
     //# Data members
-    hid_t  itsHid;
+    //# Define a union to ensure that the object always uses 64 bits, even
+    //# for older HDF5 versions where hid_t is a 32 bit integer.
+    union {
+      hid_t  itsHid;
+      Int64  itsDummyHid;
+    };
     String itsName;
 
   private:

--- a/casa/HDF5/test/tHDF5DataSet.cc
+++ b/casa/HDF5/test/tHDF5DataSet.cc
@@ -55,7 +55,7 @@ int main()
       AlwaysAssertExit (dset.getName() == "array");
       AlwaysAssertExit (dset.shape() == shape);
       AlwaysAssertExit (dset.tileShape() == shape);
-      dset.put (Slicer(IPosition(2,0), shape), iarr.data());
+      dset.put (Slicer(IPosition(2,0), shape), iarr);
       AlwaysAssertExit (HDF5DataSet::getDataType (file, "array") == TpInt);
     }
     {
@@ -68,7 +68,7 @@ int main()
       // Set the cache size in chunks.
       dset.setCacheSize (10);
       Array<Int> ires(shape);
-      dset.get (Slicer(IPosition(2,0), shape), ires.data());
+      dset.get (Slicer(IPosition(2,0), shape), ires);
       AlwaysAssertExit (allEQ(iarr, ires));
       Slicer section(IPosition(2,1), IPosition(2,2), IPosition(2,2));
       Array<Int> ires2(section.length());


### PR DESCRIPTION
In HDF5-1.10 the hid_t has been increased from 32 to 64 bits, which caused problems in HDF5Object. This has been fixed in a way that both 32 and 64 bit hid_t is supported.
Furthermore, HDF5DataSet has been extended with a get and put function to handle an Array object. Finally, the error messages in HDF5DataSet have been improved.

Close #638