### PR TITLE
Set ImageConcat restoring beam in child images

### DIFF
--- a/images/Images/ImageBeamSet.h
+++ b/images/Images/ImageBeamSet.h
@@ -140,9 +140,8 @@ public:
       { return _beams.size() == 1; }
 
     // Does this beam set contain multiple beams?
-    Bool hasMultiBeam() const {
-        return _beams.size() > 1;
-    }
+    Bool hasMultiBeam() const
+      { return _beams.size() > 1; }
 
     // Is the beam set empty?
     Bool empty() const
@@ -153,7 +152,7 @@ public:
     const IPosition& shape() const
       { return _beams.shape(); }
 
-    // Get the number of channels in the beam array. NOte that this will
+    // Get the number of channels in the beam array. Note that this will
     // always return a minimum of 1, even if nchan was specified as 0 on construction.
     uInt nchan() const
       { return _beams.shape()[0]; }
@@ -232,12 +231,14 @@ public:
     IPosition getMaxAreaBeamPosition() const
       { return _maxBeamPos; }
 
-    // Get the minimal, maximal, and median area beams and positions in the beam set matrix for
-    // the given stokes. If the stokes axis has length 1 in the beam matrix,
-    // it is valid for all stokes and no checking is done that <src>stokes</src> is valid;
-    // the requested beam for the entire beam set is simply returned in this case. If the
-    // number of stokes in the beam matrix is >1, checking is done that the specified value
-    // of <src>stokes</src> is valid and if not, an exception is thrown.
+    // Get the minimal, maximal, and median area beams and positions in the
+    // beam set matrix for the given stokes. If the stokes axis has length 1
+    // in the beam matrix, it is valid for all stokes and no checking is done
+    // that <src>stokes</src> is valid; the requested beam for the entire beam set
+    // is simply returned in this case.
+    // If the number of stokes in the beam matrix is >1, checking is done that
+    // the specified value of <src>stokes</src> is valid and if not, an exception
+    // is thrown.
     // <group>
     const GaussianBeam& getMinAreaBeamForPol(IPosition& pos,
                                              uInt stokes) const;
@@ -251,8 +252,9 @@ public:
 
     static const String& className();
 
-    // Get the beam that has the smallest minor axis. If multiple beams have the smallest minor axis,
-    // the beam in this subset with the smallest area will be returned.
+    // Get the beam that has the smallest minor axis. If multiple beams have
+    // the smallest minor axis, the beam in this subset with the smallest area
+    // will be returned.
     const GaussianBeam getSmallestMinorAxisBeam() const;
 
     // convert ImageBeamSet to and from record
@@ -264,9 +266,9 @@ public:
     // If verbose, log all beams, if not just summarize beam stats.
     void summarize(LogIO& log, Bool verbose, const CoordinateSystem& csys) const;
 
-    // Modify the beam set by rotating all beams counterclockwise through the specified angle.
-    // If unwrap=True, unwrap the new position angle(s) so that it falls in the range -90 to
-    // 90 degrees before setting it.
+    // Modify the beam set by rotating all beams counterclockwise through the
+    // specified angle. If unwrap=True, unwrap the new position angle(s) so that
+    // it falls in the range -90 to 90 degrees before setting it.
     void rotate(const Quantity& angle, Bool unwrap=False);
 
 private:
@@ -281,18 +283,21 @@ private:
 
     void _calculateAreas();
 
+    // Show the spectral info.
     static void _chanInfoToStream(
         ostream& os, const SpectralCoordinate *spCoord,
         const uInt chan, const uInt chanWidth, const uInt freqPrec,
         const uInt velWidth, const uInt velPrec
     );
 
+    // Show the beam info.
     static void _beamToStream(
         ostream& os, const GaussianBeam& beam,
         const Unit& unit
     );
 };
 
+// Show the beam set info.
 ostream &operator<<(ostream &os, const ImageBeamSet& beamSet);
 
 }

--- a/images/Images/ImageConcat.h
+++ b/images/Images/ImageConcat.h
@@ -159,6 +159,11 @@ public:
 // It can fail if, e.g., the directory to write to is not writable.
    virtual Bool setMiscInfo (const RecordInterface& newInfo);
 
+  // Set the ImageInfo in the super class ImageInterface and in each
+  // underlying image. If needed, its restoring beam is split along the
+  // frequency or polarisation axis and set in each underlying image.
+  virtual Bool setImageInfo(const ImageInfo& info);
+
 // Get the image type (returns name of derived class).
    virtual String imageType() const;
 
@@ -191,6 +196,10 @@ public:
 // Returns 0 if none yet set. 
    uInt imageDim() const
      { return latticeConcat_p.latticeDim(); }
+
+// Return a reference to the i-th image.
+  ImageInterface<T>& image(uInt i) const
+    { return dynamic_cast<ImageInterface<T>&>(*(latticeConcat_p.lattice(i))); }
 
 // Handle the (un)locking and syncing, etc.
 // <group>

--- a/images/Images/ImageInfo.cc
+++ b/images/Images/ImageInfo.cc
@@ -657,7 +657,6 @@ void ImageInfo::checkBeamSet(
 }
 
 void ImageInfo::checkBeamShape (uInt& nchan, uInt& npol,
-                                const ImageInfo& info,
                                 const IPosition& shape,
                                 const CoordinateSystem& csys) const
 {
@@ -665,14 +664,14 @@ void ImageInfo::checkBeamShape (uInt& nchan, uInt& npol,
   if (csys.hasSpectralAxis()) {
     nchan = shape[csys.spectralAxisNumber()];
   }
-  AlwaysAssert (info.getBeamSet().nchan() == nchan  ||
-                info.getBeamSet().nchan() == 1, AipsError);
+  AlwaysAssert (getBeamSet().nchan() == nchan  ||
+                getBeamSet().nchan() == 1, AipsError);
   npol = 0;
   if (csys.hasPolarizationCoordinate()) {
     npol = shape[csys.polarizationAxisNumber()];
   }
-  AlwaysAssert (info.getBeamSet().nstokes() == npol  ||
-                info.getBeamSet().nstokes() == 1, AipsError);
+  AlwaysAssert (getBeamSet().nstokes() == npol  ||
+                getBeamSet().nstokes() == 1, AipsError);
 }
 
 void ImageInfo::combineBeams (const ImageInfo& infoThat,
@@ -684,14 +683,14 @@ void ImageInfo::combineBeams (const ImageInfo& infoThat,
                               Bool relax,
                               LogIO& os)
 {
-	ImageBeamSet beamSet;
+  ImageBeamSet beamSet;
   // Check if coord shape and beam shape match.
   uInt nchan1, npol1, nchan2, npol2;
   if (hasBeam()) {
-    checkBeamShape (nchan1, npol1, *this, shapeThis, csysThis);
+    this->checkBeamShape (nchan1, npol1, shapeThis, csysThis);
   }
   if (infoThat.hasBeam()) {
-    checkBeamShape (nchan2, npol2, infoThat, shapeThat, csysThat);
+    infoThat.checkBeamShape (nchan2, npol2, shapeThat, csysThat);
   }
   // No beams if one info has no beams.
   if (hasBeam() != infoThat.hasBeam()) {
@@ -711,6 +710,37 @@ void ImageInfo::combineBeams (const ImageInfo& infoThat,
     }
   }
   _beams = beamSet;
+}
+
+uInt ImageInfo::setInfoSplitBeamSet (uInt ndone, const ImageInfo& concatInfo,
+                                     const IPosition& shape,
+                                     const CoordinateSystem& csys, Int concatAxis)
+{
+  // Copy the non-beam info.
+  _warnBeam     = concatInfo._warnBeam;
+  itsImageType  = concatInfo.itsImageType;
+  itsObjectName = concatInfo.itsObjectName;
+  // Copy the beam info, if needed part of it.
+  // If the concat is not freq nor stokes, the entire beam info can be copied.
+  // This is also the case if the beam axes have length 1.
+  // Otherwise part of the beamset has to be taken.
+  IPosition st(shape.size(), 0);
+  IPosition ss(shape);
+  st[concatAxis] = ndone;
+  if (csys.hasSpectralAxis()  &&
+      concatAxis == csys.spectralAxisNumber()  &&
+      concatInfo.getBeamSet().nchan() > 1) {
+    setBeams (concatInfo.getBeamSet().subset (Slicer(st, ss), csys));
+    return shape[concatAxis];
+  } else if (csys.hasPolarizationAxis()  &&
+             concatAxis == csys.polarizationAxisNumber()  &&
+             concatInfo.getBeamSet().nstokes() > 1) {
+    setBeams (concatInfo.getBeamSet().subset (Slicer(st, ss), csys));
+    return shape[concatAxis];
+  }
+  // Set to the entire beam set.
+  setBeams (concatInfo.getBeamSet());
+  return 1;
 }
 
 void ImageInfo::concatFreqBeams (ImageBeamSet& beamsOut,

--- a/images/Images/ImageInfo.cc
+++ b/images/Images/ImageInfo.cc
@@ -656,9 +656,9 @@ void ImageInfo::checkBeamSet(
 	}
 }
 
-void ImageInfo::checkBeamShape (uInt& nchan, uInt& npol,
-                                const IPosition& shape,
-                                const CoordinateSystem& csys) const
+void ImageInfo::_checkBeamShape (uInt& nchan, uInt& npol,
+                                 const IPosition& shape,
+                                 const CoordinateSystem& csys) const
 {
   nchan = 0;
   if (csys.hasSpectralAxis()) {
@@ -687,10 +687,10 @@ void ImageInfo::combineBeams (const ImageInfo& infoThat,
   // Check if coord shape and beam shape match.
   uInt nchan1, npol1, nchan2, npol2;
   if (hasBeam()) {
-    this->checkBeamShape (nchan1, npol1, shapeThis, csysThis);
+    this->_checkBeamShape (nchan1, npol1, shapeThis, csysThis);
   }
   if (infoThat.hasBeam()) {
-    infoThat.checkBeamShape (nchan2, npol2, shapeThat, csysThat);
+    infoThat._checkBeamShape (nchan2, npol2, shapeThat, csysThat);
   }
   // No beams if one info has no beams.
   if (hasBeam() != infoThat.hasBeam()) {

--- a/images/Images/ImageInfo.h
+++ b/images/Images/ImageInfo.h
@@ -287,11 +287,6 @@ public:
                       const IPosition& shapeThis,
                       const IPosition& shapeThat);
 
-    // Check if the beam shape matches the coordinates.
-    void checkBeamShape (uInt& nchan, uInt& npol,
-                         const IPosition& shape,
-                         const CoordinateSystem& csys) const;
-
     // Combine beam sets for the concatenation of images and replace
     // the beamset in this object by the result.
     // If channel or stokes is the concatenation axis, that beam axis
@@ -356,6 +351,12 @@ private:
 
   // Set the restoring beam from the record.
   void _setRestoringBeam(const Record& inRecord);
+
+  // Check if the beam shape matches the coordinates.
+  // It sets nchan and npol to the values in the image shape.
+  void _checkBeamShape (uInt& nchan, uInt& npol,
+                       const IPosition& shape,
+                       const CoordinateSystem& csys) const;
 
   //# Data members
   ImageBeamSet _beams;

--- a/images/Images/ImageInfo.h
+++ b/images/Images/ImageInfo.h
@@ -289,7 +289,6 @@ public:
 
     // Check if the beam shape matches the coordinates.
     void checkBeamShape (uInt& nchan, uInt& npol,
-                         const ImageInfo& info,
                          const IPosition& shape,
                          const CoordinateSystem& csys) const;
 
@@ -308,6 +307,13 @@ public:
                        Bool relax,
                        LogIO& os);
 
+    // Reset the info and beamset of this image with the appropriate part of
+    // the beam set of the concat image it is part of.
+    // It returns the number of channels or polarizations handled.
+    uInt setInfoSplitBeamSet (uInt ndone, const ImageInfo& concatInfo,
+                              const IPosition& shape,
+                              const CoordinateSystem& csys, Int concatAxis);
+  
     // Concatenate the beam sets along the frequency axis.
     void concatFreqBeams (ImageBeamSet& beamsOut,
                           const ImageInfo& infoThat,

--- a/images/Images/ImageInterface.h
+++ b/images/Images/ImageInterface.h
@@ -239,6 +239,9 @@ public:
   // <group>
   const ImageInfo& imageInfo() const
     { return imageInfo_p; }
+  // Get non-const access to the ImageInfo.
+  ImageInfo& rwImageInfo()
+    { return imageInfo_p; }
   virtual Bool setImageInfo (const ImageInfo& info);
   // </group>
 
@@ -375,10 +378,6 @@ protected:
   // Get access to the region handler.
   RegionHandler* getRegionHandler()
     { return regHandPtr_p; }
-
-  // Get non-const access to the ImageInfo.
-  ImageInfo& rwImageInfo()
-    { return imageInfo_p; }
 
 private:
   // It is the job of the derived class to make these variables valid.

--- a/images/Images/ImageInterface.tcc
+++ b/images/Images/ImageInterface.tcc
@@ -276,8 +276,8 @@ String ImageInterface<T>::makeUniqueRegionName (const String& rootName,
 template<class T>
 void ImageInterface<T>::setImageInfoMember(const ImageInfo& info)
 {
+  info.checkBeamSet (coords_p, shape(), name());
   imageInfo_p = info;
-  imageInfo_p.checkBeamSet (coords_p, shape(), name());
 }    
 
 template<class T>


### PR DESCRIPTION
CAS-10849 reported that when setting the restoring beam for a ConcatImage, it did not get updated in the child images. This has been added now and the tImageConcat test program has been extended accordingly.
Maybe Dave Mehringer should review the code before merging the PR.