### PR TITLE
Cas 10428

### DIFF
--- a/images/Images/ImageConcat.h
+++ b/images/Images/ImageConcat.h
@@ -240,9 +240,10 @@ public:
    virtual IPosition shape() const;
 
   
-// Return the best cursor shape.  This isn't very meaningful for an ImageConcat
-// Image since it isn't on disk !  But if you do copy it out, this is
-// what you should use.  The maxPixels aregument is ignored.   
+// Return the best cursor shape.  It will try to return the best cusrsor of the 
+//smallest constituent image along the non-direction axes (in order to minimize 
+//bouncing from one image to another while iterating which may involve lots of 
+//open and tempclose).  
    virtual IPosition doNiceCursorShape (uInt maxPixels) const;
 
 // Do the actual get of the data.

--- a/images/Images/ImageConcat.tcc
+++ b/images/Images/ImageConcat.tcc
@@ -487,7 +487,32 @@ Bool ImageConcat<T>::doGetMaskSlice (Array<Bool>& buffer,
 template <class T>
 IPosition ImageConcat<T>::doNiceCursorShape (uInt maxPixels) const
 {  
-   return latticeConcat_p.niceCursorShape(maxPixels);
+  //Return the smallest cursor shape along the non X-Y direction from the constituent images
+  if(nimages() > 0){
+    ///if image has 1 or  2 axes return cursor shape of first image
+    if(shape().nelements() <= 2)
+      return image(0).niceCursorShape(maxPixels);
+    Vector<Int> dirpixaxes, dirworldaxes;
+    Int coordaxis;
+    CoordinateUtil::findDirectionAxes(dirpixaxes, dirworldaxes,
+                                       coordaxis,
+				      coordinates());
+    Int64 minprod=INT64_MAX;
+    Int minimage=-1;
+    for (uInt k=0; k < nimages(); ++k){
+      IPosition curshape=image(k).niceCursorShape(maxPixels);
+      Int64 prod= curshape.product()/ Int64(curshape(dirpixaxes(0))*curshape(dirpixaxes(1)));
+      if(prod < minprod){
+	minprod=prod;
+	minimage=k;
+      }
+      return image(minimage).niceCursorShape(maxPixels);
+
+    }
+ 
+  }
+  return IPosition(0);
+
 }
  
    

--- a/images/Images/ImageConcat.tcc
+++ b/images/Images/ImageConcat.tcc
@@ -492,8 +492,9 @@ IPosition ImageConcat<T>::doNiceCursorShape (uInt maxPixels) const
   //Return the smallest cursor shape along the non X-Y direction from the constituent images
   if(nimages() > 0){
     ///if image has 1 or  2 axes return cursor shape of first image
-    if(shape().nelements() <= 2)
+    if(shape().nelements() <= 2){
       return image(0).niceCursorShape(maxPixels);
+    }
     Vector<Int> dirpixaxes, dirworldaxes;
     Int coordaxis;
     CoordinateUtil::findDirectionAxes(dirpixaxes, dirworldaxes,
@@ -508,10 +509,10 @@ IPosition ImageConcat<T>::doNiceCursorShape (uInt maxPixels) const
 	minprod=prod;
 	minimage=k;
       }
-      return image(minimage).niceCursorShape(maxPixels);
+   
 
     }
- 
+    return image(minimage).niceCursorShape(maxPixels);
   }
 
   return IPosition(0);

--- a/images/Images/ImageConcat.tcc
+++ b/images/Images/ImageConcat.tcc
@@ -487,6 +487,7 @@ Bool ImageConcat<T>::doGetMaskSlice (Array<Bool>& buffer,
 template <class T>
 IPosition ImageConcat<T>::doNiceCursorShape (uInt maxPixels) const
 {  
+  
   //Return the smallest cursor shape along the non X-Y direction from the constituent images
   if(nimages() > 0){
     ///if image has 1 or  2 axes return cursor shape of first image
@@ -497,7 +498,7 @@ IPosition ImageConcat<T>::doNiceCursorShape (uInt maxPixels) const
     CoordinateUtil::findDirectionAxes(dirpixaxes, dirworldaxes,
                                        coordaxis,
 				      coordinates());
-    Int64 minprod=INT64_MAX;
+    Int64 minprod=std::numeric_limits<Int64>::max();
     Int minimage=-1;
     for (uInt k=0; k < nimages(); ++k){
       IPosition curshape=image(k).niceCursorShape(maxPixels);

--- a/images/Images/ImageConcat.tcc
+++ b/images/Images/ImageConcat.tcc
@@ -59,7 +59,8 @@
 #include <casacore/lattices/Lattices/LatticeConcat.h>
 #include <casacore/lattices/Lattices/MaskedLattice.h>
 #include <casacore/lattices/LEL/LELCoordinates.h>
-
+#include <limits>
+#include <cstddef>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -512,6 +513,7 @@ IPosition ImageConcat<T>::doNiceCursorShape (uInt maxPixels) const
     }
  
   }
+
   return IPosition(0);
 
 }

--- a/images/Images/test/tImageConcat.cc
+++ b/images/Images/test/tImageConcat.cc
@@ -670,6 +670,41 @@ int main() {
         );
   
     }
+    {///Testing niceCursorShape 
+      	cout << "Testing niceCursorShape " << endl;
+	{
+	  ImageConcat<Float> concat(1);
+	  concat.setImage(im1, True);
+	  concat.setImage(im2, True);
+	  AlwaysAssert(concat.niceCursorShape() == im1.niceCursorShape(),
+		       AipsError);
+	 
+	}
+	{
+	  CoordinateSystem csys = CoordinateUtil::defaultCoords4D();
+	  TempImage<Float> t0(TiledShape(IPosition(4, 50, 50, 1, 10)), csys, 0);
+	  TempImage<Float> t1(TiledShape(IPosition(4, 50, 50, 1, 5)), csys, 0);
+	  {
+	    ImageConcat<Float> concat(3);
+	    concat.setImage(t0, True);
+	    concat.setImage(t1, True);
+	     AlwaysAssert(concat.niceCursorShape() == t1.niceCursorShape(),
+			  AipsError);
+	  }
+	  //reverse order of concat
+	   {
+	    ImageConcat<Float> concat(3);
+	    concat.setImage(t1, True);
+	    concat.setImage(t0, True);
+	     AlwaysAssert(concat.niceCursorShape() == t1.niceCursorShape(),
+			  AipsError);
+	    
+	  }
+	  
+	}
+
+
+    }
   } catch(const AipsError& x) {
     cerr << x.getMesg() << endl;
     return 1;


### PR DESCRIPTION
This is a change in behaviour when calling niceCursorShape for the ImageIterators. Right now ConcatImage is returning a cursor shape which is as if it a real image on disk and it can be very slow when it is trying to stride across multiple images (image statistics for example can be 10 times slower than a real concatenated image).  This change make sure that the "nice" cursor shape is the minimum of each of the constituents images (along the non X-Y axes ...e.g spectral). In doing that imageStatistics for example take the same amount of time than a real concatenated image.