### PR TITLE
Initialize preselected_p properly even if no DATA or FLOAT DATA columns exist

### DIFF
--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -571,6 +571,8 @@ void MSIter::setMSInfo()
         }
       }
     }
+    else
+      preselected_p = false;
 
     // determine the reference frame position
     String observatory;


### PR DESCRIPTION

This fixes a problem with commit 689fb9b487b2d2174faafdb19197e8fc9fd93f81
reported by valgrind. The preselected_p was left uninitialized when
these columns are not present.

This is part of fixing CAS-10458