### PR TITLE
Fix memory leaks in the Measures module

### DIFF
--- a/casa/Quanta/Euler.h
+++ b/casa/Quanta/Euler.h
@@ -190,7 +190,8 @@ class Euler
 
 private:
 //# Data
-    typedef std::pair<Vector<Double> *, Vector<Int> *> DataArrays;
+    typedef std::pair<casacore::CountedPtr<Vector<Double> >, 
+                      casacore::CountedPtr<Vector<Int> > > DataArrays;
 // data container
     DataArrays data;
 // vector with 3 Euler angles (data.first)
@@ -207,7 +208,8 @@ private:
     DataArrays get_arrays();
     void return_arrays(DataArrays array);
 #if defined(AIPS_CXX11) && !defined(__APPLE__)
-    static thread_local DataArrays arrays[50];
+    static const size_t max_array_cache = 50;
+    static thread_local std::vector<DataArrays> arrays;
     static thread_local size_t available;
 #endif
 };

--- a/casa/Quanta/MVPosition.h
+++ b/casa/Quanta/MVPosition.h
@@ -280,6 +280,15 @@ protected:
   //# Data
   // Position vector (in m)
   Vector<Double> & xyz;
+  
+  Vector<Double> * get_array();
+  void return_array(Vector<Double> * array);
+#if defined(AIPS_CXX11) && !defined(__APPLE__)
+  static const size_t max_vector_cache = 50;
+  static thread_local std::vector<std::unique_ptr<Vector<Double>>> arrays;
+  static thread_local size_t available;
+#endif
+
 };
 
 //# Global functions


### PR DESCRIPTION

This pull request fixes some memory leaks in the Euler and MVPosition classes.
The part that leaks is the caching mechanism to avoid too many allocations put in place around two year ago. The leak is actually small but it clutters the output of valgrind in almost any unit test in casa/code, by outputting 150+ errors.
I have cleanup the output of valgrind for the tMSDerivedValues unit test but there are still 8 remaining memleaks, which I didn't dare to clean up since they look a bit more complex to me.
This patch uses smart pointers to ensure RAII, with the caveat of being a bit slower than the raw pointers used before. The slowdown is around 50% (only in the construction/destructor code) but it is still 5x faster than not using cache at all.
