### PR TITLE
Initialize tableiterator in assignment like in constructor

### DIFF
--- a/tables/Tables/TableIter.cc
+++ b/tables/Tables/TableIter.cc
@@ -103,6 +103,7 @@ TableIterator& TableIterator::operator= (const TableIterator& iter)
     if (iter.tabIterPtr_p != 0) {
         tabIterPtr_p = iter.tabIterPtr_p->clone();
         subTable_p = iter.table();
+        next(); // Get first subtable, as in constructor
     }
     return *this;
 }

--- a/tables/Tables/test/tTableIter.cc
+++ b/tables/Tables/test/tTableIter.cc
@@ -228,6 +228,32 @@ void doiter3()
     iter2 = iter1;
     AlwaysAssertExit(iter2.table().nrow() == iter1.table().nrow());
 
+    // Test that copied new iterator gives the same number of rows
+    int iter1count = 0;
+    while(!iter1.pastEnd()) { iter1.next(); iter1count++; }
+    int iter2count = 0;
+    while(!iter2.pastEnd()) { iter2.next(); iter2count++; }
+    AlwaysAssertExit(iter1count == iter2count);
+    iter1.reset();
+    iter2.reset();
+
+    // Test that copied new iterator does not copy the state
+    iter1.next();
+    iter1.next(); // Advance iter1 by two, so state changes
+    iter1count = 0;
+    iter2 = iter1; // iter2 should be 'clean' and iterate 2 more than iter1
+    TableIterator iter3 = iter1;
+    iter3.copyState(iter1); // iter3 should iterate as much as iter1
+    while(!iter1.pastEnd()) { iter1.next(); iter1count++; }
+    iter2count = 0;
+    while(!iter2.pastEnd()) { iter2.next(); iter2count++; }
+    AlwaysAssertExit(iter2count == iter1count + 2);
+    int iter3count = 0;
+    while(!iter3.pastEnd()) { iter3.next(); iter3count++; }
+    AlwaysAssertExit(iter3count == iter1count);
+
+    iter1.reset();
+
     Int nr = 0;
     float l3 = -1;
     while (!iter1.pastEnd()) {


### PR DESCRIPTION
It turns out the solution in #644 did break the DPPP build; I'm not sure how this slipped (I tested it then, but I don't know how it could have passed). Unfortunately this also means that the released 2.4.0 under some circumstances does not work well with DPPP.

In the following code, I expect `iter1` and `iter2` to be really the same:
```
TableIterator iter1(tab1, iv1, compObj, orders);
TableIterator iter2 = TableIterator(tab1, iv1, compObj, orders);
```

It turns out that although they have the same `nrows()`, they yield a different number of rows. This is demonstrated in the test in this PR.

I think it is valid to call `next()` in the copy constructor, because it is also called once in the normal [constructor](https://github.com/casacore/casacore/blob/master/tables/Tables/TableIter.cc#L52) of TableIterator. This first call of `next()` yields the initial state of a newly constructed TableIterator. So I do not think it copies the state of the copied constructor, as suggested in #644.

In short, I think the solution of #624 and #625 is valid and does not copy the state as suggested in #615. It merely initializes the newly created TableIterator in the same way as in the normal constructor.