### PR TITLE
Temporarily disable travis on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ matrix:
     - os: linux
       compiler: gcc
       env: CXX11=False
-    - os: osx
-      compiler: clang
-      env: CXX11=True PYTHONVERSION=2.7
-    - os: osx
-      compiler: clang
-      env: CXX11=True PYTHONVERSION=3.4
+#    - os: osx
+#      compiler: clang
+#      env: CXX11=True PYTHONVERSION=2.7
+#    - os: osx
+#      compiler: clang
+#      env: CXX11=True PYTHONVERSION=3.4
 
 sudo: false
 


### PR DESCRIPTION
The macOS jobs are failing, see #682. This is due to some issues with the build system. While that is being fixed, I suggest to temporarily disable the test to avoid seeing the build error in every PR.