### PR TITLE
casacore configuration sans environment variables

### DIFF
--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -199,6 +199,7 @@ System/AipsrcValue2.cc
 System/AipsrcVBool.cc
 System/AipsrcVString.cc
 System/AppInfo.cc
+System/AppState.cc
 System/Casarc.cc
 System/Choice.cc
 System/ObjectID.cc
@@ -579,6 +580,7 @@ System/AipsrcValue.tcc
 System/AipsrcVector.h
 System/AipsrcVector.tcc
 System/AppInfo.h
+System/AppState.h
 System/Casarc.h
 System/Choice.h
 System/ObjectID.h

--- a/casa/System/AppState.cc
+++ b/casa/System/AppState.cc
@@ -1,0 +1,60 @@
+//# AppState.cc: casacore library configuration without environment variabes
+//# Copyright (C) 2017
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <numeric>
+#include <sys/stat.h>
+#include <casacore/casa/System/AppState.h>
+
+namespace casacore {
+
+AppState *AppStateSource::user_state = 0;
+
+std::string AppState::resolve(const std::string &subdir) const {
+    struct stat statbuf;
+    if ( stat( subdir.c_str( ), &statbuf ) == 0 ) return subdir;
+
+    struct {
+        std::string operator( )(std::string s, std::string dir) {
+            if ( s.size( ) > 0 ) return s;
+            struct stat statbuf;
+            std::string path = dir + "/" + needle;
+            return stat( path.c_str( ), &statbuf ) == 0 ? path : s;
+        }
+        std::string needle;
+    } in_lieu_of_lambda = { subdir };
+
+    const std::list<std::string> &casadata = dataPath( );
+    std::string result = std::accumulate( casadata.begin( ), casadata.end( ), std::string( ), in_lieu_of_lambda );
+//  std::string result = std::accumulate( casadata.begin( ), casadata.end( ), std::string( ),
+//                                        [&](std::string s, std::string dir ) {
+//                                            if ( s.size( ) > 0 ) return s;
+//                                            std::string path = dir + sep + subdir;
+//                                            return stat( path.c_str( ), &statbuf ) == 0 ? path : s; } );
+    return result.size( ) > 0 ? result : subdir;
+}
+
+}

--- a/casa/System/AppState.cc
+++ b/casa/System/AppState.cc
@@ -33,19 +33,21 @@ namespace casacore {
 
 AppState *AppStateSource::user_state = 0;
 
+struct FOR_GCC_4_8_DEFECTS {
+    std::string operator( )(std::string s, std::string dir) {
+        if ( s.size( ) > 0 ) return s;
+        struct stat statbuf;
+        std::string path = dir + "/" + needle;
+        return stat( path.c_str( ), &statbuf ) == 0 ? path : s;
+    }
+    std::string needle;
+};
+
 std::string AppState::resolve(const std::string &subdir) const {
     struct stat statbuf;
     if ( stat( subdir.c_str( ), &statbuf ) == 0 ) return subdir;
 
-    struct {
-        std::string operator( )(std::string s, std::string dir) {
-            if ( s.size( ) > 0 ) return s;
-            struct stat statbuf;
-            std::string path = dir + "/" + needle;
-            return stat( path.c_str( ), &statbuf ) == 0 ? path : s;
-        }
-        std::string needle;
-    } in_lieu_of_lambda = { subdir };
+    FOR_GCC_4_8_DEFECTS in_lieu_of_lambda = { subdir };
 
     const std::list<std::string> &casadata = dataPath( );
     std::string result = std::accumulate( casadata.begin( ), casadata.end( ), std::string( ), in_lieu_of_lambda );

--- a/casa/System/AppState.h
+++ b/casa/System/AppState.h
@@ -25,11 +25,12 @@
 //#
 //# $Id$
 
-#ifndef CASACORE_APPSTATE_H
-#define CASACORE_APPSTATE_H
+#ifndef CASA_APPSTATE_H
+#define CASA_APPSTATE_H
 #include <string>
 #include <list>
 #include <casacore/casa/aips.h>
+#include <casacore/casa/OS/Mutex.h>
 
 namespace casacore {
 
@@ -49,9 +50,9 @@ namespace casacore {
 // allow applications initialize casacore's state without resorting to
 // environment variables. This is done by creating an object whose
 // class is derived from this base class, and then initializing the
-// AppStateStore with the newly created object. After initialization,
-// the AppStateStore takes ownership of the object. Please see the
-// documentation for AppStateStore for more information.
+// AppStateSource with the newly created object. After initialization,
+// the AppStateSource takes ownership of the object. Please see the
+// documentation for AppStateSource for more information.
 // </synopsis>
 
 class AppState {
@@ -88,7 +89,7 @@ public:
 // primarly of static functions. An external application configures
 // casacore by calling the initialize(...) member function passing in
 // a pointer to an object which is derived from the AppState base class.
-// AppStateStore takes ownership of the provided pointer.
+// AppStateSource takes ownership of the provided pointer.
 //
 // When casacore no longer depends on compilers whose standard is older
 // than C++11, the raw pointers here should be changed to
@@ -125,6 +126,8 @@ class AppStateSource {
 public:
 
     static void initialize(AppState *init) {
+        static Mutex mutex_p;
+        ScopedMutexLock lock(mutex_p);
         if ( user_state ) delete user_state;
         user_state = init;
     }

--- a/casa/System/AppState.h
+++ b/casa/System/AppState.h
@@ -1,0 +1,145 @@
+//# AppState.h: casacore library configuration without environment variabes
+//# Copyright (C) 2017
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#ifndef CASACORE_APPSTATE_H
+#define CASACORE_APPSTATE_H
+#include <string>
+#include <list>
+#include <casacore/casa/aips.h>
+
+namespace casacore {
+
+// <summary>
+// Base class for application state
+// </summary>
+
+// <use visibility=export>
+
+// <reviewed reviewer="" date="yyyy/mm/dd" tests="" demos="">
+// </reviewed>
+
+// <prerequisite/>
+
+// <synopsis>
+// This class is the base class for casacore state. Its purpose is to
+// allow applications initialize casacore's state without resorting to
+// environment variables. This is done by creating an object whose
+// class is derived from this base class, and then initializing the
+// AppStateStore with the newly created object. After initialization,
+// the AppStateStore takes ownership of the object. Please see the
+// documentation for AppStateStore for more information.
+// </synopsis>
+
+class AppState {
+public:
+
+    // use the data path to find the filename...
+    virtual std::string resolve(const std::string &filename) const;
+
+    // get the list of directories in the data path...
+    virtual const std::list<std::string> &dataPath( ) const {
+        static std::list<std::string> result;
+        return result;
+    }
+
+    virtual bool initialized( ) const { return false; }
+
+    virtual ~AppState( ) { }
+};
+
+// <summary>
+// Allow configuration of casacore without environment variables
+// </summary>
+
+// <use visibility=export>
+
+// <reviewed reviewer="" date="yyyy/mm/dd" tests="" demos="">
+// </reviewed>
+
+// <prerequisite/>
+
+// <synopsis>
+// This class allows packages which use casacore to configure casacore
+// behavior without reverting to environment variables. It is composed
+// primarly of static functions. An external application configures
+// casacore by calling the initialize(...) member function passing in
+// a pointer to an object which is derived from the AppState base class.
+// AppStateStore takes ownership of the provided pointer.
+//
+// When casacore no longer depends on compilers whose standard is older
+// than C++11, the raw pointers here should be changed to
+// unique_ptrs. The std::unique_ptr constructor is a constexpr, and it
+// does not throw exceptions.
+// </synopsis>
+
+// <example>
+// class MyState: public casacore::AppState {
+//     public:
+//         MyState( ) { }
+//  
+//         const std::list<std::string> &dataPath( ) const {
+//             static std::list<std::string> my_path;
+//             return my_path;
+//         }
+//
+//         bool initialized( ) const { return true; }
+// };
+//
+// MyState &get_my_state( ) {
+//     if ( AppStateSource::fetch( ).initialized( ) == false )
+//         casacore::AppStateSource::initialize( new MyState );
+//     return dynamic_cast<MyState&>(AppStateSource::fetch( ));
+// }
+//
+// int main( int argc, char *argv[] ) {
+//     MyState &state = get_my_state( );
+//     ...
+//     return 0;
+// }
+// </example>
+class AppStateSource {
+public:
+
+    static void initialize(AppState *init) {
+        if ( user_state ) delete user_state;
+        user_state = init;
+    }
+    static AppState &fetch( ) {
+        static AppState default_result;
+        return user_state ? *user_state : default_result;
+    }
+
+private:
+    static AppState *user_state;
+    AppStateSource( ) { }
+    AppStateSource( AppStateSource const &) { }      // prevent copying
+    void operator=(AppStateSource const &) { }       // prevent assignment
+};
+
+} //# NAMESPACE CASACORE - END
+
+#endif

--- a/casa/System/AppState.h
+++ b/casa/System/AppState.h
@@ -62,7 +62,7 @@ public:
     virtual std::string resolve(const std::string &filename) const;
 
     // get the list of directories in the data path...
-    virtual const std::list<std::string> &dataPath( ) const {
+    virtual std::list<std::string> dataPath( ) const {
         static std::list<std::string> result;
         return result;
     }

--- a/casa/System/test/CMakeLists.txt
+++ b/casa/System/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set (tests
 tAipsrc
 tAipsrcValue
 tAppInfo
+tAppState
 tCasarc01
 tChoice
 tObjectID

--- a/casa/System/test/tAppState.cc
+++ b/casa/System/test/tAppState.cc
@@ -1,0 +1,68 @@
+//# tAppState.cc: This program tests the AppState interface
+//# Copyright (C) 2017
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This program is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU General Public License as published by the Free
+//# Software Foundation; either version 2 of the License, or (at your option)
+//# any later version.
+//#
+//# This program is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+//# more details.
+//#
+//# You should have received a copy of the GNU General Public License along
+//# with this program; if not, write to the Free Software Foundation, Inc.,
+//# 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/casa/aips.h>
+#include <casacore/casa/System/AppState.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/iostream.h>
+
+
+#include <casacore/casa/namespace.h>
+class MyState: public AppState {
+
+    public:
+        MyState( const std::list<std::string> &init ) : my_path(init) { }
+        const std::list<std::string> &dataPath( ) const { return my_path; }
+        bool initialized( ) const { return true; }
+
+    private:
+        std::list<std::string> my_path;
+
+};
+
+int main( int , char *[] ) {
+    AlwaysAssertExit(AppStateSource::fetch( ).initialized( ) == false);
+
+    std::list<std::string> my_path_state;
+
+    // in an actual implementation these would be paths
+    // to casacore tables or images... but this is just
+    // for demonstration...
+    my_path_state.push_back("/usr/bin");
+    my_path_state.push_back("/bin");
+    my_path_state.push_back("/opt/local/bin");
+    my_path_state.push_back("/home/rh/root/usr/bin");
+
+    AppState *original_state = &AppStateSource::fetch( );
+    MyState *new_state = new MyState( my_path_state );
+    AppStateSource::initialize( new_state );
+    AlwaysAssertExit(&AppStateSource::fetch( ) != original_state);
+    AlwaysAssertExit(&AppStateSource::fetch( ) == new_state);
+    AlwaysAssertExit(AppStateSource::fetch( ).dataPath( ) == my_path_state);
+
+    return 0;
+}

--- a/casa/System/test/tAppState.cc
+++ b/casa/System/test/tAppState.cc
@@ -36,7 +36,7 @@ class MyState: public AppState {
 
     public:
         MyState( const std::list<std::string> &init ) : my_path(init) { }
-        const std::list<std::string> &dataPath( ) const { return my_path; }
+        std::list<std::string> dataPath( ) const { return my_path; }
         bool initialized( ) const { return true; }
 
     private:


### PR DESCRIPTION
As work begins on CASA's (https://casa.nrao.edu) transition to Python 3, we would like to fix structural issues at the same time because the Python 3 conversion will necessarily involve changes and fixes on the part of CASA's users. Two related things we would like fix is (1) removing CASA's dependency on environment variables (CASAPATH in this case) without requiring that static paths be compiled into the application, and (2) support checking multiple directories when attempting to open image or measurement sets (i.e. a data path in the $PATH sense of the word).

This change introduces a hook for applications which use casacore to specify a data path, and it includes changes so that measures is able to find the IERS data when it is included in the optionally specified data path. Other casacore state could be added the AppState class as time goes by (and more environment variable dependencies are uncovered), but this change is sufficient for our first cut at python 3 support and its accompanying reorganization.

The use of this hook is obviously optional. Not specifying a data path (the default) leaves the behavior of casacore unchanged (at least that is the objective).