### PR TITLE
Add forgotten include to tNewMSSimulator

### DIFF
--- a/ms/MSOper/test/tNewMSSimulator.cc
+++ b/ms/MSOper/test/tNewMSSimulator.cc
@@ -26,6 +26,7 @@
 //# $Id$
 
 #define _POSIX_C_SOURCE 200809L //For mkdtemp(), stpcpy(), nftw()
+#include <casacore/casa/aips.h>
 #include <ftw.h>
 #include <stdio.h>
 #if defined(AIPS_CXX11)  


### PR DESCRIPTION
`AIPS_CXX11` gets set by `aipsenv.h`, which is included from `aips.h`. By convention, `aips.h` should be one of the first includes. I'm not sure how the test could have built before; on my system the line `#include <random>` did not get called.