### PR TITLE
Added code to use HDF5 compound data types in MS testing

### DIFF
--- a/build-tools/casacore_memcheck
+++ b/build-tools/casacore_memcheck
@@ -8,6 +8,13 @@ pgmpath=`cd $pgmpath > /dev/null 2>&1  &&  pwd`
 pgm=$1
 shift
 
+# Exit if valgrind does not exist.
+which valgrind > /dev/null 2>&1
+if [ $? != 0 ]; then
+    echo "*** memcheck of $pgm cannot be done; valgrind cannot be found ***" 1>&2
+    exit 1
+fi
+
 # Use valgrind's memcheck tool on a program.
 # Filter out possible errors to give an overview.
 rm -f ${pgm}_tmp.valgrind
@@ -26,4 +33,4 @@ if test "$errors" != "" -o "$deflost" != "" -o "$poslost" != "" -o "$openfds" !=
 then
     cat ${pgm}_tmp.valgrind >> $pgm.checktool.valgrind
 fi
-rm ${pgm}_tmp.valgrind
+rm -f ${pgm}_tmp.valgrind

--- a/build-tools/casacore_memcheck
+++ b/build-tools/casacore_memcheck
@@ -26,3 +26,4 @@ if test "$errors" != "" -o "$deflost" != "" -o "$poslost" != "" -o "$openfds" !=
 then
     cat ${pgm}_tmp.valgrind >> $pgm.checktool.valgrind
 fi
+rm ${pgm}_tmp.valgrind

--- a/build-tools/casacore_memcheck.supp
+++ b/build-tools/casacore_memcheck.supp
@@ -27,10 +27,17 @@
    fun:_ZN4casa9FiledesIO5writeExPKv
 }
 {
-   Casacore-write-not-fully-initialized-buffer-FilebufIO
+   Casacore-write-not-fully-initialized-buffer-FilebufIO-dbg
    Memcheck:Param
    write(buf)
    fun:__write_nocancel
+   fun:_ZN4casa9FilebufIO11writeBufferExPKcx
+}
+{
+   Casacore-write-not-fully-initialized-buffer-FilebufIO-opt
+   Memcheck:Param
+   write(buf)
+   fun:???
    fun:_ZN4casa9FilebufIO11writeBufferExPKcx
 }
 
@@ -56,5 +63,14 @@
    fun:malloc
    fun:nss_parse_service-list
    fun:__nss_database_lookup
+}
+
+# OpenMP with glibc-2.2.5 seems to give a pthread leak
+{
+   openmp-pthread-leak
+   Memcheck:Leak
+   fun:calloc
+   fun:_dl_allocate_tls
+   fun:pthread_create@@GLIBC_2.2.5
 }
 

--- a/casa/HDF5.h
+++ b/casa/HDF5.h
@@ -1,4 +1,4 @@
-//# HDF5.h: Classes binding casa to the HDF5 C API
+//# HDF5.h: Classes binding casacore to the HDF5 C API
 //# Copyright (C) 2008
 //# Associated Universities, Inc. Washington DC, USA.
 //#
@@ -43,7 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <module>
 //
 // <summary>
-// Classes binding casa to the HDF5 C API
+// Classes binding casacore to the HDF5 C API
 // </summary>
 
 // <prerequisite>
@@ -66,11 +66,11 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //       (the so-called hid-s) is handled in an automatic and
 //       exception-safe way.
 //  <li> The overwhelming and rather hard to use HDF5 C API is hidden.
-//  <li> The standard casa data types (scalars and arrays) are fully supported.
+//  <li> The standard casacore data types (scalars and arrays) are supported.
 //       Because HDF5 does not support empty strings, they are transparantly
 //       replaced by the value '__empty__'.
-//       Unfortunately HDF5 does not support empty arrays, thus they cannot
-//       be stored.
+//       Also HDF5 does not support empty arrays, thus they are stored
+//       in a special way using a special compound value.
 //  <li> A Record is stored as a group. Its values (scalars and arrays)
 //       are stored as attributes, while nested records are stored as
 //       nested groups.
@@ -78,21 +78,22 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //  <li> Complex values are stored as compounds of two real values.
 //  <li> Large arrays can be stored in HDF5 DataSets with an optional tile size
 //       (chunk size in HDF5 terminology). The array axes are reversed (fully
-//       transparantly) because HDF5 uses C-order, while casa Arrays use
+//       transparantly) because HDF5 uses C-order, while casacore Arrays use
 //       Fortran-order.
 //  <li> Automatic printing of HDF5 messages is disabled. All errors are
 //       thrown as exceptions (AipsError or derived from it).
 // </ul>
 //
-// The following classes are available:
+// The following interface classes are available:
 // <ul>
 //  <li> HDF5File opens or creates an HDF5 file and closes it automatically.
 //       Furthermore it has a function to test if a file is in HDF5 format.
+//  <li> HDF5DataType defines the HDF5 memory and file data type. It supports
+//       the basic data types, complex, string, arrays and compounds.
 //  <li> HDF5Record reads or writes a Record as a group in an HDF5 object.
 //  <li> HDF5DataSet opens or creates a possible tiled data set in an HDF5
 //       object. The array can be read or written in parts.
-//       Currently the only data types supported are Bool, Int, Float, Double,
-//       Complex, and DComplex.
+//       It can be created of any HDF5DataType.
 //  <li> HDF5Group opens, creates, or removes a group in an HDF5 object.
 // </ul>
 // Note that HDF5Object forms the base class of HDF5File, HDF5Group, and
@@ -102,18 +103,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // can be used directly in any HDF5 function.
 //
 // Because of HDF5 resource management the objects (e.g. HDF5File) cannot
-// be copied. However, they can be used in shared pointers (like casa's
-// CountedPtr or boost's shared_ptr).
+// be copied. However, they can be used in shared pointers (like casacore's
+// CountedPtr or std::shared_ptr).
 // <br>
 // Internally the classes use HDF5HidMeta.h which does the resource management
 // for HDF5 meta data like attributes, property lists, etc..
 //
 // <note>
 // All HDF5 classes and all their functions are compiled, but it depends on
-// the setting of HAVE_HDF5 how. If not set, all these functions are merely stubs
-// and the class constructors throw an exception when used.
+// the setting of HAVE_HDF5 how. If not set, all these functions are merely
+// stubs and the class constructors throw an exception when used.
 // The function <src>HDF5Object::hasHDF5Support()</src> tells if HDF5 is used.
-// See the casacore build instructions at casacore.googlecode.com
+// See the casacore build instructions at github.com/casacore/casacore
 // for more information.
 // </note>
 // </synopsis>
@@ -125,17 +126,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <motivation>
 // HDF5 offers a C++ interface. However, this interface is still quite complex
 // and is too much C-oriented.
-// Furthermore there was the need to support the casa data types, in particular
-// reversal of array axes was needed.
+// Furthermore there was the need to support the casacore data types,
+// in particular complex. The reversal of array axes was also needed.
 // </motivation>
 
 // <todo asof="2008/03/13">
-//  <li> Make it possible to store empty arrays (e.g. as a compound of a
-//       scalar (defining its type) and a vector (defining its shape).
 //  <li> Set the optimal data set chunk cache size from a given access pattern.
-//       The current problem is that you can only set the cache size at the
-//       HDF5 file level, not at the data set level. Furthermore, setting
-//       the cache size requires that the file is closed first.
+//       The current problem is that setting the cache size requires that
+//       the file is closed first.
 //       For the time being a fixed cache size of 16 MB is used instead of
 //       the default 1 MB.
 // </todo>

--- a/casa/HDF5/HDF5DataSet.h
+++ b/casa/HDF5/HDF5DataSet.h
@@ -58,28 +58,34 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   // <synopsis>
   // This class wraps the HDF5 functions to create and open a data set.
-  // It is meant to be used in class HDF5Array, but can be used in itself
+  // It is meant to be used in class HDF5Lattice, but can be used in itself
   // as well.
-  // Only a limited number of data types are supported.
-  // They are: boolean (stored as chars), 4-byte integer, and single and
-  // double precision real and complex.
+  // A dataset of any HDF5DataType (including compound types) can be created.
+  // For a limited number of data types special constructors exist which
+  // create the appropriate HDF5DataType themselves.
   // <br>
-  // The data set has a fixed shape, thus cannot be extended nor resized.
-  // It can be stored in a tiled (chunked) way by specifying the tile shape
-  // when creating it.
+  // A data set can be created extendible by defining the appropriate
+  // axis with length 0, whereafter the extend function can be used to
+  // extend the data set.
+  // The data can be stored in a tiled (chunked) way by specifying the tile
+  // shape when creating it.
+  // <br>
+  // When opening an existing data set, it is checked if the given data type
+  // matches the data set's data type. For a compound data type, it only
+  // checks if its size matches; it does not check if the fields match.
   // <br>
   // It is possible to read or write a section of the data set by using an
   // appropriate Slicer object. Note that the Slicer object must be fully
   // filled; it does not infer missing info from the array shape.
   // <p>
-  // Casacore arrays are in Fortran order, while HDF5 uses C order.
+  // Note that Casacore arrays are in Fortran order, while HDF5 uses C order.
   // Therefore array axes are reversed, thus axes in shapes, slicers, etc.
   // </synopsis> 
 
   // <motivation>
   // It was overkill to use the HDF5 C++ interface. Instead little wrappers
   // have been written. HDF5DataSet can be embedded in a shared pointer making
-  // it possible to share an HDF5 data set amongst various HDF5Array objects
+  // it possible to share an HDF5 data set amongst various HDF5Lattice objects
   // and close (i.e. destruct) the HDF5 data set object when needed.
   // </motivation>
 
@@ -94,6 +100,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     HDF5DataSet (const HDF5Object&, const String&, const IPosition& shape,
 		 const IPosition& tileShape, const uChar*);
     HDF5DataSet (const HDF5Object&, const String&, const IPosition& shape,
+		 const IPosition& tileShape, const Short*);
+    HDF5DataSet (const HDF5Object&, const String&, const IPosition& shape,
 		 const IPosition& tileShape, const Int*);
     HDF5DataSet (const HDF5Object&, const String&, const IPosition& shape,
 		 const IPosition& tileShape, const Int64*);
@@ -105,6 +113,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		 const IPosition& tileShape, const Complex*);
     HDF5DataSet (const HDF5Object&, const String&, const IPosition& shape,
 		 const IPosition& tileShape, const DComplex*);
+    HDF5DataSet (const HDF5Object&, const String&, const IPosition& shape,
+		 const IPosition& tileShape, const HDF5DataType&);
     // </group>
 
     // Open an existing HDF5 data set in the given hid (file or group).
@@ -112,16 +122,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // <group>
     HDF5DataSet (const HDF5Object&, const String&, const Bool*);
     HDF5DataSet (const HDF5Object&, const String&, const uChar*);
+    HDF5DataSet (const HDF5Object&, const String&, const Short*);
     HDF5DataSet (const HDF5Object&, const String&, const Int*);
     HDF5DataSet (const HDF5Object&, const String&, const Int64*);
     HDF5DataSet (const HDF5Object&, const String&, const Float*);
     HDF5DataSet (const HDF5Object&, const String&, const Double*);
     HDF5DataSet (const HDF5Object&, const String&, const Complex*);
     HDF5DataSet (const HDF5Object&, const String&, const DComplex*);
+    HDF5DataSet (const HDF5Object&, const String&, const HDF5DataType&);
     // </group>
 
     // The destructor closes the HDF5 dataset object.
-    ~HDF5DataSet();
+    virtual ~HDF5DataSet();
 
     // Close the hid if valid.
     virtual void close();
@@ -163,19 +175,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Extend the dataset if an axis in the new shape is larger.
     void extend (const IPosition& shape);
 
-    // Helper functions to convert shapes.
-    // It reverses the axes, because HDF5 uses C-order.
-    // <group>
-    static Block<hsize_t> fromShape (const IPosition& shape);
-    static IPosition toShape (const Block<hsize_t>& b);
-    // </group>
-
-  private:
-    // Copy constructor cannot be used.
-    HDF5DataSet (const HDF5DataSet& that);
-    // Assignment cannot be used.
-    HDF5DataSet& operator= (const HDF5DataSet& that);
-
+  protected:
     // Create the data set.
     void create (const HDF5Object&, const String&,
 		 const IPosition& shape, const IPosition& tileShape);
@@ -185,6 +185,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
     // Close the dataset (but not other hids).
     void closeDataSet();
+
+  private:
+    // Copy constructor cannot be used.
+    HDF5DataSet (const HDF5DataSet& that);
+    // Assignment cannot be used.
+    HDF5DataSet& operator= (const HDF5DataSet& that);
 
     HDF5HidDataSpace   itsDSid;        //# data space id
     HDF5HidProperty    itsPLid;        //# create property list id

--- a/casa/HDF5/HDF5DataType.cc
+++ b/casa/HDF5/HDF5DataType.cc
@@ -26,8 +26,12 @@
 //# $Id$
 
 #include <casacore/casa/HDF5/HDF5DataType.h>
+#include <casacore/casa/HDF5/HDF5HidMeta.h>
+#include <casacore/casa/Arrays/IPosition.h>
+#include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
+#include <cstring>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -36,104 +40,107 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   HDF5DataType::HDF5DataType (const Bool*)
     : itsSize (sizeof(Bool))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_SCHAR);
-    itsHidMem = H5Tcopy (itsHidFile);
-    H5Tset_size (itsHidMem, sizeof(Bool));
+    itsHidFile = H5Tcopy (H5T_STD_I8LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_SCHAR);
+    H5Tset_precision (itsHidMem, 8);
   }
 
   HDF5DataType::HDF5DataType (const uChar*)
     : itsSize (sizeof(uChar))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_UCHAR);
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_STD_U8LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_UCHAR);
+    H5Tset_precision (itsHidMem, 8);
   }
 
   HDF5DataType::HDF5DataType (const Short*)
     : itsSize (sizeof(Short))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_SHORT);
-    H5Tset_size (itsHidFile, sizeof(Short));
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_STD_I16LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_SHORT);
+    H5Tset_precision (itsHidMem, 8*sizeof(Short));
   }
 
   HDF5DataType::HDF5DataType (const uShort*)
     : itsSize (sizeof(uShort))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_USHORT);
-    H5Tset_size (itsHidFile, sizeof(uShort));
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_STD_U16LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_USHORT);
+    H5Tset_precision (itsHidMem, 8*sizeof(uShort));
   }
 
   HDF5DataType::HDF5DataType (const Int*)
     : itsSize (sizeof(Int))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_INT);
-    H5Tset_size (itsHidFile, sizeof(Int));
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_STD_I32LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_INT);
+    H5Tset_precision (itsHidMem, 8*sizeof(Int));
   }
 
   HDF5DataType::HDF5DataType (const uInt*)
     : itsSize (sizeof(uInt))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_UINT);
-    H5Tset_size (itsHidFile, sizeof(uInt));
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_STD_U32LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_UINT);
+    H5Tset_precision (itsHidMem, 8*sizeof(uInt));
   }
 
   HDF5DataType::HDF5DataType (const Int64*)
     : itsSize (sizeof(Int64))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_INT);
-    H5Tset_size (itsHidFile, sizeof(Int64));
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_STD_I64LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_INT);
+    H5Tset_precision (itsHidMem, 8*sizeof(Int64));
   }
 
   HDF5DataType::HDF5DataType (const Float*)
     : itsSize (sizeof(Float))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_FLOAT);
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_IEEE_F32LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_FLOAT);
   }
 
   HDF5DataType::HDF5DataType (const Double*)
     : itsSize (sizeof(Double))
   {
-    itsHidFile = H5Tcopy (H5T_NATIVE_DOUBLE);
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidFile = H5Tcopy (H5T_IEEE_F64LE);
+    itsHidMem  = H5Tcopy (H5T_NATIVE_DOUBLE);
   }
 
   HDF5DataType::HDF5DataType (const Complex*)
     : itsSize (sizeof(Complex))
   {
     itsHidFile = H5Tcreate (H5T_COMPOUND, sizeof(Complex));
-    H5Tinsert (itsHidFile, "re", 0, H5T_NATIVE_FLOAT);
-    H5Tinsert (itsHidFile, "im", sizeof(Float), H5T_NATIVE_FLOAT);
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidMem  = H5Tcreate (H5T_COMPOUND, sizeof(Complex));
+    HDF5DataType dtype((Float*)0);
+    addToCompound ("re", 0, dtype);
+    addToCompound ("im", sizeof(Float), dtype);
   }
 
   HDF5DataType::HDF5DataType (const DComplex*)
     : itsSize (sizeof(DComplex))
   {
     itsHidFile = H5Tcreate (H5T_COMPOUND, sizeof(DComplex));
-    H5Tinsert (itsHidFile, "re", 0, H5T_NATIVE_DOUBLE);
-    H5Tinsert (itsHidFile, "im", sizeof(Double), H5T_NATIVE_DOUBLE);
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidMem  = H5Tcreate (H5T_COMPOUND, sizeof(DComplex));
+    HDF5DataType dtype((Double*)0);
+    addToCompound ("re", 0, dtype);
+    addToCompound ("im", sizeof(Double), dtype);
   }
 
   HDF5DataType::HDF5DataType (const String& value)
-    : itsSize (0)
+    : itsSize (value.size())
   {
-    itsHidFile = H5Tcopy (H5T_C_S1);
-    H5Tset_size (itsHidFile, value.size());
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidMem = H5Tcopy (H5T_C_S1);
+    H5Tset_size (itsHidMem, value.size());
+    itsHidFile = H5Tcopy (itsHidMem);
   }
 
   HDF5DataType::HDF5DataType (const String*)
     : itsSize (0)
   {
-    itsHidFile = H5Tcopy (H5T_C_S1);
-    H5Tset_size (itsHidFile, H5T_VARIABLE);
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidMem = H5Tcopy (H5T_C_S1);
+    H5Tset_size (itsHidMem, H5T_VARIABLE);
+    itsHidFile = H5Tcopy (itsHidMem);
   }
 
   HDF5DataType::HDF5DataType (Int, Int)
@@ -141,18 +148,67 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // An empty array is represented by its dimensionality and type.
     // Add an extra dummy field to make the compound different from (D)Complex
     // without having to test on field names.
-    HDF5DataType dtInt((Int*)0);
     itsHidFile = H5Tcreate (H5T_COMPOUND, 3*sizeof(Int));
-    H5Tinsert (itsHidFile, "emptyarray",           0, dtInt.getHidFile());
-    H5Tinsert (itsHidFile, "rank",       sizeof(Int), dtInt.getHidFile());
-    H5Tinsert (itsHidFile, "casatype", 2*sizeof(Int), dtInt.getHidFile());
-    itsHidMem = H5Tcopy (itsHidFile);
+    itsHidMem  = H5Tcreate (H5T_COMPOUND, 3*sizeof(Int));
+    HDF5DataType dtype((Int*)0);
+    addToCompound ("emptyarray",           0, dtype);
+    addToCompound ("rank",       sizeof(Int), dtype);
+    addToCompound ("casatype", 2*sizeof(Int), dtype);
   }
 
-  HDF5DataType::~HDF5DataType()
+  HDF5DataType::HDF5DataType (const std::vector<String>& names,
+                              const std::vector<HDF5DataType>& types)
+    : itsSize (0)
   {
-    H5Tclose (itsHidMem);
-    H5Tclose(itsHidFile);
+    AlwaysAssert (names.size() > 0, AipsError);
+    AlwaysAssert (types.size() == names.size(), AipsError);
+    for (uInt i=0; i<types.size(); ++i) {
+      AlwaysAssert (types[i].size() > 0, AipsError);
+      itsSize += types[i].size();
+    }
+    itsHidFile = H5Tcreate (H5T_COMPOUND, itsSize);
+    itsHidMem  = H5Tcreate (H5T_COMPOUND, itsSize);
+    uInt offset = 0;
+    for (uInt i=0; i<types.size(); ++i) {
+      addToCompound (names[i].c_str(), offset, types[i]);
+      offset += types[i].size();
+    }
+  }
+
+  HDF5DataType::HDF5DataType (const HDF5DataType& type, const IPosition& shape)
+  {
+    AlwaysAssert (shape.product() > 0, AipsError);
+    Block<hsize_t> shp = fromShape (shape);
+    itsHidFile = H5Tarray_create (type.getHidFile(),shp.size(), shp.storage());
+    itsHidMem  = H5Tarray_create (type.getHidMem(), shp.size(), shp.storage());
+    itsSize    = type.size() * shape.product();
+  }
+
+  HDF5DataType::HDF5DataType (const HDF5DataType& that)
+    : itsHidMem  (H5Tcopy (that.itsHidMem)),
+      itsHidFile (H5Tcopy (that.itsHidFile)),
+      itsSize    (that.itsSize)
+  {}
+
+  HDF5DataType::~HDF5DataType()
+  {}
+
+  HDF5DataType& HDF5DataType::operator= (const HDF5DataType& that)
+  {
+    if (this != &that) {
+      itsHidMem  = that.itsHidMem;
+      itsHidFile = that.itsHidFile;
+      itsSize    = that.itsSize;
+    }
+    return *this;
+  }
+
+  void HDF5DataType::addToCompound (const char* name,
+                                    uInt offset,
+                                    const HDF5DataType& dtype)
+  {
+    H5Tinsert (itsHidFile, name, offset, dtype.getHidFile());
+    H5Tinsert (itsHidMem,  name, offset, dtype.getHidMem());
   }
 
   DataType HDF5DataType::getDataType (hid_t dtid)
@@ -178,6 +234,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	} else {
 	  if (sz == 1) {
 	    dtype = TpUChar;
+          } else if (sz == sizeof(uShort)) {
+	    dtype = TpUShort;
 	  } else {
 	    AlwaysAssert (sz==sizeof(uInt), AipsError);
 	    dtype = TpUInt;
@@ -197,22 +255,108 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       break;
     case H5T_COMPOUND:
       {
-	AlwaysAssert (H5Tget_nmembers(dtid)==2, AipsError);
-	if (sz == sizeof(Complex)) {
-	  dtype = TpComplex;
-	} else {
-	  AlwaysAssert (sz==sizeof(DComplex), AipsError);
-	  dtype = TpDComplex;
-	}
+	if (HDF5DataType::isComplex (dtid)) {
+          if (sz == sizeof(Complex)) {
+            dtype = TpComplex;
+          } else {
+            AlwaysAssert (sz==sizeof(DComplex), AipsError);
+            dtype = TpDComplex;
+          }
+        } else {
+          dtype = TpRecord;
+        }
       }
       break;
     case H5T_STRING:
       dtype = TpString;
       break;
+    case H5T_ARRAY:
+      {
+        HDF5HidDataType hid(H5Tget_super (dtid));
+        switch (getDataType (hid)) {
+        case TpBool:
+          dtype = TpArrayBool;
+          break;
+        case TpUChar:
+          dtype = TpArrayUChar;
+          break;
+        case TpShort:
+          dtype = TpArrayShort;
+          break;
+        case TpUShort:
+          dtype = TpArrayUShort;
+          break;
+        case TpInt:
+          dtype = TpArrayInt;
+          break;
+        case TpUInt:
+          dtype = TpArrayUInt;
+          break;
+        case TpInt64:
+          dtype = TpArrayInt64;
+          break;
+        case TpFloat:
+          dtype = TpArrayFloat;
+          break;
+        case TpDouble:
+          dtype = TpArrayDouble;
+          break;
+        case TpComplex:
+          dtype = TpArrayComplex;
+          break;
+        case TpDComplex:
+          dtype = TpArrayDComplex;
+          break;
+        case TpString:
+          dtype = TpArrayString;
+          break;
+        default:
+          break;
+        }
+      }
+      break;
     default:
       break;
     }
     return dtype;
+  }
+
+  Bool HDF5DataType::isComplex (hid_t dtid)
+  {
+    Bool res = False;
+    if (H5Tget_class(dtid) == H5T_COMPOUND  &&  H5Tget_nmembers(dtid) == 2) {
+      char* f0 = H5Tget_member_name(dtid, 0);
+      char* f1 = H5Tget_member_name(dtid, 1);
+      res = (strcmp(f0, "re") == 0  &&  strcmp (f1, "im") == 0);
+      free(f0);
+      free(f1);
+    }
+    return res;
+  }
+
+  Bool HDF5DataType::isEmptyArray (hid_t dtid)
+  {
+    Bool res = False;
+    if (H5Tget_class(dtid) == H5T_COMPOUND  &&  H5Tget_nmembers(dtid) == 3) {
+      char* f0 = H5Tget_member_name(dtid, 0);
+      char* f1 = H5Tget_member_name(dtid, 1);
+      char* f2 = H5Tget_member_name(dtid, 2);
+      res = (strcmp(f0, "emptyarray") == 0  &&  strcmp (f1, "rank") == 0  &&
+             strcmp(f2, "casatype") == 0);
+      free(f0);
+      free(f1);
+      free(f2);
+    }
+    return res;
+  }
+
+  IPosition HDF5DataType::getShape (hid_t dtid)
+  {
+    Int ndim = H5Tget_array_ndims (dtid);
+    AlwaysAssert (ndim >= 0, AipsError);
+    Block<hsize_t> dims(ndim);
+    AlwaysAssert (H5Tget_array_dims(dtid, dims.storage()) == ndim, AipsError);
+    return toShape (dims);
   }
 
 #else
@@ -287,14 +431,71 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     HDF5Object::throwNoHDF5();
   }
 
+  HDF5DataType::HDF5DataType (const std::vector<String>&,
+                              const std::vector<HDF5DataType>&)
+  {
+    HDF5Object::throwNoHDF5();
+  }
+
+  HDF5DataType::HDF5DataType (const HDF5DataType&, const IPosition&)
+  {
+    HDF5Object::throwNoHDF5();
+  }
+
+  HDF5DataType::HDF5DataType (const HDF5DataType&)
+  {}
+
   HDF5DataType::~HDF5DataType()
   {}
+
+  HDF5DataType& HDF5DataType::operator= (const HDF5DataType&)
+  {
+    return *this;
+  }
+
+  void HDF5DataType::addToCompound (const char*,
+                                    uInt,
+                                    const HDF5DataType&)
+  {
+    HDF5Object::throwNoHDF5();
+  }
 
   DataType HDF5DataType::getDataType (hid_t)
   {
     return TpOther;
   }
 
+  Bool HDF5DataType::isComplex (hid_t)
+  {
+    return False;
+  }
+
+  Bool HDF5DataType::isEmptyArray (hid_t)
+  {
+    return False;
+  }
+
+  IPosition HDF5DataType::getShape (hid_t)
+  {
+    return IPosition();
+  }
+
 #endif
+
+
+  Block<hsize_t> HDF5DataType::fromShape (const IPosition& shape)
+  {
+    // Reverse the axes (Fortran to C).
+    Block<hsize_t> b(shape.size());
+    std::reverse_copy (shape.begin(), shape.end(), b.begin());
+    return b;
+  }
+  IPosition HDF5DataType::toShape (const Block<hsize_t>& b)
+  {
+    // Reverse the axes (C to Fortran).
+    IPosition shape(b.size());
+    std::reverse_copy (b.begin(), b.end(), shape.begin());
+    return shape;
+  }
 
 }

--- a/casa/HDF5/HDF5DataType.h
+++ b/casa/HDF5/HDF5DataType.h
@@ -31,11 +31,17 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/HDF5/HDF5Object.h>
+#include <casacore/casa/HDF5/HDF5HidMeta.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/DataType.h>
+#include <vector>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
+
+  //# Forward Declarations
+  class IPosition;
+  template<typename T> class Block;
 
   // <summary>
   // A class representing an HDF5 data type.
@@ -51,51 +57,92 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   // </prerequisite>
 
   // <synopsis>
-  // This class wraps the HDF5 functions to create a data type.
-  // It creates a data type for the datas in memory and for the file.
+  // This class wraps the HDF5 functions to create a data type
+  // for the data in memory and for the file.
+  // The HDF5 file data type order is set to LittleEndian.
+  // <br>
+  // The basic constructors define a scalar of a basic data type or
+  // data type Complex and DComplex. Strings are also supported.
+  // However, it is also possible to define a fixed shaped array for any
+  // HDF5DataType. Furthermore, it is possible to define a compound data
+  // type consisting of named fields of any HDF5DataType with a fixed size.
+  // Arrays and/or compounds can be nested at will.
+  // <br>
+  // Variable length strings are supported, but cannot be used in compounds.
+  // <br>
+  // Older HDF5 versions did not support empty arrays. Therefore they are
+  // represented as a compound with 3 fields. Also they did not support
+  // boolean values; they are represented as a signed char.
+  // HDF5 does not support complex values either. They are represented
+  // as a compound with fields 're' and 'im'.
   // </synopsis> 
 
   // <motivation>
-  // It was overkill to use the HDF5 C++ interface. Instead little wrappers
-  // have been written. HDF5DataType can be embedded in a shared pointer making
-  // it possible to share an HDF5 data type amongst various HDF5Array objects
-  // and close (i.e. destruct) the HDF5 data type object when needed.
+  // The HDF5 C++ interface only supports the HDF5 C functionality and
+  // resembles that to much. For instance, it does not use STL containers.
+  // It does not support non-basic data types, in particular Complex.
   // </motivation>
 
   class HDF5DataType
   {
   public: 
+    // The default constructor makes an invalid object.
+    // It is needed to make a vector of objects.
+    HDF5DataType()
+      : itsSize(0)
+    {}
+
     // Create an HDF5 datatype object for the given fixed length type.
     // It uses the corresponding native HDF5 data type. Only for Bool it
     // uses a uchar, because the HDF5 bool type is a uint.
     // For the complex types it makes a compound HDF5 data type.
     // The String type is meant for an array of strings.
     // <group>
-    HDF5DataType (const Bool*);
-    HDF5DataType (const uChar*);
-    HDF5DataType (const Short*);
-    HDF5DataType (const uShort*);
-    HDF5DataType (const Int*);
-    HDF5DataType (const uInt*);
-    HDF5DataType (const Int64*);
-    HDF5DataType (const Float*);
-    HDF5DataType (const Double*);
-    HDF5DataType (const Complex*);
-    HDF5DataType (const DComplex*);
-    HDF5DataType (const String*);
+    explicit HDF5DataType (const Bool*);
+    explicit HDF5DataType (const uChar*);
+    explicit HDF5DataType (const Short*);
+    explicit HDF5DataType (const uShort*);
+    explicit HDF5DataType (const Int*);
+    explicit HDF5DataType (const uInt*);
+    explicit HDF5DataType (const Int64*);
+    explicit HDF5DataType (const Float*);
+    explicit HDF5DataType (const Double*);
+    explicit HDF5DataType (const Complex*);
+    explicit HDF5DataType (const DComplex*);
+    explicit HDF5DataType (const String*);
     // </group>
 
     // Create an HDF5 datatype object for a scalar string.
     // The length of the string is part of the type.
-    HDF5DataType (const String& value);
+    explicit HDF5DataType (const String& value);
 
     // Create an HDF5 datatype object for an empty array.
+    // Both arguments are dummy (needed to distinguish the constructor).
+    // An empty array as represented as a compound data type with integer
+    // field names emptyarray, rank and casatype.
     HDF5DataType (Int, Int);
+
+    // Define a compound data type consisting of the given fields and types.
+    // An exception is thrown if the vectors are empty or have mismatching
+    // sizes.
+    HDF5DataType (const std::vector<String>& names,
+                  const std::vector<HDF5DataType>& types);
+
+    // Create an array of the given data type.
+    // An exception is thrown if the shape is empty.
+    HDF5DataType (const HDF5DataType&, const IPosition& shape);
+
+    // The copy constructor makes a deep copy.
+    HDF5DataType (const HDF5DataType& that);
 
     // The destructor closes the HDF5 data type object.
     ~HDF5DataType();
 
+    // Assignment makes a deep copy.
+    HDF5DataType& operator= (const HDF5DataType& that);
+
     // Get the Casacore data type for the given HDF5 data type.
+    // TpRecord is returned for a compound data type.
     static DataType getDataType (hid_t);
 
     // Get the HID for the data type in memory.
@@ -106,22 +153,39 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     hid_t getHidFile() const
       { return itsHidFile; }
 
-    // Get the size in bytes of the data type.
+    // Get the size in bytes of the data type (in memory).
     // Note that the size of a string is variable, thus 0.
     uInt size() const
       { return itsSize; }
 
+    // Test if the data type is Complex or DComplex.
+    static Bool isComplex (hid_t dtid);
+
+    // Test if the data type is an empty array.
+    static Bool isEmptyArray (hid_t dtid);
+
+    // Get the shape of an array data type.
+    // It returns an empty IPosition for non-arrays.
+    static IPosition getShape (hid_t dtid);
+
+    // Helper functions to convert shapes.
+    // It reverses the axes, because HDF5 uses C-order.
+    // <group>
+    static Block<hsize_t> fromShape (const IPosition& shape);
+    static IPosition toShape (const Block<hsize_t>& b);
+    // </group>
+
   private:
-    // Copy constructor cannot be used.
-    HDF5DataType (const HDF5DataType& that);
+    // Add a field to a compound data type.
+    // It does it for the memory and file data type.
+    void addToCompound (const char* name,
+                        uInt offset,
+                        const HDF5DataType& dtype);
 
-    // Assignment cannot be used.
-    HDF5DataType& operator= (const HDF5DataType& that);
-
-
-    hid_t itsHidMem;
-    hid_t itsHidFile;
-    uInt  itsSize;
+    //# Data members
+    HDF5HidDataType itsHidMem;
+    HDF5HidDataType itsHidFile;
+    uInt            itsSize;
   };
 
 }

--- a/casa/HDF5/HDF5HidMeta.cc
+++ b/casa/HDF5/HDF5HidMeta.cc
@@ -26,10 +26,24 @@
 //# $Id$
 
 #include <casacore/casa/HDF5/HDF5HidMeta.h>
+#include <casacore/casa/HDF5/HDF5Object.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 #ifdef HAVE_HDF5
+
+  HDF5HidDataType::HDF5HidDataType (const HDF5HidDataType& that)
+    : itsHid(H5Tcopy(that.itsHid))
+  {}
+
+  HDF5HidDataType&HDF5HidDataType:: operator= (const HDF5HidDataType& that)
+  {
+    if (this != &that) {
+      close();
+      itsHid = H5Tcopy(that.itsHid);
+    }
+    return *this;
+  }
 
   void HDF5HidProperty::close()
   {
@@ -56,6 +70,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   }
 
 #else
+
+  HDF5HidDataType::HDF5HidDataType (const HDF5HidDataType&)
+  {}
+
+  HDF5HidDataType& HDF5HidDataType::operator= (const HDF5HidDataType&)
+  { return *this; }
 
   void HDF5HidProperty::close()
   {}

--- a/casa/HDF5/HDF5HidMeta.h
+++ b/casa/HDF5/HDF5HidMeta.h
@@ -108,9 +108,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Construct from given hid.
     HDF5HidDataType (hid_t hid)
       : itsHid(hid) {}
+    // Copy constructor makes a deep copy.
+    HDF5HidDataType (const HDF5HidDataType& that);
     // The destructor closes the hid.
     ~HDF5HidDataType()
       { close(); }
+    // Assignment makes a deep copy.
+    HDF5HidDataType& operator= (const HDF5HidDataType& that);
     // Close the hid if valid.
     void close();
     // Put hid in it. If it already contains a hid, it will be closed.
@@ -123,11 +127,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     operator hid_t() const
       { return itsHid; }
   private:
-    // Copy constructor cannot be used.
-    HDF5HidDataType (const HDF5HidDataType& that);
-    // Assignment cannot be used.
-    HDF5HidDataType& operator= (const HDF5HidDataType& that);
-
     hid_t itsHid;
   };
 

--- a/casa/HDF5/test/CMakeLists.txt
+++ b/casa/HDF5/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (tests
 tHDF5
 tHDF5DataSet
+tHDF5DataType
 tHDF5File
 tHDF5Record
 )

--- a/casa/HDF5/test/tHDF5DataType.cc
+++ b/casa/HDF5/test/tHDF5DataType.cc
@@ -1,0 +1,104 @@
+//# tHDF5DataType.cc: Test program for class HDF5DataType
+//# Copyright (C) 2018
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/casa/HDF5/HDF5DataType.h>
+#include <casacore/casa/Arrays/IPosition.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/Exceptions/Error.h>
+ 
+using namespace casacore;
+
+template<typename T>
+void testDT (DataType dt, DataType arrdt, uInt sz, Bool isC=False)
+{
+  // Test scalar.
+  HDF5DataType hdt((T*)0);
+  AlwaysAssertExit (hdt.size() == sz);
+  AlwaysAssertExit (HDF5DataType::getDataType(hdt.getHidMem()) == dt);
+  AlwaysAssertExit (HDF5DataType::getDataType(hdt.getHidFile()) == dt);
+  AlwaysAssertExit (HDF5DataType::isComplex(hdt.getHidMem()) == isC);
+  AlwaysAssertExit (HDF5DataType::isComplex(hdt.getHidFile()) == isC);
+  // Test array.
+  HDF5DataType dtarr(hdt, IPosition(2,3,4));
+  AlwaysAssertExit (dtarr.size() == 3*4*sz);
+  AlwaysAssertExit (HDF5DataType::getDataType(dtarr.getHidMem()) == arrdt);
+  AlwaysAssertExit (HDF5DataType::getShape(dtarr.getHidMem()) == IPosition(2,3,4));
+  AlwaysAssertExit (HDF5DataType::getDataType(dtarr.getHidFile()) == arrdt);
+  AlwaysAssertExit (HDF5DataType::getShape(dtarr.getHidFile()) == IPosition(2,3,4));
+}
+
+void testCompound()
+{
+  // First test with a few scalars.
+  std::vector<String> names(3);
+  std::vector<HDF5DataType> types(3);
+  names[0] = "f1";
+  names[1] = "f2";
+  names[2] = "f3";
+  types[0] = HDF5DataType((Complex*)0);
+  types[1] = HDF5DataType((Int*)0);
+  types[2] = HDF5DataType((Float*)0);
+  HDF5DataType dtcom1(names, types);
+  AlwaysAssertExit (dtcom1.size() == 16);
+  AlwaysAssertExit (HDF5DataType::getDataType(dtcom1.getHidMem()) == TpRecord);
+  // Now add a few arrays and the previous compound.
+  names.push_back ("fa1");
+  names.push_back ("fa2");
+  names.push_back ("fc");
+  types.push_back (HDF5DataType(HDF5DataType((Bool*)0), IPosition(1,8)));
+  types.push_back (HDF5DataType(HDF5DataType((DComplex*)0), IPosition(2,1,2)));
+  types.push_back (dtcom1);
+  HDF5DataType dtcom2(names, types);
+  AlwaysAssertExit (dtcom2.size() == 16 + 8 + 2*16 + 16);
+  AlwaysAssertExit (HDF5DataType::getDataType(dtcom2.getHidMem()) == TpRecord);
+}
+
+int main()
+{
+  // Exit with untested if no HDF5 support.
+  if (! HDF5Object::hasHDF5Support()) {
+    return 3;
+  }
+  try {
+    testDT<Bool> (TpBool, TpArrayBool, 1);
+    testDT<uChar> (TpUChar, TpArrayUChar, 1);
+    testDT<Short> (TpShort, TpArrayShort, 2);
+    testDT<Int> (TpInt, TpArrayInt, 4);
+    testDT<uInt> (TpUInt, TpArrayUInt, 4);
+    testDT<Int64> (TpInt64, TpArrayInt64, 8);
+    testDT<Float> (TpFloat, TpArrayFloat, 4);
+    testDT<Double> (TpDouble, TpArrayDouble, 8);
+    testDT<Complex> (TpComplex, TpArrayComplex, 8, True);
+    testDT<DComplex> (TpDComplex, TpArrayDComplex, 16, True);
+    testCompound();
+  } catch (AipsError& x) {
+    cout << "Unexpected exception: " << x.what() << endl;
+    return 1;
+  }
+  cout << "OK" << endl;
+  return 0;
+}

--- a/casa/HDF5/test/tHDF5Record.cc
+++ b/casa/HDF5/test/tHDF5Record.cc
@@ -65,7 +65,7 @@ Array<Int> arri()
 Array<uInt> arrui()
 {
   Array<uInt> arrui(IPosition(1,5));
-  indgen(arrui);
+  indgen(arrui, 32768u*65536u);
   return arrui;
 }
 Array<Int64> arri64()


### PR DESCRIPTION
Improved read/writems to store most of the MS main columns as a compound datatype when storing the visibility data in HDF5 format.
Made it possible to read HDF5 data (and MS data) without column iteration.
