### PR TITLE
Removed semicolon after extern "C" { ... }

### DIFF
--- a/casa/OS/malloc.h
+++ b/casa/OS/malloc.h
@@ -614,7 +614,7 @@ int mspace_mallopt(int, int);
 #endif  /* MSPACES */
 
 #ifdef __cplusplus
-};  /* end of extern "C" */
+}  /* end of extern "C" */
 #endif
 
 #endif /* MALLOC_280_H */


### PR DESCRIPTION
Pedantic compilers complain about the ; after extern "C" { ... }, which indeed is not required.