### PR TITLE
Fixed deprecated check for Linux.

### DIFF
--- a/casa/aipsenv.h
+++ b/casa/aipsenv.h
@@ -130,7 +130,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 #if defined(AIPS_LINUX)
 #undef AIPS_LINUX
 #endif
-#if defined(__linux)
+#if defined(__linux__)
 #define AIPS_LINUX
 #endif
 


### PR DESCRIPTION
The `__linux` define is deprecated (see https://sourceforge.net/p/predef/wiki/OperatingSystems/), we should use `__linux__` instead.