### PR TITLE
Concatenate SYSCAL tables

### DIFF
--- a/ms/MSOper/MSConcat.h
+++ b/ms/MSOper/MSConcat.h
@@ -123,6 +123,7 @@ private:
   Bool checkEphIdInField(const ROMSFieldColumns& otherFldCol) const;
   Bool copyPointing(const MSPointing& otherPoint, const Block<uInt>& newAntIndices);
   Bool copyPointingB(MSPointing& otherPoint, const Block<uInt>& newAntIndices);
+  Bool copySysCal(const MSSysCal& otherSysCal, const Block<uInt>& newAndIndices);
   Int copyObservation(const MSObservation& otherObs, const Bool remRedunObsId=True);
                              // by default remove redundant observation table rows
   Block<uInt> copyAntennaAndFeed(const MSAntenna& otherAnt,


### PR DESCRIPTION
When concatenating MeasurementSets the associated SYSCAL tables should be concatenated as well. Otherwise only Tsys values from the first MeasurementSet survive and amplitude calibration will fail for the appended data. With this change the importfitsidi task in CASA can be used to read in multiple FITS-IDI files that contain a SYSTEM_TEMPERATURE table with Tsys measurements.

For "virtual" concatenation, additional values are appended to the SYSCAL table of the first MeasurementSet when creating the MMS.