### PR TITLE
Allocator::INIT/NO_INIT and MCDoppler static state initialization prob

### DIFF
--- a/casa/Arrays/Array.h
+++ b/casa/Arrays/Array.h
@@ -196,7 +196,7 @@ public:
     // initialize elements before they are referred, especially when <src>T</src> is such type like <src>std::string</src>.
     // <srcblock>
     //   IPosition shape(1, 10);
-    //   Array<Int> ai(shape, ArrayInitPolicy::NO_INIT);
+    //   Array<Int> ai(shape, ArrayInitPolicies::NO_INIT);
     //   size_t nread = fread(ai.data(), sizeof(Int), ai.nelements(), fp);
     // </srcblock>
     Array(const IPosition &shape, ArrayInitPolicy initPolicy);
@@ -338,7 +338,7 @@ public:
     // which likely would be simpler to understand. (Should copy() 
     // be deprecated and removed?)
     //
-    Array<T> copy(ArrayInitPolicy policy = ArrayInitPolicy::NO_INIT) const;                         // Make a copy of this
+    Array<T> copy(ArrayInitPolicy policy = ArrayInitPolicies::NO_INIT) const;                         // Make a copy of this
 
     // This function copies the matching part of from array to this array.
     // The matching part is the part with the minimum size for each axis.
@@ -891,7 +891,7 @@ private:
     Allocator_private::BulkAllocator<T> *nonNewDelAllocator() const;
 protected:
     static ArrayInitPolicy defaultArrayInitPolicy() {
-        return Block<T>::init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT;
+        return Block<T>::init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT;
     }
     // pre/post processing hook of takeStorage() for subclasses.
     virtual void preTakeStorage(const IPosition &) {}

--- a/casa/Arrays/Array.tcc
+++ b/casa/Arrays/Array.tcc
@@ -216,20 +216,20 @@ template<class T> Array<T> Array<T>::copy(ArrayInitPolicy policy) const
 template<class T> void Array<T>::copyToContiguousStorage(T *storage, Array<T> const & src, ArrayInitPolicy policy)
 {
     if (src.contiguousStorage()) {
-        if (policy == ArrayInitPolicy::NO_INIT) {
+        if (policy == ArrayInitPolicies::NO_INIT) {
             objcopyctor(storage, src.begin_p, src.nels_p);
         } else {
             objcopy(storage, src.begin_p, src.nels_p);
         }
     } else if (src.ndim() == 1) {
-        if (policy == ArrayInitPolicy::NO_INIT) {
+        if (policy == ArrayInitPolicies::NO_INIT) {
             objcopyctor(storage, src.begin_p, src.length_p(0), 1U, src.inc_p(0));
         } else {
             objcopy(storage, src.begin_p, src.length_p(0), 1U, src.inc_p(0));
         }
     } else if (src.length_p(0) == 1  &&  src.ndim() == 2) {
         // Special case which can be quite common (e.g. row in a matrix).
-        if (policy == ArrayInitPolicy::NO_INIT) {
+        if (policy == ArrayInitPolicies::NO_INIT) {
             objcopyctor(storage, src.begin_p, src.length_p(1), 1U,
                     src.originalLength_p(0) * src.inc_p(1));
         } else {
@@ -240,7 +240,7 @@ template<class T> void Array<T>::copyToContiguousStorage(T *storage, Array<T> co
         // If not many elements on a line, it's better to use this loop.
         T* ptr = storage;
         const_iterator iterend = src.end();
-        if (policy == ArrayInitPolicy::NO_INIT) {
+        if (policy == ArrayInitPolicies::NO_INIT) {
             try {
                 for (const_iterator iter = src.begin(); iter != iterend;
                         ++iter) {
@@ -266,7 +266,7 @@ template<class T> void Array<T>::copyToContiguousStorage(T *storage, Array<T> co
         IPosition index(src.ndim());
         size_t count = 0;
         size_t const size = src.length_p(0);
-        if (policy == ArrayInitPolicy::NO_INIT) {
+        if (policy == ArrayInitPolicies::NO_INIT) {
             try {
                 while (!ai.pastEnd()) {
                     index = ai.pos();
@@ -303,7 +303,7 @@ template<class T> void Array<T>::copyToContiguousStorage(T *storage, Array<T> co
 template<class T> Array<T> Array<T>::copy(ArrayInitPolicy policy, Allocator_private::BulkAllocator<T> *allocator) const
 {
     DebugAssert(ok(), ArrayError);
-    DebugAssert(policy == ArrayInitPolicy::INIT
+    DebugAssert(policy == ArrayInitPolicies::INIT
             || allocator != Allocator_private::get_allocator<typename NewDelAllocator<T>::type>(),
             ArrayError);
 
@@ -369,7 +369,7 @@ template<class T> Array<T> &Array<T>::operator=(const Array<T> &other)
 	}
     } else {
 	// Array was empty; make a new copy and reference it.
-	Array<T> tmp (other.copy(ArrayInitPolicy::NO_INIT, nonNewDelAllocator()));
+	Array<T> tmp (other.copy(ArrayInitPolicies::NO_INIT, nonNewDelAllocator()));
 	reference (tmp);
     }
     return *this;
@@ -570,7 +570,7 @@ template<class T> void Array<T>::unique()
 	return;
     }
     // OK, we know we are going to need to copy.
-    Array<T> tmp (copy(ArrayInitPolicy::NO_INIT, nonNewDelAllocator()));
+    Array<T> tmp (copy(ArrayInitPolicies::NO_INIT, nonNewDelAllocator()));
     reference (tmp);
 }
 
@@ -983,7 +983,7 @@ template<class T> T *Array<T>::getStorage(Bool &deleteIt)
     }
     // ok - copy it
     try {
-        copyToContiguousStorage(storage, *this, ArrayInitPolicy::NO_INIT);
+        copyToContiguousStorage(storage, *this, ArrayInitPolicies::NO_INIT);
     } catch (...) {
         nonNewDelAllocator()->deallocate(storage, nelements());
         throw;
@@ -1095,7 +1095,7 @@ void Array<T>::takeStorage(const IPosition &shape, T *storage,
     case COPY:
         if (data_p.null() || data_p.nrefs() > 1
                 || data_p->nelements() != new_nels) {
-            data_p = new Block<T>(new_nels, ArrayInitPolicy::NO_INIT,
+            data_p = new Block<T>(new_nels, ArrayInitPolicies::NO_INIT,
                     allocator.getAllocator());
             data_p->construct(0, new_nels, storage);
         } else {

--- a/casa/Arrays/Vector.tcc
+++ b/casa/Arrays/Vector.tcc
@@ -83,7 +83,7 @@ template<class T> Vector<T>::Vector(const IPosition& len, const T &initialValue)
 }
 
 template<class T> Vector<T>::Vector(const Block<T> &other, Int64 nr)
-: Array<T>(IPosition(1, other.nelements()), ArrayInitPolicy::INIT)
+: Array<T>(IPosition(1, other.nelements()), ArrayInitPolicies::INIT)
 {
     initVector (other, nr);
     DebugAssert(ok(), ArrayError);

--- a/casa/Arrays/test/tArray.cc
+++ b/casa/Arrays/test/tArray.cc
@@ -1051,54 +1051,54 @@ size_t LifecycleChecker::assign_error_trigger = std::numeric_limits<size_t>::max
 void newCubeTest()
 {
     {
-        Cube<Int> c(IPosition(3, 2, 2, 2), ArrayInitPolicy::NO_INIT);
+        Cube<Int> c(IPosition(3, 2, 2, 2), ArrayInitPolicies::NO_INIT);
     }
     {
-        Cube<Int> c(2UL, 2UL, 2UL, ArrayInitPolicy::NO_INIT);
+        Cube<Int> c(2UL, 2UL, 2UL, ArrayInitPolicies::NO_INIT);
     }
     {
         IPosition shape(3, 2, 2, 2);
         Int *values = new Int[shape.product()];
         Cube<Int> c(shape, values, COPY, DefaultAllocator<Int>::value);
         delete[] values;
-        c.resize(IPosition(3, 2, 3, 2), False, ArrayInitPolicy::NO_INIT);
-        c.resize(2, 4, 4, False, ArrayInitPolicy::NO_INIT);
+        c.resize(IPosition(3, 2, 3, 2), False, ArrayInitPolicies::NO_INIT);
+        c.resize(2, 4, 4, False, ArrayInitPolicies::NO_INIT);
     }
 }
 
 void newMatrixTest()
 {
     {
-        Matrix<Int> c(IPosition(2, 2, 2), ArrayInitPolicy::NO_INIT);
+        Matrix<Int> c(IPosition(2, 2, 2), ArrayInitPolicies::NO_INIT);
     }
     {
-        Matrix<Int> c(2UL, 2UL, ArrayInitPolicy::NO_INIT);
+        Matrix<Int> c(2UL, 2UL, ArrayInitPolicies::NO_INIT);
     }
     {
         IPosition shape(2, 2, 2);
         Int *values = new Int[shape.product()];
         Matrix<Int> c(shape, values, COPY, DefaultAllocator<Int>::value);
         delete[] values;
-        c.resize(IPosition(2, 2, 3), False, ArrayInitPolicy::NO_INIT);
-        c.resize(4, 4, False, ArrayInitPolicy::NO_INIT);
+        c.resize(IPosition(2, 2, 3), False, ArrayInitPolicies::NO_INIT);
+        c.resize(4, 4, False, ArrayInitPolicies::NO_INIT);
     }
 }
 
 void newVectorTest()
 {
     {
-        Vector<Int> c(IPosition(1, 2), ArrayInitPolicy::NO_INIT);
+        Vector<Int> c(IPosition(1, 2), ArrayInitPolicies::NO_INIT);
     }
     {
-        Vector<Int> c(2UL, ArrayInitPolicy::NO_INIT);
+        Vector<Int> c(2UL, ArrayInitPolicies::NO_INIT);
     }
     {
         IPosition shape(1, 2);
         Int *values = new Int[shape.product()];
         Vector<Int> c(shape, values, COPY, DefaultAllocator<Int>::value);
         delete[] values;
-        c.resize(IPosition(1, 3), False, ArrayInitPolicy::NO_INIT);
-        c.resize(4, False, ArrayInitPolicy::NO_INIT);
+        c.resize(IPosition(1, 3), False, ArrayInitPolicies::NO_INIT);
+        c.resize(4, False, ArrayInitPolicies::NO_INIT);
     }
 }
 
@@ -1109,7 +1109,7 @@ void newInterfaceTest()
     newVectorTest();
     {
         for (size_t i = 0; i < 200; ++i) {
-            Array<Int> ai(IPosition(2, 2, 3), ArrayInitPolicy::NO_INIT);
+            Array<Int> ai(IPosition(2, 2, 3), ArrayInitPolicies::NO_INIT);
             intptr_t addr = (intptr_t)ai.data();
             AlwaysAssertExit(addr % DefaultAllocator<Int>::type::alignment == 0);
         }
@@ -1157,7 +1157,7 @@ void newInterfaceTest()
         {
             Array<LifecycleChecker> a;
             a.takeStorage(shape, ptr, SHARE);
-            a.resize(IPosition(2, 3, 3), False, ArrayInitPolicy::INIT);
+            a.resize(IPosition(2, 3, 3), False, ArrayInitPolicies::INIT);
         }
         delete[] ptr;
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
@@ -1167,7 +1167,7 @@ void newInterfaceTest()
         {
             Array<LifecycleChecker> a;
             a.takeStorage(shape, ptr, TAKE_OVER);
-            a.resize(IPosition(2, 3, 3), True, ArrayInitPolicy::INIT);
+            a.resize(IPosition(2, 3, 3), True, ArrayInitPolicies::INIT);
         }
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
 
@@ -1217,7 +1217,7 @@ void newInterfaceTest()
         {
             Array<LifecycleChecker> a;
             a.takeStorage(shape, ptr, SHARE, DefaultAllocator<LifecycleChecker>::value);
-            a.resize(IPosition(2, 3, 3), False, ArrayInitPolicy::INIT);
+            a.resize(IPosition(2, 3, 3), False, ArrayInitPolicies::INIT);
         }
         for (size_t i = 0; i < nelems; ++i) {
             defAlloc.destroy(&ptr[i]);
@@ -1233,7 +1233,7 @@ void newInterfaceTest()
         {
             Array<LifecycleChecker> a;
             a.takeStorage(shape, ptr, TAKE_OVER, DefaultAllocator<LifecycleChecker>::value);
-            a.resize(IPosition(2, 3, 3), True, ArrayInitPolicy::INIT);
+            a.resize(IPosition(2, 3, 3), True, ArrayInitPolicies::INIT);
         }
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
 
@@ -1286,14 +1286,14 @@ void newInterfaceTest()
         IPosition const shape(2, 2, 3);
         LifecycleChecker::clear();
         {
-            Array<LifecycleChecker> a(shape, ArrayInitPolicy::NO_INIT);
+            Array<LifecycleChecker> a(shape, ArrayInitPolicies::NO_INIT);
         }
         AlwaysAssertExit(LifecycleChecker::ctor_count == 0);
         AlwaysAssertExit(LifecycleChecker::dtor_count == (size_t)shape.product());
 
         LifecycleChecker::clear();
         {
-            Array<LifecycleChecker> a(shape, ArrayInitPolicy::INIT);
+            Array<LifecycleChecker> a(shape, ArrayInitPolicies::INIT);
         }
         AlwaysAssertExit(LifecycleChecker::ctor_count == (size_t)shape.product());
         AlwaysAssertExit(LifecycleChecker::dtor_count == (size_t)shape.product());
@@ -1301,7 +1301,7 @@ void newInterfaceTest()
         {
             Array<LifecycleChecker> a;
             LifecycleChecker::clear();
-            a.resize(shape, False, ArrayInitPolicy::NO_INIT);
+            a.resize(shape, False, ArrayInitPolicies::NO_INIT);
         }
         AlwaysAssertExit(LifecycleChecker::ctor_count == 0);
         AlwaysAssertExit(LifecycleChecker::dtor_count == (size_t )shape.product());
@@ -1309,7 +1309,7 @@ void newInterfaceTest()
         {
             Array<LifecycleChecker> a;
             LifecycleChecker::clear();
-            a.resize(shape, False, ArrayInitPolicy::INIT);
+            a.resize(shape, False, ArrayInitPolicies::INIT);
         }
         AlwaysAssertExit(LifecycleChecker::ctor_count == (size_t )shape.product());
         AlwaysAssertExit(LifecycleChecker::dtor_count == (size_t )shape.product());

--- a/casa/Containers/Allocator.cc
+++ b/casa/Containers/Allocator.cc
@@ -30,7 +30,12 @@
 
 namespace casacore {
 
+#if defined(AIPS_CXX11)
 constexpr ArrayInitPolicy ArrayInitPolicies::NO_INIT;
 constexpr ArrayInitPolicy ArrayInitPolicies::INIT;
+#else
+ArrayInitPolicy const ArrayInitPolicies::NO_INIT = ArrayInitPolicy(false);
+ArrayInitPolicy const ArrayInitPolicies::INIT = ArrayInitPolicy(true);
+#endif
 
 }

--- a/casa/Containers/Allocator.cc
+++ b/casa/Containers/Allocator.cc
@@ -30,7 +30,7 @@
 
 namespace casacore {
 
-ArrayInitPolicy const ArrayInitPolicy::NO_INIT = ArrayInitPolicy(false);
-ArrayInitPolicy const ArrayInitPolicy::INIT = ArrayInitPolicy(true);
+constexpr ArrayInitPolicy ArrayInitPolicies::NO_INIT;
+constexpr ArrayInitPolicy ArrayInitPolicies::INIT;
 
 }

--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -55,11 +55,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // ArrayInitPolicy is used in functions where an array is allocated/resized.
 // </synopsis>
 class ArrayInitPolicy {
+friend class foobar;
 public:
-  // Don't initialize elements in the array. (The array will be explicitly filled with values other than the default value.)
-  static ArrayInitPolicy const NO_INIT;
-  // Initialize all elements in the array with the default value.
-  static ArrayInitPolicy const INIT;
   Bool operator ==(ArrayInitPolicy const &other) {
     return init == other.init;
   }
@@ -68,7 +65,15 @@ public:
   }
 private:
   Bool init;
-  explicit ArrayInitPolicy(bool v): init(v) {}
+  explicit constexpr ArrayInitPolicy(bool v): init(v) {}
+  friend struct ArrayInitPolicies;
+};
+
+struct ArrayInitPolicies {
+    // Don't initialize elements in the array. (The array will be explicitly filled with values other than the default value.)
+    static constexpr ArrayInitPolicy NO_INIT = ArrayInitPolicy(false);
+    // Initialize all elements in the array with the default value.
+    static constexpr ArrayInitPolicy INIT = ArrayInitPolicy(true);
 };
 
 #if __cplusplus < 201103L

--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -55,7 +55,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // ArrayInitPolicy is used in functions where an array is allocated/resized.
 // </synopsis>
 class ArrayInitPolicy {
-friend class foobar;
 public:
   Bool operator ==(ArrayInitPolicy const &other) {
     return init == other.init;
@@ -65,7 +64,11 @@ public:
   }
 private:
   Bool init;
+#if defined(AIPS_CXX11)
   explicit constexpr ArrayInitPolicy(bool v): init(v) {}
+#else
+  explicit ArrayInitPolicy(bool v): init(v) {}
+#endif
   friend struct ArrayInitPolicies;
 };
 

--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -70,10 +70,16 @@ private:
 };
 
 struct ArrayInitPolicies {
+#if defined(AIPS_CXX11)
     // Don't initialize elements in the array. (The array will be explicitly filled with values other than the default value.)
     static constexpr ArrayInitPolicy NO_INIT = ArrayInitPolicy(false);
     // Initialize all elements in the array with the default value.
     static constexpr ArrayInitPolicy INIT = ArrayInitPolicy(true);
+#else
+    static const ArrayInitPolicy NO_INIT;
+    // Initialize all elements in the array with the default value.
+    static const ArrayInitPolicy INIT;
+#endif
 };
 
 #if __cplusplus < 201103L

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -267,7 +267,7 @@ public:
   explicit Block(size_t n) :
       allocator_p(get_allocator<typename DefaultAllocator<T>::type>()), used_p(
           n), destroyPointer(True), keep_allocator_p(False) {
-    init(init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT);
+    init(init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
 
   // Create a Block with the given number of points. The values in Block
@@ -276,7 +276,7 @@ public:
   Block(size_t n, AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), used_p(n), destroyPointer(
           True), keep_allocator_p(False) {
-    init(init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT);
+    init(init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
 
   // Create a Block with the given number of points. The values in Block
@@ -304,7 +304,7 @@ public:
   Block(size_t n, T const &val) :
       allocator_p(get_allocator<typename DefaultAllocator<T>::type>()), used_p(
           n), destroyPointer(True), keep_allocator_p(False) {
-    init(ArrayInitPolicy::NO_INIT);
+    init(ArrayInitPolicies::NO_INIT);
     try {
       allocator_p->construct(array, get_size(), val);
     } catch (...) {
@@ -319,7 +319,7 @@ public:
   Block(size_t n, T const &val, AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), used_p(n), destroyPointer(
           True), keep_allocator_p(False) {
-    init(ArrayInitPolicy::NO_INIT);
+    init(ArrayInitPolicies::NO_INIT);
     try {
       allocator_p->construct(array, get_size(), val);
     } catch (...) {
@@ -364,7 +364,7 @@ public:
   Block(const Block<T> &other) :
       allocator_p(other.allocator_p), used_p(other.size()), destroyPointer(
           True), keep_allocator_p(False) {
-    init(ArrayInitPolicy::NO_INIT);
+    init(ArrayInitPolicies::NO_INIT);
 
     try {
       //objcopy(array, other.array, get_size());
@@ -381,7 +381,7 @@ public:
   Block<T> &operator=(const Block<T> &other) {
     if (&other != this) {
       T *old = array;
-      this->resize(other.size(), True, False, ArrayInitPolicy::NO_INIT);
+      this->resize(other.size(), True, False, ArrayInitPolicies::NO_INIT);
       if (array == old) {
         objcopy(array, other.array, get_size());
       } else {
@@ -423,7 +423,7 @@ public:
   // <group>
   void resize(size_t n, Bool forceSmaller = False, Bool copyElements = True) {
     resize(n, forceSmaller, copyElements,
-        init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT);
+        init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
   void resize(size_t n, Bool forceSmaller, Bool copyElements,
       ArrayInitPolicy initPolicy) {
@@ -459,7 +459,7 @@ public:
         }
         start = nmin;
       }
-      if (initPolicy == ArrayInitPolicy::INIT) {
+      if (initPolicy == ArrayInitPolicies::INIT) {
         try {
           allocator_p->construct(&tp[start], n - start);
         } catch (...) {
@@ -490,7 +490,7 @@ public:
   // <group>
   void remove(size_t whichOne, Bool forceSmaller = True) {
     remove(whichOne, forceSmaller,
-        init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT);
+        init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
   void remove(size_t whichOne, Bool forceSmaller, ArrayInitPolicy initPolicy) {
     if (whichOne >= get_size()) {
@@ -505,7 +505,7 @@ public:
     if (forceSmaller == True) {
       T *tp = n > 0 ? allocator_p->allocate(n) : 0;
       traceAlloc(array, n);
-      if (initPolicy == ArrayInitPolicy::INIT && n > 0) {
+      if (initPolicy == ArrayInitPolicies::INIT && n > 0) {
         try {
           allocator_p->construct(tp, n);
         } catch (...) {
@@ -725,7 +725,7 @@ public:
   Block(size_t n, Allocator_private::AllocSpec<T> allocator) :
       allocator_p(allocator.allocator), used_p(n), destroyPointer(
           True), keep_allocator_p(False) {
-    init(init_anyway() ? ArrayInitPolicy::INIT : ArrayInitPolicy::NO_INIT);
+    init(init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
   Block(size_t n, T *&storagePointer, Bool takeOverStorage,
           Allocator_private::BulkAllocator<T> *allocator) :
@@ -764,7 +764,7 @@ public:
     if (get_capacity() > 0) {
       array = allocator_p->allocate(get_capacity());
       traceAlloc(array, get_capacity());
-      if (initPolicy == ArrayInitPolicy::INIT) {
+      if (initPolicy == ArrayInitPolicies::INIT) {
         try {
           allocator_p->construct(array, get_size());
         } catch (...) {

--- a/casa/Containers/test/tBlock.cc
+++ b/casa/Containers/test/tBlock.cc
@@ -125,11 +125,11 @@ void doit()
       bi.resize(91UL, True, True);
       AlwaysAssertExit(9876 == bi[44]);
       AlwaysAssertExit(0 == ((intptr_t)bi.storage()) % 32);
-      bi.resize(89UL, True, False, ArrayInitPolicy::INIT);
+      bi.resize(89UL, True, False, ArrayInitPolicies::INIT);
       AlwaysAssertExit(0 == bi[0] && 0 == bi[30]);
       AlwaysAssertExit(0 == ((intptr_t)bi.storage()) % 32);
       p = bi.storage();
-      bi.resize(87UL, False, True, ArrayInitPolicy::NO_INIT);
+      bi.resize(87UL, False, True, ArrayInitPolicies::NO_INIT);
       AlwaysAssertExit(p == bi.storage());
       AlwaysAssertExit(0 == ((intptr_t)bi.storage()) % 32);
       bi.resize(105UL);
@@ -138,7 +138,7 @@ void doit()
     {
       LifecycleChecker::clear();
       {
-        Block<LifecycleChecker> b(200, ArrayInitPolicy::INIT);
+        Block<LifecycleChecker> b(200, ArrayInitPolicies::INIT);
       }
       AlwaysAssertExit(200 <= LifecycleChecker::ctor_count);
       AlwaysAssertExit(200 <= LifecycleChecker::dtor_count);
@@ -147,7 +147,7 @@ void doit()
       LifecycleChecker::clear();
       LifecycleChecker::ctor_error_trigger = 10;
       try {
-        Block<LifecycleChecker> b(20, ArrayInitPolicy::INIT);
+        Block<LifecycleChecker> b(20, ArrayInitPolicies::INIT);
         AlwaysAssertExit(False);
       } catch (...) {
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
@@ -157,8 +157,8 @@ void doit()
       LifecycleChecker::clear();
       LifecycleChecker::ctor_error_trigger = 20 + 5;
       try {
-        Block<LifecycleChecker> b(20, ArrayInitPolicy::INIT);
-        b.resize(15, True, True, ArrayInitPolicy::NO_INIT);
+        Block<LifecycleChecker> b(20, ArrayInitPolicies::INIT);
+        b.resize(15, True, True, ArrayInitPolicies::NO_INIT);
         AlwaysAssertExit(False);
       } catch (...) {
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
@@ -168,8 +168,8 @@ void doit()
       LifecycleChecker::clear();
       LifecycleChecker::ctor_error_trigger = 20 + 5;
       try {
-        Block<LifecycleChecker> b(20, ArrayInitPolicy::INIT);
-        b.resize(15, True, True, ArrayInitPolicy::INIT);
+        Block<LifecycleChecker> b(20, ArrayInitPolicies::INIT);
+        b.resize(15, True, True, ArrayInitPolicies::INIT);
         AlwaysAssertExit(False);
       } catch (...) {
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
@@ -179,8 +179,8 @@ void doit()
       LifecycleChecker::clear();
       LifecycleChecker::ctor_error_trigger = 10 + 5;
       try {
-        Block<LifecycleChecker> b(10, ArrayInitPolicy::INIT);
-        b.resize(15, True, True, ArrayInitPolicy::NO_INIT);
+        Block<LifecycleChecker> b(10, ArrayInitPolicies::INIT);
+        b.resize(15, True, True, ArrayInitPolicies::NO_INIT);
         AlwaysAssertExit(False);
       } catch (...) {
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
@@ -190,8 +190,8 @@ void doit()
       LifecycleChecker::clear();
       LifecycleChecker::ctor_error_trigger = 10 + 10 + 3;
       try {
-        Block<LifecycleChecker> b(10, ArrayInitPolicy::INIT);
-        b.resize(15, True, True, ArrayInitPolicy::NO_INIT);
+        Block<LifecycleChecker> b(10, ArrayInitPolicies::INIT);
+        b.resize(15, True, True, ArrayInitPolicies::NO_INIT);
       } catch (...) {
         AlwaysAssertExit(False);
       }
@@ -201,8 +201,8 @@ void doit()
       LifecycleChecker::clear();
       LifecycleChecker::ctor_error_trigger = 10 + 10 + 3;
       try {
-        Block<LifecycleChecker> b(10, ArrayInitPolicy::INIT);
-        b.resize(15, True, True, ArrayInitPolicy::INIT);
+        Block<LifecycleChecker> b(10, ArrayInitPolicies::INIT);
+        b.resize(15, True, True, ArrayInitPolicies::INIT);
         AlwaysAssertExit(False);
       } catch (...) {
         AlwaysAssertExit(LifecycleChecker::ctor_count == LifecycleChecker::dtor_count);
@@ -211,7 +211,7 @@ void doit()
     {
       LifecycleChecker::clear();
       {
-        Block<LifecycleChecker> b(200, ArrayInitPolicy::NO_INIT, AllocSpec<NewDelAllocator<LifecycleChecker> >::value);
+        Block<LifecycleChecker> b(200, ArrayInitPolicies::NO_INIT, AllocSpec<NewDelAllocator<LifecycleChecker> >::value);
       }
       AlwaysAssertExit(200 <= LifecycleChecker::ctor_count);
       AlwaysAssertExit(200 <= LifecycleChecker::dtor_count);
@@ -220,7 +220,7 @@ void doit()
     {
       LifecycleChecker::clear();
       {
-        Block<LifecycleChecker> b(200, ArrayInitPolicy::NO_INIT, AllocSpec<AlignedAllocator<LifecycleChecker, 32> >::value);
+        Block<LifecycleChecker> b(200, ArrayInitPolicies::NO_INIT, AllocSpec<AlignedAllocator<LifecycleChecker, 32> >::value);
       }
       AlwaysAssertExit(0 == LifecycleChecker::ctor_count);
       AlwaysAssertExit(200 <= LifecycleChecker::dtor_count);
@@ -228,7 +228,7 @@ void doit()
     {
       LifecycleChecker::clear();
       {
-        Block<LifecycleChecker> b(200, ArrayInitPolicy::INIT);
+        Block<LifecycleChecker> b(200, ArrayInitPolicies::INIT);
       }
       AlwaysAssertExit(200 <= LifecycleChecker::ctor_count);
       AlwaysAssertExit(200 <= LifecycleChecker::dtor_count);

--- a/measures/Measures/MCDoppler.cc
+++ b/measures/Measures/MCDoppler.cc
@@ -1,5 +1,5 @@
-//# MCDoppler.cc: MDoppler conversion routines 
-//# Copyright (C) 1995,1996,1997,1998,2000
+//# MCDoppler.cc: MDoppler conversion routines
+//# Copyright (C) 1995,1996,1997,1998,2000,2018
 //# Associated Universities, Inc. Washington DC, USA.
 //#
 //# This library is free software; you can redistribute it and/or modify it
@@ -32,16 +32,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Statics
 uInt MCDoppler::ToRef_p[N_Routes][3] = {
-    {MDoppler::RADIO,	MDoppler::RATIO,	0}, 
+    {MDoppler::RADIO,	MDoppler::RATIO,	0},
     {MDoppler::Z,	MDoppler::RATIO,	0},
     {MDoppler::BETA,	MDoppler::RATIO,	0},
     {MDoppler::GAMMA,	MDoppler::RATIO,	0},
-    {MDoppler::RATIO,	MDoppler::RADIO,	0}, 
+    {MDoppler::RATIO,	MDoppler::RADIO,	0},
     {MDoppler::RATIO,	MDoppler::Z,		0},
     {MDoppler::RATIO,	MDoppler::BETA,		0},
     {MDoppler::RATIO,	MDoppler::GAMMA,	0} };
 uInt MCDoppler::FromTo_p[MDoppler::N_Types][MDoppler::N_Types];
-MutexedInit MCDoppler::theirMutexedInit (MCDoppler::doFillState);
+bool MCDoppler_initializer::initialized = false;
 
 //# Constructors
 MCDoppler::MCDoppler() {
@@ -58,7 +58,7 @@ MCDoppler::~MCDoppler() {
 //# Member functions
 
 void MCDoppler::getConvert(MConvertBase &mc,
-			   const MRBase &inref, 
+			   const MRBase &inref,
 			   const MRBase &outref) {
 
   Int iin  = inref.getType();
@@ -81,7 +81,7 @@ void MCDoppler::initConvert(uInt which, MConvertBase &mc) {
   if (False) initConvert(which, mc);	// Stop warning
 
   switch (which) {
-    
+
   default:
     break;
   }
@@ -101,13 +101,13 @@ void MCDoppler::doConvert(MVDoppler &in,
 			  const MConvertBase &mc) {
 
   if (False) {inref.getType(); outref.getType(); } // to stop warning
-    
+
   Double t = (Double) in;
 
   for (Int i=0; i<mc.nMethod(); i++) {
 
     switch (mc.getMethod(i)) {
-	
+
     case RADIO_RATIO:
       t = 1- t;
       break;
@@ -160,4 +160,3 @@ String MCDoppler::showState() {
 }
 
 } //# NAMESPACE CASACORE - END
-

--- a/measures/Measures/MCDoppler.h
+++ b/measures/Measures/MCDoppler.h
@@ -1,5 +1,5 @@
 //# MCDoppler.h: MDoppler conversion routines 
-//# Copyright (C) 1995,1996,1997,1998,1999,2002
+//# Copyright (C) 1995,1996,1997,1998,1999,2002,2018
 //# Associated Universities, Inc. Washington DC, USA.
 //#
 //# This library is free software; you can redistribute it and/or modify it
@@ -145,12 +145,9 @@ private:
   static uInt ToRef_p[N_Routes][3];
   // Transition matrix
   static uInt FromTo_p[MDoppler::N_Types][MDoppler::N_Types];
-  // Mutex for thread-safety.
-  static MutexedInit theirMutexedInit;
 
   // Fill the global state in a thread-safe way.
-  static void fillState()
-    { theirMutexedInit.exec(); }
+  static void fillState(){ }
   
   //# Member functions
   
@@ -177,10 +174,23 @@ private:
 		 const MConvertBase &mc);
   
 private:
+  friend class MCDoppler_initializer;
   // Fill the global state in a thread-safe way.
   static void doFillState (void*);  
 };
 
+static class MCDoppler_initializer {
+ public:
+    MCDoppler_initializer( ) {
+        if ( ! initialized ) {
+            initialized = true;
+            MutexedInit init(MCDoppler::doFillState);
+            init.exec( );
+        }
+    }
+ private:
+    static bool initialized;
+} _local_static_MCDoppler_init;
 
 } //# NAMESPACE CASACORE - END
 


### PR DESCRIPTION
I encountered static initialization errors when trying to compile casacore object modules directly into a stand-alone executable (i.e. a stand-alone distribution of the casa viewer). The problems arise with the Array initialization constants and the initialization of MCDoppler state. These static are initialized properly when casacore is built into the various standard libraries (libcasa_casa, etc.). However, the initialization-before-use only happens because of this particular breakdown of the code into libraries. It falls apart when the object files are compiled into a single library or a single executable. It’s easy to see the issue, but there are a couple of solutions to the static issue in general:

1. convert the static to a static function which returns the static value

1. convert to constexpr static

1. add static initialization object (one per header file inclusion)

For the problems with MCDoppler, I opted for (3) because the initialization involves something complicated (filling an array). For the Allocator static initialization issues, I opted for (2) because it was really just initializing a static boolean. However, with the ArrayInitPolicy class it cannot have static ArrayInitPolicy constexpr members because they must be defined inline and ArrayInitPolicy is an incomplete class until the class declaration is completed. So I created an ArrayInitPolicies struct (I would prefer to create an ArrayInitPolicies namespace, but the designer of ArrayInitPolicies seems want to prevent others from creating policies (why I don’t really know exactly), but a namespace cannot be a friend of a class). This has the bad affect of changing the symbol space which provides INIT and NO_INIT (i.e. from ArrayInitPolicy to ArrayInitPolicies). However, I think the correct naming is more important than preventing downstream changes in this particular case.

The failure mode for the MCDoppler case was non-termination due to an infinite loop when doing the first conversion. The failure case for Allocator was more difficult, but the problem was discovered by printing "Allocator::INIT == Allocator::NO_INIT" which yielded "true" (with proper initialization this became false).
