### PR TITLE
Preserve original exception object in ms/mssSetData

### DIFF
--- a/ms/MSSel/MSSelectionTools.cc
+++ b/ms/MSSel/MSSelectionTools.cc
@@ -150,7 +150,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     catch (AipsError& x)
       {
 	if (mymss==NULL) delete mss;
-	throw(x);
+	throw;
       }
 
     if (mymss==NULL) delete mss;
@@ -238,7 +238,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     catch (AipsError& x)
       {
 	if (mymss == NULL) delete mss;
-	throw(x);
+	throw;
       }
     if (mymss == NULL) delete mss;
     return rstat;


### PR DESCRIPTION
Fixes #707, see issue for a description of the problem. 
This simply replaces `throw(x)` with `throw` where the old `throw(x)` doesn't let us distinguish specific exception types such as  `MSSelectionNullSelection`.
