### PR TITLE
Keep numpy array printing consistent for doctest with numpy v1.14 or above

### DIFF
--- a/python/Converters/test/tConvert.py
+++ b/python/Converters/test/tConvert.py
@@ -181,7 +181,10 @@ def testnp():
 
 if __name__ == "__main__":
 
-    import numpy as NUM;
+    import numpy as NUM
+    from distutils.version import LooseVersion
+    if LooseVersion(NUM.version.version) > LooseVersion("1.13"):
+        NUM.set_printoptions(legacy="1.13")
     t = tConvert();
     print "Doing numpy/array test ..."
     testnp();


### PR DESCRIPTION
keep numpy 1.13 printoption for numpy 1.14 or above, otherwise doctest for tConvert will fail