### PR TITLE
Added new method MDirection MSFieldColumns::ephemerisDirMeas()

### DIFF
--- a/ms/MeasurementSets/MSFieldColumns.cc
+++ b/ms/MeasurementSets/MSFieldColumns.cc
@@ -128,17 +128,14 @@ MDirection ROMSFieldColumns::referenceDirMeas(Int row, Double interTime) const
 
 MDirection ROMSFieldColumns::ephemerisDirMeas(Int row, Double interTime) const
 {
-  Int npoly = numPoly()(row);
-  if(npoly>0){
-    return MSFieldColumns::interpolateDirMeas(referenceDirMeasCol()(row), 
-					      npoly,
-					      interTime, time()(row));
-  }
-  else{
+  if(measCometIndex(row)>=0){
     const MDirection zeroDir = MDirection(Quantity(0, "deg"), Quantity(0, "deg"));
     return extractDirMeas(zeroDir,
 			  measCometIndex(row),
 			  interTime, timeMeas()(row));
+  }
+  else{
+    return referenceDirMeas(row, interTime);
   }
 }
 

--- a/ms/MeasurementSets/MSFieldColumns.cc
+++ b/ms/MeasurementSets/MSFieldColumns.cc
@@ -126,6 +126,22 @@ MDirection ROMSFieldColumns::referenceDirMeas(Int row, Double interTime) const
   }
 }
 
+MDirection ROMSFieldColumns::ephemerisDirMeas(Int row, Double interTime) const
+{
+  Int npoly = numPoly()(row);
+  if(npoly>0){
+    return MSFieldColumns::interpolateDirMeas(referenceDirMeasCol()(row), 
+					      npoly,
+					      interTime, time()(row));
+  }
+  else{
+    const MDirection zeroDir = MDirection(Quantity(0, "deg"), Quantity(0, "deg"));
+    return extractDirMeas(zeroDir,
+			  measCometIndex(row),
+			  interTime, timeMeas()(row));
+  }
+}
+
 
 MRadialVelocity ROMSFieldColumns::radVelMeas(Int row, Double interTime) const
 {

--- a/ms/MeasurementSets/MSFieldColumns.h
+++ b/ms/MeasurementSets/MSFieldColumns.h
@@ -122,6 +122,11 @@ public:
   // the default time of zero will return the 0th order element of the polynomial.
   // or, if there is an ephemeris, the position at the time origin of the ephemeris.
   // 
+  // If there is an ephemeris attached to a field table row, the nominal values of the
+  // direction columns are interpreted as an offset to the ephemeris which is added to
+  // the ephemeris direction. The unaltered ephemeris direction can be queried with 
+  // the method ephemerisDirMeas(). 
+  //
   // In addtion to the directions, if there is an ephemeris available,
   // also the radial velocity and the distance rho can be accessed.
   //
@@ -134,6 +139,7 @@ public:
   MDirection delayDirMeas(Int row, Double time = 0) const;
   MDirection phaseDirMeas(Int row, Double time = 0) const;
   MDirection referenceDirMeas(Int row, Double time = 0) const;
+  MDirection ephemerisDirMeas(Int row, Double time = 0) const;
   MRadialVelocity radVelMeas(Int row, Double time = 0) const;
   Quantity rho(Int row, Double time = 0) const;
   Bool needInterTime(Int row) const;

--- a/ms/MeasurementSets/MSFieldColumns.h
+++ b/ms/MeasurementSets/MSFieldColumns.h
@@ -123,9 +123,17 @@ public:
   // or, if there is an ephemeris, the position at the time origin of the ephemeris.
   // 
   // If there is an ephemeris attached to a field table row, the nominal values of the
-  // direction columns are interpreted as an offset to the ephemeris which is added to
-  // the ephemeris direction. The unaltered ephemeris direction can be queried with 
-  // the method ephemerisDirMeas(). 
+  // direction columns are interpreted as an offset to the ephemeris. So if there is
+  // an ephemeris attached (EPHEMERIS_ID column contains value > -1), then the direction
+  // returned by  delayDirMeas, phaseDirMeas, and referenceDirMeas is the ephemeris
+  // direction plus the offset taken from the corresponding direction column.
+  // This permits the convinient implementation of mosaics where several field table
+  // rows share one ephemeris and use different offsets in each row to create the
+  // mosaic pattern.
+  // 
+  // The unaltered ephemeris direction can be queried with the method ephemerisDirMeas(). 
+  // If there is no ephemeris attached, ephemerisDirMeas() will return the same as 
+  // referenceDirMeas().
   //
   // In addtion to the directions, if there is an ephemeris available,
   // also the radial velocity and the distance rho can be accessed.

--- a/ms/MeasurementSets/test/tMSFieldEphem.cc
+++ b/ms/MeasurementSets/test/tMSFieldEphem.cc
@@ -214,6 +214,10 @@ int main() {
 	Double mjds = 50802.75*86400.;
 	MDirection dDir = msfc.delayDirMeas(row, mjds);
 	// cout << "position for row " << row << ", MJD " << mjds/86400. << ": " << dDir.getAngle(Unit("deg")) << endl;
+	MDirection rDir = msfc.referenceDirMeas(row, mjds);
+	MDirection eDir = msfc.ephemerisDirMeas(row, mjds);
+	MVDirection expDir(rDir.getAngle());
+	AlwaysAssertExit(expDir.separation(MVDirection(eDir.getAngle()))<Quantity(0.001/3600., "deg").getValue("rad"));
       }
 
       // add one row with ephemeris 

--- a/ms/MeasurementSets/test/tMSFieldEphem.cc
+++ b/ms/MeasurementSets/test/tMSFieldEphem.cc
@@ -233,6 +233,8 @@ int main() {
 	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << endl;
 	MDirection rDir = msfc.referenceDirMeas(row, mjds);
 	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << endl;
+	MDirection eDir = msfc.ephemerisDirMeas(row, mjds);
+	// cout << "ephemerisdir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << eDir.getAngle(Unit("deg")) << endl;
 
 	MDirection expected(Quantity(-54.3855, "deg"), Quantity(-19.8873, "deg"), MDirection::APP);
 	MVDirection expDir(expected.getAngle());
@@ -243,6 +245,8 @@ int main() {
 	AlwaysAssertExit(pDir.type()==expected.type());
 	AlwaysAssertExit(expDir.separation(MVDirection(rDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
 	AlwaysAssertExit(rDir.type()==expected.type());
+	AlwaysAssertExit(expDir.separation(MVDirection(eDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
+	AlwaysAssertExit(eDir.type()==expected.type());
       }      
 
       Vector<Double> dirb(2); dirb(0)=Quantity(1.,"deg").getValue("rad"), dirb(1)=dirb(0)/2.;
@@ -263,9 +267,12 @@ int main() {
 	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << endl;
 	MDirection rDir = msfc.referenceDirMeas(row, mjds);
 	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << endl;
+	MDirection eDir = msfc.ephemerisDirMeas(row, mjds);
+	// cout << "ephemerisdir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << eDir.getAngle(Unit("deg")) << endl;
 
 	MVDirection original(Quantity(305.6145129, "deg"),
 			     Quantity(-19.8873316, "deg"));
+	MDirection unalteredExpected(original, MDirection::TOPO);
 	original.shift(dirb(0), dirb(1), True);
 	MDirection expected(original, MDirection::TOPO);
 
@@ -273,6 +280,7 @@ int main() {
  	//		    Quantity(-19.88733167+dirb(1)*180./3.14159265, "deg"), 
  	//		    MDirection::TOPO);
 	MVDirection expDir(expected.getAngle());
+	MVDirection unalteredExpDir(unalteredExpected.getAngle());
 
 	// cout << "separation " << expDir.separation(MVDirection(dDir.getAngle()), "deg") << endl;
 
@@ -285,6 +293,9 @@ int main() {
 	// cout << "types " << rDir.getRef() << " " << expected.getRef() << endl;
 
 	AlwaysAssertExit(rDir.getRef().getType()  == expected.getRef().getType() );
+	AlwaysAssertExit(unalteredExpDir.separation(MVDirection(eDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
+	AlwaysAssertExit(eDir.type()==expected.type());
+
       }      
       // add one row with GEO ephemeris 
       ms.field().addRow();


### PR DESCRIPTION
Added MDirection ephemerisDirMeas(Int row, Double time = 0) const;
(CASA ticket CAS-11214); added corresponding unit test code and documentation in the header file.
The new method behaves exactly like, e.g., 
MDirection referenceDirMeas(Int row, Double time = 0) const;
however, it does not apply any offsets which might be stored in the nominal direction columns. 
I.e. it always gives the unaltered direction of the attached ephemeris or, if there is no ephemeris attached, simply the same as referenceDirMeas().
