### PR TITLE
CAS-11195. Make LatticeApply::lineMultiApply more effecient at reading

### DIFF
--- a/images/Images/FITSImage.cc
+++ b/images/Images/FITSImage.cc
@@ -339,7 +339,13 @@ ImageInterface<Float>* FITSImage::cloneII() const
 
 String FITSImage::imageType() const
 {
-   return "FITSImage";
+   return className();
+}
+
+String FITSImage::className()
+{
+    static const string x = "FITSImage";
+    return x;
 }
 
 Bool FITSImage::isMasked() const

--- a/images/Images/FITSImage.h
+++ b/images/Images/FITSImage.h
@@ -144,6 +144,10 @@ public:
   // Get the image type (returns FITSImage).
   virtual String imageType() const;
 
+  // returns "FITSImage". Added so callers don't require an object to get
+  // the image type.
+  static String className();
+
   // Function which changes the shape of the FITSImage.
   // Throws an exception as FITSImage is not writable.
   virtual void resize(const TiledShape& newShape);

--- a/lattices/LatticeMath/LatticeApply.h
+++ b/lattices/LatticeMath/LatticeApply.h
@@ -27,7 +27,6 @@
 
 #ifndef LATTICES_LATTICEAPPLY_H
 #define LATTICES_LATTICEAPPLY_H
- 
 
 //# Includes
 #include <casacore/casa/aips.h>
@@ -44,7 +43,6 @@ template <class T> class MaskedLattice;
 class LatticeProgress;
 class IPosition;
 class LatticeRegion;
-
 
 // <summary>
 // Optimally iterate through a Lattice and apply provided function object
@@ -173,6 +171,7 @@ public:
 				LineCollapser<T,U>& collapser,
 				uInt collapseAxis,
 				LatticeProgress* tellProgress = 0);
+
     static void lineMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut, 
 				const MaskedLattice<T>& latticeIn,
 				const LatticeRegion& region,
@@ -247,9 +246,11 @@ private:
 			      const IPosition& shapeOut,
 			      const IPosition& collapseAxes,
 			      Int newOutAxis);
+
+    static IPosition _chunkShape(
+        uInt axis, const MaskedLattice<T>& latticeIn
+    );
 };
-
-
 
 } //# NAMESPACE CASACORE - END
 


### PR DESCRIPTION
add static method to FITSImage to be able to test for name of
image type without having to create an object to do it