### PR TITLE
Remove altogether the Vector cache for MVPosition and Euler classes.

### DIFF
--- a/casa/Quanta/Euler.cc
+++ b/casa/Quanta/Euler.cc
@@ -38,43 +38,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Euler class
 
-// simplistic Vector(3) cache to reduce allocation overhead for temporaries
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-thread_local size_t Euler::available = 0;
-thread_local std::vector<Euler::DataArrays> Euler::arrays(max_array_cache);
-#endif
-
-Euler::DataArrays Euler::get_arrays()
-{
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-  if (available > 0) {
-    return arrays[--available];
-  }
-#endif
-  return std::make_pair(casacore::CountedPtr<Vector<Double> >(new Vector<Double>(3)), 
-                        casacore::CountedPtr<Vector<Int> >(new Vector<Int>(3)));
-}
-
-void Euler::return_arrays(Euler::DataArrays array)
-{
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-  if (available < max_array_cache &&
-		  array.first->size() == 3 && array.second->size() == 3 &&
-		  array.first->nrefs() == 1 && array.second->nrefs() == 1) {
-    arrays[available++] = array;
-    return;
-  }
-#endif
-}
-
 //# Constructors
-Euler::Euler() : data(get_arrays()), euler(*data.first), axes(*data.second) {
+Euler::Euler() : euler(3), axes(3) {
     euler = Double(0.0);
     indgen(axes,1,1);
 }
 
 Euler::Euler(const Euler &other) : 
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     euler = other.euler;
     axes = other.axes;
 }
@@ -88,7 +59,7 @@ Euler &Euler::operator=(const Euler &other) {
 }
 
 Euler::Euler(Double in0, Double in1, Double in2) : 
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+euler(3), axes(3) {
     euler(0) = in0;
     euler(1) = in1;
     euler(2) = in2;
@@ -98,7 +69,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 
 Euler::Euler(Double in0, uInt ax0, Double in1, uInt ax1, Double in2,
 	     uInt ax2) : 
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     DebugAssert(ax0 <= 3 && ax1 <=3 && ax2 <=3, AipsError);
     euler(0) = in0;
     euler(1) = in1;
@@ -109,7 +80,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 
 Euler::Euler(const Quantity &in0) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     euler(0) = Euler::makeRad(in0);
     euler(1) = 0;
     euler(2) = 0;
@@ -117,7 +88,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 
 Euler::Euler(const Quantity &in0, const Quantity &in1) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     euler(0) = Euler::makeRad(in0);
     euler(1) = Euler::makeRad(in1);
     euler(2) = 0;
@@ -125,7 +96,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 
 Euler::Euler(const Quantity &in0, const Quantity &in1, const Quantity &in2) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     euler(0) = Euler::makeRad(in0);
     euler(1) = Euler::makeRad(in1);
     euler(2) = Euler::makeRad(in2);
@@ -133,7 +104,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 
 Euler::Euler(const Quantity &in0, uInt ax0) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     DebugAssert(ax0 <= 3, AipsError);
     euler(0) = Euler::makeRad(in0);
     euler(1) = 0;
@@ -143,7 +114,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
     axes(2) = 0;
 }
 Euler::Euler(const Quantity &in0, uInt ax0, const Quantity &in1, uInt ax1) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     DebugAssert(ax0 <= 3 && ax1 <=3, AipsError);
     euler(0) = Euler::makeRad(in0);
     euler(1) = Euler::makeRad(in1);
@@ -154,7 +125,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 Euler::Euler(const Quantity &in0, uInt ax0, const Quantity &in1, uInt ax1,
 	     const Quantity &in2, uInt ax2) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     DebugAssert(ax0 <= 3 && ax1 <=3 && ax2 <=3, AipsError);
     euler(0) = Euler::makeRad(in0);
     euler(1) = Euler::makeRad(in1);
@@ -165,7 +136,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 
 Euler::Euler(const Quantum<Vector<Double> > &in) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+ euler(3), axes(3) {
     Int i;
     Vector<Double> tmp = Euler::makeRad(in);
     Int j=tmp.size(); j=min(j,3);
@@ -179,7 +150,7 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 }
 
 Euler::Euler(const Quantum<Vector<Double> > &in, const Vector<uInt> &ax) :
-data(get_arrays()), euler(*data.first), axes(*data.second) {
+  euler(3), axes(3) {
     Vector<Double> tmp = Euler::makeRad(in);
     Int j=tmp.size(); j=min(j,3); Int i=ax.size(); j=min(j,i);
     for (i=0; i<j; i++) {
@@ -195,7 +166,6 @@ data(get_arrays()), euler(*data.first), axes(*data.second) {
 
 //# Destructor
 Euler::~Euler() {
-  return_arrays(data);
 }
 
 //# Operators

--- a/casa/Quanta/Euler.h
+++ b/casa/Quanta/Euler.h
@@ -190,14 +190,10 @@ class Euler
 
 private:
 //# Data
-    typedef std::pair<casacore::CountedPtr<Vector<Double> >, 
-                      casacore::CountedPtr<Vector<Int> > > DataArrays;
-// data container
-    DataArrays data;
 // vector with 3 Euler angles (data.first)
-    Vector<Double> & euler;
+    Vector<Double> euler;
 // Axes (data.second)
-    Vector<Int> & axes;
+    Vector<Int> axes;
 
 //# Private Member Functions
 // The makeRad functions check and convert the input Quantities to radians
@@ -205,13 +201,6 @@ private:
     static Double makeRad(const Quantity &in);
     static Vector<Double> makeRad(const Quantum<Vector<Double> > &in);
 // </group>
-    DataArrays get_arrays();
-    void return_arrays(DataArrays array);
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-    static const size_t max_array_cache = 50;
-    static thread_local std::vector<DataArrays> arrays;
-    static thread_local size_t available;
-#endif
 };
 
 

--- a/casa/Quanta/MVPosition.cc
+++ b/casa/Quanta/MVPosition.cc
@@ -46,44 +46,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 const Double MVPosition::loLimit = 743.568;
 const Double MVPosition::hiLimit = 743.569;
 
-// simplistic vector(3) cache to reduce allocation overhead for temporaries
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-thread_local size_t MVPosition::available = 0;
-thread_local std::vector<std::unique_ptr<Vector<Double>>> MVPosition::arrays(max_vector_cache);
-#endif
-
-Vector<Double> * MVPosition::get_array()
-{
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-  if (available > 0) {
-      return arrays[--available].release();
-  }
-#endif
-  return new Vector<Double>(3);
-}
-
-void MVPosition::return_array(Vector<Double> * array)
-{
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-  if (available < max_vector_cache &&
-		  array->size() == 3 &&
-		  array->nrefs() == 1) {
-      arrays[available++].reset(array);
-    return;
-  }
-#endif
-  delete array;
-}
-
 //# Constructors
 MVPosition::MVPosition() :
-  xyz(*get_array()) {
-    xyz = Double(0.0);
+  xyz(3)
+{
+  xyz = Double(0.0);
 }
 
 MVPosition::MVPosition(const MVPosition &other) : 
   MeasValue(),
-  xyz(*get_array())
+  xyz(3)
 {
   xyz = other.xyz;
 }
@@ -96,27 +68,30 @@ MVPosition &MVPosition::operator=(const MVPosition &other) {
 }
 
 MVPosition::MVPosition(Double in) :
-	xyz(*get_array()) {
-    xyz = Double(0.0);
-    xyz(2) = in;
-  }
+  xyz(3)
+{
+  xyz = Double(0.0);
+  xyz(2) = in;
+}
 
 MVPosition::MVPosition(const Quantity &l) :
-  xyz(*get_array()) {
-    xyz = Double(0.0);
-    l.assure(UnitVal::LENGTH);
-    xyz(2) = l.getBaseValue();
-  }
+  xyz(3)
+{
+  xyz = Double(0.0);
+  l.assure(UnitVal::LENGTH);
+  xyz(2) = l.getBaseValue();
+}
 
 MVPosition::MVPosition(Double in0, Double in1, Double in2) : 
-	xyz(*get_array()) {
-    xyz(0) = in0;
-    xyz(1) = in1;
-    xyz(2) = in2;
-  }
+  xyz(3) 
+{
+  xyz(0) = in0;
+  xyz(1) = in1;
+  xyz(2) = in2;
+}
 
 MVPosition::MVPosition(const Quantity &l, Double angle0, Double angle1) : 
-  xyz(*get_array()) {
+  xyz(3) {
   Double loc = std::cos(angle1);
   xyz(0) = std::cos(angle0)*loc;
   xyz(1) = std::sin(angle0)*loc;
@@ -129,7 +104,7 @@ MVPosition::MVPosition(const Quantity &l, Double angle0, Double angle1) :
 
 MVPosition::MVPosition(const Quantity &l, const Quantity &angle0, 
 		       const Quantity &angle1) : 
-  xyz(*get_array()) {
+  xyz(3) {
   Double loc = (cos(angle1)).getValue();
   xyz(0) = ((cos(angle0)).getValue()) * loc;
   xyz(1) = ((sin(angle0)).getValue()) * loc;
@@ -142,7 +117,7 @@ MVPosition::MVPosition(const Quantity &l, const Quantity &angle0,
 }
 
 MVPosition::MVPosition(const Quantum<Vector<Double> > &angle) :
-  xyz(*get_array()) {
+  xyz(3) {
   uInt i; i = angle.getValue().nelements();
   if (i > 3 ) {
     throw (AipsError("Illegeal vector length in MVPosition constructor"));
@@ -168,7 +143,7 @@ MVPosition::MVPosition(const Quantum<Vector<Double> > &angle) :
 
 MVPosition::MVPosition(const Quantity &l, 
 		       const Quantum<Vector<Double> > &angle) :
-	xyz(*get_array()) {
+  xyz(3) {
     uInt i; i = angle.getValue().nelements();
     if (i > 3 ) {
       throw (AipsError("Illegal vector length in MVPosition constructor"));
@@ -195,7 +170,7 @@ MVPosition::MVPosition(const Quantity &l,
   }
 
 MVPosition::MVPosition(const Vector<Double> &other) :
-	xyz(*get_array()) {
+  xyz(3) {
     uInt i; i = other.nelements();
     if (i > 3 ) {
       throw (AipsError("Illegal vector length in MVPosition constructor"));
@@ -219,7 +194,7 @@ MVPosition::MVPosition(const Vector<Double> &other) :
   }
 
 MVPosition::MVPosition(const Vector<Quantity> &other) :
-  xyz(*get_array()) {
+  xyz(3) {
   if (!putValue(other)) {
     throw (AipsError("Illegal quantum vector in MVPosition constructor"));
   }
@@ -228,7 +203,6 @@ MVPosition::MVPosition(const Vector<Quantity> &other) :
 //# Destructor
 MVPosition::~MVPosition()
 {
-  return_array(&xyz);
 }
 
 //# Operators

--- a/casa/Quanta/MVPosition.h
+++ b/casa/Quanta/MVPosition.h
@@ -279,16 +279,7 @@ protected:
   Double getLat(Double ln) const;
   //# Data
   // Position vector (in m)
-  Vector<Double> & xyz;
-  
-  Vector<Double> * get_array();
-  void return_array(Vector<Double> * array);
-#if defined(AIPS_CXX11) && !defined(__APPLE__)
-  static const size_t max_vector_cache = 50;
-  static thread_local std::vector<std::unique_ptr<Vector<Double>>> arrays;
-  static thread_local size_t available;
-#endif
-
+  Vector<Double> xyz;
 };
 
 //# Global functions

--- a/casa/Quanta/test/tMVPosition.cc
+++ b/casa/Quanta/test/tMVPosition.cc
@@ -46,14 +46,14 @@ void test_parallel()
 #if defined(AIPS_CXX11) && !defined(__APPLE__)
   double sum = 0;
   static const size_t thread_max = 50;
-  static const size_t loop_max = 50 * 2; //50 is the value for max_cache_array inside MVPosition
+  static const size_t loop_max = 50 * 2; 
   std::vector<std::thread> threads(thread_max);
   std::mutex sum_mutex;
   for(size_t i = 0; i < thread_max ; ++i)
   {
      threads[i] = std::thread([&sum, &sum_mutex]()
        {
-         MVPosition positions[loop_max];
+         std::unique_ptr<MVPosition[]> positions (new MVPosition[loop_max]);
          double part_sum = 0;
          for(size_t j = 0; j < loop_max ; ++j)
          {


### PR DESCRIPTION
This PR removes altogether the Vector cache for MVPosition and Euler classes that was introduced
in #258 and modified in #680.
The cache was implemented using a thread_local storage, which means that the cache shouldn't be shared among different threads. This was unfortunately the case, since the MeasTable class creates some global objects that include instances of MVPosition derived classes. This causes
undefined behaviours, since the constructors for thread_local variables are called before the destructors for the global variables, according to the C++11 standard. Running the tTableMeasures test triggered in fact a segmentation fault due to this and valgrind reports those errors.

The original cache implementation didn't clean the memory, so the problem was simply hidden. The original idea of the cache was to improve the performance, achieving around 5x boost when objects are constantly being allocated and deleted. However, in a quick test I replaced Vector<Double> with std::array<double,3> (C++11) and I got a ~70x performance boost without any extra cache, so that might be a better route to explore, rather than a cache that is difficult to get it right.