### PR TITLE
Measures conversion of ephemerides table direction is ignoring the frame

### DIFF
--- a/measures/Measures/MeasComet.cc
+++ b/measures/Measures/MeasComet.cc
@@ -49,7 +49,7 @@ MeasComet::MeasComet() :
   mtype_p(MDirection::APP), // default, if the keyword obsloc is not defined, is apparent geocentric
   msgDone_p(False), tp_p(),
   haveDiskLongLat_p(false),
-  ncols_p(5)
+  ncols_p(5), hasPosrefsys_p(false),  posrefsystype_p(MDirection::APP)
 {
   String path;
   if (Aipsrc::find(path, String("measures.comet.file"))) initMeas(path);
@@ -63,7 +63,7 @@ MeasComet::MeasComet(const String &path) :
   mtype_p(MDirection::APP),
   msgDone_p(False), tp_p(path),
   haveDiskLongLat_p(false),
-  ncols_p(5)
+  ncols_p(5), hasPosrefsys_p(false),  posrefsystype_p(MDirection::APP)
 {
   initMeas(path);
   for (uInt i=0; i<2; i++) lnr_p[i] = -1;
@@ -76,7 +76,7 @@ MeasComet::MeasComet(const Table &tabin, const String &path) :
   mtype_p(MDirection::APP),
   msgDone_p(False), tp_p(path),
   haveDiskLongLat_p(false),
-  ncols_p(5)
+  ncols_p(5), hasPosrefsys_p(false),  posrefsystype_p(MDirection::APP)
 {
   initMeas(path, &tabin);
   for (uInt i=0; i<2; i++) lnr_p[i] = -1;
@@ -89,7 +89,7 @@ MeasComet::MeasComet(const MeasComet &other) :
   mtype_p(MDirection::APP),
   msgDone_p(False), tp_p(other.tp_p),
   haveDiskLongLat_p(other.haveDiskLongLat_p),
-  ncols_p(other.ncols_p)
+  ncols_p(other.ncols_p), hasPosrefsys_p(other.hasPosrefsys_p),  posrefsystype_p(other.posrefsystype_p)
 {
   initMeas(other.tp_p);
   for (uInt i=0; i<2; i++) lnr_p[i] = -1;
@@ -129,6 +129,14 @@ Double MeasComet::getEnd() const {
 Int MeasComet::nelements() const {
   return nrow_p;
 }
+ 
+  Bool MeasComet::hasPosrefsys() const {
+    return hasPosrefsys_p;
+  }
+  MDirection::Types MeasComet::getPosrefsysType() const {
+
+    return posrefsystype_p;
+  }
 
 Bool MeasComet::get(MVPosition &returnValue, Double date) const {
   if(!fillMeas(date)){
@@ -271,6 +279,8 @@ Bool MeasComet::initMeas(const String &which, const Table *tabin) {
 	     << kws.asString("posrefsys")
              << " - possible are J2000, B1950, APP, ICRS, TOPO" << LogIO::POST;
 	}
+	posrefsystype_p=mtype_p;
+	hasPosrefsys_p=true;
       } else if (kws.asDouble("GeoDist") != 0.0){
 	mtype_p = MDirection::TOPO;
       }

--- a/measures/Measures/MeasComet.h
+++ b/measures/Measures/MeasComet.h
@@ -184,6 +184,11 @@ class MeasComet {
   // Convenience function that returns the absolute path to the ephemeris table
   // connected to the MeasComet object
   String getTablePath();
+  ////Comet table has posrefsys defined
+  Bool hasPosrefsys() const;
+  ///Get the posrefsys dir type
+  MDirection::Types getPosrefsysType() const;
+  
 
  private:
   
@@ -254,6 +259,8 @@ class MeasComet {
   Bool haveTriedExtras_p;
   Double temperature_p;
   Double mean_rad_p;
+  Bool hasPosrefsys_p;
+  MDirection::Types posrefsystype_p;
 };
 
 //# Inline Implementations


### PR DESCRIPTION
The code in MCDirection setting up the conversion for ephemerides is hardwired hardwired to MDirection::APP. This is a fix for it. 
[meascomet_bug.py.txt](https://github.com/casacore/casacore/files/1857876/meascomet_bug.py.txt)

You can try the attached file (edit it to point to your data repository ephemerides) in any  casa and you'll see that it gets nearly 0.13 deg difference between the value given by DE405  and the ephemerides

*here is the output of the script in non-fixed casa*

Direct value for JPL table  18:44:52.203168 -023.02.14.394480

Using Measures me.direction("SUN") converted 18:44:52.202443 -023.02.14.390270

Using Measures me.direction("SUN") converted correcting for parallax 18:44:51.692250 -023.02.19.888463

Using measures  me.direction("COMET") converted  18:44:16.891719 -023.02.44.318668

Using measures me.direction("COMET") converted  correcting for parallax 18:44:16.381059 -023.02.49.809811

=
Once fixed ...the difference is of the order of arcsecs.
