### PR TITLE
Fixed problem with isDefined on derivedmscal columns

### DIFF
--- a/derivedmscal/DerivedMC/DerivedColumn.cc
+++ b/derivedmscal/DerivedMC/DerivedColumn.cc
@@ -57,6 +57,10 @@ namespace casacore {
   {
     return IPosition(1,2);
   }
+  Bool HaDecColumn::isShapeDefined (uInt)
+  {
+    return True;
+  }
   void HaDecColumn::getArray (uInt rowNr, Array<Double>& data)
   {
     itsEngine->getHaDec (itsAntNr, rowNr, data);
@@ -67,6 +71,10 @@ namespace casacore {
   IPosition AzElColumn::shape (uInt)
   {
     return IPosition(1,2);
+  }
+  Bool AzElColumn::isShapeDefined (uInt)
+  {
+    return True;
   }
   void AzElColumn::getArray (uInt rowNr, Array<Double>& data)
   {
@@ -79,6 +87,10 @@ namespace casacore {
   {
     return IPosition(1,2);
   }
+  Bool ItrfColumn::isShapeDefined (uInt)
+  {
+    return True;
+  }
   void ItrfColumn::getArray (uInt rowNr, Array<Double>& data)
   {
     itsEngine->getItrf (itsAntNr, rowNr, data);
@@ -89,6 +101,10 @@ namespace casacore {
   IPosition UVWJ2000Column::shape (uInt)
   {
     return IPosition(1,3);
+  }
+  Bool UVWJ2000Column::isShapeDefined (uInt)
+  {
+    return True;
   }
   void UVWJ2000Column::getArray (uInt rowNr, Array<Double>& data)
   {

--- a/derivedmscal/DerivedMC/DerivedColumn.h
+++ b/derivedmscal/DerivedMC/DerivedColumn.h
@@ -100,6 +100,7 @@ namespace casacore {
     {}
     virtual ~HaDecColumn();
     virtual IPosition shape (uInt rownr);
+    virtual Bool isShapeDefined (uInt rownr);
     virtual void getArray (uInt rowNr, Array<Double>& data);
   private:
     MSCalEngine* itsEngine;
@@ -118,6 +119,7 @@ namespace casacore {
     {}
     virtual ~AzElColumn();
     virtual IPosition shape (uInt rownr);
+    virtual Bool isShapeDefined (uInt rownr);
     virtual void getArray (uInt rowNr, Array<Double>& data);
   private:
     MSCalEngine* itsEngine;
@@ -136,6 +138,7 @@ namespace casacore {
     {}
     virtual ~ItrfColumn();
     virtual IPosition shape (uInt rownr);
+    virtual Bool isShapeDefined (uInt rownr);
     virtual void getArray (uInt rowNr, Array<Double>& data);
   private:
     MSCalEngine* itsEngine;
@@ -153,6 +156,7 @@ namespace casacore {
     {}
     virtual ~UVWJ2000Column();
     virtual IPosition shape (uInt rownr);
+    virtual Bool isShapeDefined (uInt rownr);
     virtual void getArray (uInt rowNr, Array<Double>& data);
   private:
     MSCalEngine* itsEngine;

--- a/derivedmscal/DerivedMC/test/tDerivedMSCal.cc
+++ b/derivedmscal/DerivedMC/test/tDerivedMSCal.cc
@@ -60,6 +60,9 @@ void check (MSDerivedValues& mdv,
   Vector<double> mazel = mdv.azel().getValue().get();
   Vector<double> tazel = azel(rownr);
   AlwaysAssertExit (allNear(mazel, tazel, 1e-10));
+  AlwaysAssertExit (azel.shape(rownr) == IPosition(1,2));
+  AlwaysAssertExit (azel.ndim(rownr) == 1);
+  AlwaysAssertExit (azel.isDefined(rownr));
 }
 
 void check (MSDerivedValues& mdv,
@@ -72,6 +75,9 @@ void check (MSDerivedValues& mdv,
   check (mdv, rownr, ha, last, azel);
   Vector<double> titrf = itrf(rownr);
   cout << titrf << endl;
+  AlwaysAssertExit (itrf.shape(rownr) == IPosition(1,2));
+  AlwaysAssertExit (itrf.ndim(rownr) == 1);
+  AlwaysAssertExit (itrf.isDefined(rownr));
 }
 
 void check (MSDerivedValues& mdv,
@@ -99,6 +105,12 @@ void check (uInt rownr,
     }
     AlwaysAssertExit (allNear (uvwJ2000(rownr), uvw(rownr), 1e-5));
   }
+  AlwaysAssertExit (uvw.shape(rownr) == IPosition(1,3));
+  AlwaysAssertExit (uvw.ndim(rownr) == 1);
+  AlwaysAssertExit (uvw.isDefined(rownr));
+  AlwaysAssertExit (uvwJ2000.shape(rownr) == IPosition(1,3));
+  AlwaysAssertExit (uvwJ2000.ndim(rownr) == 1);
+  AlwaysAssertExit (uvwJ2000.isDefined(rownr));
 }
 
 int main(int argc, char* argv[])

--- a/tables/DataMan/VirtArrCol.h
+++ b/tables/DataMan/VirtArrCol.h
@@ -182,7 +182,7 @@ protected:
     virtual Bool isShapeDefined (uInt rownr);
 
     // Get the dimensionality of the item in the given row.
-    // By default it throws a "not possible" exception.
+    // By default it returns the length of the shape of that row.
     virtual uInt ndim (uInt rownr);
 
     // Get the shape of the item in the given row.

--- a/tables/DataMan/VirtArrCol.tcc
+++ b/tables/DataMan/VirtArrCol.tcc
@@ -322,21 +322,17 @@ Bool VirtualArrayColumn<T>::isShapeDefined (uInt)
 {
     throw DataManInvOper ("VirtualArrayColumn::isShapeDefined not possible"
                           " for column " + columnName());
-    return False;
 }
 template<class T>
-uInt VirtualArrayColumn<T>::ndim (uInt)
+uInt VirtualArrayColumn<T>::ndim (uInt rownr)
 {
-    throw DataManInvOper ("VirtualArrayColumn::ndim not possible"
-                          " for column " + columnName());
-    return 0;
+    return shape(rownr).size();
 }
 template<class T>
 IPosition VirtualArrayColumn<T>::shape (uInt)
 {
     throw DataManInvOper ("VirtualArrayColumn::shape not possible"
                           " for column " + columnName());
-    return IPosition(0);
 }
 
 } //# NAMESPACE CASACORE - END


### PR DESCRIPTION
pyrap gave an error on a derivedmscal column when getting a row from a table.
It appeared that DerivedColumn did not have isShapeDefined implemented.
