### PR TITLE
[Travis] Fix Travis OSX environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ matrix:
     - os: linux
       compiler: gcc
       env: CXX11=False
-#    - os: osx
-#      compiler: clang
-#      env: CXX11=True PYTHONVERSION=2.7
-#    - os: osx
-#      compiler: clang
-#      env: CXX11=True PYTHONVERSION=3.4
+    - os: osx
+      compiler: clang
+      env: CXX11=True PYTHONVERSION=2.7
+    - os: osx
+      compiler: clang
+      env: CXX11=True PYTHONVERSION=3.4
 
 sudo: false
 

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -37,8 +37,8 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
     BUILD_PYTHON3=On
   fi
 
-  CMAKE_PREFIX_PATH=/Users/travis/miniconda/envs/testenv/lib
-  ls /Users/travis/miniconda/envs/testenv/lib
+  CMAKE_PREFIX_PATH=/Users/travis/miniconda/envs/testenv/
+  ls /Users/travis/miniconda/envs/testenv/
 else
   PYTHON2_EXECUTABLE=/usr/bin/python2.7
   PYTHON3_EXECUTABLE=/usr/bin/python3.4

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,8 +8,8 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
   wget https://repo.continuum.io/miniconda/Miniconda${MAJORPYTHONVERSION}-latest-MacOSX-x86_64.sh -O miniconda.sh;
 
   brew update >/dev/null
-  brew tap homebrew/science
-  brew install cfitsio wcslib fftw hdf5 ccache
+  brew cask uninstall oclint
+  brew install fftw hdf5 ccache
 
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
@@ -18,7 +18,7 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
   conda update -q conda
   conda config --add channels conda-forge
   conda info -a
-  conda create -q -n testenv python=${PYTHONVERSION} numpy
+  conda create -q -n testenv python=${PYTHONVERSION} numpy wcslib cfitsio
   source activate testenv
   conda install -q -y -c meznom boost-python
 fi


### PR DESCRIPTION
The repo homebrew/science became outdated, and no there seems to be no
way to install wcslib through homebrew. Move to conda for both cfitsio
and wcslib.
Fix a brew compiler installation error: uninstall oclint, see
https://github.com/travis-ci/travis-ci/issues/8826

Fixes #682