### PR TITLE
Align the unit for atmospheric pressure with documentation

### DIFF
--- a/ms/MeasurementSets/MSWeather.cc
+++ b/ms/MeasurementSets/MSWeather.cc
@@ -157,7 +157,7 @@ void MSWeather::init()
 		  "Flag for average column density of electrons","","");
 	// PRESSURE
 	colMapDef(PRESSURE, "PRESSURE", TpFloat,
-		  "Ambient atmospheric pressure","Pa","");
+		  "Ambient atmospheric pressure","hPa","");
 	// PRESSURE_FLAG
 	colMapDef(PRESSURE_FLAG, "PRESSURE_FLAG", TpBool,
 		  "Flag for ambient atmospheric pressure","","");

--- a/msfits/MSFits/MSFitsOutput.cc
+++ b/msfits/MSFits/MSFitsOutput.cc
@@ -2538,8 +2538,8 @@ Bool MSFitsOutput::writeWX(FitsOutput *output, const MeasurementSet &ms) {
             *temperature = 0.0;
         }
         if (hasPressure) {
-            //covert from Pa to mbar
-            *pressure = weatherColumns.pressure()(i) / 100;
+            //covert whatever units to mbar
+        	*pressure = weatherColumns.pressureQuant()(i).getValue(Unit("mbar"));
         } else {
             *pressure = 0.0;
         }

--- a/msfits/MSFits/MSFitsOutput.cc
+++ b/msfits/MSFits/MSFitsOutput.cc
@@ -2539,7 +2539,7 @@ Bool MSFitsOutput::writeWX(FitsOutput *output, const MeasurementSet &ms) {
         }
         if (hasPressure) {
             //covert whatever units to mbar
-        	*pressure = weatherColumns.pressureQuant()(i).getValue(Unit("mbar"));
+            *pressure = weatherColumns.pressureQuant()(i).getValue(Unit("mbar"));
         } else {
             *pressure = 0.0;
         }


### PR DESCRIPTION
In [MSv2 design document](http://casacore.github.io/casacore-notes/264), the unit for atmospheric pressure is defined as
"hPa". However, implementation was different (Pa). This commit fix the
unit to be consistent with the documentation.

cf. https://open-jira.nrao.edu/browse/CAS-11528
