### PR TITLE
Make casacore namespace default

### DIFF
--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -56,6 +56,5 @@ CXX="ccache $CXX" cmake .. \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
     -DDATA_DIR=$PWD \
     -DSOFA_ROOT_DIR=$HOME \
-    -DUseCasacoreNamespace=True \
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/installed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ if( CASA_BUILD )
    set(USE_FFTW3 ON)
    set(USE_OPENMP ON)
    set(USE_THREADS ON)
-   set(UseCasacoreNamespace 1) # Force casacore routines to live in casacore rather than casa namespace
    set(BUILD_PYTHON OFF)
    set(Boost_NO_BOOST_CMAKE 1)
    if (EXISTS "/opt/casa/02/include/python2.7")
@@ -166,15 +165,11 @@ else()
     option (BUILD_SHARED_LIBS "" NO)
 endif (ENABLE_SHARED)
 
-if (UseCasacoreNamespace)
-
-    add_definitions (-DUseCasacoreNamespace)
-    message (STATUS "Using namespace casacore.")
-
+if (UseCasaNamespace)
+    add_definitions (-DUseCasaNamespace)
+    message (STATUS "Using namespace casa. This will be deprecated at some point.")
 else ()
-
-    message (STATUS "Namespace casacore 'merged' into namespace casa.")
-
+    message (STATUS "Using namespace casacore.")
 endif ()
 
 # Define the compiler flags to be used.

--- a/casa/aipstype.h
+++ b/casa/aipstype.h
@@ -31,7 +31,7 @@
 // For temporary backward namespace compatibility, use casa as alias for casacore.
 //# Note: namespace casa = casacore; does not work for forward declarations.
 
-#if ! defined (UseCasacoreNamespace)
+#if defined (UseCasaNamespace)
 #   define casacore casa
 #endif
 


### PR DESCRIPTION
With this change, the `casacore` namespace becomes the default. It can be defined to `casa` at compile time. Currently, the behavior is the opposite: without specifying anything on the command line, the `casa` namespace is used.