### PR TITLE
Added MPI support for parallel CTDS I/O

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ option (USE_HDF5 "Build HDF5 " NO)
 option (USE_FFTW3 "Use FFTW instead of FFTPack" NO)
 option (USE_THREADS "Use Mutex thread synchronization" NO)
 option (USE_OPENMP "Use OpenMP threading" NO)
+option (USE_MPI "Use MPI for parallel IO" NO)
 option (USE_STACKTRACE "Show stacktrace in case of exception" NO)
 option (CASA_BUILD "Building in the CASA (http://casa.nrao.edu) environment" NO)
 
@@ -408,6 +409,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
    set(CASACORE_ARCH_LIBS ${CASACORE_ARCH_LIBS} -L${INTEL_LIB_PATH} -limf -lsvml -lirng -lintlc -lifport -lifcore -liomp5)
 endif()
 
+if(USE_MPI)
+    find_package(MPI COMPONENTS C REQUIRED)
+endif(USE_MPI)
+
 if(USE_OPENMP)
     set (USE_THREADS YES)
     find_package (OpenMP)
@@ -520,6 +525,7 @@ message (STATUS "CMAKE_INSTALL_NAME_DIR  = ${CMAKE_INSTALL_NAME_DIR}")
 message (STATUS "ENABLE_TABLELOCKING ... = ${ENABLE_TABLELOCKING}")
 message (STATUS "USE_THREADS ........... = ${USE_THREADS}")
 message (STATUS "USE_OPENMP ............ = ${USE_OPENMP}")
+message (STATUS "USE_MPI ............... = ${USE_MPI}")
 message (STATUS "USE_STACKTRACE ........ = ${USE_STACKTRACE}")
 message (STATUS "CMAKE_CXX_COMPILER .... = ${CMAKE_CXX_COMPILER}")
 message (STATUS "CMAKE_CXX_FLAGS ....... = ${CMAKE_CXX_FLAGS}")
@@ -565,6 +571,7 @@ endif (BUILD_PYTHON3)
 #  USE_FFTW3                     NO
 #  USE_THREADS                   NO
 #  USE_OPENMP                    NO
+#  USE_MPI                       NO
 #  USE_STACKTRACE                NO
 #  DATA_DIR                      ${CMAKE_INSTALL_PREFIX}/share/casacore/data
 #  MODULE                        all

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -187,7 +187,14 @@ ${BISON_TableGram_OUTPUTS}
 ${FLEX_TableGram_OUTPUTS}
 )
 
-target_link_libraries (casa_tables casa_casa ${CASACORE_ARCH_LIBS})
+if(USE_MPI)
+    target_compile_definitions(casa_tables PRIVATE HAVE_MPI)
+    target_link_libraries(casa_tables casa_casa ${CASACORE_ARCH_LIBS} MPI::MPI_C)
+else()
+    target_link_libraries (casa_tables casa_casa ${CASACORE_ARCH_LIBS})
+endif()
+
+
 
 add_subdirectory (apps)
 

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -188,6 +188,7 @@ ${FLEX_TableGram_OUTPUTS}
 )
 
 if(MPI_FOUND)
+    add_definitions(-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX)
     target_compile_definitions(casa_tables PRIVATE HAVE_MPI)
     target_link_libraries(casa_tables casa_casa ${CASACORE_ARCH_LIBS} MPI::MPI_C)
 else()

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -187,7 +187,7 @@ ${BISON_TableGram_OUTPUTS}
 ${FLEX_TableGram_OUTPUTS}
 )
 
-if(USE_MPI)
+if(MPI_FOUND)
     target_compile_definitions(casa_tables PRIVATE HAVE_MPI)
     target_link_libraries(casa_tables casa_casa ${CASACORE_ARCH_LIBS} MPI::MPI_C)
 else()

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -192,9 +192,13 @@ Bool BaseTable::makeTableDir()
 {
 #ifdef HAVE_MPI
     int rank;
-    MPI_Comm_rank(itsMpiComm, &rank);
-    if(rank > 0){
-        return false;
+    int mpi_initialized;
+    MPI_Initialized(&mpi_initialized);
+    if(mpi_initialized){
+        MPI_Comm_rank(itsMpiComm, &rank);
+        if(rank > 0){
+            return false;
+        }
     }
 #endif
     //# Exit if the table directory has already been created.
@@ -253,9 +257,13 @@ Bool BaseTable::openedForWrite() const
 {
 #ifdef HAVE_MPI
     int rank;
-    MPI_Comm_rank(itsMpiComm, &rank);
-    if(rank > 0){
-        return false;
+    int mpi_initialized;
+    MPI_Initialized(&mpi_initialized);
+    if(mpi_initialized){
+        MPI_Comm_rank(itsMpiComm, &rank);
+        if(rank > 0){
+            return false;
+        }
     }
 #endif
     AlwaysAssert (!isNull(), AipsError);

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -160,6 +160,9 @@ void BaseTable::scratchCallback (Bool isScratch, const String& oldName) const
 
 Bool BaseTable::makeTableDir()
 {
+#ifdef HAVE_MPI
+    return false;
+#endif
     //# Exit if the table directory has already been created.
     if (madeDir_p) {
 	return False;
@@ -214,6 +217,9 @@ Bool BaseTable::makeTableDir()
 
 Bool BaseTable::openedForWrite() const
 {
+#ifdef HAVE_MPI
+    return false;
+#endif
     AlwaysAssert (!isNull(), AipsError);
     return (option_p==Table::Old || option_p==Table::Delete  ?  False : True);
 }
@@ -354,7 +360,7 @@ void BaseTable::prepareCopyRename (const String& newName,
 	if (tableOption == Table::Update) {
             throw (TableNoFile(newName));
 	}
-    }   
+    }
 }
 
 //# Rename a table.

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -60,63 +60,46 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // The constructor of the derived class should call unmarkForDelete
 // when the construction ended succesfully.
 BaseTable::BaseTable (const String& name, int option, uInt nrrow)
-: nrlink_p    (0),
-  nrrow_p     (nrrow),
-  nrrowToAdd_p(0),
-  tdescPtr_p  (0),
-  name_p      (name),
-  option_p    (option),
-  noWrite_p   (False),
-  delete_p    (False),
-  madeDir_p   (True),
-  itsTraceId  (-1)
 {
-    if (name_p.empty()) {
-	name_p = File::newUniqueName ("", "tab").originalName();
-    }
-    // Make name absolute in case a chdir is done in e.g. Python.
-    name_p = makeAbsoluteName (name_p);
-    if (option_p == Table::Scratch) {
-	option_p = Table::New;
-    }
-    // Mark initially a new table for delete.
-    // When the construction ends successfully, it can be unmarked.
-    if (option_p == Table::New  ||  option_p == Table::NewNoReplace) {
-	markForDelete (False, "");
-	madeDir_p = False;
-    }
+    BaseTableCommon(name, option, nrrow);
 }
 
 #ifdef HAVE_MPI
 BaseTable::BaseTable (MPI_Comm mpiComm, const String& name, int option, uInt nrrow)
-: nrlink_p    (0),
-  nrrow_p     (nrrow),
-  nrrowToAdd_p(0),
-  tdescPtr_p  (0),
-  name_p      (name),
-  option_p    (option),
-  noWrite_p   (False),
-  delete_p    (False),
-  madeDir_p   (True),
-  itsTraceId  (-1),
-  itsMpiComm  (mpiComm)
+    :itsMpiComm  (mpiComm)
 {
+    BaseTableCommon(name, option, nrrow);
+}
+#endif
+
+void BaseTable::BaseTableCommon (const String& name, int option, uInt nrrow)
+{
+    nrlink_p = 0;
+    nrrow_p = nrrow;
+    nrrowToAdd_p = 0;
+    tdescPtr_p = 0;
+    name_p = name;
+    option_p = option;
+    noWrite_p = False;
+    delete_p = False;
+    madeDir_p = True;
+    itsTraceId = -1;
+
     if (name_p.empty()) {
-	name_p = File::newUniqueName ("", "tab").originalName();
+        name_p = File::newUniqueName ("", "tab").originalName();
     }
     // Make name absolute in case a chdir is done in e.g. Python.
     name_p = makeAbsoluteName (name_p);
     if (option_p == Table::Scratch) {
-	option_p = Table::New;
+        option_p = Table::New;
     }
     // Mark initially a new table for delete.
     // When the construction ends successfully, it can be unmarked.
     if (option_p == Table::New  ||  option_p == Table::NewNoReplace) {
-	markForDelete (False, "");
-	madeDir_p = False;
+        markForDelete (False, "");
+        madeDir_p = False;
     }
 }
-#endif
 
 BaseTable::~BaseTable()
 {

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -174,7 +174,7 @@ void BaseTable::scratchCallback (Bool isScratch, const String& oldName) const
 Bool BaseTable::makeTableDir()
 {
 #ifdef HAVE_MPI
-    int rank;
+    int rank = 0;
     int mpi_initialized, mpi_finalized;
     MPI_Initialized(&mpi_initialized);
     MPI_Finalized(&mpi_finalized);
@@ -191,8 +191,10 @@ Bool BaseTable::makeTableDir()
     }
     //# Check option.
     if (!openedForWrite()) {
+#ifndef HAVE_MPI
 	throw (TableInvOpt ("BaseTable::makeTableDir",
 			    "must be Table::New, NewNoReplace or Update"));
+#endif
     }
     //# Check if the table directory name already exists
     //# and is a directory indeed.
@@ -240,7 +242,7 @@ Bool BaseTable::makeTableDir()
 Bool BaseTable::openedForWrite() const
 {
 #ifdef HAVE_MPI
-    int rank;
+    int rank = 0;
     int mpi_initialized, mpi_finalized;
     MPI_Initialized(&mpi_initialized);
     MPI_Finalized(&mpi_finalized);

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -175,9 +175,10 @@ Bool BaseTable::makeTableDir()
 {
 #ifdef HAVE_MPI
     int rank;
-    int mpi_initialized;
+    int mpi_initialized, mpi_finalized;
     MPI_Initialized(&mpi_initialized);
-    if(mpi_initialized){
+    MPI_Finalized(&mpi_finalized);
+    if(mpi_initialized == true && mpi_finalized == false){
         MPI_Comm_rank(itsMpiComm, &rank);
         if(rank > 0){
             return false;
@@ -240,10 +241,10 @@ Bool BaseTable::openedForWrite() const
 {
 #ifdef HAVE_MPI
     int rank;
-    int mpi_initialized;
+    int mpi_initialized, mpi_finalized;
     MPI_Initialized(&mpi_initialized);
-    if(mpi_initialized){
-        MPI_Comm_rank(itsMpiComm, &rank);
+    MPI_Finalized(&mpi_finalized);
+    if(mpi_initialized == true && mpi_finalized == false){
         if(rank > 0){
             return false;
         }

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -108,8 +108,12 @@ public:
     BaseTable (const String& tableName, int tableOption, uInt nrrow);
 
 #ifdef HAVE_MPI
+    // MPI version of the constructor
     BaseTable (MPI_Comm mpiComm, const String& tableName, int tableOption, uInt nrrow);
 #endif
+
+    // Common code shared by the MPI constructor and non-MPI constructor
+    void BaseTableCommon (const String& tableName, int tableOption, uInt nrrow);
 
     virtual ~BaseTable();
 
@@ -587,7 +591,10 @@ private:
     String makeAbsoluteName (const String& name) const;
 
 #ifdef HAVE_MPI
-    MPI_Comm       itsMpiComm;          //# mpi communicator for parallel I/O
+    // MPI communicator for parallel I/O
+    // Set the default to MPI_COMM_WORLD to keep the compatibility for
+    // non-MPI apps to work with the MPI-enabled casacore build.
+    MPI_Comm itsMpiComm = MPI_COMM_WORLD;
 #endif
 };
 

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -39,6 +39,10 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/IO/FileLocker.h>
 
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
@@ -79,7 +83,7 @@ class AipsIO;
 // BaseTable is the (abstract) base class for different kind of tables.
 // </etymology>
 
-// <synopsis> 
+// <synopsis>
 // BaseTables defines many virtual functions, which are actually
 // implemented in the underlying table classes like PlainTable and
 // RefTable. Other functions like sort and select are implemented
@@ -88,7 +92,7 @@ class AipsIO;
 // The functions in BaseTable and its derived classes can only be
 // used by the table system classes. All user access is via the
 // envelope class Table, which references (counted) BaseTable.
-// </synopsis> 
+// </synopsis>
 
 // <todo asof="$DATE:$">
 //# A List of bugs, limitations, extensions or planned refinements.
@@ -102,6 +106,10 @@ public:
 
     // Initialize the object.
     BaseTable (const String& tableName, int tableOption, uInt nrrow);
+
+#ifdef HAVE_MPI
+    BaseTable (MPI_Comm mpiComm, const String& tableName, int tableOption, uInt nrrow);
+#endif
 
     virtual ~BaseTable();
 
@@ -240,7 +248,7 @@ public:
     // Get the table option.
     int tableOption() const
 	{ return option_p; }
-    
+
     // Mark the table for delete.
     // This means that the underlying table gets deleted when it is
     // actually destructed.
@@ -255,7 +263,7 @@ public:
     // Test if the table is marked for delete.
     Bool isMarkedForDelete() const
 	{ return delete_p; }
-    
+
     // Get the table description.
     const TableDesc& tableDesc() const
 	{ return (tdescPtr_p == 0  ?  makeTableDesc() : *tdescPtr_p); }
@@ -577,6 +585,10 @@ private:
     // Make the name absolute.
     // It first checks if the name contains valid characters (not only . and /).
     String makeAbsoluteName (const String& name) const;
+
+#ifdef HAVE_MPI
+    MPI_Comm       itsMpiComm;          //# mpi communicator for parallel I/O
+#endif
 };
 
 

--- a/tables/Tables/PlainTable.cc
+++ b/tables/Tables/PlainTable.cc
@@ -481,11 +481,11 @@ uInt PlainTable::getModifyCounter() const
 void PlainTable::flush (Bool fsync, Bool recursive)
 {
     if (openedForWrite()) {
-	putFile (False);
-	// Flush subtables if wanted.
-	if (recursive) {
-	    keywordSet().flushTables (fsync);
-	}
+        putFile (False);
+        // Flush subtables if wanted.
+        if (recursive) {
+            keywordSet().flushTables (fsync);
+        }
     }
 }
 

--- a/tables/Tables/PlainTable.cc
+++ b/tables/Tables/PlainTable.cc
@@ -613,8 +613,8 @@ TableRecord& PlainTable::rwKeywordSet()
     tableChanged_p = True;
     return rec;
 }
-    
-    
+
+
 
 //# Get a column object.
 BaseColumn* PlainTable::getColumn (uInt columnIndex) const

--- a/tables/Tables/PlainTable.cc
+++ b/tables/Tables/PlainTable.cc
@@ -49,122 +49,37 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //# Initialize the static TableCache object.
 TableCache PlainTable::theirTableCache;
 
-
 PlainTable::PlainTable (SetupNewTable& newtab, uInt nrrow, Bool initialize,
-			const TableLock& lockOptions, int endianFormat,
-                        const TSMOption& tsmOption)
-#ifdef HAVE_MPI
-: BaseTable      (MPI_COMM_WORLD, newtab.name(), newtab.option(), 0),
-#else
-: BaseTable      (newtab.name(), newtab.option(), 0),
-#endif
-  colSetPtr_p    (0),
-  tableChanged_p (True),
-  addToCache_p   (True),
-  lockPtr_p      (0),
-  tsmOption_p    (tsmOption)
+        const TableLock& lockOptions, int endianFormat,
+        const TSMOption& tsmOption)
+    : BaseTable (newtab.name(), newtab.option(), 0)
 {
-  try {
-    // Determine and set the endian option.
-    setEndian (endianFormat);
-    // Replace default TSM option for new table.
-    tsmOption_p.fillOption (True);
-    // Set initially to no write in destructor.
-    // At the end it is reset. In this way nothing is written if
-    // an exception is thrown during initialization.
-    noWrite_p  = True;
-    //# Check if another Table was already constructed using this
-    //# SetupNewTable (which is invalid).
-    if (newtab.isUsed()) {
-	throw (TableInvOper
-	             ("SetupNewTable object already used for another Table"));
-    }
-    //# Check if a table with this name is not in the table cache.
-    if (tableCache()(name_p) != 0) {
-        // OK it's in the cache but is it really there?
-        if(File(name_p).exists()){
-	   throw (TableInvOper ("SetupNewTable " + name_p +
-			     " is already opened (is in the table cache)"));
-        } else {
-          tableCache().remove (name_p);
-        }
-    }
-    //# If the table already exists, exit if it is in use.
-    if (Table::isReadable (name_p)) {
-	TableLockData tlock (TableLock (TableLock::UserLocking, 0));
-	tlock.makeLock (name_p, False, FileLocker::Write);
-	if (tlock.isMultiUsed()) {
-	    throw (TableError ("Table " + name_p + " cannot be created; "
-			       "it is in use in another process"));
-	}
-    }
-    //# Create the data managers for unbound columns.
-    //# Check if there are no data managers with equal names.
-    newtab.handleUnbound();
-    newtab.columnSetPtr()->checkDataManagerNames (name_p);
-    //# Get the data from the SetupNewTable object.
-    //# Set SetupNewTable object to in use.
-    tdescPtr_p  = newtab.tableDescPtr();
-    colSetPtr_p = newtab.columnSetPtr();
-    colSetPtr_p->linkToTable (this);
-    newtab.setInUse();
-    //# Create the table directory (and possibly delete existing files)
-    //# as needed.
-    makeTableDir();
-    //# Create the lock object.
-    //# When needed, it sets a permanent write lock.
-    //# Acquire a write lock.
-    lockPtr_p = new TableLockData (lockOptions, releaseCallBack, this);
-    lockPtr_p->makeLock (name_p, True, FileLocker::Write);
-    lockPtr_p->acquire (0, FileLocker::Write, 1);
-    colSetPtr_p->linkToLockObject (lockPtr_p);
-    //# Initialize the data managers.
-    Table tab(this, False);
-    nrrowToAdd_p = nrrow;
-    colSetPtr_p->initDataManagers (nrrow, bigEndian_p, tsmOption_p, tab);
-    //# Initialize the columns if needed.
-    if (initialize  &&  nrrow > 0) {
-	colSetPtr_p->initialize (0, nrrow-1);
-    }
-    //# Nrrow_p has to be set here, otherwise data managers may use the
-    //# incorrect number of rows (similar behaviour as in function addRow).
-    nrrowToAdd_p = 0;
-    nrrow_p = nrrow;
-    //# Release the write lock if UserLocking is used.
-    if (lockPtr_p->option() == TableLock::UserLocking) {
-	lockPtr_p->release();
-    }
-    //# Unmark for delete when needed.
-    if (! newtab.isMarkedForDelete()) {
-	unmarkForDelete (True, "");
-    }
-    //# The destructor can (in principle) write.
-    noWrite_p = False;
-    //# Add it to the table cache.
-    tableCache().define (name_p, this);
-    //# Trace if needed.
-    itsTraceId = TableTrace::traceTable (name_p, 'n');
-  } catch (AipsError&) {
-    delete lockPtr_p;
-    lockPtr_p = 0;
-    delete colSetPtr_p;
-    colSetPtr_p = 0;
-    throw;
-  }
+    PlainTableCommon(newtab, nrrow, initialize, lockOptions,
+            endianFormat, tsmOption);
 }
 
 #ifdef HAVE_MPI
-PlainTable::PlainTable (MPI_Comm mpiComm, SetupNewTable& newtab, uInt nrrow, Bool initialize,
-			const TableLock& lockOptions, int endianFormat,
-                        const TSMOption& tsmOption)
-: BaseTable      (mpiComm, newtab.name(), newtab.option(), 0),
-  colSetPtr_p    (0),
-  tableChanged_p (True),
-  addToCache_p   (True),
-  lockPtr_p      (0),
-  tsmOption_p    (tsmOption)
+PlainTable::PlainTable (MPI_Comm mpiComm, SetupNewTable& newtab, uInt nrrow,
+        Bool initialize, const TableLock& lockOptions, int endianFormat,
+        const TSMOption& tsmOption)
+    : BaseTable (mpiComm, newtab.name(), newtab.option(), 0)
 {
-  try {
+    PlainTableCommon(newtab, nrrow, initialize, lockOptions,
+            endianFormat, tsmOption);
+}
+#endif
+
+void PlainTable::PlainTableCommon (SetupNewTable& newtab, uInt nrrow,
+        Bool initialize, const TableLock& lockOptions, int endianFormat,
+        const TSMOption& tsmOption)
+{
+    colSetPtr_p = 0;
+    tableChanged_p = True;
+    addToCache_p = True;
+    lockPtr_p = 0;
+    tsmOption_p = tsmOption;
+
+    try {
     // Determine and set the endian option.
     setEndian (endianFormat);
     // Replace default TSM option for new table.
@@ -252,7 +167,6 @@ PlainTable::PlainTable (MPI_Comm mpiComm, SetupNewTable& newtab, uInt nrrow, Boo
     throw;
   }
 }
-#endif
 
 PlainTable::PlainTable (AipsIO&, uInt version, const String& tabname,
 			const String& type, uInt nrrow, int opt,

--- a/tables/Tables/PlainTable.h
+++ b/tables/Tables/PlainTable.h
@@ -70,12 +70,12 @@ class MemoryIO;
 // RefTable, which is a view on a PlainTable.
 // </etymology>
 
-// <synopsis> 
+// <synopsis>
 // PlainTable is a table consisting of a keyword set and a number of
 // filled and virtual columns. The table control information and the
 // keyword set is stored in an AipsIO file. The data in the filled columns
 // are stored separately by storage managers.
-// </synopsis> 
+// </synopsis>
 
 // <todo asof="$DATE:$">
 //# A List of bugs, limitations, extensions or planned refinements.

--- a/tables/Tables/PlainTable.h
+++ b/tables/Tables/PlainTable.h
@@ -91,14 +91,20 @@ public:
     // all storage managers. The given number of rows is stored in
     // the table and initialized if the flag is set.
     PlainTable (SetupNewTable&, uInt nrrow, Bool initialize,
-		const TableLock& lockOptions, int endianFormat,
-                const TSMOption& tsmOption);
+            const TableLock& lockOptions, int endianFormat,
+            const TSMOption& tsmOption);
 
 #ifdef HAVE_MPI
-    PlainTable (MPI_Comm mpiComm, SetupNewTable&, uInt nrrow, Bool initialize,
-		const TableLock& lockOptions, int endianFormat,
-                const TSMOption& tsmOption);
+    // MPI version of the constructor
+    PlainTable (MPI_Comm mpiComm, SetupNewTable&, uInt nrrow,
+            Bool initialize, const TableLock& lockOptions,
+            int endianFormat, const TSMOption& tsmOption);
 #endif
+
+    // Common part of the constructor shared by MPI and non-MPI
+    void PlainTableCommon (SetupNewTable&, uInt nrrow, Bool initialize,
+            const TableLock& lockOptions, int endianFormat,
+            const TSMOption& tsmOption);
 
     // Construct the object for an existing table.
     // It opens the table file, reads the table control information

--- a/tables/Tables/PlainTable.h
+++ b/tables/Tables/PlainTable.h
@@ -94,6 +94,12 @@ public:
 		const TableLock& lockOptions, int endianFormat,
                 const TSMOption& tsmOption);
 
+#ifdef HAVE_MPI
+    PlainTable (MPI_Comm mpiComm, SetupNewTable&, uInt nrrow, Bool initialize,
+		const TableLock& lockOptions, int endianFormat,
+                const TSMOption& tsmOption);
+#endif
+
     // Construct the object for an existing table.
     // It opens the table file, reads the table control information
     // and creates and initializes the required storage managers.

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -90,7 +90,7 @@ Table::Table (const String& name, const TableLock& lockOptions,
 {
   open (name, "", option, lockOptions, tsmOpt);
 }
-    
+
   Table::Table (const String& name, const String& type, TableOption option,
                 const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
@@ -99,7 +99,7 @@ Table::Table (const String& name, const TableLock& lockOptions,
 {
   open (name, type, option, TableLock(), tsmOpt);
 }
-    
+
 Table::Table (const String& name, const String& type,
 	      const TableLock& lockOptions, TableOption option,
               const TSMOption& tsmOpt)
@@ -190,6 +190,95 @@ Table::Table (SetupNewTable& newtab, const TableLock& lockOptions,
 				   endianFormat, tsmOpt);
     baseTabPtr_p->link();
 }
+
+#ifdef HAVE_MPI
+
+Table::Table (MPI_Comm mpiComm, Table::TableType type, Table::EndianFormat endianFormat,
+                const TSMOption& tsmOpt)
+: baseTabPtr_p     (0),
+  isCounted_p      (True),
+  lastModCounter_p (0)
+{
+    SetupNewTable newtab("", TableDesc(), Table::Scratch);
+    if (type == Table::Memory) {
+        baseTabPtr_p = new MemoryTable (newtab, 0, False);
+    } else {
+        baseTabPtr_p = new PlainTable (mpiComm, newtab, 0, False,
+				       TableLock(), endianFormat, tsmOpt);
+    }
+    baseTabPtr_p->link();
+}
+
+Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, uInt nrrow, Bool initialize,
+	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
+: baseTabPtr_p     (0),
+  isCounted_p      (True),
+  lastModCounter_p (0)
+{
+    baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
+				   TableLock(), endianFormat, tsmOpt);
+    baseTabPtr_p->link();
+}
+
+Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, Table::TableType type,
+	      uInt nrrow, Bool initialize,
+	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
+: baseTabPtr_p     (0),
+  isCounted_p      (True),
+  lastModCounter_p (0)
+{
+    if (type == Table::Memory) {
+        baseTabPtr_p = new MemoryTable (newtab, nrrow, initialize);
+    } else {
+        baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
+				       TableLock(), endianFormat, tsmOpt);
+    }
+    baseTabPtr_p->link();
+}
+
+Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, Table::TableType type,
+	      const TableLock& lockOptions,
+	      uInt nrrow, Bool initialize,
+	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
+: baseTabPtr_p     (0),
+  isCounted_p      (True),
+  lastModCounter_p (0)
+{
+    if (type == Table::Memory) {
+        baseTabPtr_p = new MemoryTable (newtab, nrrow, initialize);
+    } else {
+        baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
+				       lockOptions, endianFormat, tsmOpt);
+    }
+    baseTabPtr_p->link();
+}
+
+Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, TableLock::LockOption lockOption,
+	      uInt nrrow, Bool initialize, Table::EndianFormat endianFormat,
+              const TSMOption& tsmOpt)
+: baseTabPtr_p     (0),
+  isCounted_p      (True),
+  lastModCounter_p (0)
+{
+    baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
+				   TableLock(lockOption),
+				   endianFormat, tsmOpt);
+    baseTabPtr_p->link();
+}
+
+Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, const TableLock& lockOptions,
+	      uInt nrrow, Bool initialize, Table::EndianFormat endianFormat,
+              const TSMOption& tsmOpt)
+: baseTabPtr_p     (0),
+  isCounted_p      (True),
+  lastModCounter_p (0)
+{
+    baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize, lockOptions,
+				   endianFormat, tsmOpt);
+    baseTabPtr_p->link();
+}
+
+#endif
 
 Table::Table (const Block<Table>& tables,
 	      const Block<String>& subTables,
@@ -568,7 +657,7 @@ BaseTable* Table::makeBaseTable (const String& name, const String& type,
     }
     return baseTabPtr;
 }
-	
+
 BaseTable* Table::lookCache (const String& name, int tableOption,
 			     const TableLock& lockOptions)
 {
@@ -910,7 +999,7 @@ Bool Table::isReadable (const String& tableName, Bool throwIf)
             throw;
         }
 	valid = False;
-    } 
+    }
     return valid;
 }
 //# Test if table exists and is writable.
@@ -1018,7 +1107,7 @@ void Table::showKeywords (ostream& ios, Bool showSubTables,
     }
   }
 }
-  
+
 void Table::showKeywordSets (ostream& ios,
                              Bool showTabKey, Bool showColKey,
                              Int maxVal) const

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -289,6 +289,25 @@ public:
     Table (SetupNewTable&, const TableLock& lockOptions,
 	   uInt nrrow = 0, Bool initialize = False,
 	   EndianFormat = Table::AipsrcEndian, const TSMOption& = TSMOption());
+#ifdef HAVE_MPI
+    explicit Table (MPI_Comm mpiComm, TableType, EndianFormat = Table::AipsrcEndian,
+                    const TSMOption& = TSMOption());
+    explicit Table (MPI_Comm mpiComm, SetupNewTable&, uInt nrrow = 0, Bool initialize = False,
+		    EndianFormat = Table::AipsrcEndian,
+                    const TSMOption& = TSMOption());
+    Table (MPI_Comm mpiComm, SetupNewTable&, TableType,
+	   uInt nrrow = 0, Bool initialize = False,
+	   EndianFormat = Table::AipsrcEndian, const TSMOption& = TSMOption());
+    Table (MPI_Comm mpiComm, SetupNewTable&, TableType, const TableLock& lockOptions,
+	   uInt nrrow = 0, Bool initialize = False,
+	   EndianFormat = Table::AipsrcEndian, const TSMOption& = TSMOption());
+    Table (MPI_Comm mpiComm, SetupNewTable&, TableLock::LockOption,
+	   uInt nrrow = 0, Bool initialize = False,
+	   EndianFormat = Table::AipsrcEndian, const TSMOption& = TSMOption());
+    Table (MPI_Comm mpiComm, SetupNewTable&, const TableLock& lockOptions,
+	   uInt nrrow = 0, Bool initialize = False,
+	   EndianFormat = Table::AipsrcEndian, const TSMOption& = TSMOption());
+#endif
     // </group>
 
     // Create a table object as the virtual concatenation of
@@ -1100,9 +1119,6 @@ private:
     // Sort the columns if needed.
     void showColumnInfo (ostream& os, const TableDesc&, uInt maxNameLength,
                          const Array<String>& columnNames, Bool sort) const;
-#ifdef HAVE_MPI
-    MPI_Comm mpiComm = MPI_COMM_WORLD;
-#endif
 };
 
 

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -37,6 +37,10 @@
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/casa/Utilities/Sort.h>
 
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
@@ -553,7 +557,7 @@ public:
                        Bool showTabKey=True,
                        Bool showColKey=False,
                        Int maxVal=25) const;
-  
+
     // Show the table and/or column keywords of this table.
     // Maximum <src>maxVal> values of Arrays will be shown.
     void showKeywordSets (std::ostream&,
@@ -726,7 +730,7 @@ public:
 
     // Test if the table is marked for delete.
     Bool isMarkedForDelete() const;
-    
+
     // Get the number of rows.
     // It is unsynchronized meaning that it will not check if another
     // process updated the table, thus possible increased the number of rows.
@@ -1096,6 +1100,9 @@ private:
     // Sort the columns if needed.
     void showColumnInfo (ostream& os, const TableDesc&, uInt maxNameLength,
                          const Array<String>& columnNames, Bool sort) const;
+#ifdef HAVE_MPI
+    MPI_Comm mpiComm = MPI_COMM_WORLD;
+#endif
 };
 
 


### PR DESCRIPTION
See discussions in #729 

This PR added MPI support for the casacore table data system. Previously we can partially achieve parallel I/O by introducing a parallel storage manager (e.g. https://github.com/SKA-ScienceDataProcessor/AdiosStMan). However, the table layer API was strictly serial for writing. In this PR, I added MPI-awareness to the table layer API. The logic is to write the table files only on Rank 0, while other ranks do not write any data. This fixed the issue that slave ranks of user applications have to pass in garbage tables with the table API to avoid conflicts when writing table files. 

To use this feature, one must configure casacore using the following flags

-DUSE_MPI=ON 
-DENABLE_TABLELOCKING=OFF

Also, one must use a parallel CTDS storage manager. Some of the existing parallel storage managers are:
https://github.com/SKA-ScienceDataProcessor/AdiosStMan
https://github.com/JasonRuonanWang/Adios2StMan
https://github.com/JasonRuonanWang/Hdf5StMan