### PR TITLE
Import FITS-IDI FLAG tables and store translated flagging commands in a MS FLAG_CMD table.

### DIFF
--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -399,6 +399,11 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
       mssub.rename (itsMSOut+"/SYSCAL",Table::New);
       msmain.rwKeywordSet().defineTable("SYSCAL",mssub);
     }
+    if (subTableName(isub)=="FLAG") {
+      Table mssub(itsMSOut+"_tmp/"+subTableName(isub)+"/FLAG_CMD",Table::Update);
+      mssub.rename (itsMSOut+"/FLAG_CMD",Table::New);
+      msmain.rwKeywordSet().defineTable("FLAG_CMD",mssub);
+    }
     if (subTableName(isub)=="WEATHER") {
       Table mssub(itsMSOut+"_tmp/"+subTableName(isub)+"/WEATHER",Table::Update);
       mssub.rename (itsMSOut+"/WEATHER",Table::New);


### PR DESCRIPTION
Not all possible flagging commands are supported, but this seems to be enough to support the flagging commands provided by the VLBA, which is far as I know the only array that provides FLAG tables in their FITS-IDI tables.