### PR TITLE
Fix addColumn in ConcatTable

### DIFF
--- a/tables/Tables/ConcatColumn.cc
+++ b/tables/Tables/ConcatColumn.cc
@@ -119,6 +119,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     return refColPtr_p[tableNr]->shape (tabRownr);
   }
 
+  IPosition ConcatColumn::tileShape(uInt rownr) const
+  {
+    uInt tableNr, tabRownr;
+    refTabPtr_p->rows().mapRownr (tableNr, tabRownr, rownr);
+    return refColPtr_p[tableNr]->tileShape (tabRownr);
+  }
+
   Bool ConcatColumn::isDefined (uInt rownr) const
   {
     uInt tableNr, tabRownr;

--- a/tables/Tables/ConcatColumn.h
+++ b/tables/Tables/ConcatColumn.h
@@ -137,6 +137,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Get the shape of an array in a particular cell.
     virtual IPosition shape (uInt rownr) const;
 
+    // Get the tile shape of an array in a particular cell.
+    virtual IPosition tileShape (uInt rownr) const;
+
     // It can change shape if the underlying column can.
     virtual Bool canChangeShape() const;
 

--- a/tables/Tables/ConcatTable.cc
+++ b/tables/Tables/ConcatTable.cc
@@ -501,7 +501,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     const String& name = tdescPtr_p->columnDesc(columnIndex).name();
     return colMap_p(name);
   }
-    
+
+  void ConcatTable::addConcatCol (const ColumnDesc& columnDesc)
+  {
+    ColumnDesc& cd = tdescPtr_p->addColumn(columnDesc);
+    colMap_p.define(cd.name(), cd.makeConcatColumn(this));
+    changed_p = True;
+  }
+
+  void ConcatTable::addConcatCol (const TableDesc& tdesc)
+  {
+    for (uInt i=0; i<tdesc.ncolumn(); ++i) {
+        addConcatCol(tdesc[i]);
+    }
+  }
 
 void ConcatTable::checkAddColumn (const String& name, Bool addToParent)
 {
@@ -518,15 +531,15 @@ void ConcatTable::checkAddColumn (const String& name, Bool addToParent)
   }
 }
 
-
 void ConcatTable::addColumn (const ColumnDesc& columnDesc, Bool addToParent)
 {
   checkAddColumn (columnDesc.name(), addToParent);
   for (uInt i=0; i<baseTabPtr_p.nelements(); ++i) {
     baseTabPtr_p[i]->addColumn (columnDesc, addToParent);
   }
-  tdescPtr_p->addColumn (columnDesc);
+  addConcatCol (columnDesc);
 }
+
 void ConcatTable::addColumn (const ColumnDesc& columnDesc,
                              const String& dataManager, Bool byName,
                              Bool addToParent)
@@ -535,8 +548,9 @@ void ConcatTable::addColumn (const ColumnDesc& columnDesc,
   for (uInt i=0; i<baseTabPtr_p.nelements(); ++i) {
     baseTabPtr_p[i]->addColumn (columnDesc, dataManager, byName, addToParent); 
   }
-  tdescPtr_p->addColumn (columnDesc);
+  addConcatCol (columnDesc);
 }
+
 void ConcatTable::addColumn (const ColumnDesc& columnDesc,
                              const DataManager& dataManager,
                              Bool addToParent)
@@ -545,8 +559,9 @@ void ConcatTable::addColumn (const ColumnDesc& columnDesc,
   for (uInt i=0; i<baseTabPtr_p.nelements(); ++i) {
     baseTabPtr_p[i]->addColumn (columnDesc,dataManager, addToParent);
   }
-  tdescPtr_p->addColumn (columnDesc);
+  addConcatCol (columnDesc);
 }
+
 void ConcatTable::addColumn (const TableDesc& tableDesc,
                              const DataManager& dataManager,
                              Bool addToParent)
@@ -560,9 +575,7 @@ void ConcatTable::addColumn (const TableDesc& tableDesc,
   for (uInt i=0; i<baseTabPtr_p.nelements(); ++i) {
     baseTabPtr_p[i]->addColumn (tableDesc, dataManager, addToParent);
   }
-  for (uInt i=0; i<tableDesc.ncolumn(); ++i) {
-    tdescPtr_p->addColumn (tableDesc[i]);
-  }
+  addConcatCol(tableDesc);
 }
 
   //# Rows and columns cannot be removed and renamed.

--- a/tables/Tables/ConcatTable.h
+++ b/tables/Tables/ConcatTable.h
@@ -91,7 +91,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   // <motivation>
   // Sometimes a very large MeasurementSet is split into multiple smaller ones
-  // using the time axis. Using ConcatTable they can still b viewed as a
+  // using the time axis. Using ConcatTable they can still be viewed as a
   // single MS. The SYSCAL subtable is split in time as well, thus it has
   // to be possible to concatenate that one as well.
   // <note>An MS split in subband could be concatenated as well provided that
@@ -353,6 +353,11 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
     // Check if the column can be added, thus does not exist yet.
     void checkAddColumn (const String& name, Bool addToParent);
+
+    // Add a column, with internal bookeeping (columns map).
+    void addConcatCol (const ColumnDesc& cd);
+    // Add multiple columns, with internal bookeeping (columns map).
+    void addConcatCol (const TableDesc& tdesc);
 
     //# Data members
     Block<String>     subTableNames_p;


### PR DESCRIPTION
Fixes #753.

See issue for a description of the problem. I've extended tConcatTable to catch this kind of issue (but I'm not totally sure I'm following the casacore test conventions properly). 
In CASA, this fixes the issue for the calibrater tool and uvcontsub (for which we had an ugly workaround) and tclean (for which we don't have a workaround).