### PR TITLE
MSHistoryHandler: don't flush the HISTORY subtable for every addMessage()

### DIFF
--- a/ms/MeasurementSets/MSHistoryHandler.cc
+++ b/ms/MeasurementSets/MSHistoryHandler.cc
@@ -35,14 +35,14 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-MSHistoryHandler::MSHistoryHandler(MeasurementSet& ms, String app){
+MSHistoryHandler::MSHistoryHandler(MeasurementSet& ms, const String& app){
   histTable_p = ms.history();
   msHistCol_p= new MSHistoryColumns(histTable_p);
   application_p=app;
 }
 
 
-MSHistoryHandler &MSHistoryHandler::operator=(MSHistoryHandler& other){
+MSHistoryHandler &MSHistoryHandler::operator=(const MSHistoryHandler& other){
 
   if(this != &other){
     histTable_p=other.histTable_p;
@@ -55,14 +55,14 @@ MSHistoryHandler &MSHistoryHandler::operator=(MSHistoryHandler& other){
 
 
 MSHistoryHandler::~MSHistoryHandler(){
+  histTable_p.flush();
   delete msHistCol_p;
-
 }
 
-void MSHistoryHandler::addMessage(MeasurementSet& ms, String message,
-				  String app,
-				  String cliComm, 
-				  String origin){
+void MSHistoryHandler::addMessage(MeasurementSet& ms, const String& message,
+				  const String& app,
+				  const String& cliComm,
+				  const String& origin){
 
   if (message.length() == 0 && cliComm.length() == 0) {
     // No need to record an entry.
@@ -94,8 +94,8 @@ void MSHistoryHandler::addMessage(MeasurementSet& ms, String message,
 
 
 
-void MSHistoryHandler::addMessage(String message, String cliComm, 
-				  String origin){
+void MSHistoryHandler::addMessage(const String& message, const String& cliComm,
+				  const String& origin){
 
   if (message.length() == 0 && cliComm.length() == 0) {
     // No need to record an entry.
@@ -121,10 +121,9 @@ void MSHistoryHandler::addMessage(String message, String cliComm,
   msHistCol_p->cliCommand().put(row, cliseq);
   cliseq[0]="";
   msHistCol_p->appParams().put(row, cliseq);
-  histTable_p.flush();
 }
 
-void MSHistoryHandler::addMessage(LogSinkInterface& sink, String cliComm){
+void MSHistoryHandler::addMessage(LogSinkInterface& sink, const String& cliComm){
 
   Int row = histTable_p.nrow();
   uInt newrows = sink.nelements();
@@ -155,15 +154,14 @@ void MSHistoryHandler::addMessage(LogSinkInterface& sink, String cliComm){
   }
 
   sink.clearLocally();
-  histTable_p.flush();
 }
 
-void MSHistoryHandler::addMessage(LogIO& os, String cliComm){
+void MSHistoryHandler::addMessage(LogIO& os, const String& cliComm){
 
   addMessage(os.localSink(), cliComm);
 }
 
-void MSHistoryHandler::cliCommand(String& cliComm){
+void MSHistoryHandler::cliCommand(const String& cliComm){
   String m("");
   String o("MSHistoryHandler::cliCommand()");
   this->addMessage(m,cliComm,o);
@@ -199,7 +197,6 @@ void MSHistoryHandler::cliCommand(LogSinkInterface& sink){
  msHistCol_p->appParams().put(row, dum);
 
  sink.clearLocally();
- histTable_p.flush();
 }
 
 } //# NAMESPACE CASACORE - END

--- a/ms/MeasurementSets/MSHistoryHandler.h
+++ b/ms/MeasurementSets/MSHistoryHandler.h
@@ -48,8 +48,8 @@ class LogSinkInterface;
 // </etymology>
 // <synopsis>
 // This class provides access to the MS history via single method calls
-// A couple of the simple methods are independent and can be called without 
-// constructing.  
+// One of the methods is static and can be called on a MeasurementSet without
+// constructing any MSHistoryHandler objects.
 // </synopsis>
 
 class MSHistoryHandler
@@ -57,9 +57,9 @@ class MSHistoryHandler
 
  public: 
   //Construct the history handler from an ms
-  MSHistoryHandler(MeasurementSet& ms, String app="");
+  MSHistoryHandler(MeasurementSet& ms, const String &app="");
 
-  MSHistoryHandler &operator=(MSHistoryHandler &other);
+  MSHistoryHandler &operator=(const MSHistoryHandler &other);
   // Destructor
   ~MSHistoryHandler();
 
@@ -68,20 +68,21 @@ class MSHistoryHandler
   //Add a string message
 
   // This method does not need construction ...can be called explicitly 
-  //
-  static void addMessage(MeasurementSet& ms, String message,
-	     String app="",
-	     String cliComm="", 
-	     String origin="");
+  // it flushes the history table of the ms
+  static void addMessage(MeasurementSet& ms, const String& message,
+	     const String& app="",
+	     const String& cliComm="",
+	     const String& origin="");
 
-  // Add message and/or CLI command to the history table
-  void addMessage(String message, String cliComm="", String origin="");
+  // Add message and/or CLI command to the history table. It does not flush the table (the
+  // destructor will flush).
+  void addMessage(const String& message, const String& cliComm="", const String& origin="");
   // In this version the LogIO object need to have a valid LogSink with 
   // messages in it. 
-  void addMessage(LogIO& message, String cliComm="");
-  void addMessage(LogSinkInterface& sink, String cliComm="");
+  void addMessage(LogIO& message, const String& cliComm="");
+  void addMessage(LogSinkInterface& sink, const String& cliComm="");
 
-  void cliCommand(String& cliComm);
+  void cliCommand(const String& cliComm);
   void cliCommand(LogIO& cliComm);
   void cliCommand(LogSinkInterface& sink);
 


### PR DESCRIPTION
Fixes #758.

This PR modifies the non-static addMessage() methods to not do a flush(). This is deferred to the destructor.
The static addMessage() still does flush(), and that makes sense to me as it is a one-off message add operation.
