### PR TITLE
Fix version number check for numpy print option

### DIFF
--- a/python/Converters/test/tConvert.py
+++ b/python/Converters/test/tConvert.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
 
     import numpy as NUM
     from distutils.version import LooseVersion
-    if LooseVersion(NUM.version.version) > LooseVersion("1.13"):
+    if LooseVersion(NUM.version.version) >= LooseVersion("1.14"):
         NUM.set_printoptions(legacy="1.13")
     t = tConvert();
     print "Doing numpy/array test ..."


### PR DESCRIPTION
This is a followup to 7d47522e044b7fcb23eb894f3827c64da5209500. The test should be being comparing with 1.14; for 1.13 there exists a 1.13.1 which still cannot use the `set_printoptions` function.