### PR TITLE
Take care similary shaped data overwrites existing data

### DIFF
--- a/build-tools/casacore_memcheck.supp
+++ b/build-tools/casacore_memcheck.supp
@@ -1,4 +1,5 @@
 # This file contains the valgrind errors to be suppressed for casacore.
+# Where needed, it has lines for namespace casa and casacore.
 
 # Very often libc gives an invalid free error at exit.
 {
@@ -12,33 +13,60 @@
 
 # putenv takes over the pointer, but valgrind does not notice.
 {
-   Class-EnvVar-putenv-takes-over-pointer
+   Class-EnvVar-putenv-takes-over-pointer-4
    Memcheck:Leak
    fun:_Znam
    fun:_ZN4casa19EnvironmentVariable3setERKNS_6StringES3_
 }
+{
+   Class-EnvVar-putenv-takes-over-pointer-8
+   Memcheck:Leak
+   fun:_Znam
+   fun:_ZN8casacore19EnvironmentVariable3setERKNS_6StringES3_
+}
 
 # Casacore's IO sometimes uses uninitialized fill characters.
 {
-   Casacore-write-not-fully-initialized-buffer-LargeFilebufIO
+   Casacore-write-not-fully-initialized-buffer-LargeFilebufIO-4
    Memcheck:Param
    write(buf)
    fun:__write_nocancel
    fun:_ZN4casa9FiledesIO5writeExPKv
 }
 {
-   Casacore-write-not-fully-initialized-buffer-FilebufIO-dbg
+   Casacore-write-not-fully-initialized-buffer-LargeFilebufIO-8
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_ZN8casacore9FiledesIO5writeExPKv
+}
+{
+   Casacore-write-not-fully-initialized-buffer-FilebufIO-dbg4
    Memcheck:Param
    write(buf)
    fun:__write_nocancel
    fun:_ZN4casa9FilebufIO11writeBufferExPKcx
 }
 {
-   Casacore-write-not-fully-initialized-buffer-FilebufIO-opt
+   Casacore-write-not-fully-initialized-buffer-FilebufIO-dbg8
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   fun:_ZN8casacore9FilebufIO11writeBufferExPKcx
+}
+{
+   Casacore-write-not-fully-initialized-buffer-FilebufIO-opt4
    Memcheck:Param
    write(buf)
    fun:???
    fun:_ZN4casa9FilebufIO11writeBufferExPKcx
+}
+{
+   Casacore-write-not-fully-initialized-buffer-FilebufIO-opt8
+   Memcheck:Param
+   write(buf)
+   fun:???
+   fun:_ZN8casacore9FilebufIO11writeBufferExPKcx
 }
 
 # The function strlen is optimized by testing multiple byte simultaneously.

--- a/tables/DataMan/SSMIndColumn.cc
+++ b/tables/DataMan/SSMIndColumn.cc
@@ -109,8 +109,11 @@ void SSMIndColumn::setShapeColumn (const IPosition& aShape)
 void SSMIndColumn::setShape (uInt aRowNr, const IPosition& aShape)
 {
   // Get the current entry. If none, make empty one.
-  if (getArrayPtr (aRowNr) == 0) {
+  StIndArray* aPtr = getArrayPtr (aRowNr);
+  if (aPtr == 0) {
     itsIndArray = StIndArray(0);
+  } else {
+    aPtr->getShape (*itsIosFile);
   }
   // put the new shape (if changed)
   // when changed put the file offset

--- a/tables/DataMan/SSMIndColumn.cc
+++ b/tables/DataMan/SSMIndColumn.cc
@@ -113,6 +113,7 @@ void SSMIndColumn::setShape (uInt aRowNr, const IPosition& aShape)
   if (aPtr == 0) {
     itsIndArray = StIndArray(0);
   } else {
+    // Note that getArrayPtr sets itsIndArray (which is equal to aPtr).
     aPtr->getShape (*itsIosFile);
   }
   // put the new shape (if changed)

--- a/tables/DataMan/test/tStandardStMan.out
+++ b/tables/DataMan/test/tStandardStMan.out
@@ -2060,3 +2060,27 @@ Col-11: Int
 []
 Col-10: String
 []
+
+testInd ...
+size 152
+size 284
+size 420
+size 556
+size 692
+
+testInd2 ...
+nrow 1
+rec1   j: String "x"
+size 99
+nrow 1
+rec1   j: String "x"
+size 99
+nrow 1
+rec1   j: String "x"
+size 99
+nrow 1
+rec1   j: String "x"
+size 99
+nrow 1
+rec1   j: String "x"
+size 99


### PR DESCRIPTION
With the StandardStMan the indirect array file (e.g., table.f0i) grew if an array (or record) with the same shape was written. It has been fixed by taking care the existing shape is known.\

close #721 #767 