### PR TITLE
Change HDF5Object hid type to match hdf5 headers.

### DIFF
--- a/casa/HDF5/HDF5Object.h
+++ b/casa/HDF5/HDF5Object.h
@@ -38,7 +38,7 @@
 #ifdef HAVE_HDF5
 # include <hdf5.h>
 #else 
-  typedef casacore::Int64 hid_t;
+  typedef int64_t hid_t;
   typedef casacore::uInt64 hsize_t;
 #endif
 
@@ -122,7 +122,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     //# for older HDF5 versions where hid_t is a 32 bit integer.
     union {
       hid_t  itsHid;
-      Int64  itsDummyHid;
+      int64_t  itsDummyHid;
     };
     String itsName;
 


### PR DESCRIPTION
Fixes #771.
Casacore defines it's own 64-bit integer type, Int64, in casacore/casa/aips.h as 'long long'. The HDF5 library defines it's hid_t as int64_t from <stdint.h>. On different systems int64_t can be 'long long' or simply 'long', and in the latter case the compiler cannot match HDF5Group::init's arguments for the constructor that uses implicit conversion from HDF5Object to hid_t.