### PR TITLE
Add support for extra optional columns in the spectral window subtable.

### DIFF
--- a/ms/MeasurementSets/MSSpWindowColumns.cc
+++ b/ms/MeasurementSets/MSSpWindowColumns.cc
@@ -93,6 +93,8 @@ ROMSSpWindowColumns(const MSSpectralWindow& msSpWindow):
   bbcSideband_p(),
   dopplerId_p(),
   receiverId_p(),
+  sdmWindowFunction_p(),
+  sdmNumBin_p(),
   chanFreqMeas_p(msSpWindow, MSSpectralWindow::
 		 columnName(MSSpectralWindow::CHAN_FREQ)),
   refFrequencyMeas_p(msSpWindow, MSSpectralWindow::
@@ -320,6 +322,8 @@ ROMSSpWindowColumns::ROMSSpWindowColumns():
   bbcSideband_p(),
   dopplerId_p(),
   receiverId_p(),
+  sdmWindowFunction_p(),
+  sdmNumBin_p(),
   chanFreqMeas_p(),
   refFrequencyMeas_p(),
   chanFreqQuant_p(),
@@ -402,6 +406,12 @@ attachOptionalCols(const MSSpectralWindow& msSpWindow)
   const String& receiverId=
     MSSpectralWindow::columnName(MSSpectralWindow::RECEIVER_ID);
   if (cds.isDefined(receiverId)) receiverId_p.attach(msSpWindow,receiverId);
+  const String& sdmWindowFunction=
+    MSSpectralWindow::columnName(MSSpectralWindow::SDM_WINDOW_FUNCTION);
+  if (cds.isDefined(sdmWindowFunction)) sdmWindowFunction_p.attach(msSpWindow,sdmWindowFunction);
+  const String& sdmNumBin=
+    MSSpectralWindow::columnName(MSSpectralWindow::SDM_NUM_BIN);
+  if (cds.isDefined(sdmNumBin)) sdmNumBin_p.attach(msSpWindow,sdmNumBin);
 }
 
 Bool ROMSSpWindowColumns::
@@ -599,6 +609,8 @@ MSSpWindowColumns::MSSpWindowColumns(MSSpectralWindow& msSpWindow):
   bbcSideband_p(),
   dopplerId_p(),
   receiverId_p(),
+  sdmWindowFunction_p(),
+  sdmNumBin_p(),
   chanFreqMeas_p(msSpWindow, MSSpectralWindow::
 		 columnName(MSSpectralWindow::CHAN_FREQ)),
   refFrequencyMeas_p(msSpWindow, MSSpectralWindow::
@@ -643,6 +655,8 @@ MSSpWindowColumns::MSSpWindowColumns():
   bbcSideband_p(),
   dopplerId_p(),
   receiverId_p(),
+  sdmWindowFunction_p(),
+  sdmNumBin_p(),
   chanFreqMeas_p(),
   refFrequencyMeas_p(),
   chanFreqQuant_p(),
@@ -726,6 +740,12 @@ attachOptionalCols(MSSpectralWindow& msSpWindow)
   const String& receiverId=
     MSSpectralWindow::columnName(MSSpectralWindow::RECEIVER_ID);
   if (cds.isDefined(receiverId)) receiverId_p.attach(msSpWindow,receiverId);
+  const String& sdmWindowFunction=
+    MSSpectralWindow::columnName(MSSpectralWindow::SDM_WINDOW_FUNCTION);
+  if (cds.isDefined(sdmWindowFunction)) sdmWindowFunction_p.attach(msSpWindow,sdmWindowFunction);
+  const String& sdmNumBin=
+    MSSpectralWindow::columnName(MSSpectralWindow::SDM_NUM_BIN);
+  if (cds.isDefined(sdmNumBin)) sdmNumBin_p.attach(msSpWindow,sdmNumBin);
 }
 
 

--- a/ms/MeasurementSets/MSSpWindowColumns.h
+++ b/ms/MeasurementSets/MSSpWindowColumns.h
@@ -131,6 +131,8 @@ public:
   const ROScalarColumn<Int>& bbcSideband() const {return bbcSideband_p;}
   const ROScalarColumn<Int>& dopplerId() const {return dopplerId_p;}
   const ROScalarColumn<Int>& receiverId() const {return receiverId_p;}
+  const ROScalarColumn<String>& sdmWindowFunction() const {return sdmWindowFunction_p;}
+  const ROScalarColumn<Int>& sdmNumBin() const {return sdmNumBin_p;}
   // </group>
 
   // Convenience function that returns the number of rows in any of the columns
@@ -228,6 +230,8 @@ private:
   ROScalarColumn<Int> bbcSideband_p;
   ROScalarColumn<Int> dopplerId_p;
   ROScalarColumn<Int> receiverId_p;
+  ROScalarColumn<String> sdmWindowFunction_p;
+  ROScalarColumn<Int> sdmNumBin_p;
 
   //# Access to Measure columns
   ROArrayMeasColumn<MFrequency> chanFreqMeas_p;
@@ -324,6 +328,8 @@ public:
   ScalarColumn<Int>& bbcSideband() {return bbcSideband_p;}
   ScalarColumn<Int>& dopplerId() {return dopplerId_p;}
   ScalarColumn<Int>& receiverId() {return receiverId_p;}
+  ScalarColumn<String>& sdmWindowFunction() {return sdmWindowFunction_p;}
+  ScalarColumn<Int>& sdmNumBin() {return sdmNumBin_p;}
   // </group>
 
   // Read-only access to required columns
@@ -388,6 +394,10 @@ public:
     return ROMSSpWindowColumns::dopplerId();}
   const ROScalarColumn<Int>& receiverId() const {
     return ROMSSpWindowColumns::receiverId();}
+  const ROScalarColumn<String>& sdmWindowFunction() const {
+    return ROMSSpWindowColumns::sdmWindowFunction();}
+  const ROScalarColumn<Int>& sdmNumBin() const {
+    return ROMSSpWindowColumns::sdmNumBin();}
   // </group>
 
 protected:
@@ -429,6 +439,8 @@ private:
   ScalarColumn<Int> bbcSideband_p;
   ScalarColumn<Int> dopplerId_p;
   ScalarColumn<Int> receiverId_p;
+  ScalarColumn<String> sdmWindowFunction_p;
+  ScalarColumn<Int> sdmNumBin_p;
 
   //# Access to Measure columns
   ArrayMeasColumn<MFrequency> chanFreqMeas_p;

--- a/ms/MeasurementSets/MSSpWindowEnums.h
+++ b/ms/MeasurementSets/MSSpWindowEnums.h
@@ -134,8 +134,14 @@ public:
     // May point to optional RECEIVER table <BR>
     // Int
     RECEIVER_ID,
+    // The window function used in some correlator setups, like ALMA and VLA in WIDAR mode.
+    // String
+    SDM_WINDOW_FUNCTION,
+    // The number of bins used by the windowing function (SDM_WINDOW_FUNCTION) in some correlator setups
+    // Int
+    SDM_NUM_BIN,
     // Not a column, but just a final enum specifying the number of enums.
-    NUMBER_PREDEFINED_COLUMNS=RECEIVER_ID
+    NUMBER_PREDEFINED_COLUMNS=SDM_NUM_BIN
     };
   
     // Keywords with a predefined meaning

--- a/ms/MeasurementSets/MSSpectralWindow.cc
+++ b/ms/MeasurementSets/MSSpectralWindow.cc
@@ -191,7 +191,13 @@ void MSSpectralWindow::init()
 		"Hz","");
       // TOTAL_BANDWIDTH
       colMapDef(TOTAL_BANDWIDTH, "TOTAL_BANDWIDTH", TpDouble,
-		"The total bandwidth for this window","Hz","");
+        "The total bandwidth for this window","Hz","");
+      // SDM_WINDOW_FUNCTION
+      colMapDef(SDM_WINDOW_FUNCTION, "SDM_WINDOW_FUNCTION", TpString,
+        "The correlator windowing function","","");
+      // SDM_NUM_BIN
+      colMapDef(SDM_NUM_BIN, "SDM_NUM_BIN", TpInt,
+        "The correlator windowing binning","","");
       // PredefinedKeywords
       
       // init requiredTableDesc


### PR DESCRIPTION
Some correlators, including ALMA and VLA in WIDAR mode, include a functionality
to apply a windowing function with a number of bins. This information,so far,
hasn't been readly available to CASA.
This patch adds support for two extra optional columns in the spectral window
subtable, namely SDM_WINDOW_FUNCTION and SDM_NUM_BIN. See CASA ticket CAS_11547
(and tickets mentioned therein) for a background.

Fixes partially CAS-11547

This has high priority since it is blocking the release of CASA 5.4.1