### PR TITLE
Fixing warnings due to misleading indentations

### DIFF
--- a/fits/FITS/hdu.tcc
+++ b/fits/FITS/hdu.tcc
@@ -491,10 +491,11 @@ void PrimaryArray<TYPE>::copy(double *target, FITS::FitsArrayOption opt) const {
 	    C_factor = &sub[dims()];
 	    // compute the C_factors
 	    Int i;
-	    for (i = 0; i < (dims() - 1); ++i)
+	    for (i = 0; i < (dims() - 1); ++i) {
 		C_factor[i] = 1;
 		for (Int j = i + 1; j < dims(); ++j)
 		    C_factor[i] *= dim(j);
+	    }
 	    C_factor[i] = 1;
 	    // algorithm for converting F-order to C-order
 	    count = 0;
@@ -574,10 +575,11 @@ void PrimaryArray<TYPE>::copy(float *target, FITS::FitsArrayOption opt) const {
 	    C_factor = &sub[dims()];
 	    // compute the C_factors
 	    Int i;
-	    for (i = 0; i < (dims() - 1); ++i)
+	    for (i = 0; i < (dims() - 1); ++i) {
 		C_factor[i] = 1;
 		for (Int j = i + 1; j < dims(); ++j)
 		    C_factor[i] *= dim(j);
+	    }
 	    C_factor[i] = 1;
 	    // algorithm for converting F-order to C-order
 	    count = 0;
@@ -632,10 +634,11 @@ void PrimaryArray<TYPE>::move(TYPE *target, FITS::FitsArrayOption opt) const {
 	    C_factor = &sub[dims()];
 	    // compute the C_factors
 	    Int i;
-	    for (i = 0; i < uInt(dims() - 1); ++i)
+	    for (i = 0; i < uInt(dims() - 1); ++i) {
 		C_factor[i] = 1;
 		for (Int j = i + 1; j < uInt(dims()); ++j)
 		    C_factor[i] *= dim(j);
+	    }
 	    C_factor[i] = 1;
 	    // algorithm for converting F-order to C-order
 	    count = 0;

--- a/fits/FITS/hdu2.cc
+++ b/fits/FITS/hdu2.cc
@@ -765,7 +765,9 @@ int HeaderDataUnit::skip(uInt n) {
 	return (fin ? fin->skip(hdu_type,n) : 0); }
 //=============================================================================
 int HeaderDataUnit::skip() {
-	if (fin) fin->skip_all(hdu_type); return 0; }
+	if (fin) fin->skip_all(hdu_type);
+	return 0;
+}
 //=============================================================================
 int HeaderDataUnit::write_hdr(FitsOutput &f) {	
 	if(f.write_hdr(kwlist_,hdu_type,data_type,fits_data_size,fits_item_size)){

--- a/lattices/LatticeMath/LatticeConvolver.tcc
+++ b/lattices/LatticeMath/LatticeConvolver.tcc
@@ -145,8 +145,14 @@ operator=(const LatticeConvolver<T> & other) {
 template<class T> LatticeConvolver<T>::
 ~LatticeConvolver()
 {
-  if(itsPsf) delete itsPsf; itsPsf=0;
-  if(itsXfr) delete itsXfr; itsXfr=0;
+  if(itsPsf) {
+    delete itsPsf;
+    itsPsf = 0;
+  }
+  if(itsXfr) {
+    delete itsXfr;
+    itsXfr = 0;
+  }
 }
 
 template<class T> void LatticeConvolver<T>::
@@ -388,7 +394,10 @@ makeXfr(const Lattice<T> & psf) {
     IPosition XFRShape = itsFFTShape;
     XFRShape(0) = (XFRShape(0)+2)/2;
     //    XFRShape(1) = (XFRShape(1)/2+1)*2;
-    if(itsXfr) delete itsXfr; itsXfr=0;
+    if(itsXfr) {
+      delete itsXfr;
+      itsXfr = 0;
+    }
     itsXfr = new TempLattice<typename NumericTraits<T>::ConjugateType>(XFRShape, 
 								   maxLatSize);
     if (itsFFTShape == itsPsfShape) { // no need to pad the psf
@@ -402,12 +411,18 @@ makeXfr(const Lattice<T> & psf) {
   // Only cache the psf if it cannot be reconstructed from the transfer
   // function.
   if (itsFFTShape < itsPsfShape) {
-    if(itsPsf) delete itsPsf; itsPsf=0;
+    if(itsPsf) {
+      delete itsPsf;
+      itsPsf = 0;
+    }
     itsPsf = new TempLattice<T>(itsPsfShape, 1); // Prefer to put this on disk
     itsPsf->copyData(psf);
     itsCachedPsf = True;
   } else {
-    if(itsPsf) delete itsPsf; itsPsf=0;
+    if(itsPsf) {
+      delete itsPsf;
+      itsPsf = 0;
+    }
     itsPsf = new TempLattice<T>();
     itsCachedPsf = False;
   }

--- a/measures/Measures/test/tMeasJPL.cc
+++ b/measures/Measures/test/tMeasJPL.cc
@@ -75,8 +75,8 @@ int main()
       os << "Venus:      " << val << endl;
       for (uInt i=0; i<3; i++) {
         mvd1(i) = val(i);
-        mvd1.adjust();
       }
+      mvd1.adjust();
       os << "Venus:      " << mvd1 << endl;
       MeasJPL::get(val, MeasJPL::DE200, MeasJPL::EARTH, dat);
       os << "Earth:      " << val << endl;

--- a/measures/Measures/test/tMeasJPL.cc
+++ b/measures/Measures/test/tMeasJPL.cc
@@ -73,7 +73,10 @@ int main()
       os << "Mercury:    " << val << endl;
       MeasJPL::get(val, MeasJPL::DE200, MeasJPL::VENUS, dat);
       os << "Venus:      " << val << endl;
-      for (uInt i=0; i<3; i++) mvd1(i) = val(i); mvd1.adjust();
+      for (uInt i=0; i<3; i++) {
+        mvd1(i) = val(i);
+        mvd1.adjust();
+      }
       os << "Venus:      " << mvd1 << endl;
       MeasJPL::get(val, MeasJPL::DE200, MeasJPL::EARTH, dat);
       os << "Earth:      " << val << endl;

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -1729,30 +1729,34 @@ void MSSummary::listTables (LogIO& os, Bool verbose) const
     // Do things on this side
     // whether verbose or not
     os << "Tables";
-    if (!verbose) os << "(rows)";            os << ":";
+    if (!verbose) os << "(rows)";
+    os << ":";
     if (!verbose) os << "   (-1 = table absent)";
     os << endl;
     for (uInt i=0; i<18; i++) {
         if (verbose) {
             os.output().setf(ios::left, ios::adjustfield);
             os.output().width(3);
-        }                        os << "   ";
+        }
+        os << "   ";
         if (verbose) {
             os.output().width(20);
-        }                        os << tableStrings(i);
+        }
+        os << tableStrings(i);
         if (verbose && tableRows(i)>0) {
             os.output().setf(ios::right, ios::adjustfield);
             os.output().width(8);
         }
         if (!verbose) os << "(";
-        if (!verbose || tableRows(i)>0)        os << tableRows(i);
+        if (!verbose || tableRows(i)>0) os << tableRows(i);
         if (!verbose) os << ")";
         if (verbose) {
             os.output().setf(ios::left, ios::adjustfield);
-            os.output().width(10);    os << rowStrings(i);
+            os.output().width(10);
+            os << rowStrings(i);
             os << endl;
         }
-        else {if ((i%5)==0) os << endl;}
+        else if ((i%5)==0) os << endl;
     }
     os << LogIO::POST;
 }

--- a/ms/MeasurementSets/MSDoppler.cc
+++ b/ms/MeasurementSets/MSDoppler.cc
@@ -122,9 +122,9 @@ MSDoppler::MSDoppler(const MSDoppler &other)
     // verify that other is valid
     if (&other != this) 
         addVelDef();
-	if (! validate(this->tableDesc()))
-	    throw (AipsError("MSDoppler(const MSDoppler &) - "
-			     "table is not a valid MSDoppler"));
+    if (! validate(this->tableDesc()))
+        throw (AipsError("MSDoppler(const MSDoppler &) - "
+                        "table is not a valid MSDoppler"));
 }
 
 MSDoppler::~MSDoppler()


### PR DESCRIPTION
In the spirit of clearing warnings before 3.0, please have a look at these. I found them with gcc 6.3 + -Wall (in particular with -Wmisleading-indent) some time ago. Most of the changes are statements that should have been within brackets in the first place. The commit message contains more information.