### PR TITLE
Fixed TaQL segfault and a valgrind error

### DIFF
--- a/tables/TaQL/ExprFuncNode.cc
+++ b/tables/TaQL/ExprFuncNode.cc
@@ -297,7 +297,7 @@ void TableExprFuncNode::fillChildNodes (const vector<TENShPtr>& nodes,
   }
   // Convert String to Date if needed
   for (uInt i=0; i<nodes.size(); i++) {
-    if (dtypeOper[i] == NTDate) {
+    if (i < dtypeOper.size()  &&  dtypeOper[i] == NTDate) {
       if (nodes[i]->dataType() == NTString) {
         TableExprNode dNode = datetime (operands_p[i]);
         operands_p[i] = dNode.getRep();

--- a/tables/TaQL/TableParse.cc
+++ b/tables/TaQL/TableParse.cc
@@ -3317,6 +3317,9 @@ Table TableParseSelect::doProject
 {
   Timer timer;
   Table tabp;
+  // doProjectExpr might have been done for some columns, so clear first to avoid
+  // they are calculated twice.
+  update_p.clear();
   if (nrSelExprUsed_p > 0) {
     // Expressions used, so make a real table.
     tabp = doProjectExpr (False, groups);

--- a/tables/Tables/NullTable.cc
+++ b/tables/Tables/NullTable.cc
@@ -52,239 +52,203 @@ Bool NullTable::isNull() const
 
 void NullTable::reopenRW()
 {
-  throwError ("reopenRW");
+  throw makeError ("reopenRW");
 }
 
 Bool NullTable::asBigEndian() const
 {
-  throwError ("asBigEndian");
-  return True;
+  throw makeError ("asBigEndian");
 }
 
 Bool NullTable::isMultiUsed (Bool) const
 {
-  throwError ("isMultiUsed");
-  return False;
+  throw makeError ("isMultiUsed");
 }
 
 const StorageOption& NullTable::storageOption() const
 {
-  throwError ("storageOption");
-  // to satisfy compiler, explicitly construct new object, don't call function
-  // recursively or compiler will still complain about infinite recursion
-  return *std::unique_ptr<StorageOption>(new StorageOption());          
+  throw makeError ("storageOption");
 }
 
 const TableLock& NullTable::lockOptions() const
 {
-  throwError ("lockOptions");
-  // to satisfy compiler, explicitly construct new object, don't call function
-  // recursively or compiler will still complain about infinite recursion
-  return *std::unique_ptr<TableLock>(new TableLock());          
+  throw makeError ("lockOptions");
 }
 
 void NullTable::mergeLock (const TableLock&)
 {
-  throwError ("mergeLoc");
+  throw makeError ("mergeLoc");
 }
 
 Bool NullTable::hasLock (FileLocker::LockType) const
 {
-  throwError ("hasLock");
-  return False;
+  throw makeError ("hasLock");
 }
 
 Bool NullTable::lock (FileLocker::LockType, uInt)
 {
-  throwError ("lock");
-  return False;
+  throw makeError ("lock");
 }
 
 void NullTable::unlock()
 {
-  throwError ("unlock");
+  throw makeError ("unlock");
 }
 
 void NullTable::flush (Bool, Bool)
 {
-  throwError ("flush");
+  throw makeError ("flush");
 }
 
 void NullTable::resync()
 {
-  throwError ("resync");
+  throw makeError ("resync");
 }
 
 uInt NullTable::getModifyCounter() const
 {
-  throwError ("getModifyCounter");
-  return 0;
+  throw makeError ("getModifyCounter");
 }
 
 Bool NullTable::isWritable() const
 {
-  throwError ("isWritable");
-  return False;
+  throw makeError ("isWritable");
 }
 
 void NullTable::deepCopy (const String&, const Record&,
                           const StorageOption&, int, Bool,
 			  int, Bool) const
 {
-  throwError ("deepCopy");
+  throw makeError ("deepCopy");
 }
 
 TableDesc NullTable::actualTableDesc() const
 {
-  throwError ("actualTableDesc");
-  // to satisfy compiler, explicitly construct new object, don't call function
-  // recursively or compiler will still complain about infinite recursion
-  return TableDesc();          
+  throw makeError ("actualTableDesc");
 }
 
 Record NullTable::dataManagerInfo() const
 {
-  throwError ("dataManagerInfo");
-  // to satisfy compiler, explicitly construct new object, don't call function
-  // recursively or compiler will still complain about infinite recursion
-  return Record();          
+  throw makeError ("dataManagerInfo");
 }
 
 TableRecord& NullTable::keywordSet()
 {
-  throwError ("keywordSet");
-  // to satisfy compiler, explicitly construct new object, don't call function
-  // recursively or compiler will still complain about infinite recursion
-  return *std::unique_ptr<TableRecord>(new TableRecord());
+  throw makeError ("keywordSet");
 }
 
 TableRecord& NullTable::rwKeywordSet()
 {
-  throwError ("rwKeywordSet");
-  // to satisfy compiler, explicitly construct new object, don't call function
-  // recursively or compiler will still complain about infinite recursion
-  return *std::unique_ptr<TableRecord>(new TableRecord());
+  throw makeError ("rwKeywordSet");
 }
 
 BaseColumn* NullTable::getColumn (uInt) const
 {
-  throwError ("getColumn");
-  return 0;
+  throw makeError ("getColumn");
 }
 
 BaseColumn* NullTable::getColumn (const String&) const
 {
-  throwError ("getColumn");
-  return 0;
+  throw makeError ("getColumn");
 }
 
 Bool NullTable::canAddRow() const
 {
-  throwError ("canAddRow");
-  return False;
+  throw makeError ("canAddRow");
 }
 
 void NullTable::addRow (uInt, Bool)
 {
-  throwError ("addRow");
+  throw makeError ("addRow");
 }
 
 Bool NullTable::canRemoveRow() const
 {
-  throwError ("canRemoveRow");
-  return False;
+  throw makeError ("canRemoveRow");
 }
 
 void NullTable::removeRow (uInt)
 {
-  throwError ("removeRow");
+  throw makeError ("removeRow");
 }
 
 DataManager* NullTable::findDataManager (const String&, Bool) const
 {
-  throwError ("findDataManager");
-  return 0;
+  throw makeError ("findDataManager");
 }
 
 void NullTable::addColumn (const ColumnDesc&, Bool)
 {
-  throwError ("addColumn");
+  throw makeError ("addColumn");
 }
 
 void NullTable::addColumn (const ColumnDesc&,
 			   const String&, Bool, Bool)
 {
-  throwError ("addColumn");
+  throw makeError ("addColumn");
 }
 
 void NullTable::addColumn (const ColumnDesc&,
 			   const DataManager&, Bool)
 {
-  throwError ("addColumn");
+  throw makeError ("addColumn");
 }
 
 void NullTable::addColumn (const TableDesc& ,
 			   const DataManager&, Bool)
 {
-  throwError ("addColumn");
+  throw makeError ("addColumn");
 }
 
 Bool NullTable::canRemoveColumn (const Vector<String>&) const
 {
-  throwError ("canRemoveColumn");
-  return False;
+  throw makeError ("canRemoveColumn");
 }
 
 void NullTable::removeColumn (const Vector<String>&)
 {
-  throwError ("removeColumn");
+  throw makeError ("removeColumn");
 }
 
 Bool NullTable::canRenameColumn (const String&) const
 {
-  throwError ("canRenameColumn");
-  return False;
+  throw makeError ("canRenameColumn");
 }
 
 void NullTable::renameColumn (const String&, const String&)
 {
-  throwError ("renameColumn");
+  throw makeError ("renameColumn");
 }
 
 void NullTable::renameHypercolumn (const String&, const String&)
 {
-  throwError ("renameHypercolumn");
+  throw makeError ("renameHypercolumn");
 }
 
 Vector<uInt> NullTable::rowNumbers() const
 {
-  throwError ("rowNumbers");
-  return Vector<uInt>();
+  throw makeError ("rowNumbers");
 }
 
 BaseTable* NullTable::root()
 {
-  throwError ("root");
-  return 0;
+  throw makeError ("root");
 }
 
 Bool NullTable::rowOrder() const
 {
-  throwError ("rowOrde");
-  return False;
+  throw makeError ("rowOrde");
 }
 
 Vector<uInt>* NullTable::rowStorage()
 {
-  throwError ("rowStorage");
-  return 0;
+  throw makeError ("rowStorage");
 }
 
 Bool NullTable::adjustRownrs (uInt, Vector<uInt>&,
 			      Bool) const
 {
-  throwError ("adjustRownrs");
-  return False;
+  throw makeError ("adjustRownrs");
 }
 
 BaseTable* NullTable::doSort (PtrBlock<BaseColumn*>&,
@@ -292,20 +256,19 @@ BaseTable* NullTable::doSort (PtrBlock<BaseColumn*>&,
 			      const Block<Int>&,
 			      int)
 {
-  throwError ("doSort");
-  return 0;
+  throw makeError ("doSort");
 }
 
 void NullTable::renameSubTables (const String&,
 				 const String&)
 {
-  throwError ("renameSubTables");
+  throw makeError ("renameSubTables");
 }
 
 
-void NullTable::throwError (const String& name) const
+TableError NullTable::makeError (const String& name) const
 {
-  throw TableError ("NullTable::" + name + " - Table object is empty");
+  return TableError ("NullTable::" + name + " - Table object is empty");
 }
 
 } //# NAMESPACE CASACORE - END

--- a/tables/Tables/NullTable.h
+++ b/tables/Tables/NullTable.h
@@ -32,6 +32,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseTable.h>
+#include <casacore/tables/Tables/TableError.h>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -52,13 +53,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // <etymology>
 // NullTable represents a null table object, i.e. a Table object without
-// an underlying table..
+// an underlying table.
 // </etymology>
 
 // <synopsis> 
-// Nullable is used to represent a null table.
+// NullTable is used to represent a null table.
 // The default Table constructor used to a create a null pointer
-// which results in core dumps when the Table object is actually used.
+// which resulted in core dumps when the Table object was actually used.
 // The NullTable object makes it possible to catch such cases
 // and throw an appropriate exception.
 // </synopsis> 
@@ -148,8 +149,8 @@ private:
   // Declaring it private, makes it unusable.
   NullTable& operator= (const NullTable&);
 
-  // Throw an exception with the name of the function.
-  void throwError (const String& name) const;
+  // Make an exception message with the name of the function.
+  TableError makeError (const String& name) const;
 };
 
 


### PR DESCRIPTION
valgrind found an array bound error in ExprFuncNode.cc.
It also improves NullTable how to avoid compiler warnings.

Close #812