### PR TITLE
Fix call_once with USE_THREADS=OFF and fix use of auto_ptr

### DIFF
--- a/casa/OS/Mutex.h
+++ b/casa/OS/Mutex.h
@@ -215,10 +215,22 @@ namespace casacore {
   {
   public:
     CallOnce0()
-    { }
+    {
+#ifndef USE_THREADS
+      itsFlag = True;
+#endif
+    }
 
     void operator()(void (*fn)()) {
+      //# call_once does not work properly without threads.
+#ifdef USE_THREADS
       std::call_once(itsFlag, fn);
+#else
+      if (itsFlag) {
+        fn();
+        itsFlag = False;
+      }
+#endif
     }
 
 private:
@@ -227,7 +239,11 @@ private:
     // Forbid assignment.
     CallOnce0& operator= (const CallOnce0&);
 
+#ifdef USE_THREADS
     std::once_flag itsFlag;
+#else
+    Bool itsFlag;
+#endif
   };
 
   // CallOnce: func has one arg.
@@ -236,11 +252,22 @@ private:
   {
   public:
     CallOnce()
-    { }
+    {
+#ifndef USE_THREADS
+      itsFlag = True;
+#endif
+    }
 
     template<typename T>
     void operator()(void (*fn)(T), T t) {
+#ifdef USE_THREADS
       std::call_once(itsFlag, fn, t);
+#else
+      if (itsFlag) {
+        fn(t);
+        itsFlag = False;
+      }
+#endif
     }
 
   private:
@@ -249,7 +276,11 @@ private:
     // Forbid assignment.
     CallOnce& operator= (const CallOnce&);
 
+#ifdef USE_THREADS
     std::once_flag itsFlag;
+#else
+    Bool itsFlag;
+#endif
   };
 
 } // namespace casacore

--- a/ms/MSOper/test/tNewMSSimulator.cc
+++ b/ms/MSOper/test/tNewMSSimulator.cc
@@ -102,7 +102,7 @@ public:
     nftw(msName_p.c_str(), removeFile, 64, FTW_DEPTH | FTW_PHYS);
   }
 
-  std::auto_ptr<casacore::NewMSSimulator> simulator_p;
+  std::unique_ptr<casacore::NewMSSimulator> simulator_p;
   std::string msName_p; 
 
 };


### PR DESCRIPTION
class CallOnce and CallOnce0 did not work well when used with USE_THREADS=OFF. Certainly std::call_once failed on Linux with gcc-4.8.2 when used without threading. It has been fixed by using a Bool flag if USE_THREADS=OFF is used.

The obsolete auto_ptr was replaced by unique_ptr in tNewMSSimulator.cc.

Close #815 
Close #808 
