### PR TITLE
Fix another compile error in LatticeStatistics

### DIFF
--- a/lattices/LatticeMath/LatticeApply.tcc
+++ b/lattices/LatticeMath/LatticeApply.tcc
@@ -355,10 +355,10 @@ IPosition LatticeApply<T,U>::_chunkShape(
         // can only go row by row
         return chunkShape;
     }
-    uInt x = maxChunkSize;
+    ssize_t x = maxChunkSize;
     for (uInt i=0; i<ndim; ++i) {
         if (i != axis) {
-            chunkShape[i] = min(x, latShape[i]);
+            chunkShape[i] = std::min(x, latShape[i]);
             // integer division
             x /= chunkShape[i];
             if (x == 0) {


### PR DESCRIPTION
This is a followup to #827 which did not fix the 32-bit issue completely. Same pattern however ;-)
Now it builds fine on [x86 32 bit](https://buildd.debian.org/status/fetch.php?pkg=casacore&arch=i386&ver=3.0.0-3&stamp=1542884655&raw=0).