### PR TITLE
Improve calculation of TSM cache size; specify max in MiB

### DIFF
--- a/tables/DataMan/ISMBase.h
+++ b/tables/DataMan/ISMBase.h
@@ -128,7 +128,7 @@ public:
     virtual Record getProperties() const;
 
     // Modify data manager properties.
-    // Only ActualCacheSize can be used. It is similar to function setCacheSize
+    // Only MaxCacheSize can be used. It is similar to function setCacheSize
     // with <src>canExceedNrBuckets=False</src>.
     virtual void setProperties (const Record& spec);
 

--- a/tables/DataMan/SSMBase.h
+++ b/tables/DataMan/SSMBase.h
@@ -194,7 +194,7 @@ public:
   virtual Record getProperties() const;
 
   // Modify data manager properties.
-  // Only ActualCacheSize can be used. It is similar to function setCacheSize
+  // Only MaxCacheSize can be used. It is similar to function setCacheSize
   // with <src>canExceedNrBuckets=False</src>.
   virtual void setProperties (const Record& spec);
 

--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -161,7 +161,7 @@ void TSMCube::showCacheStatistics (ostream& os) const
         os << ">>> TSMCube cache statistics:" << endl;
         os << "cubeShape: " << cubeShape_p << endl;
         os << "tileShape: " << tileShape_p << endl;
-        os << "maxCacheSz:" << stmanPtr_p->maximumCacheSize() << endl;
+        os << "maxCacheSz:" << stmanPtr_p->maximumCacheSize() << " MiB" << endl;
         cache_p->showStatistics (os);
         os << "<<<" << endl;
     }
@@ -720,14 +720,14 @@ uInt TSMCube::validateCacheSize (uInt cacheSize) const
                             bucketSize_p);
 }
 
-uInt TSMCube::validateCacheSize (uInt cacheSize, uInt maxSize,
+uInt TSMCube::validateCacheSize (uInt cacheSize, uInt maxSizeMiB,
                                  uInt bucketSize)
 {
     // An overdraft of 10% is allowed.
-    if (maxSize > 0  &&  cacheSize * bucketSize > maxSize) {
-        uInt size = maxSize / bucketSize;
-        if (10 * cacheSize  >  11 * size) {
-            return size;
+    uInt maxnb = std::max(1u, uInt(1024. * 1024. * maxSizeMiB / bucketSize));
+    if (maxSizeMiB > 0  &&  cacheSize > maxnb) {
+        if (10 * cacheSize  >  11 * maxnb) {
+            return maxnb;
         }
     }
     return cacheSize;
@@ -757,10 +757,10 @@ void TSMCube::setCacheSize (const IPosition& sliceShape,
 {
     uInt cacheSize = calcCacheSize (sliceShape, windowStart,
 				    windowLength, axisPath);
-    // If not userset and if the entire cube needs to be cached,
-    // do not cache if more than 20% of the memory is needed.
-    if (!userSet  &&  cacheSize >= nrTiles_p) {
-      uInt maxSize = uInt(HostInfo::memoryTotal() * 1024.*0.2 / bucketSize_p);
+    // If not userset, do not cache if more than 25% of the memory is needed.
+    if (!userSet) {
+      uInt maxSize = uInt(HostInfo::memoryTotal(True) * 1024.*0.25 /
+                          bucketSize_p);
       if (cacheSize > maxSize) {
 	cacheSize = 1;
       }

--- a/tables/DataMan/TSMCube.h
+++ b/tables/DataMan/TSMCube.h
@@ -165,10 +165,11 @@ public:
     // Is the hypercube extensible?
     Bool isExtensible() const;
 
-    // Get the bucket size (which is the length of a tile in external format).
+    // Get the bucket size (bytes).
+    // It is the length of a tile in external format.
     uInt bucketSize() const;
 
-    // Get the length of a tile in local format.
+    // Get the length of a tile (in bytes) in local format.
     uInt localTileLength() const;
 
     // Set the hypercube shape.
@@ -244,7 +245,7 @@ public:
                                const IPosition& windowStart,
                                const IPosition& windowLength,
                                const IPosition& axisPath,
-                               uInt maxCacheSize, uInt bucketSize);
+                               uInt maxCacheSizeMiB, uInt bucketSize);
     // </group>
 
     // Set the cache size for the given slice and access path.
@@ -264,11 +265,12 @@ public:
     virtual void setCacheSize (uInt cacheSize, Bool forceSmaller, Bool userSet);
 
     // Validate the cache size (in buckets).
-    // This means it will return the given cache size if smaller
-    // than the maximum cache size. Otherwise the maximum is returned.
+    // This means it will return the given cache size (in buckets) if
+    // smaller than the maximum cache size (given in MiB).
+    // Otherwise the maximum is returned.
     // <group>
     uInt validateCacheSize (uInt cacheSize) const;
-    static uInt validateCacheSize (uInt cacheSize, uInt maxSize,
+    static uInt validateCacheSize (uInt cacheSize, uInt maxSizeMiB,
                                    uInt bucketSize);
     // </group>
 
@@ -376,7 +378,7 @@ protected:
     TSMShape        expandedTilesPerDim_p;
     // Number of tiles in all but last dimension (used when extending).
     uInt            nrTilesSubCube_p;
-    // The tilesize in pixels.
+    // The tilesize in bytes.
     uInt            tileSize_p;
     // Pointer to the TSMFile object holding the data.
     TSMFile*        filePtr_p;

--- a/tables/DataMan/TSMOption.h
+++ b/tables/DataMan/TSMOption.h
@@ -101,9 +101,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //       It defaults to value <src>default</src>.
 //       Note that <src>mmapold</src> is almost the same as <src>default</src>.
 //       Only on 32-bit systems it is different.
-//  <li> <src>table.tsm.maxcachesizemb</src> gives the maximum cache size in MB
-//       for option <src>TSMOption::Cache</src>. A value -1 means that
-//       the system determines the maximum. A value 0 means unlimited.
+//  <li> <src>table.tsm.maxcachesizemb</src> gives the maximum cache size in
+//       MibiByte for option <src>TSMOption::Cache</src>. A value -1 means
+//       that the system determines the maximum. A value 0 means unlimited.
 //       It defaults to -1.
 //       Note it can always be overridden using class ROTiledStManAccessor.
 //  <li> <src>table.tsm.buffersize</src> gives the buffer size for option
@@ -133,6 +133,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Create an option object.
     // The parameter values are described in the synopsis.
     // A size value -2 means reading that size from the aipsrc file.
+    // The buffer size has to be given in bytes.
+    // The maximum cache size has to be given in MibiBytes (1024*1024 bytes).
     TSMOption (Option option=Aipsrc, Int bufferSize=-2,
                Int maxCacheSizeMB=-2);
 
@@ -148,7 +150,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Int bufferSize() const
       { return itsBufferSize; }
 
-    // Get the maximum cache size. -1 means undefined.
+    // Get the maximum cache size (in MibiByte). -1 means undefined.
     Int maxCacheSizeMB() const
       { return itsMaxCacheSize; }
 

--- a/tables/DataMan/TiledStMan.cc
+++ b/tables/DataMan/TiledStMan.cc
@@ -353,8 +353,8 @@ void TiledStMan::deleteManager()
     DOos::remove (fileName(), False, False);
 }
 
-void TiledStMan::setMaximumCacheSize (uInt nbytes)
-    { maxCacheSize_p = nbytes; }
+void TiledStMan::setMaximumCacheSize (uInt nMiB)
+    { maxCacheSize_p = nMiB; }
 
 
 Bool TiledStMan::canChangeShape() const

--- a/tables/DataMan/TiledStMan.h
+++ b/tables/DataMan/TiledStMan.h
@@ -111,13 +111,13 @@ public:
     TiledStMan();
 
     // Create a TiledStMan storage manager.
-    // The given maximum cache size is persistent,
+    // The given maximum cache size (in MibiByte) is persistent,
     // thus will be reused when the table is read back. Note that the class
     // <linkto class=ROTiledStManAccessor>ROTiledStManAccessor</linkto>
     // allows one to overwrite the maximum cache size temporarily.
     // Its description contains a discussion about the effects of
     // setting a maximum cache.
-    TiledStMan (const String& hypercolumnName, uInt maximumCacheSize);
+    TiledStMan (const String& hypercolumnName, uInt maximumCacheSizeMiB);
 
     virtual ~TiledStMan();
 
@@ -131,12 +131,12 @@ public:
     virtual Record dataManagerSpec() const;
 
     // Get data manager properties that can be modified.
-    // It is only ActualCacheSize (the actual cache size in buckets).
+    // It is only MaxCacheSize (the maximum cache size in MibiByte).
     // It is a subset of the data manager specification.
     virtual Record getProperties() const;
 
     // Modify data manager properties.
-    // Only ActualCacheSize can be used. It is similar to function setCacheSize
+    // Only MaxCacheSize can be used. It is similar to function setCacheSize
     // with <src>canExceedNrBuckets=False</src>.
     virtual void setProperties (const Record& spec);
 
@@ -167,10 +167,10 @@ public:
 				    uInt maxNrPixelsPerTile = 32768);
     // </group>
 
-    // Set the maximum cache size (in bytes) in a non-persistent way.
-    virtual void setMaximumCacheSize (uInt nbytes);
+    // Set the maximum cache size (in MiB) in a non-persistent way.
+    virtual void setMaximumCacheSize (uInt nMiB);
 
-    // Get the current maximum cache size (in bytes).
+    // Get the current maximum cache size (in MiB (MibiByte)).
     uInt maximumCacheSize() const;
 
     // Get the current cache size (in buckets) for the hypercube in
@@ -380,8 +380,8 @@ public:
       { return dataCols_p[colnr]; }
 
 protected:
-    // Set the persistent maximum cache size.
-    void setPersMaxCacheSize (uInt nbytes);
+    // Set the persistent maximum cache size (in MiB).
+    void setPersMaxCacheSize (uInt nMiB);
 
     // Get the bindings of the columns with the given names.
     // If bound, the pointer to the TSMColumn object is stored in the block.
@@ -508,9 +508,9 @@ protected:
     PtrBlock<TSMFile*> fileSet_p;
     // The assembly of all TSMCube objects.
     PtrBlock<TSMCube*> cubeSet_p;
-    // The persistent maximum cache size for a hypercube.
+    // The persistent maximum cache size (in MiB) for a hypercube.
     uInt      persMaxCacheSize_p;
-    // The actual maximum cache size for a hypercube.
+    // The actual maximum cache size for a hypercube (in MiB).
     uInt      maxCacheSize_p;
     // The dimensionality of the hypercolumn.
     uInt      nrdim_p;
@@ -551,10 +551,10 @@ inline const TSMCube* TiledStMan::getTSMCube (uInt hypercube) const
 inline const TSMCube* TiledStMan::getHypercube (uInt rownr) const
     { return const_cast<TiledStMan*>(this)->getHypercube (rownr); }
 
-inline void TiledStMan::setPersMaxCacheSize (uInt nbytes)
+inline void TiledStMan::setPersMaxCacheSize (uInt nMiB)
 {
-    persMaxCacheSize_p = nbytes;
-    maxCacheSize_p = nbytes;
+    persMaxCacheSize_p = nMiB;
+    maxCacheSize_p = nMiB;
 }
 
 

--- a/tables/DataMan/TiledStManAccessor.h
+++ b/tables/DataMan/TiledStManAccessor.h
@@ -143,7 +143,7 @@ class Record;
 //  // Open a table.
 //  Table table("someName.data");
 //  // Set the maximum cache size of its tiled hypercube storage
-//  // manager TSMExample to 0.5 Mb.
+//  // manager TSMExample to 0.5 MiB.
 //  ROTiledStManAccessor accessor(table, "TSMExample");
 //  accessor.setMaximumCacheSize (512*1024);
 // </srcblock>
@@ -176,16 +176,16 @@ public:
     // Assignment (reference semantics).
     ROTiledStManAccessor& operator= (const ROTiledStManAccessor& that);
 
-    // Set the maximum cache size (in bytes) to be used by a hypercube
+    // Set the maximum cache size (in MibiByte) to be used by a hypercube
     // in the storage manager. Note that each hypercube has its own cache.
     // 0 means unlimited.
     // The initial maximum cache size is unlimited.
     // The maximum cache size given in this way is not persistent.
     // Only the maximum cache size given to the constructors of the tiled
     // storage managers, is persistent.
-    void setMaximumCacheSize (uInt nbytes);
+    void setMaximumCacheSize (uInt nMiB);
 
-    // Get the maximum cache size (in bytes).
+    // Get the maximum cache size (in MiB).
     uInt maximumCacheSize() const;
 
     // Get the current cache size (in buckets) for the hypercube in


### PR DESCRIPTION
The calculation of the TSM cache size has been improved by avoiding a 32-bit overflow problem.
The cache size is now specified in MiB instead of bytes.
Also the maximum memory limit is always checked to avoid using too much memory.

Close #822