### PR TITLE
Improved nonDegenerate testing in Matrix and Cube

### DIFF
--- a/casa/Arrays/Cube.tcc
+++ b/casa/Arrays/Cube.tcc
@@ -276,7 +276,7 @@ void Cube<T>::doNonDegenerate (const Array<T> &other,
 {
     Array<T> tmp(*this);
     tmp.nonDegenerate (other, ignoreAxes);
-    if (tmp.ndim() != 1) {
+    if (tmp.ndim() != 3) {
 	throw (ArrayError ("Cube::nonDegenerate (other, ignoreAxes) - "
 			   "removing degenerate axes from other "
 			   "does not result in cube"));

--- a/casa/Arrays/Matrix.tcc
+++ b/casa/Arrays/Matrix.tcc
@@ -363,7 +363,7 @@ void Matrix<T>::doNonDegenerate (const Array<T> &other,
 {
     Array<T> tmp(*this);
     tmp.nonDegenerate (other, ignoreAxes);
-    if (tmp.ndim() != 1) {
+    if (tmp.ndim() != 2) {
 	throw (ArrayError ("Matrix::nonDegenerate (other, ignoreAxes) - "
 			   "removing degenerate axes from other "
 			   "does not result in matrix"));

--- a/casa/Arrays/test/tArray.cc
+++ b/casa/Arrays/test/tArray.cc
@@ -1446,6 +1446,29 @@ int main()
 	  AlwaysAssertExit(a4.shape() == IPosition(3,1,2,3));
 	  AlwaysAssertExit(a4(IPosition(3,0,0,0)) == 0);
 	  AlwaysAssertExit(a4(IPosition(3,0,1,2)) == 99);
+          // Test if a non-degerate Cube throws an exception.
+          Bool caught = False;
+          Cube<Int> c1(IPosition(3,1,2,3));
+          Cube<Int> cr;
+          try {
+            cr.nonDegenerate(c1);
+          } catch (const std::exception&) {
+            caught = True;
+          }
+          AlwaysAssertExit (caught);
+          cr.nonDegenerate(c1, 1);
+          AlwaysAssertExit (cr.shape() == IPosition(3,1,2,3));
+          // Test if a non-degerate Matrix throws an exception.
+          Matrix<Int> m1(IPosition(2,1,2));
+          Matrix<Int> mr;
+          try {
+            mr.nonDegenerate(m1);
+          } catch (const std::exception&) {
+            caught = True;
+          }
+          AlwaysAssertExit (caught);
+          mr.nonDegenerate(m1, 1);
+          AlwaysAssertExit (mr.shape() == IPosition(2,1,2));
  	}
   	{
  	  // Test the addDegenerate() function


### PR DESCRIPTION
Matrix::doNonDegenerate tested on ndim==1 instead of 2. It appeared that the same error was made in Cube::doNonDegenerate.
Both has been fixed and a test has been added for them.

Close #852