### PR TITLE
Correct method name in error messages

### DIFF
--- a/tables/DataMan/StManColumn.cc
+++ b/tables/DataMan/StManColumn.cc
@@ -858,11 +858,8 @@ void StManColumn::putColumnSliceCellsV (const RefRows& rownrs,
 }
 
 
-void StManColumn::throwGetArray() const
-    { throw (DataManInvOper ("StManColumn::getArray not possible"
-                             " for column " + columnName())); }
-void StManColumn::throwPutArray() const
-    { throw (DataManInvOper ("StManColumn::putArray not possible"
+void StManColumn::throwInvalidOp(const String &op) const
+    { throw (DataManInvOper ("StManColumn::" + op + " not possible"
                              " for column " + columnName())); }
 
 
@@ -910,21 +907,21 @@ void StManColumn::aips_name2(putBlock,NM) \
     } \
 } \
 void StManColumn::aips_name2(getArray,NM) (uInt, Array<T>*) \
-    { throwGetArray(); } \
+    { throwInvalidOp("getArray" #NM); } \
 void StManColumn::aips_name2(putArray,NM) (uInt, const Array<T>*) \
-    { throwPutArray(); } \
+    { throwInvalidOp("putArray" #NM); } \
 void StManColumn::aips_name2(getSlice,NM) (uInt, const Slicer&, Array<T>*) \
-    { throwGetArray(); } \
+    { throwInvalidOp("getSlice" #NM); } \
 void StManColumn::aips_name2(putSlice,NM) (uInt, const Slicer&, const Array<T>*) \
-    { throwPutArray(); } \
+    { throwInvalidOp("putSlice" #NM); } \
 void StManColumn::aips_name2(getArrayColumn,NM) (Array<T>*) \
-    { throwGetArray(); } \
+    { throwInvalidOp("getArrayColumn" #NM); } \
 void StManColumn::aips_name2(putArrayColumn,NM) (const Array<T>*) \
-    { throwPutArray(); } \
+    { throwInvalidOp("putArrayColumn" #NM); } \
 void StManColumn::aips_name2(getColumnSlice,NM) (const Slicer&, Array<T>*) \
-    { throwGetArray(); } \
+    { throwInvalidOp("getColumnSlice" #NM); } \
 void StManColumn::aips_name2(putColumnSlice,NM) (const Slicer&, const Array<T>*) \
-    { throwPutArray(); } \
+    { throwInvalidOp("putColumnSlice" #NM); } \
 void StManColumn::aips_name2(getScalarColumnCells,NM) \
                                              (const RefRows& rownrs, \
 					      Vector<T>* values) \

--- a/tables/DataMan/StManColumn.h
+++ b/tables/DataMan/StManColumn.h
@@ -287,12 +287,7 @@ private:
 
     // Throw an "invalid operation" exception for the default
     // implementation of getArray.
-    void throwGetArray() const;
-
-    // Throw an "invalid operation" exception for the default
-    // implementation of putArray.
-    void throwPutArray() const;
-
+    void throwInvalidOp(const String &op) const;
 
 protected:
     // Get the scalar values in the entire column.


### PR DESCRIPTION
Today while playing with the Adios2StMan I was surprised to see a
reference to putArray in my error messages, as I was actually juggling
with the putSlice* methods. I dug a bit and realized that the error
message was misleading. This patch fixes that, giving the correct method
name in the error message.