### PR TITLE
Further Adios2StMan fixes

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -27,6 +27,7 @@
 
 #include "Adios2StManColumn.h"
 #include <casacore/casa/Containers/Record.h>
+#include <casacore/tables/DataMan/DataManError.h>
 
 namespace casacore
 {
@@ -255,6 +256,8 @@ DataManagerColumn *Adios2StMan::makeColumnCommon(const String &name,
         case TpArrayString:
             aColumn = new Adios2StManColumnT<std::string>(this, aDataType, name, itsAdiosIO);
             break;
+        default:
+            throw (DataManInvDT (name));
     }
     itsColumnPtrBlk[ncolumn()] = aColumn;
     return aColumn;

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -28,7 +28,13 @@
 #ifndef ADIOS2STMAN_H
 #define ADIOS2STMAN_H
 
-#include <adios2.h>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+
 #include <casacore/casa/IO/AipsIO.h>
 #include <casacore/tables/DataMan/DataManager.h>
 #include <casacore/tables/Tables/Table.h>
@@ -36,10 +42,10 @@
 namespace casacore
 {
 
-class Adios2StManColumn;
-
 class Adios2StMan : public DataManager
 {
+    friend class Adios2StManColumn;
+    template<typename T> friend class Adios2StManColumnT;
 public:
     Adios2StMan(MPI_Comm mpiComm = MPI_COMM_WORLD);
     Adios2StMan(MPI_Comm mpiComm, std::string engineType,
@@ -52,11 +58,9 @@ public:
     virtual String dataManagerType() const;
     virtual String dataManagerName() const;
     virtual void create(uInt aNrRows);
-    virtual void open(uInt aRowNr, AipsIO &);
+    virtual void open(uInt aRowNr, AipsIO &ios);
     virtual void resync(uInt aRowNr);
     virtual Bool flush(AipsIO &, Bool doFsync);
-    DataManagerColumn *makeColumnCommon(const String &aName, int aDataType,
-                                        const String &aDataTypeID);
     virtual DataManagerColumn *makeScalarColumn(const String &aName,
                                                 int aDataType,
                                                 const String &aDataTypeID);
@@ -73,23 +77,8 @@ public:
     uInt getNrRows();
 
 private:
-    String itsDataManName = "Adios2StMan";
-    uInt itsRows;
-    int itsStManColumnType;
-    PtrBlock<Adios2StManColumn *> itsColumnPtrBlk;
-
-    std::shared_ptr<adios2::ADIOS> itsAdios;
-    std::shared_ptr<adios2::IO> itsAdiosIO;
-    std::shared_ptr<adios2::Engine> itsAdiosEngine;
-
-    char itsOpenMode;
-
-    static std::string itsAdiosEngineType;
-    static adios2::Params itsAdiosEngineParams;
-    static std::vector<adios2::Params> itsAdiosTransportParamsVec;
-
-    static MPI_Comm itsMpiComm;
-
+	 class impl;
+	 std::unique_ptr<impl> pimpl;
 }; // end of class Adios2StMan
 
 extern "C" void register_adios2stman();

--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -97,6 +97,34 @@ void Adios2StManColumn::setShape (uInt aRowNr, const IPosition& aShape)
     itsCasaShapes[aRowNr] = aShape;
 }
 
+void Adios2StManColumn::scalarVToSelection(uInt rownr)
+{
+    itsAdiosStart[0] = rownr;
+    itsAdiosCount[0] = 1;
+}
+
+void Adios2StManColumn::arrayVToSelection(uInt rownr)
+{
+    itsAdiosStart[0] = rownr;
+    itsAdiosCount[0] = 1;
+    for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+    {
+        itsAdiosStart[i] = 0;
+        itsAdiosCount[i] = itsAdiosShape[i];
+    }
+}
+
+void Adios2StManColumn::sliceVToSelection(uInt rownr, const Slicer &ns)
+{
+    itsAdiosStart[0] = rownr;
+    itsAdiosCount[0] = 1;
+    for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+    {
+        itsAdiosStart[i] = ns.start()(ns.ndim() - i);
+        itsAdiosCount[i] = ns.length()(ns.ndim() - i);
+    }
+}
+
 void Adios2StManColumn::putBoolV(uInt rownr, const Bool *dataPtr)
 {
     putScalarV(rownr, dataPtr);

--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -31,7 +31,7 @@ namespace casacore
 {
 
 Adios2StManColumn::Adios2StManColumn(
-        Adios2StMan *aParent,
+        Adios2StMan::impl *aParent,
         int aDataType,
         String aColName,
         std::shared_ptr<adios2::IO> aAdiosIO)

--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -138,6 +138,30 @@ void Adios2StManColumn::putDComplexV(uInt rownr, const DComplex *dataPtr)
     putScalarV(rownr, dataPtr);
 }
 
+#define DEFINE_GETPUTSLICE(T) \
+void Adios2StManColumn::putSlice ## T ## V(uInt rownr, const Slicer& ns, const Array<T>* dataPtr) \
+{ \
+    putSliceV(rownr, ns, dataPtr); \
+}\
+\
+void Adios2StManColumn::getSlice ## T ## V(uInt rownr, const Slicer& ns, Array<T>* dataPtr) \
+{ \
+    getSliceV(rownr, ns, dataPtr); \
+}
+
+DEFINE_GETPUTSLICE(Bool)
+DEFINE_GETPUTSLICE(uChar)
+DEFINE_GETPUTSLICE(Short)
+DEFINE_GETPUTSLICE(uShort)
+DEFINE_GETPUTSLICE(Int)
+DEFINE_GETPUTSLICE(uInt)
+DEFINE_GETPUTSLICE(float)
+DEFINE_GETPUTSLICE(double)
+DEFINE_GETPUTSLICE(Complex)
+DEFINE_GETPUTSLICE(DComplex)
+DEFINE_GETPUTSLICE(String)
+#undef DEFINE_PUTSLICE
+
 void Adios2StManColumn::getBoolV(uInt rownr, Bool *dataPtr)
 {
     getScalarV(rownr, dataPtr);
@@ -242,5 +266,18 @@ void Adios2StManColumnT<std::string>::getArrayV(uInt rownr, void *dataPtr)
     }
     reinterpret_cast<Array<String>*>(dataPtr)->putStorage(reinterpret_cast<String *&>(data), deleteIt);
 }
+
+template<>
+void Adios2StManColumnT<std::string>::getSliceV(uInt /*aRowNr*/, const Slicer &/*ns*/, void */*dataPtr*/)
+{
+    throw std::runtime_error("Not implemented yet");
+}
+
+template<>
+void Adios2StManColumnT<std::string>::putSliceV(uInt /*aRowNr*/, const Slicer &/*ns*/, const void */*dataPtr*/)
+{
+    throw std::runtime_error("Not implemented yet");
+}
+
 
 } // namespace casacore

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -186,6 +186,7 @@ public:
     virtual void putScalarV(uInt rownr, const void *dataPtr)
     {
         itsAdiosStart[0] = rownr;
+        itsAdiosCount[0] = 1;
         toAdios(reinterpret_cast<const T *>(dataPtr));
     }
 

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -28,12 +28,13 @@
 #ifndef ADIOS2STMANCOLUMN_H
 #define ADIOS2STMANCOLUMN_H
 
-#include "Adios2StMan.h"
-
 #include <unordered_map>
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/tables/DataMan/StManColumn.h>
 #include <casacore/tables/Tables/RefRows.h>
+
+#include "Adios2StManImpl.h"
+
 
 namespace casacore
 {
@@ -41,7 +42,7 @@ namespace casacore
 class Adios2StManColumn : public StManColumn
 {
 public:
-    Adios2StManColumn(Adios2StMan *aParent, int aDataType, String aColName, std::shared_ptr<adios2::IO> aAdiosIO);
+    Adios2StManColumn(Adios2StMan::impl *aParent, int aDataType, String aColName, std::shared_ptr<adios2::IO> aAdiosIO);
 
     virtual Bool canAccessSlice (Bool& reask) const { reask = false; return true; };
 
@@ -112,7 +113,7 @@ protected:
     void getArrayWrapper(uint64_t rowStart, uint64_t nrRows, const Slicer &ns,
                          void *dataPtr);
 
-    Adios2StMan *itsStManPtr;
+    Adios2StMan::impl *itsStManPtr;
 
     String itsColumnName;
     IPosition itsCasaShape;
@@ -135,7 +136,7 @@ class Adios2StManColumnT : public Adios2StManColumn
 public:
 
     Adios2StManColumnT(
-            Adios2StMan *aParent,
+            Adios2StMan::impl *aParent,
             int aDataType,
             String aColName,
             std::shared_ptr<adios2::IO> aAdiosIO)

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -110,8 +110,9 @@ public:
 
 
 protected:
-    void getArrayWrapper(uint64_t rowStart, uint64_t nrRows, const Slicer &ns,
-                         void *dataPtr);
+    void scalarVToSelection(uInt rownr);
+    void arrayVToSelection(uInt rownr);
+    void sliceVToSelection(uInt rownr, const Slicer &ns);
 
     Adios2StMan::impl *itsStManPtr;
 
@@ -161,39 +162,25 @@ public:
 
     virtual void putArrayV(uInt rownr, const void *dataPtr)
     {
-        itsAdiosStart[0] = rownr;
-        itsAdiosCount[0] = 1;
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = 0;
-            itsAdiosCount[i] = itsAdiosShape[i];
-        }
+        arrayVToSelection(rownr);
         toAdios(dataPtr);
     }
 
     virtual void getArrayV(uInt rownr, void *dataPtr)
     {
-        itsAdiosStart[0] = rownr;
-        itsAdiosCount[0] = 1;
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = 0;
-            itsAdiosCount[i] = itsAdiosShape[i];
-        }
+        arrayVToSelection(rownr);
         fromAdios(dataPtr);
     }
 
     virtual void putScalarV(uInt rownr, const void *dataPtr)
     {
-        itsAdiosStart[0] = rownr;
-        itsAdiosCount[0] = 1;
+        scalarVToSelection(rownr);
         toAdios(reinterpret_cast<const T *>(dataPtr));
     }
 
     virtual void getScalarV(uInt aRowNr, void *data)
     {
-        itsAdiosStart[0] = aRowNr;
-        itsAdiosCount[0] = 1;
+        scalarVToSelection(aRowNr);
         fromAdios(reinterpret_cast<T *>(data));
     }
 
@@ -245,25 +232,13 @@ public:
 
     virtual void getSliceV(uInt aRowNr, const Slicer &ns, void *dataPtr)
     {
-        itsAdiosStart[0] = aRowNr;
-        itsAdiosCount[0] = 1;
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = ns.start()(ns.ndim() - i);
-            itsAdiosCount[i] = ns.length()(ns.ndim() - i);
-        }
+        sliceVToSelection(aRowNr, ns);
         fromAdios(dataPtr);
     }
 
     virtual void putSliceV(uInt aRowNr, const Slicer &ns, const void *dataPtr)
     {
-        itsAdiosStart[0] = aRowNr;
-        itsAdiosCount[0] = 1;
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = ns.start()(ns.ndim() - i);
-            itsAdiosCount[i] = ns.length()(ns.ndim() - i);
-        }
+        sliceVToSelection(aRowNr, ns);
         toAdios(dataPtr);
     }
 

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -1,0 +1,100 @@
+//# Adios2StManImpl.h: Implementation class definition of the ADIOS2 Storage Manager
+//
+//# ICRAR - International Centre for Radio Astronomy Research
+//# (c) UWA - The University of Western Australia, 2018
+//# Copyright by UWA (in the framework of the ICRAR)
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusettes Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+
+#ifndef ADIOS2STMANIMPL_H
+#define ADIOS2STMANIMPL_H
+
+#include <adios2.h>
+
+#include "Adios2StMan.h"
+
+namespace casacore
+{
+
+class Adios2StManColumn;
+
+class Adios2StMan::impl
+{
+public:
+    impl(Adios2StMan &parent, MPI_Comm mpiComm = MPI_COMM_WORLD);
+    impl(Adios2StMan &parent, MPI_Comm mpiComm, std::string engineType,
+            std::map<std::string, std::string> engineParams,
+            std::vector<std::map<std::string, std::string>> transportParams);
+
+    ~impl();
+
+    DataManager *clone() const;
+    String dataManagerType() const;
+    String dataManagerName() const;
+    void create(uInt aNrRows);
+    void open(uInt aRowNr, AipsIO &ios);
+    void resync(uInt aRowNr);
+    Bool flush(AipsIO &ios, Bool doFsync);
+    DataManagerColumn *makeColumnCommon(const String &aName, int aDataType,
+                                        const String &aDataTypeID);
+    DataManagerColumn *makeScalarColumn(const String &aName,
+                                        int aDataType,
+                                        const String &aDataTypeID);
+    DataManagerColumn *makeDirArrColumn(const String &aName,
+                                        int aDataType,
+                                        const String &aDataTypeID);
+    DataManagerColumn *makeIndArrColumn(const String &aName,
+                                        int aDataType,
+                                        const String &aDataTypeID);
+    void deleteManager();
+    void addRow(uInt aNrRows);
+    static DataManager *makeObject(const String &aDataManType,
+                                   const Record &spec);
+    uInt getNrRows();
+
+private:
+    Adios2StMan &parent;
+    String itsDataManName = "Adios2StMan";
+    uInt itsRows;
+    int itsStManColumnType;
+    PtrBlock<Adios2StManColumn *> itsColumnPtrBlk;
+
+    std::shared_ptr<adios2::ADIOS> itsAdios;
+    std::shared_ptr<adios2::IO> itsAdiosIO;
+    std::shared_ptr<adios2::Engine> itsAdiosEngine;
+
+    char itsOpenMode;
+
+    static std::string itsAdiosEngineType;
+    static adios2::Params itsAdiosEngineParams;
+    static std::vector<adios2::Params> itsAdiosTransportParamsVec;
+
+    static MPI_Comm itsMpiComm;
+
+    uInt ncolumn() const { return parent.ncolumn(); }
+    String fileName() const { return parent.fileName(); }
+};
+
+} // namespace casacore
+
+#endif // ADIOS2STMANIMPL_H

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -25,6 +25,9 @@
 //#
 //# $Id$
 
+#include <thread>
+#include <utility>
+
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseTable.h>
 #include <casacore/tables/Tables/Table.h>
@@ -170,35 +173,68 @@ void BaseTable::scratchCallback (Bool isScratch, const String& oldName) const
     }
 }
 
+#ifdef HAVE_MPI
+template <typename Func, typename ... Args>
+void safe_mpi_invoke(Func &&mpi_func, const char *errmsg, Args && ... args)
+{
+    if (mpi_func(std::forward<Args>(args)...)) {
+        throw std::runtime_error(errmsg);
+    }
+}
+
+static bool is_mpi_initialized()
+{
+    int mpi_initialized;
+    safe_mpi_invoke(MPI_Initialized, "Error when checking for initialized MPI", &mpi_initialized);
+    return mpi_initialized != 0;
+}
+
+static bool is_mpi_finalized()
+{
+    int mpi_finalized;
+    safe_mpi_invoke(MPI_Finalized, "Error when checking for finalized MPI", &mpi_finalized);
+    return mpi_finalized != 0;
+}
+
+static std::once_flag ensure_mpi_flag;
+
+static void ensure_mpi()
+{
+    std::call_once(ensure_mpi_flag, [&]{
+        if (is_mpi_initialized() || is_mpi_finalized()) {
+            return;
+        }
+#ifdef USE_THREADS
+       int provided;
+       safe_mpi_invoke(MPI_Init_thread, "Error when initializing MPI", nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+       // Checking if provided == MPI_THREAD_MULTIPLE is not necessarily
+       // the best option. Down here we have no idea how users are intending
+       // to use these objects, and therefore throwing an exception is not
+       // correct. For instance, with OpenMPI @ Ubuntu 16.04.05 lots
+       // of unit tests fail.
+#else
+       safe_mpi_invoke(MPI_Init, "Error when initializing MPI", nullptr, nullptr);
+#endif // USE_THREADS
+    });
+}
+
+static bool is_rank_0(MPI_Comm comm)
+{
+    ensure_mpi();
+    if (is_mpi_finalized()) {
+        return false;
+    }
+    int rank;
+    safe_mpi_invoke(MPI_Comm_rank, "Error when getting MPI rank", comm, &rank);
+    return rank == 0;
+}
+#endif // HAVE_MPI
 
 Bool BaseTable::makeTableDir()
 {
 #ifdef HAVE_MPI
-    int mpi_finalized;
-    MPI_Finalized(&mpi_finalized);
-    if(!mpi_finalized)
-    {
-        int mpi_initialized;
-        MPI_Initialized(&mpi_initialized);
-        if(!mpi_initialized){
-#ifdef USE_THREADS
-            int provided;
-            MPI_Init_thread(0,0,MPI_THREAD_MULTIPLE, &provided);
-            if(provided != MPI_THREAD_MULTIPLE)
-            {
-                throw(std::runtime_error(
-                            "Casacore is built with thread and MPI enabled, \
-                            but the MPI installation does not support threads"));
-            }
-#else
-            MPI_Init(0,0);
-#endif
-        }
-        int rank = 0;
-        MPI_Comm_rank(itsMpiComm, &rank);
-        if(rank > 0){
-            return false;
-        }
+    if (!is_rank_0(itsMpiComm)) {
+        return false;
     }
 #endif
     //# Exit if the table directory has already been created.
@@ -258,31 +294,8 @@ Bool BaseTable::makeTableDir()
 Bool BaseTable::openedForWrite() const
 {
 #ifdef HAVE_MPI
-    int mpi_finalized;
-    MPI_Finalized(&mpi_finalized);
-    if(!mpi_finalized)
-    {
-        int mpi_initialized;
-        MPI_Initialized(&mpi_initialized);
-        if(!mpi_initialized){
-#ifdef USE_THREADS
-            int provided;
-            MPI_Init_thread(0,0,MPI_THREAD_MULTIPLE, &provided);
-            if(provided != MPI_THREAD_MULTIPLE)
-            {
-                throw(std::runtime_error(
-                            "Casacore is built with thread and MPI enabled, \
-                            but the MPI installation does not support threads"));
-            }
-#else
-            MPI_Init(0,0);
-#endif
-        }
-        int rank = 0;
-        MPI_Comm_rank(itsMpiComm, &rank);
-        if(rank > 0){
-            return false;
-        }
+    if (!is_rank_0(itsMpiComm)) {
+        return false;
     }
 #endif
     AlwaysAssert (!isNull(), AipsError);


### PR DESCRIPTION
After playing with the Adios2StMan for a while now, including using it within the [OSKAR](https://github.com/OxfordSKA/OSKAR) simulator to write measurement sets, we have come up with the following set of fixes and improvements for it. They include:

 * Adding `getSlice`/`setSlice` support
 * Avoiding code duplication in the `Adios2StMan` and `Adios2StManColumn` classes
 * Implemented `Adios2StMan` using a pimpl idiom to avoid passing on ADIOS-specific dependencies to users
 * Improved the MPI checks on the `BaseTable` class, including error checking, code centralization and serialization of the initial MPI checks.

I've run these changes through @JasonRuonanWang already and he thinks they seem fine.