### PR TITLE
python-casacore getcol gives incorrect result

### DIFF
--- a/python/Converters/PycArrayComCC.h
+++ b/python/Converters/PycArrayComCC.h
@@ -142,27 +142,27 @@
 
 
   template <typename T>
-  void ArrayCopy<T>::toPy (void* to, const T* from, uInt nr)
+  void ArrayCopy<T>::toPy (void* to, const T* from, size_t nr)
   {
     if (sizeof(T) == sizeof(typename TypeConvTraits<T>::python_type)) {
       ::memcpy (to, from, nr*sizeof(T));
     } else {
       typename TypeConvTraits<T>::python_type* dst =
 	static_cast<typename TypeConvTraits<T>::python_type*>(to);
-      for (uInt i=0; i<nr; i++) {
+      for (size_t i=0; i<nr; i++) {
 	dst[i] = from[i];
       }
     }
   }
   template <typename T>
-  void  ArrayCopy<T>::fromPy (T* to, const void* from, uInt nr)
+  void  ArrayCopy<T>::fromPy (T* to, const void* from, size_t nr)
   {
     if (sizeof(T) == sizeof(typename TypeConvTraits<T>::python_type)) {
       ::memcpy (to, from, nr*sizeof(T));
     } else {
       const typename TypeConvTraits<T>::python_type* src =
 	static_cast<const typename TypeConvTraits<T>::python_type*>(from);
-      for (uInt i=0; i<nr; i++) {
+      for (size_t i=0; i<nr; i++) {
 	to[i] = src[i];
       }
     }
@@ -187,14 +187,14 @@
   }
 
 
-  void ArrayCopy<Complex>::toPy (void* to, const Complex* from, uInt nr)
+  void ArrayCopy<Complex>::toPy (void* to, const Complex* from, size_t nr)
   {
     if (sizeof(Complex) != sizeof(TypeConvTraits<Complex>::python_type)) {
       throw AipsError("PycArray: size of Complex data type mismatches");
     }
     ::memcpy (to, from, nr*sizeof(Complex));
   }
-  void ArrayCopy<Complex>::fromPy (Complex* to, const void* from, uInt nr)
+  void ArrayCopy<Complex>::fromPy (Complex* to, const void* from, size_t nr)
   {
     if (sizeof(Complex) != sizeof(TypeConvTraits<Complex>::python_type)) {
       throw AipsError("PycArray: size of Complex data type mismatches");
@@ -215,14 +215,14 @@
   }
 
 
-  void ArrayCopy<DComplex>::toPy (void* to, const DComplex* from, uInt nr)
+  void ArrayCopy<DComplex>::toPy (void* to, const DComplex* from, size_t nr)
   {
     if (sizeof(DComplex) != sizeof(TypeConvTraits<DComplex>::python_type)) {
       throw AipsError("PycArray: size of DComplex data type mismatches");
     }
     ::memcpy (to, from, nr*sizeof(DComplex));
   }
-  void ArrayCopy<DComplex>::fromPy (DComplex* to, const void* from, uInt nr)
+  void ArrayCopy<DComplex>::fromPy (DComplex* to, const void* from, size_t nr)
   {
     if (sizeof(DComplex) != sizeof(TypeConvTraits<DComplex>::python_type)) {
       throw AipsError("PycArray: size of DComplex data type mismatches");
@@ -243,10 +243,10 @@
   }
 
 
-  void ArrayCopy<String>::toPy (void* to, const String* from, uInt nr)
+  void ArrayCopy<String>::toPy (void* to, const String* from, size_t nr)
   {
     PyObject** dst = static_cast<PyObject**>(to);
-    for (uInt i=0; i<nr; i++) {
+    for (size_t i=0; i<nr; i++) {
 #ifdef IS_PY3K
       dst[i] = PyUnicode_FromString(from[i].chars());
 #else
@@ -254,11 +254,11 @@
 #endif
     }
   }
-  void ArrayCopy<String>::fromPy (String* to, const void* from, uInt nr)
+  void ArrayCopy<String>::fromPy (String* to, const void* from, size_t nr)
   {
     using namespace boost::python;
     PyObject** src = (PyObject**)from;
-    for (uInt i=0; i<nr; i++) {
+    for (size_t i=0; i<nr; i++) {
       handle<> py_elem_hdl(src[i]);
       object py_elem_obj(py_elem_hdl);
       extract<std::string> elem_proxy(py_elem_obj);
@@ -358,7 +358,7 @@
 	convertArray (res, *uarr);
 	return ValueHolder(res);
       } else if (PyArray_TYPE(po) == NPY_STRING) {
-	int slen = 0;
+	size_t slen = 0;
 	if (nd > 0) {
 	  slen = PyArray_STRIDES(po)[nd-1];
 	}

--- a/python/Converters/PycArrayComH.h
+++ b/python/Converters/PycArrayComH.h
@@ -47,39 +47,39 @@
   // <group>
   template <typename T> struct ArrayCopy
   {
-    static void toPy (void* to, const T* from, uInt nr);
-    static void fromPy (T* to, const void* from, uInt nr);
+    static void toPy (void* to, const T* from, size_t nr);
+    static void fromPy (T* to, const void* from, size_t nr);
     static Array<T> toArray (const IPosition& shape,
 			     void* data, bool copy);
   };
 
   template <> struct ArrayCopy<Complex>
   {
-    static void toPy (void* to, const Complex* from, uInt nr);
-    static void fromPy (Complex* to, const void* from, uInt nr);
+    static void toPy (void* to, const Complex* from, size_t nr);
+    static void fromPy (Complex* to, const void* from, size_t nr);
     static Array<Complex> toArray (const IPosition& shape,
 				   void* data, bool copy);
   };
 
   template <> struct ArrayCopy<DComplex>
   {
-    static void toPy (void* to, const DComplex* from, uInt nr);
-    static void fromPy (DComplex* to, const void* from, uInt nr);
+    static void toPy (void* to, const DComplex* from, size_t nr);
+    static void fromPy (DComplex* to, const void* from, size_t nr);
     static Array<DComplex> toArray (const IPosition& shape,
 				    void* data, bool copy);
   };
 
   template <> struct ArrayCopy<String>
   {
-    static void toPy (void* to, const String* from, uInt nr);
-    static void fromPy (String* to, const void* from, uInt nr);
+    static void toPy (void* to, const String* from, size_t nr);
+    static void fromPy (String* to, const void* from, size_t nr);
     static Array<String> toArray (const IPosition& shape,
 				  void* data, bool copy);
   };
   // </group>
 
   Array<String> ArrayCopyStr_toArray (const IPosition& shape,
-				      void* data, uInt slen);
+				      void* data, size_t slen);
 
   // Convert a Casacore array to a Python array object.
   template <typename T>

--- a/python/Converters/PycArrayNP.cc
+++ b/python/Converters/PycArrayNP.cc
@@ -47,7 +47,7 @@ namespace casacore { namespace python { namespace numpy {
   }
 
   Array<String> ArrayCopyStr_toArray (const IPosition& shape,
-				      void* data, uInt slen)
+				      void* data, size_t slen)
   {
     // This code converts from a numpy String array.
     // The longest string determines the length of each value.
@@ -55,8 +55,8 @@ namespace casacore { namespace python { namespace numpy {
     Array<String> arr(shape);
     String* to = arr.data();
     const char* src = static_cast<const char*>(data);
-    uInt nr = arr.size();
-    for (uInt i=0; i<nr; ++i) {
+    size_t nr = arr.size();
+    for (size_t i=0; i<nr; ++i) {
       if (src[slen-1] == 0) {
 	to[i] = String(src);
       } else {


### PR DESCRIPTION
Reading a very large column (> 32 GB) gives incorrect results.
It appeared that the C++-Python conversion used uInt instead of size_t, which had the effect that only (size modulo 2**32) was handled. This has been fixed.
