### PR TITLE
Made static initialisation of Unit and MS more robust

### DIFF
--- a/casa/Quanta/UnitMap2.cc
+++ b/casa/Quanta/UnitMap2.cc
@@ -32,46 +32,47 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Initialise the maps
-void UnitMap::initUMPrefix() {
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+void UnitMap::initUMPrefix (UMaps& maps) {
+  map<String, UnitName>& mapPref = maps.mapPref;
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("Y", UnitName("Y", C::yotta, "yotta")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("Z", UnitName("Z", C::zetta, "zetta")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("E", UnitName("E", C::exa,   "exa")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("P", UnitName("P", C::peta,  "peta")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("T", UnitName("T", C::tera,  "tera")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("G", UnitName("G", C::giga,  "giga")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("M", UnitName("M", C::mega,  "mega")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("k", UnitName("k", C::kilo,  "kilo")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("h", UnitName("h", C::hecto, "hecto")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("da",UnitName("da",C::deka,  "deka")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("d", UnitName("d", C::deci,  "deci")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("c", UnitName("c", C::centi, "centi")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("m", UnitName("m", C::milli, "milli")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("u", UnitName("u", C::micro, "micro")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("n", UnitName("n", C::nano,  "nano")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("p", UnitName("p", C::pico,  "pico")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("f", UnitName("f", C::femto, "femto")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("a", UnitName("a", C::atto,  "atto")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("z", UnitName("z", C::zepto, "zepto")));
-  UnitMap::mapPref->insert(map<String, UnitName>::value_type
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("y", UnitName("y", C::yocto, "yocto")));
 }
 

--- a/casa/Quanta/UnitMap3.cc
+++ b/casa/Quanta/UnitMap3.cc
@@ -34,111 +34,113 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //# constants
 
 // Initialise the maps
-void UnitMap::initUMSI1() {
+void UnitMap::initUMSI1(UMaps& maps) {
+  map<String, UnitName>& mapDef = maps.mapDef;
+  map<String, UnitName>& mapSI  = maps.mapSI;
   for (Int i=0; i<UnitDim::Dnumber; i++) {
-    UnitMap::mapDef->insert(map<String, UnitName>::value_type
+    mapDef.insert(map<String, UnitName>::value_type
 			    (UnitDim::dimName(i),
 			     UnitName(UnitDim::dimName(i),
-				      UnitVal(1.0,i),
+				      UnitVal(1.0, i),
 				      UnitDim::dimFull(i))));
     
     // SI units
     if (i != UnitDim::Dkg) {
-      UnitMap::mapSI->insert(map<String, UnitName>::value_type
+      mapSI.insert(map<String, UnitName>::value_type
 			     (UnitDim::dimName(i),
 			      UnitName(UnitDim::dimName(i),
-				       UnitVal(1.0,i),
+				       UnitVal(1.0, i),
 				       UnitDim::dimFull(i))));
     }
   }
   
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("$",	UnitName("$",
-					 UnitVal(1.,UnitDim::Dnon),
+					 UnitVal(1., UnitDim::Dnon),
 					 "currency")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("%",	UnitName("%",
 					 UnitVal(0.01),
 					 "percent")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("%%",	UnitName("%%",
 					 UnitVal(0.001),
 					 "permille")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("g",	UnitName("g",
-					 UnitVal(0.001,UnitDim::Dkg),
+					 UnitVal(0.001, UnitDim::Dkg),
 					 "gram")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Bq",  UnitName("Bq",
-					  UnitVal(1.,"s-1"),
+					  UnitVal(1., "s-1", &maps),
 					  "becquerel")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Hz",  UnitName("Hz",
-					  UnitVal(1.,"s-1"),
+					  UnitVal(1., "s-1", &maps),
 					  "hertz")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("C",   UnitName("C",
-					  UnitVal(1.,"A.s"),
+					  UnitVal(1.,"A.s", &maps),
 					  "coulomb")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("lm",  UnitName("lm",
-					  UnitVal(1.,"cd.sr"),
+					  UnitVal(1., "cd.sr", &maps),
 					  "lumen")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("N",	UnitName("N",
-					 UnitVal(1.,"kg.m.s-2"),
+					 UnitVal(1., "kg.m.s-2", &maps),
 					 "newton")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("J",   UnitName("J",
-					  UnitVal(1.,"N.m"),
+					  UnitVal(1., "N.m", &maps),
 					  "joule")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("W",   UnitName("W",
-					  UnitVal(1.,"J.s-1"),
+					  UnitVal(1., "J.s-1", &maps),
 					  "watt")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("V",   UnitName("V",
-					  UnitVal(1.,"W.A-1"),
+					  UnitVal(1., "W.A-1", &maps),
 					  "volt")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("F",   UnitName("F",
-					  UnitVal(1.,"C.V-1"),
+					  UnitVal(1., "C.V-1", &maps),
 					  "farad")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Gy",  UnitName("Gy",
-					  UnitVal(1.,"J.kg-1"),
+					  UnitVal(1., "J.kg-1", &maps),
 					  "gray")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("lx",  UnitName("lx",
-					  UnitVal(1.,"lm.m-2"),
+					  UnitVal(1., "lm.m-2", &maps),
 					  "lux")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Ohm", UnitName("Ohm",
-					  UnitVal(1.,"V.A-1"),
+					  UnitVal(1., "V.A-1", &maps),
 					  "ohm")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Pa",  UnitName("Pa",
-					  UnitVal(1.,"N.m-2"),
+					  UnitVal(1., "N.m-2", &maps),
 					  "pascal")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("S",   UnitName("S",
-					  UnitVal(1.,"Ohm-1"),
+					  UnitVal(1., "Ohm-1", &maps),
 					  "siemens")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Sv",  UnitName("Sv",
-					  UnitVal(1.,"J.kg-1"),
+					  UnitVal(1., "J.kg-1", &maps),
 					  "sievert")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Wb",  UnitName("Wb",
-					  UnitVal(1.,"V.s"),
+					  UnitVal(1., "V.s", &maps),
 					  "weber")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("H",   UnitName("H",
-					  UnitVal(1.,"Wb.A-1"),
+					  UnitVal(1., "Wb.A-1", &maps),
 					  "henry")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("T",   UnitName("T",
-					  UnitVal(1.,"Wb.m-2"),
+					  UnitVal(1., "Wb.m-2", &maps),
 					  "tesla")));
 }  
 

--- a/casa/Quanta/UnitMap4.cc
+++ b/casa/Quanta/UnitMap4.cc
@@ -37,86 +37,87 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 static const Double IAU_tauA=499.0047837;	
 
 // Initialise the maps
-void UnitMap::initUMSI2() {
+void UnitMap::initUMSI2 (UMaps& maps) {
+  map<String, UnitName>& mapSI = maps.mapSI;
   // non-metric SI units
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("deg",   	UnitName("deg",
-						 UnitVal(C::degree,"rad"),
+						 UnitVal(C::degree, "rad", &maps),
 						 "degree")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("arcmin",  	UnitName("arcmin",
-						 UnitVal(C::arcmin,"rad"),
+						 UnitVal(C::arcmin, "rad", &maps),
 						 "arcmin")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("arcsec",  	UnitName("arcsec",
-						 UnitVal(C::arcsec,"rad"),
+						 UnitVal(C::arcsec, "rad", &maps),
 						 "arcsec")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("as", 		UnitName("as",
-							 UnitVal(1.,"arcsec"),
+							 UnitVal(1., "arcsec", &maps),
 							 "arcsec")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("L",   	UnitName("L",
-						 UnitVal(1.,"dm3"),
+						 UnitVal(1., "dm3", &maps),
 						 "litre")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("l",   	UnitName("l",
-						 UnitVal(1.,"L"),
+						 UnitVal(1., "L", &maps),
 						 "litre")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("d",   	UnitName("d",
-						 UnitVal(C::day,"s"),
+						 UnitVal(C::day, "s", &maps),
 						 "day")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("h",   	UnitName("h",
-						 UnitVal(C::hour,"s"),
+						 UnitVal(C::hour, "s", &maps),
 						 "hour")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("min",   	UnitName("min",
-						 UnitVal(C::minute,"s"),
+						 UnitVal(C::minute, "s", &maps),
 						 "minute")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("a",   	UnitName("a",
-						 UnitVal(24.*3600.*365.25,"s"),
+						 UnitVal(24.*3600.*365.25, "s", &maps),
 						 "year")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("t",   	UnitName("t",
-						 UnitVal(1000.,"kg"),
+						 UnitVal(1000., "kg", &maps),
 						 "tonne")));
   
   // Astronomical SI units
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("Jy",   	UnitName("Jy",
-						 UnitVal(1.0e-26,"W/m2/Hz"),
+						 UnitVal(1.0e-26, "W/m2/Hz", &maps),
 						 "jansky")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("AU",   	UnitName("AU",
-						 UnitVal(C::c * IAU_tauA,"m"),
+						 UnitVal(C::c * IAU_tauA, "m", &maps),
 						 "astronomical unit")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("UA",   	UnitName("UA",
-						 UnitVal(1.,"AU"),
+						 UnitVal(1., "AU", &maps),
 						 "astronomical unit")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("AE",   	UnitName("AE",
-						 UnitVal(1.,"AU"),
+						 UnitVal(1., "AU", &maps),
 						 "astronomical unit")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("S0",   	UnitName("S0",
 						 UnitVal(IAU_k*IAU_k/6.67259e-11,
-							 "AU3/d2/(m3/kg/s2)"),
+							 "AU3/d2/(m3/kg/s2)", &maps),
 						 "solar mass")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("M0",   	UnitName("M0",
-						 UnitVal(1.,"S0"),
+						 UnitVal(1., "S0", &maps),
 						 "solar mass")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("pc",   	UnitName("pc",
-						 UnitVal(1./C::arcsec,"AU"),
+						 UnitVal(1./C::arcsec, "AU", &maps),
 						 "parsec")));
-  UnitMap::mapSI->insert(map<String, UnitName>::value_type
+  mapSI.insert(map<String, UnitName>::value_type
 			 ("cy",   	UnitName("cy",
-						 UnitVal(24.*3600.*36525,"s"),
+						 UnitVal(24.*3600.*36525, "s", &maps),
 						 "century")));
 }
 

--- a/casa/Quanta/UnitMap5.cc
+++ b/casa/Quanta/UnitMap5.cc
@@ -32,78 +32,79 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Initialise the maps
-void UnitMap::initUMCust1() {
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+void UnitMap::initUMCust1 (UMaps& maps) {
+  map<String, UnitName>& mapCust = maps.mapCust;
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("sq_deg", 	UnitName("sq_deg",
-						 UnitVal(C::square_degree,"sr"),
+						 UnitVal(C::square_degree, "sr", &maps),
 						 "square degree")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("sq_arcmin", UnitName("sq_arcmin",
-						  UnitVal(C::square_arcmin,"sr"),
+						  UnitVal(C::square_arcmin, "sr", &maps),
 						  "square arcmin")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("sq_arcsec", UnitName("sq_arcsec",
-						  UnitVal(C::square_arcsec,"sr"),
+						  UnitVal(C::square_arcsec, "sr", &maps),
 						  "square arcsec")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("deg_2",  	UnitName("deg_2",
-						 UnitVal(C::square_degree,"sr"),
+						 UnitVal(C::square_degree, "sr", &maps),
 						 "square degree")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("arcmin_2",  UnitName("arcmin_2",
-						  UnitVal(C::square_arcmin,"sr"),
+						  UnitVal(C::square_arcmin,"sr", &maps),
 						  "square arcmin")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("arcsec_2",  UnitName("arcsec_2",
-						  UnitVal(C::square_arcsec,"sr"),
+						  UnitVal(C::square_arcsec, "sr", &maps),
 						  "square arcsec")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("'",   	UnitName("'",
-						 UnitVal(C::arcmin,"rad"),
+						 UnitVal(C::arcmin, "rad", &maps),
 						 "arcmin")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("''",   	UnitName("''",
-						 UnitVal(C::arcsec,"rad"),
+						 UnitVal(C::arcsec, "rad", &maps),
 						 "arcsec")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("\"",   	UnitName("\"",
-						 UnitVal(C::arcsec,"rad"),
+						 UnitVal(C::arcsec, "rad", &maps),
 						 "arcsec")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("'_2",  	UnitName("'_2",
-						 UnitVal(C::square_arcmin,"sr"),
+						 UnitVal(C::square_arcmin, "sr", &maps),
 						 "square arcmin")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("''_2",  	UnitName("''_2",
-						 UnitVal(C::square_arcsec,"sr"),
+						 UnitVal(C::square_arcsec, "sr", &maps),
 						 "square arcsec")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("\"_2",  	UnitName("\"_2",
-						 UnitVal(C::square_arcsec,"sr"),
+						 UnitVal(C::square_arcsec, "sr", &maps),
 						 "square arcsec")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   (":",   	UnitName(":",
-						 UnitVal(1.,"h"),
+						 UnitVal(1., "h", &maps),
 						 "hour")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("::",   	UnitName("::",
-						 UnitVal(1.,"min"),
+						 UnitVal(1., "min", &maps),
 						 "minute")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   (":::",   	UnitName(":::",
-						 UnitVal(1.,"s"),
+						 UnitVal(1., "s", &maps),
 						 "second")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("FU",   	UnitName("FU",
-						 UnitVal(1.,"Jy"),
+						 UnitVal(1., "Jy", &maps),
 						 "flux unit")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("fu",   	UnitName("fu",
-						 UnitVal(1.,"FU"),
+						 UnitVal(1., "FU", &maps),
 						 "flux unit")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("WU",   	UnitName("WU",
-						 UnitVal(5.,"mJy"),
+						 UnitVal(5., "mJy", &maps),
 						 "WSRT flux unit")));
 }
 

--- a/casa/Quanta/UnitMap6.cc
+++ b/casa/Quanta/UnitMap6.cc
@@ -32,118 +32,119 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Initialise the maps
-void UnitMap::initUMCust2() {
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+void UnitMap::initUMCust2 (UMaps& maps) {
+  map<String, UnitName>& mapCust = maps.mapCust;
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("abA",   	UnitName("abA",
-						 UnitVal(10.0,"A"),
+						 UnitVal(10.0, "A", &maps),
 						 "abampere")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("abC",   	UnitName("abC",
-						 UnitVal(10.0,"C"),
+						 UnitVal(10.0, "C", &maps),
 						 "abcoulomb")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("abF",   	UnitName("abF",
-						 UnitVal(1.0e+9,"F"),
+						 UnitVal(1.0e+9, "F", &maps),
 						 "abfarad")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("abH",   	UnitName("abH",
-						 UnitVal(1.0e-9,"H"),
+						 UnitVal(1.0e-9, "H", &maps),
 						 "abhenry")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("abOhm", 	UnitName("abOhm",
-						 UnitVal(1.0e-9,"Ohm"),
+						 UnitVal(1.0e-9, "Ohm", &maps),
 						 "abohm")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("abV",   	UnitName("abV",
-						 UnitVal(1.0e-8,"V"),
+						 UnitVal(1.0e-8, "V", &maps),
 						 "abvolt")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("statA", 	UnitName("statA",
-						 UnitVal((0.1/C::c),"A"),
+						 UnitVal((0.1/C::c), "A", &maps),
 						 "statampere")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("statC", 	UnitName("statC",
-						 UnitVal((0.1/C::c),"C"),
+						 UnitVal((0.1/C::c), "C", &maps),
 						 "statcoulomb")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("statF", 	UnitName("statF",
-						 UnitVal(1.0/(3.0e+3*C::c),"F"),
+						 UnitVal(1.0/(3.0e+3*C::c), "F", &maps),
 						 "statfarad")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("statH", 	UnitName("statH",
-						 UnitVal((3.0e+3*C::c),"H"),
+						 UnitVal((3.0e+3*C::c), "H", &maps),
 						 "stathenry")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("statOhm", 	UnitName("statOhm",
-						 UnitVal((3.0e+3*C::c),"Ohm"),
+						 UnitVal((3.0e+3*C::c), "Ohm", &maps),
 						 "statohm")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("statV",   	UnitName("statV",
-						 UnitVal((C::c*1.0e-6),"V"),
+						 UnitVal((C::c*1.0e-6), "V", &maps),
 						 "statvolt")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("debye", UnitName("debye",
-						 UnitVal(10e-18, "statC.cm"),
+						 UnitVal(10e-18, "statC.cm", &maps),
 						 "statvolt")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("ac",   	UnitName("ac",
-						 UnitVal(4.0*40*16.5*12*2.54e-2*16.5*12*2.54e-2,"m2"),
+						 UnitVal(4.0*40*16.5*12*2.54e-2*16.5*12*2.54e-2, "m2", &maps),
 						 "acre")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Ah",   	UnitName("Ah",
-						 UnitVal(1.,"A.h"),
+						 UnitVal(1., "A.h", &maps),
 						 "ampere hour")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Angstrom", 	UnitName("Angstrom",
-							 UnitVal(1.0e-10,"m"),
+							 UnitVal(1.0e-10, "m", &maps),
 							 "angstrom")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("atm",   	UnitName("atm",
-						 UnitVal(1.01325e+5,"Pa"),
+						 UnitVal(1.01325e+5, "Pa", &maps),
 						 "standard atmosphere")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("ata",   	UnitName("ata",
-						 UnitVal(9.80665,"N.cm-2"),
+						 UnitVal(9.80665, "N.cm-2", &maps),
 						 "technical atmosphere")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("u",   	UnitName("u",
-						 UnitVal(1.661e-27,"kg"),
+						 UnitVal(1.661e-27, "kg", &maps),
 						 "atomic mass unit")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("bar",   	UnitName("bar",
-						 UnitVal(1.0e+5,"Pa"),
+						 UnitVal(1.0e+5, "Pa", &maps),
 						 "bar")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Btu",   	UnitName("Btu",
-						 UnitVal(1055.056,"J"),
+						 UnitVal(1055.056, "J", &maps),
 						 "British thermal unit (Int)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("cal",   	UnitName("cal",
-						 UnitVal(4.1868,"J"),
+						 UnitVal(4.1868, "J", &maps),
 						 "calorie (Int)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Cal",   	UnitName("Cal",
-						 UnitVal(1.,"kcal"),
+						 UnitVal(1., "kcal", &maps),
 						 "large calorie (Int)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("CM",   	UnitName("CM",
-						 UnitVal((1e-3/5.0),"kg"),
+						 UnitVal((1e-3/5.0), "kg", &maps),
 						 "metric carat")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("mHg",   	UnitName("mHg",
-						 UnitVal(13.5951*9.80665,"kPa"),
+						 UnitVal(13.5951*9.80665, "kPa", &maps),
 						 "metre of mercury")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("dyn",   	UnitName("dyn",
-						 UnitVal(1.0e-5,"N"),
+						 UnitVal(1.0e-5, "N", &maps),
 						 "dyne")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("eV",   	UnitName("eV",
-						 UnitVal(1.60217733e-19,"J"),
+						 UnitVal(1.60217733e-19, "J", &maps),
 						 "electron volt")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("erg",   	UnitName("erg",
-						 UnitVal(1.0e-7,"J"),
+						 UnitVal(1.0e-7, "J", &maps),
 						 "erg")));
 }
 

--- a/casa/Quanta/UnitMap7.cc
+++ b/casa/Quanta/UnitMap7.cc
@@ -32,132 +32,133 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // Initialise the maps
-void UnitMap::initUMCust3() {
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+void UnitMap::initUMCust3 (UMaps& maps) {
+  map<String, UnitName>& mapCust = maps.mapCust;
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("fl_oz", 	UnitName("fl_oz",
-						 UnitVal(277.4193*2.54*2.54*2.54/5/4/2/4,"cm3"),
+						 UnitVal(277.4193*2.54*2.54*2.54/5/4/2/4, "cm3", &maps),
 						 "fluid ounce (Imp)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("USfl_oz", 	UnitName("USfl_oz",
-						 UnitVal(231*2.54*2.54*2.54/4/4/2/4,"cm3"),
+						 UnitVal(231*2.54*2.54*2.54/4/4/2/4, "cm3", &maps),
 						 "fluid ounce (US)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("ft",   	UnitName("ft",
-						 UnitVal(12*2.54e-2,"m"),
+						 UnitVal(12*2.54e-2, "m", &maps),
 						 "foot")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("fur",   	UnitName("fur",
-						 UnitVal(220*3*12*2.54,"cm"),
+						 UnitVal(220*3*12*2.54, "cm", &maps),
 						 "furlong")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Gal",   	UnitName("Gal",
-						 UnitVal(1.,"cm/s2"),
+						 UnitVal(1., "cm/s2", &maps),
 						 "gal")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("gal",   	UnitName("gal",
-						 UnitVal(277.4193*2.54*2.54*2.54,"cm3"),
+						 UnitVal(277.4193*2.54*2.54*2.54, "cm3", &maps),
 						 "gallon (Imp)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("USgal", 	UnitName("USgal",
-						 UnitVal(231*2.54*2.54*2.54,"cm3"),
+						 UnitVal(231*2.54*2.54*2.54, "cm3", &maps),
 						 "gallon (US)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("G",   	UnitName("G",
-						 UnitVal(1.0e-4,"T"),
+						 UnitVal(1.0e-4, "T", &maps),
 						 "gauss")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Gb",   	UnitName("Gb",
-						 UnitVal(10.0/(4.0 * C::pi),"A"),
+						 UnitVal(10.0/(4.0 * C::pi), "A", &maps),
 						 "gilbert")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("ha",   	UnitName("ha",
-						 UnitVal(1.,"hm2"),
+						 UnitVal(1.,"hm2", &maps),
 						 "hectare")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("hp",   	UnitName("hp",
-						 UnitVal(745.7,"W"),
+						 UnitVal(745.7, "W", &maps),
 						 "horsepower")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("cwt",   	UnitName("cwt",
-						 UnitVal(4*2*14*0.45359237,"kg"),
+						 UnitVal(4*2*14*0.45359237, "kg", &maps),
 						 "hundredweight")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("in",   	UnitName("in",
-						 UnitVal(2.54,"cm"),
+						 UnitVal(2.54, "cm", &maps),
 						 "inch")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("kn",   	UnitName("kn",
-						 UnitVal(6080*12*2.54,"cm/h"),
+						 UnitVal(6080*12*2.54, "cm/h", &maps),
 						 "knot (Imp)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("ly",   	UnitName("ly",
-						 UnitVal(9.46073047e+15,"m"),
+						 UnitVal(9.46073047e+15, "m", &maps),
 						 "light year")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Mx",   	UnitName("Mx",
-						 UnitVal(1.0e-8,"Wb"),
+						 UnitVal(1.0e-8, "Wb", &maps),
 						 "maxwell")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("mile",  	UnitName("mile",
-						 UnitVal(5280*12*2.54e-2,"m"),
+						 UnitVal(5280*12*2.54e-2, "m", &maps),
 						 "mile")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("n_mile", 	UnitName("n_mile",
-						 UnitVal(6080*12*2.54,"cm"),
+						 UnitVal(6080*12*2.54, "cm", &maps),
 						 "nautical mile (Imp)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Oe",   	UnitName("Oe",
-						 UnitVal(1000.0/(4.0*C::pi),"A/m"),
+						 UnitVal(1000.0/(4.0*C::pi), "A/m", &maps),
 						 "oersted")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("oz",   	UnitName("oz",
-						 UnitVal(1./16.*0.45359237,"kg"),
+						 UnitVal(1./16.*0.45359237, "kg", &maps),
 						 "ounce (avoirdupois)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("lb",   	UnitName("lb",
-						 UnitVal(0.45359237,"kg"),
+						 UnitVal(0.45359237, "kg", &maps),
 						 "pound (avoirdupois)")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("R",   	UnitName("R",
-						 UnitVal(2.58e-4,"C/kg"),
+						 UnitVal(2.58e-4, "C/kg", &maps),
 						 "mile")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("sb",   	UnitName("sb",
-						 UnitVal(1e4,"cd/m2"),
+						 UnitVal(1e4, "cd/m2", &maps),
 						 "stilb")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("St",   	UnitName("St",
-						 UnitVal(1.,"cm2/s"),
+						 UnitVal(1., "cm2/s", &maps),
 						 "stokes")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("Torr",  	UnitName("Torr",
-						 UnitVal((1.0/760.0)*1.01325e+5,"Pa"),
+						 UnitVal((1.0/760.0)*1.01325e+5, "Pa", &maps),
 						 "torr")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("yd",   	UnitName("yd",
-						 UnitVal(3*12*2.54,"cm"),
+						 UnitVal(3*12*2.54, "cm", &maps),
 						 "yard")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("yr",   	UnitName("yr",
-						 UnitVal(24.*3600.*365.25,"s"),
+						 UnitVal(24.*3600.*365.25, "s", &maps),
 						 "year")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("adu",	UnitName("adu",
 						 UnitVal(1.,UnitDim::Dnon),
 						 "dimensionless ADC unit")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("beam",	UnitName("beam",
 						 UnitVal(1.,UnitDim::Dnon),
 						 "undefined beam area")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
                            ("count", 	UnitName("count",
                                                  UnitVal(1.,UnitDim::Dnon),
                                                  "count")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("pixel",	UnitName("pixel",
 						 UnitVal(1.,UnitDim::Dnon),
 						 "pixel")));
-  UnitMap::mapCust->insert(map<String, UnitName>::value_type
+  mapCust.insert(map<String, UnitName>::value_type
 			   ("lambda",	UnitName("lambda",
 						 UnitVal(1.,UnitDim::Dnon),
 						 "lambda")));

--- a/casa/Quanta/UnitVal.h
+++ b/casa/Quanta/UnitVal.h
@@ -40,6 +40,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 class String;
 class MUString;
 class UnitMap;
+class UMaps;
 
 // 
 // <summary>
@@ -188,7 +189,7 @@ class UnitVal {
   // <thrown>
   //   <li> AipsError
   // </thrown>
-  UnitVal(Double factor, const String &s);
+  UnitVal(Double factor, const String &s, UMaps* = 0);
   
   // Construct a value with a single unit at position specified
   UnitVal(Double factor, Int pos) { init(factor, pos); }
@@ -278,8 +279,8 @@ class UnitVal {
   
   // Convert (and check) a unit string to an SI value representation
   // <group>
-  static Bool create(const String &s, UnitVal &res);
-  static Bool create(MUString &str, UnitVal &res);
+  static Bool create(const String &s, UnitVal &res, UMaps* = 0);
+  static Bool create(MUString &str, UnitVal &res, UMaps* = 0);
   // </group>
   
   // Determine sign of unit power (i.e. if '.' or '/')
@@ -289,7 +290,7 @@ class UnitVal {
   static Int power(MUString &str);
   
   // Determine symbol name in unit string
-  static Bool field(MUString &str, UnitVal &res);
+  static Bool field(MUString &str, UnitVal &res, UMaps*);
   
 };
 

--- a/casa/Utilities/MUString.cc
+++ b/casa/Utilities/MUString.cc
@@ -277,9 +277,7 @@ Bool MUString::testChar(Char ch) const {
 }
 
 Bool MUString::testCharNC(Char ch) const {
-  Regex ex(String("[") + downcase(String(ch)) +
-	   upcase(String(ch)) + String("]"));
-  return testChar(ex);
+  return (ptr < len && (str[ptr] == toupper(ch)  ||  str[ptr] == tolower(ch)));
 }
 
 Bool MUString::testChar(const Regex &ex) const {

--- a/ms/MeasurementSets/MSAntenna.cc
+++ b/ms/MeasurementSets/MSAntenna.cc
@@ -44,8 +44,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSAntenna::MSAntenna():hasBeenDestroyed_p(True) { }
 
 MSAntenna::MSAntenna(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSAntennaEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -55,8 +54,7 @@ MSAntenna::MSAntenna(const String &tableName, TableOption option)
 
 MSAntenna::MSAntenna(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSAntennaEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -67,8 +65,7 @@ MSAntenna::MSAntenna(const String& tableName, const String &tableDescName,
 
 MSAntenna::MSAntenna(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSAntennaEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -78,8 +75,7 @@ MSAntenna::MSAntenna(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSAntenna::MSAntenna(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSAntennaEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -88,8 +84,7 @@ MSAntenna::MSAntenna(const Table &table)
 }
 
 MSAntenna::MSAntenna(const MSAntenna &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSAntennaEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -117,86 +112,82 @@ MSAntenna::~MSAntenna()
 MSAntenna& MSAntenna::operator=(const MSAntenna &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSAntennaEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSAntenna::initMap()
+MSTableMaps MSAntenna::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // DISH_DIAMETER
-  colMapDef(DISH_DIAMETER, "DISH_DIAMETER", TpDouble,
+  colMapDef(maps, DISH_DIAMETER, "DISH_DIAMETER", TpDouble,
             "Physical diameter of dish","m","");
   // FLAG_ROW
-  colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
+  colMapDef(maps, FLAG_ROW,"FLAG_ROW",TpBool,
             "Flag for this row","","");
   // MOUNT
-  colMapDef(MOUNT,"MOUNT",TpString,
+  colMapDef(maps, MOUNT,"MOUNT",TpString,
             "Mount type e.g. alt-az, equatorial, etc.","","");
   // NAME
-  colMapDef(NAME,"NAME",TpString,
+  colMapDef(maps, NAME,"NAME",TpString,
             "Antenna name, e.g. VLA22, CA03","","");
   // OFFSET
-  colMapDef(OFFSET,"OFFSET",TpArrayDouble,
+  colMapDef(maps, OFFSET,"OFFSET",TpArrayDouble,
             "Axes offset of mount to FEED REFERENCE point",
             "m","Position");
   // POSITION
-  colMapDef(POSITION,"POSITION",TpArrayDouble,
+  colMapDef(maps, POSITION,"POSITION",TpArrayDouble,
             "Antenna X,Y,Z phase reference position","m","Position");
   // STATION
-  colMapDef(STATION,"STATION",TpString,
+  colMapDef(maps, STATION,"STATION",TpString,
             "Station (antenna pad) name","","");
   // TYPE
-  colMapDef(TYPE,"TYPE", TpString,
+  colMapDef(maps, TYPE,"TYPE", TpString,
             "Antenna type (e.g. SPACE-BASED)","","");
 
   // Optional columns follow 
   // MEAN_ORBIT
-  colMapDef(MEAN_ORBIT,"MEAN_ORBIT",TpArrayDouble,
+  colMapDef(maps, MEAN_ORBIT,"MEAN_ORBIT",TpArrayDouble,
             "Mean Keplerian elements","","");
   // ORBIT_ID
-  colMapDef(ORBIT_ID,"ORBIT_ID",TpInt,
+  colMapDef(maps, ORBIT_ID,"ORBIT_ID",TpInt,
             "index into ORBIT table (ignore if<0)","","");
   // PHASED_ARRAY_ID
-  colMapDef(PHASED_ARRAY_ID,"PHASED_ARRAY_ID",TpInt,
+  colMapDef(maps, PHASED_ARRAY_ID,"PHASED_ARRAY_ID",TpInt,
             "index into PHASED_ARRAY table","","");
-  // PredefinedKeywords
-}
 
-void MSAntenna::initDesc()
-{
+  // PredefinedKeywords
+
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   // First define the columns with fixed size arrays
   IPosition shape(1,3);
   ColumnDesc::Option option=ColumnDesc::Direct;
-  addColumnToDesc(requiredTD, OFFSET, shape, option);
-  addColumnToDesc(requiredTD, POSITION, shape, option);
+  addColumnToDesc(maps, OFFSET, shape, option);
+  addColumnToDesc(maps, POSITION, shape, option);
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSAntenna MSAntenna::referenceCopy(const String& newTableName, 
 		    const Block<String>& writableColumns) const
 {
-    return MSAntenna(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSAntenna(MSTable<MSAntennaEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSAntenna.cc
+++ b/ms/MeasurementSets/MSAntenna.cc
@@ -124,70 +124,72 @@ MSAntenna& MSAntenna::operator=(const MSAntenna &other)
     return *this;
 }
 
-void MSAntenna::init()
+void MSAntenna::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// DISH_DIAMETER
-	colMapDef(DISH_DIAMETER, "DISH_DIAMETER", TpDouble,
-		  "Physical diameter of dish","m","");
-	// FLAG_ROW
-	colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
-		  "Flag for this row","","");
-	// MOUNT
-	colMapDef(MOUNT,"MOUNT",TpString,
-		  "Mount type e.g. alt-az, equatorial, etc.","","");
-	// NAME
-	colMapDef(NAME,"NAME",TpString,
-		  "Antenna name, e.g. VLA22, CA03","","");
-	// OFFSET
-	colMapDef(OFFSET,"OFFSET",TpArrayDouble,
-		  "Axes offset of mount to FEED REFERENCE point",
-		  "m","Position");
-	// POSITION
-	colMapDef(POSITION,"POSITION",TpArrayDouble,
-		  "Antenna X,Y,Z phase reference position","m","Position");
-	// STATION
-	colMapDef(STATION,"STATION",TpString,
-		  "Station (antenna pad) name","","");
-	// TYPE
-	colMapDef(TYPE,"TYPE", TpString,
-		  "Antenna type (e.g. SPACE-BASED)","","");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // DISH_DIAMETER
+  colMapDef(DISH_DIAMETER, "DISH_DIAMETER", TpDouble,
+            "Physical diameter of dish","m","");
+  // FLAG_ROW
+  colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
+            "Flag for this row","","");
+  // MOUNT
+  colMapDef(MOUNT,"MOUNT",TpString,
+            "Mount type e.g. alt-az, equatorial, etc.","","");
+  // NAME
+  colMapDef(NAME,"NAME",TpString,
+            "Antenna name, e.g. VLA22, CA03","","");
+  // OFFSET
+  colMapDef(OFFSET,"OFFSET",TpArrayDouble,
+            "Axes offset of mount to FEED REFERENCE point",
+            "m","Position");
+  // POSITION
+  colMapDef(POSITION,"POSITION",TpArrayDouble,
+            "Antenna X,Y,Z phase reference position","m","Position");
+  // STATION
+  colMapDef(STATION,"STATION",TpString,
+            "Station (antenna pad) name","","");
+  // TYPE
+  colMapDef(TYPE,"TYPE", TpString,
+            "Antenna type (e.g. SPACE-BASED)","","");
 
-	// Optional columns follow 
-	// MEAN_ORBIT
-	colMapDef(MEAN_ORBIT,"MEAN_ORBIT",TpArrayDouble,
-		  "Mean Keplerian elements","","");
-	// ORBIT_ID
-	colMapDef(ORBIT_ID,"ORBIT_ID",TpInt,
-		  "index into ORBIT table (ignore if<0)","","");
-	// PHASED_ARRAY_ID
-	colMapDef(PHASED_ARRAY_ID,"PHASED_ARRAY_ID",TpInt,
-		  "index into PHASED_ARRAY table","","");
-	// PredefinedKeywords
+  // Optional columns follow 
+  // MEAN_ORBIT
+  colMapDef(MEAN_ORBIT,"MEAN_ORBIT",TpArrayDouble,
+            "Mean Keplerian elements","","");
+  // ORBIT_ID
+  colMapDef(ORBIT_ID,"ORBIT_ID",TpInt,
+            "index into ORBIT table (ignore if<0)","","");
+  // PHASED_ARRAY_ID
+  colMapDef(PHASED_ARRAY_ID,"PHASED_ARRAY_ID",TpInt,
+            "index into PHASED_ARRAY table","","");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	// First define the columns with fixed size arrays
-	IPosition shape(1,3);
-	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, OFFSET, shape, option);
-	addColumnToDesc(requiredTD, POSITION, shape, option);
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSAntenna::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  // First define the columns with fixed size arrays
+  IPosition shape(1,3);
+  ColumnDesc::Option option=ColumnDesc::Direct;
+  addColumnToDesc(requiredTD, OFFSET, shape, option);
+  addColumnToDesc(requiredTD, POSITION, shape, option);
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSAntenna.h
+++ b/ms/MeasurementSets/MSAntenna.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSAntenna.h
+++ b/ms/MeasurementSets/MSAntenna.h
@@ -77,8 +77,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 
 class MSAntenna:public MSAntennaEnums,
-                public MSTable<MSAntennaEnums::PredefinedColumns,
-		               MSAntennaEnums::PredefinedKeywords>
+                public MSTable<MSAntennaEnums>
 {
 public:
     // This constructs an empty MSAntenna
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSDataDescription.cc
+++ b/ms/MeasurementSets/MSDataDescription.cc
@@ -125,40 +125,42 @@ MSDataDescription& MSDataDescription::operator=(const MSDataDescription &other)
     return *this;
 }
 
-void MSDataDescription::init()
+void MSDataDescription::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-        // FLAG_ROW
-	colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
-		  "Flag this row","","");
-	// LAG_ID
-	colMapDef(LAG_ID,"LAG_ID",TpInt,"The lag index","","");
-	// POLARIZATION_ID
-	colMapDef(POLARIZATION_ID,"POLARIZATION_ID",TpInt,
-		  "Pointer to polarization table","","");
-	// SPECTRAL_WINDOW_ID
-	colMapDef(SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
-		  "Pointer to spectralwindow table","","");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // FLAG_ROW
+  colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
+            "Flag this row","","");
+  // LAG_ID
+  colMapDef(LAG_ID,"LAG_ID",TpInt,"The lag index","","");
+  // POLARIZATION_ID
+  colMapDef(POLARIZATION_ID,"POLARIZATION_ID",TpInt,
+            "Pointer to polarization table","","");
+  // SPECTRAL_WINDOW_ID
+  colMapDef(SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
+            "Pointer to spectralwindow table","","");
 
-	// PredefinedKeywords
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSDataDescription::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSDataDescription.cc
+++ b/ms/MeasurementSets/MSDataDescription.cc
@@ -45,8 +45,7 @@ MSDataDescription::MSDataDescription():hasBeenDestroyed_p(True) { }
 
 MSDataDescription::MSDataDescription(const String &tableName, 
 				     TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSDataDescriptionEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -56,8 +55,7 @@ MSDataDescription::MSDataDescription(const String &tableName,
 
 MSDataDescription::MSDataDescription(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSDataDescriptionEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -68,8 +66,7 @@ MSDataDescription::MSDataDescription(const String& tableName, const String &tabl
 
 MSDataDescription::MSDataDescription(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSDataDescriptionEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -79,8 +76,7 @@ MSDataDescription::MSDataDescription(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSDataDescription::MSDataDescription(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSDataDescriptionEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -89,8 +85,7 @@ MSDataDescription::MSDataDescription(const Table &table)
 }
 
 MSDataDescription::MSDataDescription(const MSDataDescription &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSDataDescriptionEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -118,56 +113,51 @@ MSDataDescription::~MSDataDescription()
 MSDataDescription& MSDataDescription::operator=(const MSDataDescription &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSDataDescriptionEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSDataDescription::initMap()
+MSTableMaps MSDataDescription::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // FLAG_ROW
-  colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
+  colMapDef(maps, FLAG_ROW,"FLAG_ROW", TpBool,
             "Flag this row","","");
   // LAG_ID
-  colMapDef(LAG_ID,"LAG_ID",TpInt,"The lag index","","");
+  colMapDef(maps, LAG_ID,"LAG_ID",TpInt,"The lag index","","");
   // POLARIZATION_ID
-  colMapDef(POLARIZATION_ID,"POLARIZATION_ID",TpInt,
+  colMapDef(maps, POLARIZATION_ID,"POLARIZATION_ID",TpInt,
             "Pointer to polarization table","","");
   // SPECTRAL_WINDOW_ID
-  colMapDef(SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
+  colMapDef(maps, SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
             "Pointer to spectralwindow table","","");
 
   // PredefinedKeywords
-}
 
-void MSDataDescription::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSDataDescription MSDataDescription::referenceCopy(const String& newTableName, 
 		    const Block<String>& writableColumns) const
 {
-    return MSDataDescription(MSTable<PredefinedColumns,PredefinedKeywords>::
+  return MSDataDescription(MSTable<MSDataDescriptionEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSDataDescription.h
+++ b/ms/MeasurementSets/MSDataDescription.h
@@ -77,8 +77,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 
 class MSDataDescription:public MSDataDescriptionEnums,
-                public MSTable<MSDataDescriptionEnums::PredefinedColumns,
-		               MSDataDescriptionEnums::PredefinedKeywords>
+                        public MSTable<MSDataDescriptionEnums>
 {
 public:
     // This constructs an empty MSDataDescription
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSDataDescription.h
+++ b/ms/MeasurementSets/MSDataDescription.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSDoppler.cc
+++ b/ms/MeasurementSets/MSDoppler.cc
@@ -46,8 +46,7 @@ MSDoppler::MSDoppler():hasBeenDestroyed_p(True) { }
 
 MSDoppler::MSDoppler(const String &tableName, 
 				     TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSDopplerEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     addVelDef();
@@ -79,8 +78,7 @@ void MSDoppler::addVelDef()
 
 MSDoppler::MSDoppler(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSDopplerEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -92,8 +90,7 @@ MSDoppler::MSDoppler(const String& tableName, const String &tableDescName,
 
 MSDoppler::MSDoppler(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSDopplerEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -104,8 +101,7 @@ MSDoppler::MSDoppler(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSDoppler::MSDoppler(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSDopplerEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     addVelDef();
@@ -115,8 +111,7 @@ MSDoppler::MSDoppler(const Table &table)
 }
 
 MSDoppler::MSDoppler(const MSDoppler &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSDopplerEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -145,56 +140,51 @@ MSDoppler::~MSDoppler()
 MSDoppler& MSDoppler::operator=(const MSDoppler &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSDopplerEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSDoppler::initMap()
+MSTableMaps MSDoppler::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // 
-  colMapDef(DOPPLER_ID,"DOPPLER_ID", TpInt,
+  colMapDef(maps, DOPPLER_ID,"DOPPLER_ID", TpInt,
             "Doppler tracking id","","");
   // SOURCE_ID
-  colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
+  colMapDef(maps, SOURCE_ID, "SOURCE_ID", TpInt,
             "Pointer to SOURCE table","","");
   // TRANSITION_ID
-  colMapDef(TRANSITION_ID,"TRANSITION_ID",TpInt,
+  colMapDef(maps, TRANSITION_ID,"TRANSITION_ID",TpInt,
             "Pointer to list of transitions in SOURCE table","","");
   // VELDEF
-  colMapDef(VELDEF, "VELDEF", TpDouble, 
+  colMapDef(maps, VELDEF, "VELDEF", TpDouble, 
             "Velocity Definition for Doppler shift","m/s","Doppler");
   // PredefinedKeywords
-}
 
-void MSDoppler::initDesc()
-{    
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSDoppler MSDoppler::referenceCopy(const String& newTableName, 
 		    const Block<String>& writableColumns) const
 {
-    return MSDoppler(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSDoppler(MSTable<MSDopplerEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSDoppler.cc
+++ b/ms/MeasurementSets/MSDoppler.cc
@@ -152,40 +152,42 @@ MSDoppler& MSDoppler::operator=(const MSDoppler &other)
     return *this;
 }
 
-void MSDoppler::init()
+void MSDoppler::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-        // the PredefinedColumns
-        // 
-	colMapDef(DOPPLER_ID,"DOPPLER_ID", TpInt,
-		  "Doppler tracking id","","");
-	// SOURCE_ID
-	colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
-		  "Pointer to SOURCE table","","");
-	// TRANSITION_ID
-	colMapDef(TRANSITION_ID,"TRANSITION_ID",TpInt,
-		  "Pointer to list of transitions in SOURCE table","","");
-	// VELDEF
-	colMapDef(VELDEF, "VELDEF", TpDouble, 
-		  "Velocity Definition for Doppler shift","m/s","Doppler");
-	// PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // 
+  colMapDef(DOPPLER_ID,"DOPPLER_ID", TpInt,
+            "Doppler tracking id","","");
+  // SOURCE_ID
+  colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
+            "Pointer to SOURCE table","","");
+  // TRANSITION_ID
+  colMapDef(TRANSITION_ID,"TRANSITION_ID",TpInt,
+            "Pointer to list of transitions in SOURCE table","","");
+  // VELDEF
+  colMapDef(VELDEF, "VELDEF", TpDouble, 
+            "Velocity Definition for Doppler shift","m/s","Doppler");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSDoppler::initDesc()
+{    
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSDoppler.h
+++ b/ms/MeasurementSets/MSDoppler.h
@@ -77,8 +77,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 
 class MSDoppler:public MSDopplerEnums,
-                public MSTable<MSDopplerEnums::PredefinedColumns,
-		               MSDopplerEnums::PredefinedKeywords>
+                public MSTable<MSDopplerEnums>
 {
 public:
     // This constructs an empty MSDoppler
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
     // temporary function to add the VELDEF

--- a/ms/MeasurementSets/MSDoppler.h
+++ b/ms/MeasurementSets/MSDoppler.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
     // temporary function to add the VELDEF

--- a/ms/MeasurementSets/MSFeed.cc
+++ b/ms/MeasurementSets/MSFeed.cc
@@ -123,86 +123,88 @@ MSFeed& MSFeed::operator=(const MSFeed &other)
     return *this;
 }
 
-void MSFeed::init()
+void MSFeed::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// ANTENNA_ID
-	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
-		  "ID of antenna in this array","","");
-	// BEAM_ID
-	colMapDef(BEAM_ID,"BEAM_ID",TpInt,
-		  "Id for BEAM model","","");
-	// BEAM_OFFSET
-	colMapDef(BEAM_OFFSET,"BEAM_OFFSET",TpArrayDouble,
-		  "Beam position offset (on sky but in antenna"
-		  "reference frame)","rad","Direction");
-	// FEED_ID
-	colMapDef(FEED_ID,"FEED_ID",TpInt,
-		  "Feed id","","");
-	// FOCUS_LENGTH
-	colMapDef(FOCUS_LENGTH,"FOCUS_LENGTH",TpDouble,
-		  "Focus length","m","");
-	// INTERVAL
-	colMapDef(INTERVAL,"INTERVAL",TpDouble,
-		  "Interval for which this set of parameters is accurate",
-		  "s","");
-	// NUM_RECEPTORS
-	colMapDef(NUM_RECEPTORS,"NUM_RECEPTORS",TpInt,
-		  "Number of receptors on this feed (probably 1 or 2)","","");
-	// PHASED_FEED_ID
-	colMapDef(PHASED_FEED_ID,"PHASED_FEED_ID",TpInt,
-		  "index into PHASED_FEED table (ignore if<0)","","");
-	// POL_RESPONSE
-	colMapDef(POL_RESPONSE,"POL_RESPONSE",TpArrayComplex,
-		  "D-matrix i.e. leakage between two receptors","","");
-	// POLARIZATION_TYPE
-	colMapDef(POLARIZATION_TYPE,"POLARIZATION_TYPE",TpArrayString,
-		  "Type of polarization to which a given RECEPTOR responds",
-		  "","");
-	// POSITION
-	colMapDef(POSITION,"POSITION",TpArrayDouble,
-		  "Position of feed relative to feed reference position",
-		  "m","Position");
-	// RECEPTOR_ANGLE
-	colMapDef(RECEPTOR_ANGLE,"RECEPTOR_ANGLE",TpArrayDouble,
-		  "The reference angle for polarization","rad","");
-	// SPECTRAL_WINDOW_ID
-	colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
-		  "ID for this spectral window setup","","");
-	// TIME
-	colMapDef(TIME,"TIME",TpDouble,
-		  "Midpoint of time for which this set of "
-		  "parameters is accurate","s","Epoch");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // ANTENNA_ID
+  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+            "ID of antenna in this array","","");
+  // BEAM_ID
+  colMapDef(BEAM_ID,"BEAM_ID",TpInt,
+            "Id for BEAM model","","");
+  // BEAM_OFFSET
+  colMapDef(BEAM_OFFSET,"BEAM_OFFSET",TpArrayDouble,
+            "Beam position offset (on sky but in antenna"
+            "reference frame)","rad","Direction");
+  // FEED_ID
+  colMapDef(FEED_ID,"FEED_ID",TpInt,
+            "Feed id","","");
+  // FOCUS_LENGTH
+  colMapDef(FOCUS_LENGTH,"FOCUS_LENGTH",TpDouble,
+            "Focus length","m","");
+  // INTERVAL
+  colMapDef(INTERVAL,"INTERVAL",TpDouble,
+            "Interval for which this set of parameters is accurate",
+            "s","");
+  // NUM_RECEPTORS
+  colMapDef(NUM_RECEPTORS,"NUM_RECEPTORS",TpInt,
+            "Number of receptors on this feed (probably 1 or 2)","","");
+  // PHASED_FEED_ID
+  colMapDef(PHASED_FEED_ID,"PHASED_FEED_ID",TpInt,
+            "index into PHASED_FEED table (ignore if<0)","","");
+  // POL_RESPONSE
+  colMapDef(POL_RESPONSE,"POL_RESPONSE",TpArrayComplex,
+            "D-matrix i.e. leakage between two receptors","","");
+  // POLARIZATION_TYPE
+  colMapDef(POLARIZATION_TYPE,"POLARIZATION_TYPE",TpArrayString,
+            "Type of polarization to which a given RECEPTOR responds",
+            "","");
+  // POSITION
+  colMapDef(POSITION,"POSITION",TpArrayDouble,
+            "Position of feed relative to feed reference position",
+            "m","Position");
+  // RECEPTOR_ANGLE
+  colMapDef(RECEPTOR_ANGLE,"RECEPTOR_ANGLE",TpArrayDouble,
+            "The reference angle for polarization","rad","");
+  // SPECTRAL_WINDOW_ID
+  colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
+            "ID for this spectral window setup","","");
+  // TIME
+  colMapDef(TIME,"TIME",TpDouble,
+            "Midpoint of time for which this set of "
+            "parameters is accurate","s","Epoch");
+  
+  // PredefinedKeywords
+}
 
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	// First define the columns with fixed size arrays
-	IPosition shape(1,3);
-	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, POSITION, shape, option);
-	// define the columns with known dimensionality
-	addColumnToDesc(requiredTD, BEAM_OFFSET, 2);
-	addColumnToDesc(requiredTD, POLARIZATION_TYPE, 1);
-	addColumnToDesc(requiredTD, POL_RESPONSE, 2);
-	addColumnToDesc(requiredTD, RECEPTOR_ANGLE, 1);
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSFeed::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  // First define the columns with fixed size arrays
+  IPosition shape(1,3);
+  ColumnDesc::Option option=ColumnDesc::Direct;
+  addColumnToDesc(requiredTD, POSITION, shape, option);
+  // define the columns with known dimensionality
+  addColumnToDesc(requiredTD, BEAM_OFFSET, 2);
+  addColumnToDesc(requiredTD, POLARIZATION_TYPE, 1);
+  addColumnToDesc(requiredTD, POL_RESPONSE, 2);
+  addColumnToDesc(requiredTD, RECEPTOR_ANGLE, 1);
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 MSFeed MSFeed::referenceCopy(const String& newTableName, 

--- a/ms/MeasurementSets/MSFeed.cc
+++ b/ms/MeasurementSets/MSFeed.cc
@@ -43,8 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSFeed::MSFeed():hasBeenDestroyed_p(True) { }
 
 MSFeed::MSFeed(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSFeedEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +53,7 @@ MSFeed::MSFeed(const String &tableName, TableOption option)
 
 MSFeed::MSFeed(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSFeedEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +64,7 @@ MSFeed::MSFeed(const String& tableName, const String &tableDescName,
 
 MSFeed::MSFeed(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSFeedEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +74,7 @@ MSFeed::MSFeed(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSFeed::MSFeed(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSFeedEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +83,7 @@ MSFeed::MSFeed(const Table &table)
 }
 
 MSFeed::MSFeed(const MSFeed &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSFeedEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,101 +111,97 @@ MSFeed::~MSFeed()
 MSFeed& MSFeed::operator=(const MSFeed &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSFeedEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSFeed::initMap()
+MSTableMaps MSFeed::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
+  AlwaysAssert (maps.columnMap_p.empty(), AipsError);
   // the PredefinedColumns
   // ANTENNA_ID
-  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+  colMapDef(maps, ANTENNA_ID, "ANTENNA_ID", TpInt,
             "ID of antenna in this array","","");
   // BEAM_ID
-  colMapDef(BEAM_ID,"BEAM_ID",TpInt,
+  colMapDef(maps, BEAM_ID,"BEAM_ID",TpInt,
             "Id for BEAM model","","");
   // BEAM_OFFSET
-  colMapDef(BEAM_OFFSET,"BEAM_OFFSET",TpArrayDouble,
+  colMapDef(maps, BEAM_OFFSET,"BEAM_OFFSET",TpArrayDouble,
             "Beam position offset (on sky but in antenna"
             "reference frame)","rad","Direction");
   // FEED_ID
-  colMapDef(FEED_ID,"FEED_ID",TpInt,
+  colMapDef(maps, FEED_ID,"FEED_ID",TpInt,
             "Feed id","","");
   // FOCUS_LENGTH
-  colMapDef(FOCUS_LENGTH,"FOCUS_LENGTH",TpDouble,
+  colMapDef(maps, FOCUS_LENGTH,"FOCUS_LENGTH",TpDouble,
             "Focus length","m","");
   // INTERVAL
-  colMapDef(INTERVAL,"INTERVAL",TpDouble,
+  colMapDef(maps, INTERVAL,"INTERVAL",TpDouble,
             "Interval for which this set of parameters is accurate",
             "s","");
   // NUM_RECEPTORS
-  colMapDef(NUM_RECEPTORS,"NUM_RECEPTORS",TpInt,
+  colMapDef(maps, NUM_RECEPTORS,"NUM_RECEPTORS",TpInt,
             "Number of receptors on this feed (probably 1 or 2)","","");
   // PHASED_FEED_ID
-  colMapDef(PHASED_FEED_ID,"PHASED_FEED_ID",TpInt,
+  colMapDef(maps, PHASED_FEED_ID,"PHASED_FEED_ID",TpInt,
             "index into PHASED_FEED table (ignore if<0)","","");
   // POL_RESPONSE
-  colMapDef(POL_RESPONSE,"POL_RESPONSE",TpArrayComplex,
+  colMapDef(maps, POL_RESPONSE,"POL_RESPONSE",TpArrayComplex,
             "D-matrix i.e. leakage between two receptors","","");
   // POLARIZATION_TYPE
-  colMapDef(POLARIZATION_TYPE,"POLARIZATION_TYPE",TpArrayString,
+  colMapDef(maps, POLARIZATION_TYPE,"POLARIZATION_TYPE",TpArrayString,
             "Type of polarization to which a given RECEPTOR responds",
             "","");
   // POSITION
-  colMapDef(POSITION,"POSITION",TpArrayDouble,
+  colMapDef(maps, POSITION,"POSITION",TpArrayDouble,
             "Position of feed relative to feed reference position",
             "m","Position");
   // RECEPTOR_ANGLE
-  colMapDef(RECEPTOR_ANGLE,"RECEPTOR_ANGLE",TpArrayDouble,
+  colMapDef(maps, RECEPTOR_ANGLE,"RECEPTOR_ANGLE",TpArrayDouble,
             "The reference angle for polarization","rad","");
   // SPECTRAL_WINDOW_ID
-  colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
+  colMapDef(maps, SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
             "ID for this spectral window setup","","");
   // TIME
-  colMapDef(TIME,"TIME",TpDouble,
+  colMapDef(maps, TIME,"TIME",TpDouble,
             "Midpoint of time for which this set of "
             "parameters is accurate","s","Epoch");
   
   // PredefinedKeywords
-}
 
-void MSFeed::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   // First define the columns with fixed size arrays
   IPosition shape(1,3);
   ColumnDesc::Option option=ColumnDesc::Direct;
-  addColumnToDesc(requiredTD, POSITION, shape, option);
+  addColumnToDesc(maps, POSITION, shape, option);
   // define the columns with known dimensionality
-  addColumnToDesc(requiredTD, BEAM_OFFSET, 2);
-  addColumnToDesc(requiredTD, POLARIZATION_TYPE, 1);
-  addColumnToDesc(requiredTD, POL_RESPONSE, 2);
-  addColumnToDesc(requiredTD, RECEPTOR_ANGLE, 1);
+  addColumnToDesc(maps, BEAM_OFFSET, 2);
+  addColumnToDesc(maps, POLARIZATION_TYPE, 1);
+  addColumnToDesc(maps, POL_RESPONSE, 2);
+  addColumnToDesc(maps, RECEPTOR_ANGLE, 1);
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 MSFeed MSFeed::referenceCopy(const String& newTableName, 
 			     const Block<String>& writableColumns) const
 {
-    return MSFeed(MSTable<PredefinedColumns,PredefinedKeywords>::referenceCopy
+    return MSFeed(MSTable<MSFeedEnums>::referenceCopy
 		  (newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSFeed.h
+++ b/ms/MeasurementSets/MSFeed.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSFeed:public MSFeedEnums,
-                public MSTable<MSFeedEnums::PredefinedColumns,
-		               MSFeedEnums::PredefinedKeywords>
+             public MSTable<MSFeedEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSFeed.h
+++ b/ms/MeasurementSets/MSFeed.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSField.cc
+++ b/ms/MeasurementSets/MSField.cc
@@ -125,68 +125,70 @@ MSField& MSField::operator=(const MSField &other)
     return *this;
 }
 
-void MSField::init()
+void MSField::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// CODE
-	colMapDef(CODE, "CODE", TpString,
-		  "Special characteristics of field, "
-		  "e.g. Bandpass calibrator","","");
-	// DELAY_DIR
-	colMapDef(DELAY_DIR, "DELAY_DIR", TpArrayDouble,
-		  "Direction of delay center (e.g. RA, DEC)" 
-		  "as polynomial in time.","rad","Direction");
-	// EPHEMERIS_ID
-	colMapDef(EPHEMERIS_ID,"EPHEMERIS_ID", TpInt,
-		  "Ephemeris id, pointer to EPHEMERIS table","","");
-	// FLAG_ROW
-	colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
-		  "Row Flag","","");
-	// NAME
-	colMapDef(NAME, "NAME", TpString,
-		  "Name of this field","","");
-	// NUM_POLY
-	colMapDef(NUM_POLY, "NUM_POLY", TpInt,
-		  "Polynomial order of _DIR columns","","");
-	// PHASE_DIR 
-	colMapDef(PHASE_DIR, "PHASE_DIR", TpArrayDouble,
-		  "Direction of phase center (e.g. RA, DEC).",
-		  "rad","Direction");
-	// REFERENCE_DIR 
-	colMapDef(REFERENCE_DIR, "REFERENCE_DIR", TpArrayDouble,
-		  "Direction of REFERENCE center (e.g. RA, DEC)."
-		  "as polynomial in time.","rad","Direction");
-	// SOURCE_ID
-	colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
-		  "Source id","","");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble,
-		  "Time origin for direction and rate","s","Epoch");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // CODE
+  colMapDef(CODE, "CODE", TpString,
+            "Special characteristics of field, "
+            "e.g. Bandpass calibrator","","");
+  // DELAY_DIR
+  colMapDef(DELAY_DIR, "DELAY_DIR", TpArrayDouble,
+            "Direction of delay center (e.g. RA, DEC)" 
+            "as polynomial in time.","rad","Direction");
+  // EPHEMERIS_ID
+  colMapDef(EPHEMERIS_ID,"EPHEMERIS_ID", TpInt,
+            "Ephemeris id, pointer to EPHEMERIS table","","");
+  // FLAG_ROW
+  colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
+            "Row Flag","","");
+  // NAME
+  colMapDef(NAME, "NAME", TpString,
+            "Name of this field","","");
+  // NUM_POLY
+  colMapDef(NUM_POLY, "NUM_POLY", TpInt,
+            "Polynomial order of _DIR columns","","");
+  // PHASE_DIR 
+  colMapDef(PHASE_DIR, "PHASE_DIR", TpArrayDouble,
+            "Direction of phase center (e.g. RA, DEC).",
+            "rad","Direction");
+  // REFERENCE_DIR 
+  colMapDef(REFERENCE_DIR, "REFERENCE_DIR", TpArrayDouble,
+            "Direction of REFERENCE center (e.g. RA, DEC)."
+            "as polynomial in time.","rad","Direction");
+  // SOURCE_ID
+  colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
+            "Source id","","");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble,
+            "Time origin for direction and rate","s","Epoch");
+  
+  // PredefinedKeywords
+}
 
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	// First define the columns with known dimensionality
-	addColumnToDesc(requiredTD, DELAY_DIR, 2);
-	addColumnToDesc(requiredTD, PHASE_DIR, 2);
-	addColumnToDesc(requiredTD, REFERENCE_DIR, 2);
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSField::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  // First define the columns with known dimensionality
+  addColumnToDesc(requiredTD, DELAY_DIR, 2);
+  addColumnToDesc(requiredTD, PHASE_DIR, 2);
+  addColumnToDesc(requiredTD, REFERENCE_DIR, 2);
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSField.cc
+++ b/ms/MeasurementSets/MSField.cc
@@ -45,8 +45,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSField::MSField():hasBeenDestroyed_p(True) { }
 
 MSField::MSField(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSFieldEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -56,8 +55,7 @@ MSField::MSField(const String &tableName, TableOption option)
 
 MSField::MSField(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSFieldEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -68,8 +66,7 @@ MSField::MSField(const String& tableName, const String &tableDescName,
 
 MSField::MSField(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSFieldEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -79,8 +76,7 @@ MSField::MSField(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSField::MSField(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSFieldEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -89,8 +85,7 @@ MSField::MSField(const Table &table)
 }
 
 MSField::MSField(const MSField &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSFieldEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -118,84 +113,79 @@ MSField::~MSField()
 MSField& MSField::operator=(const MSField &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSFieldEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSField::initMap()
+MSTableMaps MSField::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // CODE
-  colMapDef(CODE, "CODE", TpString,
+  colMapDef(maps, CODE, "CODE", TpString,
             "Special characteristics of field, "
             "e.g. Bandpass calibrator","","");
   // DELAY_DIR
-  colMapDef(DELAY_DIR, "DELAY_DIR", TpArrayDouble,
+  colMapDef(maps, DELAY_DIR, "DELAY_DIR", TpArrayDouble,
             "Direction of delay center (e.g. RA, DEC)" 
             "as polynomial in time.","rad","Direction");
   // EPHEMERIS_ID
-  colMapDef(EPHEMERIS_ID,"EPHEMERIS_ID", TpInt,
+  colMapDef(maps, EPHEMERIS_ID,"EPHEMERIS_ID", TpInt,
             "Ephemeris id, pointer to EPHEMERIS table","","");
   // FLAG_ROW
-  colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
+  colMapDef(maps, FLAG_ROW, "FLAG_ROW", TpBool,
             "Row Flag","","");
   // NAME
-  colMapDef(NAME, "NAME", TpString,
+  colMapDef(maps, NAME, "NAME", TpString,
             "Name of this field","","");
   // NUM_POLY
-  colMapDef(NUM_POLY, "NUM_POLY", TpInt,
+  colMapDef(maps, NUM_POLY, "NUM_POLY", TpInt,
             "Polynomial order of _DIR columns","","");
   // PHASE_DIR 
-  colMapDef(PHASE_DIR, "PHASE_DIR", TpArrayDouble,
+  colMapDef(maps, PHASE_DIR, "PHASE_DIR", TpArrayDouble,
             "Direction of phase center (e.g. RA, DEC).",
             "rad","Direction");
   // REFERENCE_DIR 
-  colMapDef(REFERENCE_DIR, "REFERENCE_DIR", TpArrayDouble,
+  colMapDef(maps, REFERENCE_DIR, "REFERENCE_DIR", TpArrayDouble,
             "Direction of REFERENCE center (e.g. RA, DEC)."
             "as polynomial in time.","rad","Direction");
   // SOURCE_ID
-  colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
+  colMapDef(maps, SOURCE_ID, "SOURCE_ID", TpInt,
             "Source id","","");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble,
+  colMapDef(maps, TIME, "TIME", TpDouble,
             "Time origin for direction and rate","s","Epoch");
   
   // PredefinedKeywords
-}
 
-void MSField::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   // First define the columns with known dimensionality
-  addColumnToDesc(requiredTD, DELAY_DIR, 2);
-  addColumnToDesc(requiredTD, PHASE_DIR, 2);
-  addColumnToDesc(requiredTD, REFERENCE_DIR, 2);
+  addColumnToDesc(maps, DELAY_DIR, 2);
+  addColumnToDesc(maps, PHASE_DIR, 2);
+  addColumnToDesc(maps, REFERENCE_DIR, 2);
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSField MSField::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MSField(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSField(MSTable<MSFieldEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSField.h
+++ b/ms/MeasurementSets/MSField.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSField:public MSFieldEnums,
-                public MSTable<MSFieldEnums::PredefinedColumns,
-		               MSFieldEnums::PredefinedKeywords>
+              public MSTable<MSFieldEnums>
 {
 public:
 
@@ -139,8 +138,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSField.h
+++ b/ms/MeasurementSets/MSField.h
@@ -139,7 +139,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSFieldColumns.h
+++ b/ms/MeasurementSets/MSFieldColumns.h
@@ -41,7 +41,6 @@
 #include <casacore/tables/Tables/ArrayColumn.h>
 #include <casacore/tables/Tables/ScalarColumn.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/ms/MeasurementSets/MSFlagCmd.cc
+++ b/ms/MeasurementSets/MSFlagCmd.cc
@@ -123,55 +123,57 @@ MSFlagCmd& MSFlagCmd::operator=(const MSFlagCmd &other)
     return *this;
 }
 
-void MSFlagCmd::init()
+void MSFlagCmd::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// APPLIED
-	colMapDef(APPLIED, "APPLIED", TpBool,
-		  "True if flag has been applied to main table","","");
-	// COMMAND
-	colMapDef(COMMAND, "COMMAND", TpString,
-		  "Flagging command","","");
-	// INTERVAL
-	colMapDef(INTERVAL,"INTERVAL", TpDouble,
-		  "Time interval for which this flag is valid","s","");
-	// LEVEL
-	colMapDef(LEVEL, "LEVEL", TpInt,
-		  "Flag level - revision level ","","");
-	// REASON
-	colMapDef(REASON, "REASON", TpString,
-		  "Flag reason","","");
-	// SEVERITY
-	colMapDef(SEVERITY, "SEVERITY", TpInt,
-		  "Severity code (0-10) ","","");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble,
-		  "Midpoint of interval for which this flag is valid",
-		  "s","Epoch");
-	// TYPE
-	colMapDef(TYPE, "TYPE", TpString,
-		  "Type of flag (FLAG or UNFLAG)","","");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // APPLIED
+  colMapDef(APPLIED, "APPLIED", TpBool,
+            "True if flag has been applied to main table","","");
+  // COMMAND
+  colMapDef(COMMAND, "COMMAND", TpString,
+            "Flagging command","","");
+  // INTERVAL
+  colMapDef(INTERVAL,"INTERVAL", TpDouble,
+            "Time interval for which this flag is valid","s","");
+  // LEVEL
+  colMapDef(LEVEL, "LEVEL", TpInt,
+            "Flag level - revision level ","","");
+  // REASON
+  colMapDef(REASON, "REASON", TpString,
+            "Flag reason","","");
+  // SEVERITY
+  colMapDef(SEVERITY, "SEVERITY", TpInt,
+            "Severity code (0-10) ","","");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble,
+            "Midpoint of interval for which this flag is valid",
+            "s","Epoch");
+  // TYPE
+  colMapDef(TYPE, "TYPE", TpString,
+            "Type of flag (FLAG or UNFLAG)","","");
+  
+  // PredefinedKeywords
+}
 
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSFlagCmd::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSFlagCmd.cc
+++ b/ms/MeasurementSets/MSFlagCmd.cc
@@ -43,8 +43,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSFlagCmd::MSFlagCmd():hasBeenDestroyed_p(True) { }
 
 MSFlagCmd::MSFlagCmd(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+  : MSTable<MSFlagCmdEnums>(tableName, option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +54,7 @@ MSFlagCmd::MSFlagCmd(const String &tableName, TableOption option)
 
 MSFlagCmd::MSFlagCmd(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSFlagCmdEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +65,7 @@ MSFlagCmd::MSFlagCmd(const String& tableName, const String &tableDescName,
 
 MSFlagCmd::MSFlagCmd(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSFlagCmdEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +75,7 @@ MSFlagCmd::MSFlagCmd(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSFlagCmd::MSFlagCmd(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSFlagCmdEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +84,7 @@ MSFlagCmd::MSFlagCmd(const Table &table)
 }
 
 MSFlagCmd::MSFlagCmd(const MSFlagCmd &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSFlagCmdEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,71 +112,66 @@ MSFlagCmd::~MSFlagCmd()
 MSFlagCmd& MSFlagCmd::operator=(const MSFlagCmd &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSFlagCmdEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSFlagCmd::initMap()
+MSTableMaps MSFlagCmd::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // APPLIED
-  colMapDef(APPLIED, "APPLIED", TpBool,
+  colMapDef(maps, APPLIED, "APPLIED", TpBool,
             "True if flag has been applied to main table","","");
   // COMMAND
-  colMapDef(COMMAND, "COMMAND", TpString,
+  colMapDef(maps, COMMAND, "COMMAND", TpString,
             "Flagging command","","");
   // INTERVAL
-  colMapDef(INTERVAL,"INTERVAL", TpDouble,
+  colMapDef(maps, INTERVAL,"INTERVAL", TpDouble,
             "Time interval for which this flag is valid","s","");
   // LEVEL
-  colMapDef(LEVEL, "LEVEL", TpInt,
+  colMapDef(maps, LEVEL, "LEVEL", TpInt,
             "Flag level - revision level ","","");
   // REASON
-  colMapDef(REASON, "REASON", TpString,
+  colMapDef(maps, REASON, "REASON", TpString,
             "Flag reason","","");
   // SEVERITY
-  colMapDef(SEVERITY, "SEVERITY", TpInt,
+  colMapDef(maps, SEVERITY, "SEVERITY", TpInt,
             "Severity code (0-10) ","","");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble,
+  colMapDef(maps, TIME, "TIME", TpDouble,
             "Midpoint of interval for which this flag is valid",
             "s","Epoch");
   // TYPE
-  colMapDef(TYPE, "TYPE", TpString,
+  colMapDef(maps, TYPE, "TYPE", TpString,
             "Type of flag (FLAG or UNFLAG)","","");
   
   // PredefinedKeywords
-}
 
-void MSFlagCmd::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSFlagCmd MSFlagCmd::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MSFlagCmd(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSFlagCmd(MSTable<MSFlagCmdEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSFlagCmd.h
+++ b/ms/MeasurementSets/MSFlagCmd.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSFlagCmd:public MSFlagCmdEnums,
-                public MSTable<MSFlagCmdEnums::PredefinedColumns,
-		               MSFlagCmdEnums::PredefinedKeywords>
+                public MSTable<MSFlagCmdEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSFlagCmd.h
+++ b/ms/MeasurementSets/MSFlagCmd.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSFreqOffset.cc
+++ b/ms/MeasurementSets/MSFreqOffset.cc
@@ -123,51 +123,53 @@ MSFreqOffset& MSFreqOffset::operator=(const MSFreqOffset &other)
     return *this;
 }
 
-void MSFreqOffset::init()
+void MSFreqOffset::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// ANTENNA1
-	colMapDef(ANTENNA1, "ANTENNA1", TpInt,
-		  "Antenna1 id","","");
-	// ANTENNA2
-	colMapDef(ANTENNA2, "ANTENNA2", TpInt,
-		  "Antenna2 id","","");
-	// FEED_ID
-	colMapDef(FEED_ID, "FEED_ID", TpInt,
-		  "Feed id","","");
-	// INTERVAL
-	colMapDef(INTERVAL, "INTERVAL", TpDouble,
-		  "Time interval","s","");
-	// OFFSET
-	colMapDef(OFFSET, "OFFSET", TpDouble,
-		  "Frequency offset - antenna based","Hz","");
-	// SPECTRAL_WINDOW_ID
-	colMapDef(SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
-		  "Spectral window id","","");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble,
-		  "Midpoint of interval","s","Epoch");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // ANTENNA1
+  colMapDef(ANTENNA1, "ANTENNA1", TpInt,
+            "Antenna1 id","","");
+  // ANTENNA2
+  colMapDef(ANTENNA2, "ANTENNA2", TpInt,
+            "Antenna2 id","","");
+  // FEED_ID
+  colMapDef(FEED_ID, "FEED_ID", TpInt,
+            "Feed id","","");
+  // INTERVAL
+  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+            "Time interval","s","");
+  // OFFSET
+  colMapDef(OFFSET, "OFFSET", TpDouble,
+            "Frequency offset - antenna based","Hz","");
+  // SPECTRAL_WINDOW_ID
+  colMapDef(SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
+            "Spectral window id","","");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble,
+            "Midpoint of interval","s","Epoch");
+  
+  // PredefinedKeywords
+}
 
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSFreqOffset::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSFreqOffset.cc
+++ b/ms/MeasurementSets/MSFreqOffset.cc
@@ -43,8 +43,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSFreqOffset::MSFreqOffset():hasBeenDestroyed_p(True) { }
 
 MSFreqOffset::MSFreqOffset(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+  : MSTable<MSFreqOffsetEnums>(tableName, option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,9 +54,8 @@ MSFreqOffset::MSFreqOffset(const String &tableName, TableOption option)
 
 MSFreqOffset::MSFreqOffset(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
-      hasBeenDestroyed_p(False)
+  : MSTable<MSFreqOffsetEnums>(tableName, tableDescName, option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -66,9 +65,8 @@ MSFreqOffset::MSFreqOffset(const String& tableName, const String &tableDescName,
 
 MSFreqOffset::MSFreqOffset(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
-      hasBeenDestroyed_p(False)
+  : MSTable<MSFreqOffsetEnums>(newTab, nrrow, initialize),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -77,8 +75,8 @@ MSFreqOffset::MSFreqOffset(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSFreqOffset::MSFreqOffset(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+  : MSTable<MSFreqOffsetEnums>(table),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,9 +85,8 @@ MSFreqOffset::MSFreqOffset(const Table &table)
 }
 
 MSFreqOffset::MSFreqOffset(const MSFreqOffset &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
-      hasBeenDestroyed_p(False)
+  : MSTable<MSFreqOffsetEnums>(other),
+    hasBeenDestroyed_p(False)
 {
     // verify that other is valid
     if (&other != this) 
@@ -116,68 +113,63 @@ MSFreqOffset::~MSFreqOffset()
 MSFreqOffset& MSFreqOffset::operator=(const MSFreqOffset &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
-	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
+      MSTable<MSFreqOffsetEnums>::operator=(other);
+      hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSFreqOffset::initMap()
+MSTableMaps MSFreqOffset::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // ANTENNA1
-  colMapDef(ANTENNA1, "ANTENNA1", TpInt,
+  colMapDef(maps, ANTENNA1, "ANTENNA1", TpInt,
             "Antenna1 id","","");
   // ANTENNA2
-  colMapDef(ANTENNA2, "ANTENNA2", TpInt,
+  colMapDef(maps, ANTENNA2, "ANTENNA2", TpInt,
             "Antenna2 id","","");
   // FEED_ID
-  colMapDef(FEED_ID, "FEED_ID", TpInt,
+  colMapDef(maps, FEED_ID, "FEED_ID", TpInt,
             "Feed id","","");
   // INTERVAL
-  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+  colMapDef(maps, INTERVAL, "INTERVAL", TpDouble,
             "Time interval","s","");
   // OFFSET
-  colMapDef(OFFSET, "OFFSET", TpDouble,
+  colMapDef(maps, OFFSET, "OFFSET", TpDouble,
             "Frequency offset - antenna based","Hz","");
   // SPECTRAL_WINDOW_ID
-  colMapDef(SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
+  colMapDef(maps, SPECTRAL_WINDOW_ID, "SPECTRAL_WINDOW_ID", TpInt,
             "Spectral window id","","");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble,
+  colMapDef(maps, TIME, "TIME", TpDouble,
             "Midpoint of interval","s","Epoch");
   
   // PredefinedKeywords
-}
 
-void MSFreqOffset::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSFreqOffset MSFreqOffset::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MSFreqOffset(MSTable<PredefinedColumns,PredefinedKeywords>::
-		     referenceCopy(newTableName,writableColumns));
+  return MSFreqOffset(MSTable<MSFreqOffsetEnums>::
+                      referenceCopy(newTableName,writableColumns));
 }
 
 

--- a/ms/MeasurementSets/MSFreqOffset.h
+++ b/ms/MeasurementSets/MSFreqOffset.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSFreqOffset:public MSFreqOffsetEnums,
-                public MSTable<MSFreqOffsetEnums::PredefinedColumns,
-		               MSFreqOffsetEnums::PredefinedKeywords>
+                   public MSTable<MSFreqOffsetEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSFreqOffset.h
+++ b/ms/MeasurementSets/MSFreqOffset.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSHistory.cc
+++ b/ms/MeasurementSets/MSHistory.cc
@@ -123,57 +123,59 @@ MSHistory& MSHistory::operator=(const MSHistory &other)
     return *this;
 }
 
-void MSHistory::init()
+void MSHistory::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-      // the PredefinedColumns
-      // APPLICATION
-      colMapDef(APPLICATION,"APPLICATION",TpString,
-		"Application name","","");
-      // APP_PARAMS
-      colMapDef(APP_PARAMS,"APP_PARAMS",TpArrayString,
-		"Application parameters","","");
-      // CLI_COMMAND
-      colMapDef(CLI_COMMAND,"CLI_COMMAND",TpArrayString,
-		"CLI command sequence","","");
-      // MESSAGE
-      colMapDef(MESSAGE,"MESSAGE",TpString,
-		"Log message","","");
-      // OBJECT_ID
-      colMapDef(OBJECT_ID,"OBJECT_ID",TpInt,
-		"Originating ObjectID","","");
-      // OBSERVATION_ID
-      colMapDef(OBSERVATION_ID, "OBSERVATION_ID", TpInt,
-		"Observation id (index in OBSERVATION table)","","");
-      // ORIGIN
-      colMapDef(ORIGIN,"ORIGIN",TpString,
-		"(Source code) origin from which message originated","","");
-      // PRIORITY
-      colMapDef(PRIORITY,"PRIORITY",TpString,
-		"Message priority","","");
-      // TIME
-      colMapDef(TIME,"TIME",TpDouble,
-		"Timestamp of message","s","Epoch");
-      // PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // APPLICATION
+  colMapDef(APPLICATION,"APPLICATION",TpString,
+            "Application name","","");
+  // APP_PARAMS
+  colMapDef(APP_PARAMS,"APP_PARAMS",TpArrayString,
+            "Application parameters","","");
+  // CLI_COMMAND
+  colMapDef(CLI_COMMAND,"CLI_COMMAND",TpArrayString,
+            "CLI command sequence","","");
+  // MESSAGE
+  colMapDef(MESSAGE,"MESSAGE",TpString,
+            "Log message","","");
+  // OBJECT_ID
+  colMapDef(OBJECT_ID,"OBJECT_ID",TpInt,
+            "Originating ObjectID","","");
+  // OBSERVATION_ID
+  colMapDef(OBSERVATION_ID, "OBSERVATION_ID", TpInt,
+            "Observation id (index in OBSERVATION table)","","");
+  // ORIGIN
+  colMapDef(ORIGIN,"ORIGIN",TpString,
+            "(Source code) origin from which message originated","","");
+  // PRIORITY
+  colMapDef(PRIORITY,"PRIORITY",TpString,
+            "Message priority","","");
+  // TIME
+  colMapDef(TIME,"TIME",TpDouble,
+            "Timestamp of message","s","Epoch");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	// define the columns with known dimensionality
-	addColumnToDesc(requiredTD, APP_PARAMS, 1);
-	addColumnToDesc(requiredTD, CLI_COMMAND, 1);
-	// all required columns 
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSHistory::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  // define the columns with known dimensionality
+  addColumnToDesc(requiredTD, APP_PARAMS, 1);
+  addColumnToDesc(requiredTD, CLI_COMMAND, 1);
+  // all required columns 
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSHistory.cc
+++ b/ms/MeasurementSets/MSHistory.cc
@@ -40,11 +40,13 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-MSHistory::MSHistory():hasBeenDestroyed_p(True) { }
+MSHistory::MSHistory()
+  : hasBeenDestroyed_p(True)
+{}
 
 MSHistory::MSHistory(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+  : MSTable<MSHistoryEnums>(tableName, option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,9 +56,8 @@ MSHistory::MSHistory(const String &tableName, TableOption option)
 
 MSHistory::MSHistory(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
-      hasBeenDestroyed_p(False)
+  : MSTable<MSHistoryEnums>(tableName, tableDescName,option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -66,8 +67,7 @@ MSHistory::MSHistory(const String& tableName, const String &tableDescName,
 
 MSHistory::MSHistory(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSHistoryEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +77,7 @@ MSHistory::MSHistory(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSHistory::MSHistory(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSHistoryEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +86,7 @@ MSHistory::MSHistory(const Table &table)
 }
 
 MSHistory::MSHistory(const MSHistory &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSHistoryEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,74 +114,70 @@ MSHistory::~MSHistory()
 MSHistory& MSHistory::operator=(const MSHistory &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSHistoryEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSHistory::initMap()
+MSTableMaps MSHistory::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // APPLICATION
-  colMapDef(APPLICATION,"APPLICATION",TpString,
+  colMapDef(maps, APPLICATION,"APPLICATION",TpString,
             "Application name","","");
   // APP_PARAMS
-  colMapDef(APP_PARAMS,"APP_PARAMS",TpArrayString,
+  colMapDef(maps, APP_PARAMS,"APP_PARAMS",TpArrayString,
             "Application parameters","","");
   // CLI_COMMAND
-  colMapDef(CLI_COMMAND,"CLI_COMMAND",TpArrayString,
+  colMapDef(maps, CLI_COMMAND,"CLI_COMMAND",TpArrayString,
             "CLI command sequence","","");
   // MESSAGE
-  colMapDef(MESSAGE,"MESSAGE",TpString,
+  colMapDef(maps, MESSAGE,"MESSAGE",TpString,
             "Log message","","");
   // OBJECT_ID
-  colMapDef(OBJECT_ID,"OBJECT_ID",TpInt,
+  colMapDef(maps, OBJECT_ID,"OBJECT_ID",TpInt,
             "Originating ObjectID","","");
   // OBSERVATION_ID
-  colMapDef(OBSERVATION_ID, "OBSERVATION_ID", TpInt,
+  colMapDef(maps, OBSERVATION_ID, "OBSERVATION_ID", TpInt,
             "Observation id (index in OBSERVATION table)","","");
   // ORIGIN
-  colMapDef(ORIGIN,"ORIGIN",TpString,
+  colMapDef(maps, ORIGIN,"ORIGIN",TpString,
             "(Source code) origin from which message originated","","");
   // PRIORITY
-  colMapDef(PRIORITY,"PRIORITY",TpString,
+  colMapDef(maps, PRIORITY,"PRIORITY",TpString,
             "Message priority","","");
   // TIME
-  colMapDef(TIME,"TIME",TpDouble,
+  colMapDef(maps, TIME,"TIME",TpDouble,
             "Timestamp of message","s","Epoch");
   // PredefinedKeywords
-}
 
-void MSHistory::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
   // define the columns with known dimensionality
-  addColumnToDesc(requiredTD, APP_PARAMS, 1);
-  addColumnToDesc(requiredTD, CLI_COMMAND, 1);
+  addColumnToDesc(maps, APP_PARAMS, 1);
+  addColumnToDesc(maps, CLI_COMMAND, 1);
   // all required columns 
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSHistory MSHistory::referenceCopy(const String& newTableName, 
 				   const Block<String>& writableColumns) const
 {
-  return MSHistory(MSTable<PredefinedColumns,PredefinedKeywords>::referenceCopy
-		 (newTableName,writableColumns));
+  return MSHistory(MSTable<MSHistoryEnums>::referenceCopy
+                   (newTableName,writableColumns));
 }
 
 } //# NAMESPACE CASACORE - END

--- a/ms/MeasurementSets/MSHistory.h
+++ b/ms/MeasurementSets/MSHistory.h
@@ -124,7 +124,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSHistory.h
+++ b/ms/MeasurementSets/MSHistory.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSHistory:public MSHistoryEnums,
-		public MSTable<MSHistoryEnums::PredefinedColumns,
-		               MSHistoryEnums::PredefinedKeywords>
+		public MSTable<MSHistoryEnums>
 {
 public:
 
@@ -124,8 +123,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSObservation.cc
+++ b/ms/MeasurementSets/MSObservation.cc
@@ -43,8 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSObservation::MSObservation():hasBeenDestroyed_p(True) { }
 
 MSObservation::MSObservation(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSObservationEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +53,7 @@ MSObservation::MSObservation(const String &tableName, TableOption option)
 
 MSObservation::MSObservation(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSObservationEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +64,7 @@ MSObservation::MSObservation(const String& tableName, const String &tableDescNam
 
 MSObservation::MSObservation(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSObservationEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +74,7 @@ MSObservation::MSObservation(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSObservation::MSObservation(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSObservationEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +83,7 @@ MSObservation::MSObservation(const Table &table)
 }
 
 MSObservation::MSObservation(const MSObservation &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSObservationEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,77 +111,72 @@ MSObservation::~MSObservation()
 MSObservation& MSObservation::operator=(const MSObservation &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSObservationEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSObservation::initMap()
+MSTableMaps MSObservation::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // FLAG_ROW
-  colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
+  colMapDef(maps, FLAG_ROW,"FLAG_ROW",TpBool,
             "Row flag","","");
   // LOG
-  colMapDef(LOG,"LOG",TpArrayString,
+  colMapDef(maps, LOG,"LOG",TpArrayString,
             "Observing log","","");
   // OBSERVER
-  colMapDef(OBSERVER, "OBSERVER", TpString,
+  colMapDef(maps, OBSERVER, "OBSERVER", TpString,
             "Name of observer(s)","","");
   // PROJECT
-  colMapDef(PROJECT,"PROJECT",TpString,
+  colMapDef(maps, PROJECT,"PROJECT",TpString,
             "Project identification string","","");
   // RELEASE_DATE
-  colMapDef(RELEASE_DATE,"RELEASE_DATE",TpDouble,
+  colMapDef(maps, RELEASE_DATE,"RELEASE_DATE",TpDouble,
             "Release date when data becomes public","s","Epoch");
   // SCHEDULE
-  colMapDef(SCHEDULE,"SCHEDULE",TpArrayString,
+  colMapDef(maps, SCHEDULE,"SCHEDULE",TpArrayString,
             "Observing schedule","","");
   // SCHEDULE_TYPE
-  colMapDef(SCHEDULE_TYPE,"SCHEDULE_TYPE",TpString,
+  colMapDef(maps, SCHEDULE_TYPE,"SCHEDULE_TYPE",TpString,
             "Observing schedule type","","");
   // TELESCOPE_NAME
-  colMapDef(TELESCOPE_NAME,"TELESCOPE_NAME",TpString,
+  colMapDef(maps, TELESCOPE_NAME,"TELESCOPE_NAME",TpString,
             "Telescope Name (e.g. WSRT, VLBA)");
   // TIME_RANGE
-  colMapDef(TIME_RANGE,"TIME_RANGE",TpArrayDouble,
+  colMapDef(maps, TIME_RANGE,"TIME_RANGE",TpArrayDouble,
             "Start and end of observation","s","Epoch");
   // PredefinedKeywords
-}
 
-void MSObservation::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   // Define the columns with fixed size arrays
   IPosition shape(1,2);
   ColumnDesc::Option option=ColumnDesc::Direct;
-  addColumnToDesc(requiredTD, TIME_RANGE, shape, option);
+  addColumnToDesc(maps, TIME_RANGE, shape, option);
   // Define the columns with known dimensionality
-  addColumnToDesc(requiredTD, LOG, 1);
-  addColumnToDesc(requiredTD, SCHEDULE, 1);
+  addColumnToDesc(maps, LOG, 1);
+  addColumnToDesc(maps, SCHEDULE, 1);
   for (Int i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   for (Int i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSObservation MSObservation::referenceCopy(const String& newTableName, 
 				    const Block<String>& writableColumns) const
 {
-  return MSObservation(MSTable<PredefinedColumns,PredefinedKeywords>::referenceCopy
+  return MSObservation(MSTable<MSObservationEnums>::referenceCopy
 		 (newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSObservation.cc
+++ b/ms/MeasurementSets/MSObservation.cc
@@ -123,61 +123,63 @@ MSObservation& MSObservation::operator=(const MSObservation &other)
     return *this;
 }
 
-void MSObservation::init()
+void MSObservation::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// FLAG_ROW
-	colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
-		  "Row flag","","");
-	// LOG
-	colMapDef(LOG,"LOG",TpArrayString,
-		  "Observing log","","");
-	// OBSERVER
-	colMapDef(OBSERVER, "OBSERVER", TpString,
-		  "Name of observer(s)","","");
-	// PROJECT
-	colMapDef(PROJECT,"PROJECT",TpString,
-		  "Project identification string","","");
-	// RELEASE_DATE
-	colMapDef(RELEASE_DATE,"RELEASE_DATE",TpDouble,
-		  "Release date when data becomes public","s","Epoch");
-	// SCHEDULE
-	colMapDef(SCHEDULE,"SCHEDULE",TpArrayString,
-		  "Observing schedule","","");
-	// SCHEDULE_TYPE
-	colMapDef(SCHEDULE_TYPE,"SCHEDULE_TYPE",TpString,
-		  "Observing schedule type","","");
-	// TELESCOPE_NAME
-	colMapDef(TELESCOPE_NAME,"TELESCOPE_NAME",TpString,
-		  "Telescope Name (e.g. WSRT, VLBA)");
-	// TIME_RANGE
-	colMapDef(TIME_RANGE,"TIME_RANGE",TpArrayDouble,
-		  "Start and end of observation","s","Epoch");
-	// PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // FLAG_ROW
+  colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
+            "Row flag","","");
+  // LOG
+  colMapDef(LOG,"LOG",TpArrayString,
+            "Observing log","","");
+  // OBSERVER
+  colMapDef(OBSERVER, "OBSERVER", TpString,
+            "Name of observer(s)","","");
+  // PROJECT
+  colMapDef(PROJECT,"PROJECT",TpString,
+            "Project identification string","","");
+  // RELEASE_DATE
+  colMapDef(RELEASE_DATE,"RELEASE_DATE",TpDouble,
+            "Release date when data becomes public","s","Epoch");
+  // SCHEDULE
+  colMapDef(SCHEDULE,"SCHEDULE",TpArrayString,
+            "Observing schedule","","");
+  // SCHEDULE_TYPE
+  colMapDef(SCHEDULE_TYPE,"SCHEDULE_TYPE",TpString,
+            "Observing schedule type","","");
+  // TELESCOPE_NAME
+  colMapDef(TELESCOPE_NAME,"TELESCOPE_NAME",TpString,
+            "Telescope Name (e.g. WSRT, VLBA)");
+  // TIME_RANGE
+  colMapDef(TIME_RANGE,"TIME_RANGE",TpArrayDouble,
+            "Start and end of observation","s","Epoch");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-        // Define the columns with fixed size arrays
-        IPosition shape(1,2);
-        ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, TIME_RANGE, shape, option);
-	// Define the columns with known dimensionality
-	addColumnToDesc(requiredTD, LOG, 1);
-	addColumnToDesc(requiredTD, SCHEDULE, 1);
-	for (Int i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	for (Int i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSObservation::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  // Define the columns with fixed size arrays
+  IPosition shape(1,2);
+  ColumnDesc::Option option=ColumnDesc::Direct;
+  addColumnToDesc(requiredTD, TIME_RANGE, shape, option);
+  // Define the columns with known dimensionality
+  addColumnToDesc(requiredTD, LOG, 1);
+  addColumnToDesc(requiredTD, SCHEDULE, 1);
+  for (Int i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  for (Int i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSObservation.h
+++ b/ms/MeasurementSets/MSObservation.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSObservation:public MSObservationEnums,
-                     public MSTable<MSObservationEnums::PredefinedColumns,
-                                    MSObservationEnums::PredefinedKeywords>
+                    public MSTable<MSObservationEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 
@@ -138,8 +136,3 @@ private:
 } //# NAMESPACE CASACORE - END
 
 #endif
-
-
-
-
-

--- a/ms/MeasurementSets/MSObservation.h
+++ b/ms/MeasurementSets/MSObservation.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSPointing.cc
+++ b/ms/MeasurementSets/MSPointing.cc
@@ -43,8 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSPointing::MSPointing():hasBeenDestroyed_p(True) { }
 
 MSPointing::MSPointing(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSPointingEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +53,7 @@ MSPointing::MSPointing(const String &tableName, TableOption option)
 
 MSPointing::MSPointing(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSPointingEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +64,7 @@ MSPointing::MSPointing(const String& tableName, const String &tableDescName,
 
 MSPointing::MSPointing(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSPointingEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +74,7 @@ MSPointing::MSPointing(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSPointing::MSPointing(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSPointingEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +83,7 @@ MSPointing::MSPointing(const Table &table)
 }
 
 MSPointing::MSPointing(const MSPointing &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSPointingEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,95 +111,91 @@ MSPointing::~MSPointing()
 MSPointing& MSPointing::operator=(const MSPointing &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSPointingEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSPointing::initMap()
+MSTableMaps MSPointing::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // ANTENNA_ID
-  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+  colMapDef(maps, ANTENNA_ID, "ANTENNA_ID", TpInt,
             "Antenna Id","","");
   // DIRECTION
-  colMapDef(DIRECTION, "DIRECTION", TpArrayDouble,
+  colMapDef(maps, DIRECTION, "DIRECTION", TpArrayDouble,
             "Antenna pointing direction as polynomial in time","rad"
             ,"Direction");
   // INTERVAL
-  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+  colMapDef(maps, INTERVAL, "INTERVAL", TpDouble,
             "Time interval","s","");
   // NAME
-  colMapDef(NAME, "NAME", TpString,
+  colMapDef(maps, NAME, "NAME", TpString,
             "Pointing position name","","");
   // NUM_POLY
-  colMapDef(NUM_POLY, "NUM_POLY", TpInt,
+  colMapDef(maps, NUM_POLY, "NUM_POLY", TpInt,
             "Series order","","");
   // TARGET
-  colMapDef(TARGET, "TARGET", TpArrayDouble,
+  colMapDef(maps, TARGET, "TARGET", TpArrayDouble,
             "target direction as polynomial in time","rad"
             ,"Direction");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble,
+  colMapDef(maps, TIME, "TIME", TpDouble,
             "Time interval midpoint","s","Epoch");
   // TIME_ORIGIN
-  colMapDef(TIME_ORIGIN, "TIME_ORIGIN", TpDouble,
+  colMapDef(maps, TIME_ORIGIN, "TIME_ORIGIN", TpDouble,
             "Time origin for direction","s","Epoch");
   // TRACKING
-  colMapDef(TRACKING, "TRACKING", TpBool,
+  colMapDef(maps, TRACKING, "TRACKING", TpBool,
             "Tracking flag - True if on position","","");
   // ENCODER
-  colMapDef(ENCODER, "ENCODER", TpArrayDouble,
+  colMapDef(maps, ENCODER, "ENCODER", TpArrayDouble,
             "Encoder values","rad","Direction");
   // ON_SOURCE
-  colMapDef(ON_SOURCE, "ON_SOURCE", TpBool,
+  colMapDef(maps, ON_SOURCE, "ON_SOURCE", TpBool,
             "On source flag","","");
   // OVER_THE_TOP
-  colMapDef(OVER_THE_TOP, "OVER_THE_TOP", TpBool,
+  colMapDef(maps, OVER_THE_TOP, "OVER_THE_TOP", TpBool,
             "Antenna over the top","","");
   // POINTING_MODEL_ID
-  colMapDef(POINTING_MODEL_ID,"POINTING_MODEL_ID",TpInt,
+  colMapDef(maps, POINTING_MODEL_ID,"POINTING_MODEL_ID",TpInt,
             "Pointing model id","","");
   // POINTING_OFFSET
-  colMapDef(POINTING_OFFSET, "POINTING_OFFSET", TpArrayDouble,
+  colMapDef(maps, POINTING_OFFSET, "POINTING_OFFSET", TpArrayDouble,
             "A priori pointing correction as polynomial in time",
             "rad","Direction");
   // SOURCE_OFFSET
-  colMapDef(SOURCE_OFFSET, "SOURCE_OFFSET", TpArrayDouble,
+  colMapDef(maps, SOURCE_OFFSET, "SOURCE_OFFSET", TpArrayDouble,
             "Offset from source as polynomial in time","rad","Direction");
-  // PredefinedKeywords
-}
 
-void MSPointing::initDesc()
-{
+  // PredefinedKeywords
+
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   // First define the columns with known dimensionality
-  addColumnToDesc(requiredTD, DIRECTION, 2);
+  addColumnToDesc(maps, DIRECTION, 2);
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSPointing MSPointing::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MSPointing(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSPointing(MSTable<MSPointingEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSPointing.cc
+++ b/ms/MeasurementSets/MSPointing.cc
@@ -123,79 +123,81 @@ MSPointing& MSPointing::operator=(const MSPointing &other)
     return *this;
 }
 
-void MSPointing::init()
+void MSPointing::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// ANTENNA_ID
-	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
-		  "Antenna Id","","");
-	// DIRECTION
-	colMapDef(DIRECTION, "DIRECTION", TpArrayDouble,
-		  "Antenna pointing direction as polynomial in time","rad"
-		  ,"Direction");
-	// INTERVAL
-	colMapDef(INTERVAL, "INTERVAL", TpDouble,
-		  "Time interval","s","");
-	// NAME
-	colMapDef(NAME, "NAME", TpString,
-		  "Pointing position name","","");
-	// NUM_POLY
-	colMapDef(NUM_POLY, "NUM_POLY", TpInt,
-		  "Series order","","");
-	// TARGET
-	colMapDef(TARGET, "TARGET", TpArrayDouble,
-		  "target direction as polynomial in time","rad"
-		  ,"Direction");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble,
-		  "Time interval midpoint","s","Epoch");
-	// TIME_ORIGIN
-	colMapDef(TIME_ORIGIN, "TIME_ORIGIN", TpDouble,
-		  "Time origin for direction","s","Epoch");
-	// TRACKING
-	colMapDef(TRACKING, "TRACKING", TpBool,
-		  "Tracking flag - True if on position","","");
-	// ENCODER
-	colMapDef(ENCODER, "ENCODER", TpArrayDouble,
-		  "Encoder values","rad","Direction");
-	// ON_SOURCE
-	colMapDef(ON_SOURCE, "ON_SOURCE", TpBool,
-		  "On source flag","","");
-	// OVER_THE_TOP
-	colMapDef(OVER_THE_TOP, "OVER_THE_TOP", TpBool,
-		  "Antenna over the top","","");
-	// POINTING_MODEL_ID
-	colMapDef(POINTING_MODEL_ID,"POINTING_MODEL_ID",TpInt,
-		  "Pointing model id","","");
-	// POINTING_OFFSET
-	colMapDef(POINTING_OFFSET, "POINTING_OFFSET", TpArrayDouble,
-		  "A priori pointing correction as polynomial in time",
-		  "rad","Direction");
-	// SOURCE_OFFSET
-	colMapDef(SOURCE_OFFSET, "SOURCE_OFFSET", TpArrayDouble,
-		  "Offset from source as polynomial in time","rad","Direction");
-	// PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // ANTENNA_ID
+  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+            "Antenna Id","","");
+  // DIRECTION
+  colMapDef(DIRECTION, "DIRECTION", TpArrayDouble,
+            "Antenna pointing direction as polynomial in time","rad"
+            ,"Direction");
+  // INTERVAL
+  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+            "Time interval","s","");
+  // NAME
+  colMapDef(NAME, "NAME", TpString,
+            "Pointing position name","","");
+  // NUM_POLY
+  colMapDef(NUM_POLY, "NUM_POLY", TpInt,
+            "Series order","","");
+  // TARGET
+  colMapDef(TARGET, "TARGET", TpArrayDouble,
+            "target direction as polynomial in time","rad"
+            ,"Direction");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble,
+            "Time interval midpoint","s","Epoch");
+  // TIME_ORIGIN
+  colMapDef(TIME_ORIGIN, "TIME_ORIGIN", TpDouble,
+            "Time origin for direction","s","Epoch");
+  // TRACKING
+  colMapDef(TRACKING, "TRACKING", TpBool,
+            "Tracking flag - True if on position","","");
+  // ENCODER
+  colMapDef(ENCODER, "ENCODER", TpArrayDouble,
+            "Encoder values","rad","Direction");
+  // ON_SOURCE
+  colMapDef(ON_SOURCE, "ON_SOURCE", TpBool,
+            "On source flag","","");
+  // OVER_THE_TOP
+  colMapDef(OVER_THE_TOP, "OVER_THE_TOP", TpBool,
+            "Antenna over the top","","");
+  // POINTING_MODEL_ID
+  colMapDef(POINTING_MODEL_ID,"POINTING_MODEL_ID",TpInt,
+            "Pointing model id","","");
+  // POINTING_OFFSET
+  colMapDef(POINTING_OFFSET, "POINTING_OFFSET", TpArrayDouble,
+            "A priori pointing correction as polynomial in time",
+            "rad","Direction");
+  // SOURCE_OFFSET
+  colMapDef(SOURCE_OFFSET, "SOURCE_OFFSET", TpArrayDouble,
+            "Offset from source as polynomial in time","rad","Direction");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	// First define the columns with known dimensionality
-	addColumnToDesc(requiredTD, DIRECTION, 2);
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSPointing::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  // First define the columns with known dimensionality
+  addColumnToDesc(requiredTD, DIRECTION, 2);
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSPointing.h
+++ b/ms/MeasurementSets/MSPointing.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSPointing:public MSPointingEnums,
-		 public MSTable<MSPointingEnums::PredefinedColumns,
-		                MSPointingEnums::PredefinedKeywords>
+		 public MSTable<MSPointingEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 
@@ -138,8 +136,3 @@ private:
 } //# NAMESPACE CASACORE - END
 
 #endif
-
-
-
-
-

--- a/ms/MeasurementSets/MSPointing.h
+++ b/ms/MeasurementSets/MSPointing.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSPolarization.cc
+++ b/ms/MeasurementSets/MSPolarization.cc
@@ -43,8 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSPolarization::MSPolarization():hasBeenDestroyed_p(True) { }
 
 MSPolarization::MSPolarization(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSPolarizationEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +53,7 @@ MSPolarization::MSPolarization(const String &tableName, TableOption option)
 
 MSPolarization::MSPolarization(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSPolarizationEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +64,7 @@ MSPolarization::MSPolarization(const String& tableName, const String &tableDescN
 
 MSPolarization::MSPolarization(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSPolarizationEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +74,7 @@ MSPolarization::MSPolarization(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSPolarization::MSPolarization(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSPolarizationEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +83,7 @@ MSPolarization::MSPolarization(const Table &table)
 }
 
 MSPolarization::MSPolarization(const MSPolarization &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSPolarizationEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,61 +111,57 @@ MSPolarization::~MSPolarization()
 MSPolarization& MSPolarization::operator=(const MSPolarization &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSPolarizationEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSPolarization::initMap()
+MSTableMaps MSPolarization::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // CORR_PRODUCT
-  colMapDef(CORR_PRODUCT, "CORR_PRODUCT", TpArrayInt,
+  colMapDef(maps, CORR_PRODUCT, "CORR_PRODUCT", TpArrayInt,
             "Indices describing receptors of feed going into correlation","","");
   // CORR_TYPE
-  colMapDef(CORR_TYPE, "CORR_TYPE", TpArrayInt,
+  colMapDef(maps, CORR_TYPE, "CORR_TYPE", TpArrayInt,
             "The polarization type for each correlation product,"
             " as a Stokes enum.","","");
   // FLAG_ROW
-  colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
+  colMapDef(maps, FLAG_ROW, "FLAG_ROW", TpBool,
             "Row flag","","");
   // NUM_CORR
-  colMapDef(NUM_CORR, "NUM_CORR", TpInt,
+  colMapDef(maps, NUM_CORR, "NUM_CORR", TpInt,
             "Number of correlation products","","");
-  // PredefinedKeywords
-}
 
-void MSPolarization::initDesc()
-{
+  // PredefinedKeywords
+
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-	
   // all required columns 
   // First define the columns with known dimensionality
-  addColumnToDesc(requiredTD, CORR_TYPE, 1);
-  addColumnToDesc(requiredTD, CORR_PRODUCT, 2);
+  addColumnToDesc(maps, CORR_TYPE, 1);
+  addColumnToDesc(maps, CORR_PRODUCT, 2);
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSPolarization MSPolarization::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MSPolarization(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSPolarization(MSTable<MSPolarizationEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSPolarization.cc
+++ b/ms/MeasurementSets/MSPolarization.cc
@@ -123,45 +123,47 @@ MSPolarization& MSPolarization::operator=(const MSPolarization &other)
     return *this;
 }
 
-void MSPolarization::init()
+void MSPolarization::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// CORR_PRODUCT
-	colMapDef(CORR_PRODUCT, "CORR_PRODUCT", TpArrayInt,
-		  "Indices describing receptors of feed going into correlation","","");
-	// CORR_TYPE
-	colMapDef(CORR_TYPE, "CORR_TYPE", TpArrayInt,
-		  "The polarization type for each correlation product,"
-		  " as a Stokes enum.","","");
-	// FLAG_ROW
-	colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
-		  "Row flag","","");
-	// NUM_CORR
-	colMapDef(NUM_CORR, "NUM_CORR", TpInt,
-		  "Number of correlation products","","");
-	// PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // CORR_PRODUCT
+  colMapDef(CORR_PRODUCT, "CORR_PRODUCT", TpArrayInt,
+            "Indices describing receptors of feed going into correlation","","");
+  // CORR_TYPE
+  colMapDef(CORR_TYPE, "CORR_TYPE", TpArrayInt,
+            "The polarization type for each correlation product,"
+            " as a Stokes enum.","","");
+  // FLAG_ROW
+  colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
+            "Row flag","","");
+  // NUM_CORR
+  colMapDef(NUM_CORR, "NUM_CORR", TpInt,
+            "Number of correlation products","","");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
+void MSPolarization::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
 	
-	// all required columns 
-	// First define the columns with known dimensionality
-	addColumnToDesc(requiredTD, CORR_TYPE, 1);
-	addColumnToDesc(requiredTD, CORR_PRODUCT, 2);
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+  // all required columns 
+  // First define the columns with known dimensionality
+  addColumnToDesc(requiredTD, CORR_TYPE, 1);
+  addColumnToDesc(requiredTD, CORR_PRODUCT, 2);
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSPolarization.h
+++ b/ms/MeasurementSets/MSPolarization.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSPolarization:public MSPolarizationEnums,
-		 public MSTable<MSPolarizationEnums::PredefinedColumns,
-		                MSPolarizationEnums::PredefinedKeywords>
+                     public MSTable<MSPolarizationEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSPolarization.h
+++ b/ms/MeasurementSets/MSPolarization.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSProcessor.cc
+++ b/ms/MeasurementSets/MSProcessor.cc
@@ -123,47 +123,49 @@ MSProcessor& MSProcessor::operator=(const MSProcessor &other)
     return *this;
 }
 
-void MSProcessor::init()
+void MSProcessor::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// FLAG_ROW
-	colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
-		  "Row flag","","");
-	// 
-	colMapDef(MODE_ID, "MODE_ID", TpInt,
-		  "Processor mode id","","");
-	// PASS_ID
-	colMapDef(PASS_ID, "PASS_ID", TpInt,
-		  "Processor pass number","","");
-	// TYPE
-	colMapDef(TYPE, "TYPE", TpString,
-		  "Processor type","","");
-	// TYPE_ID
-	colMapDef(TYPE_ID, "TYPE_ID", TpInt,
-		  "Processor type id","","");
-	// SUB_TYPE
-	colMapDef(SUB_TYPE, "SUB_TYPE", TpString,
-		  "Processor sub type","","");
-	// PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // FLAG_ROW
+  colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
+            "Row flag","","");
+  // 
+  colMapDef(MODE_ID, "MODE_ID", TpInt,
+            "Processor mode id","","");
+  // PASS_ID
+  colMapDef(PASS_ID, "PASS_ID", TpInt,
+            "Processor pass number","","");
+  // TYPE
+  colMapDef(TYPE, "TYPE", TpString,
+            "Processor type","","");
+  // TYPE_ID
+  colMapDef(TYPE_ID, "TYPE_ID", TpInt,
+            "Processor type id","","");
+  // SUB_TYPE
+  colMapDef(SUB_TYPE, "SUB_TYPE", TpString,
+            "Processor sub type","","");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
+void MSProcessor::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
 	
-	// all required columns 
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+  // all required columns 
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSProcessor.cc
+++ b/ms/MeasurementSets/MSProcessor.cc
@@ -43,8 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSProcessor::MSProcessor():hasBeenDestroyed_p(True) { }
 
 MSProcessor::MSProcessor(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSProcessorEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +53,7 @@ MSProcessor::MSProcessor(const String &tableName, TableOption option)
 
 MSProcessor::MSProcessor(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSProcessorEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +64,7 @@ MSProcessor::MSProcessor(const String& tableName, const String &tableDescName,
 
 MSProcessor::MSProcessor(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSProcessorEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +74,7 @@ MSProcessor::MSProcessor(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSProcessor::MSProcessor(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSProcessorEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +83,7 @@ MSProcessor::MSProcessor(const Table &table)
 }
 
 MSProcessor::MSProcessor(const MSProcessor &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSProcessorEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,63 +111,59 @@ MSProcessor::~MSProcessor()
 MSProcessor& MSProcessor::operator=(const MSProcessor &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSProcessorEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSProcessor::initMap()
+MSTableMaps MSProcessor::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // FLAG_ROW
-  colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
+  colMapDef(maps, FLAG_ROW, "FLAG_ROW", TpBool,
             "Row flag","","");
   // 
-  colMapDef(MODE_ID, "MODE_ID", TpInt,
+  colMapDef(maps, MODE_ID, "MODE_ID", TpInt,
             "Processor mode id","","");
   // PASS_ID
-  colMapDef(PASS_ID, "PASS_ID", TpInt,
+  colMapDef(maps, PASS_ID, "PASS_ID", TpInt,
             "Processor pass number","","");
   // TYPE
-  colMapDef(TYPE, "TYPE", TpString,
+  colMapDef(maps, TYPE, "TYPE", TpString,
             "Processor type","","");
   // TYPE_ID
-  colMapDef(TYPE_ID, "TYPE_ID", TpInt,
+  colMapDef(maps, TYPE_ID, "TYPE_ID", TpInt,
             "Processor type id","","");
   // SUB_TYPE
-  colMapDef(SUB_TYPE, "SUB_TYPE", TpString,
+  colMapDef(maps, SUB_TYPE, "SUB_TYPE", TpString,
             "Processor sub type","","");
-  // PredefinedKeywords
-}
 
-void MSProcessor::initDesc()
-{
+  // PredefinedKeywords
+
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-	
   // all required columns 
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSProcessor MSProcessor::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MSProcessor(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSProcessor(MSTable<MSProcessorEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSProcessor.h
+++ b/ms/MeasurementSets/MSProcessor.h
@@ -124,7 +124,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSProcessor.h
+++ b/ms/MeasurementSets/MSProcessor.h
@@ -75,8 +75,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSProcessor:public MSProcessorEnums,
-		  public MSTable<MSProcessorEnums::PredefinedColumns,
-		                 MSProcessorEnums::PredefinedKeywords>
+		  public MSTable<MSProcessorEnums>
 {
 public:
 
@@ -124,8 +123,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSSource.cc
+++ b/ms/MeasurementSets/MSSource.cc
@@ -123,86 +123,88 @@ MSSource& MSSource::operator=(const MSSource &other)
     return *this;
 }
 
-void MSSource::init()
+void MSSource::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// CALIBRATION_GROUP 
-	colMapDef(CALIBRATION_GROUP, "CALIBRATION_GROUP", TpInt,
-		  "Number of grouping for calibration purpose.","","");
-	// CODE
-	colMapDef(CODE, "CODE", TpString,
-		  "Special characteristics of source, "
-		  "e.g. Bandpass calibrator","","");
-	// DIRECTION 
-	colMapDef(DIRECTION, "DIRECTION", TpArrayDouble,
-		  "Direction (e.g. RA, DEC).","rad","Direction");
-	// INTERVAL
-	colMapDef(INTERVAL, "INTERVAL", TpDouble,
-		  "Interval of time for which this set of parameters "
-		  "is accurate","s","");
-	// NAME
-	colMapDef(NAME, "NAME", TpString,
-		  "Name of source as given during observations","","");
-	// NUM_LINES
-	colMapDef(NUM_LINES, "NUM_LINES", TpInt,
-		  "Number of spectral lines","","");
-	// POSITION
-	colMapDef(POSITION, "POSITION", TpArrayDouble,
-		  "Position (e.g. for solar system objects",
-		  "m","Position");
-	// PROPER_MOTION
-	colMapDef(PROPER_MOTION, "PROPER_MOTION", TpArrayDouble,
-		  "Proper motion","rad/s","");
-	// PULSAR_ID
-	colMapDef(PULSAR_ID, "PULSAR_ID", TpInt,
-		  "Pulsar Id, pointer to pulsar table","","");
-	// REST_FREQUENCY
-	colMapDef(REST_FREQUENCY, "REST_FREQUENCY", TpArrayDouble,
-		  "Line rest frequency","Hz","Frequency");
-	// SOURCE_ID
-	colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
-		  "Source id","","");
-	// SOURCE_MODEL
-	colMapDef(SOURCE_MODEL, "SOURCE_MODEL", TpRecord,
-		  "Component Source Model","","");
-	// SPECTRAL_WINDOW_ID
-	colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
-		  "ID for this spectral window setup","","");
-	// SYSVEL
-	colMapDef(SYSVEL, "SYSVEL", TpArrayDouble,
-		  "Systemic velocity at reference","m/s","Radialvelocity");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble,
-		  "Midpoint of time for which this set of parameters "
-		  "is accurate.","s","Epoch");
-	// TRANSITION
-	colMapDef(TRANSITION, "TRANSITION", TpArrayString,
-		  "Line Transition name","","");
-	// PredefinedKeywords
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // CALIBRATION_GROUP 
+  colMapDef(CALIBRATION_GROUP, "CALIBRATION_GROUP", TpInt,
+            "Number of grouping for calibration purpose.","","");
+  // CODE
+  colMapDef(CODE, "CODE", TpString,
+            "Special characteristics of source, "
+            "e.g. Bandpass calibrator","","");
+  // DIRECTION 
+  colMapDef(DIRECTION, "DIRECTION", TpArrayDouble,
+            "Direction (e.g. RA, DEC).","rad","Direction");
+  // INTERVAL
+  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+            "Interval of time for which this set of parameters "
+            "is accurate","s","");
+  // NAME
+  colMapDef(NAME, "NAME", TpString,
+            "Name of source as given during observations","","");
+  // NUM_LINES
+  colMapDef(NUM_LINES, "NUM_LINES", TpInt,
+            "Number of spectral lines","","");
+  // POSITION
+  colMapDef(POSITION, "POSITION", TpArrayDouble,
+            "Position (e.g. for solar system objects",
+            "m","Position");
+  // PROPER_MOTION
+  colMapDef(PROPER_MOTION, "PROPER_MOTION", TpArrayDouble,
+            "Proper motion","rad/s","");
+  // PULSAR_ID
+  colMapDef(PULSAR_ID, "PULSAR_ID", TpInt,
+            "Pulsar Id, pointer to pulsar table","","");
+  // REST_FREQUENCY
+  colMapDef(REST_FREQUENCY, "REST_FREQUENCY", TpArrayDouble,
+            "Line rest frequency","Hz","Frequency");
+  // SOURCE_ID
+  colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
+            "Source id","","");
+  // SOURCE_MODEL
+  colMapDef(SOURCE_MODEL, "SOURCE_MODEL", TpRecord,
+            "Component Source Model","","");
+  // SPECTRAL_WINDOW_ID
+  colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
+            "ID for this spectral window setup","","");
+  // SYSVEL
+  colMapDef(SYSVEL, "SYSVEL", TpArrayDouble,
+            "Systemic velocity at reference","m/s","Radialvelocity");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble,
+            "Midpoint of time for which this set of parameters "
+            "is accurate.","s","Epoch");
+  // TRANSITION
+  colMapDef(TRANSITION, "TRANSITION", TpArrayString,
+            "Line Transition name","","");
+  // PredefinedKeywords
+}
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
+void MSSource::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
 	
-	// all required columns 
-	// First define the columns with fixed size arrays
-	IPosition shape(1,2);
-	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, DIRECTION, shape, option);
-	addColumnToDesc(requiredTD, PROPER_MOTION, shape, option);
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+  // all required columns 
+  // First define the columns with fixed size arrays
+  IPosition shape(1,2);
+  ColumnDesc::Option option=ColumnDesc::Direct;
+  addColumnToDesc(requiredTD, DIRECTION, shape, option);
+  addColumnToDesc(requiredTD, PROPER_MOTION, shape, option);
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSSource.cc
+++ b/ms/MeasurementSets/MSSource.cc
@@ -43,8 +43,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSSource::MSSource():hasBeenDestroyed_p(True) { }
 
 MSSource::MSSource(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+  : MSTable<MSSourceEnums>(tableName, option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +54,7 @@ MSSource::MSSource(const String &tableName, TableOption option)
 
 MSSource::MSSource(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSSourceEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +65,7 @@ MSSource::MSSource(const String& tableName, const String &tableDescName,
 
 MSSource::MSSource(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSSourceEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +75,7 @@ MSSource::MSSource(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSSource::MSSource(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSSourceEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +84,7 @@ MSSource::MSSource(const Table &table)
 }
 
 MSSource::MSSource(const MSSource &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSSourceEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,102 +112,97 @@ MSSource::~MSSource()
 MSSource& MSSource::operator=(const MSSource &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSSourceEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSSource::initMap()
+MSTableMaps MSSource::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // CALIBRATION_GROUP 
-  colMapDef(CALIBRATION_GROUP, "CALIBRATION_GROUP", TpInt,
+  colMapDef(maps, CALIBRATION_GROUP, "CALIBRATION_GROUP", TpInt,
             "Number of grouping for calibration purpose.","","");
   // CODE
-  colMapDef(CODE, "CODE", TpString,
+  colMapDef(maps, CODE, "CODE", TpString,
             "Special characteristics of source, "
             "e.g. Bandpass calibrator","","");
   // DIRECTION 
-  colMapDef(DIRECTION, "DIRECTION", TpArrayDouble,
+  colMapDef(maps, DIRECTION, "DIRECTION", TpArrayDouble,
             "Direction (e.g. RA, DEC).","rad","Direction");
   // INTERVAL
-  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+  colMapDef(maps, INTERVAL, "INTERVAL", TpDouble,
             "Interval of time for which this set of parameters "
             "is accurate","s","");
   // NAME
-  colMapDef(NAME, "NAME", TpString,
+  colMapDef(maps, NAME, "NAME", TpString,
             "Name of source as given during observations","","");
   // NUM_LINES
-  colMapDef(NUM_LINES, "NUM_LINES", TpInt,
+  colMapDef(maps, NUM_LINES, "NUM_LINES", TpInt,
             "Number of spectral lines","","");
   // POSITION
-  colMapDef(POSITION, "POSITION", TpArrayDouble,
+  colMapDef(maps, POSITION, "POSITION", TpArrayDouble,
             "Position (e.g. for solar system objects",
             "m","Position");
   // PROPER_MOTION
-  colMapDef(PROPER_MOTION, "PROPER_MOTION", TpArrayDouble,
+  colMapDef(maps, PROPER_MOTION, "PROPER_MOTION", TpArrayDouble,
             "Proper motion","rad/s","");
   // PULSAR_ID
-  colMapDef(PULSAR_ID, "PULSAR_ID", TpInt,
+  colMapDef(maps, PULSAR_ID, "PULSAR_ID", TpInt,
             "Pulsar Id, pointer to pulsar table","","");
   // REST_FREQUENCY
-  colMapDef(REST_FREQUENCY, "REST_FREQUENCY", TpArrayDouble,
+  colMapDef(maps, REST_FREQUENCY, "REST_FREQUENCY", TpArrayDouble,
             "Line rest frequency","Hz","Frequency");
   // SOURCE_ID
-  colMapDef(SOURCE_ID, "SOURCE_ID", TpInt,
+  colMapDef(maps, SOURCE_ID, "SOURCE_ID", TpInt,
             "Source id","","");
   // SOURCE_MODEL
-  colMapDef(SOURCE_MODEL, "SOURCE_MODEL", TpRecord,
+  colMapDef(maps, SOURCE_MODEL, "SOURCE_MODEL", TpRecord,
             "Component Source Model","","");
   // SPECTRAL_WINDOW_ID
-  colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
+  colMapDef(maps, SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
             "ID for this spectral window setup","","");
   // SYSVEL
-  colMapDef(SYSVEL, "SYSVEL", TpArrayDouble,
+  colMapDef(maps, SYSVEL, "SYSVEL", TpArrayDouble,
             "Systemic velocity at reference","m/s","Radialvelocity");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble,
+  colMapDef(maps, TIME, "TIME", TpDouble,
             "Midpoint of time for which this set of parameters "
             "is accurate.","s","Epoch");
   // TRANSITION
-  colMapDef(TRANSITION, "TRANSITION", TpArrayString,
+  colMapDef(maps, TRANSITION, "TRANSITION", TpArrayString,
             "Line Transition name","","");
   // PredefinedKeywords
-}
 
-void MSSource::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-	
   // all required columns 
   // First define the columns with fixed size arrays
   IPosition shape(1,2);
   ColumnDesc::Option option=ColumnDesc::Direct;
-  addColumnToDesc(requiredTD, DIRECTION, shape, option);
-  addColumnToDesc(requiredTD, PROPER_MOTION, shape, option);
+  addColumnToDesc(maps, DIRECTION, shape, option);
+  addColumnToDesc(maps, PROPER_MOTION, shape, option);
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSSource MSSource::referenceCopy(const String& newTableName, 
 				 const Block<String>& writableColumns) const
 {
-    return MSSource(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSSource(MSTable<MSSourceEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSSource.h
+++ b/ms/MeasurementSets/MSSource.h
@@ -75,8 +75,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSSource:public MSSourceEnums,
-	       public MSTable<MSSourceEnums::PredefinedColumns,
-	                      MSSourceEnums::PredefinedKeywords>
+	       public MSTable<MSSourceEnums>
 {
 public:
 
@@ -124,8 +123,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 
@@ -137,8 +135,3 @@ private:
 } //# NAMESPACE CASACORE - END
 
 #endif
-
-
-
-
-

--- a/ms/MeasurementSets/MSSource.h
+++ b/ms/MeasurementSets/MSSource.h
@@ -124,7 +124,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSSpectralWindow.cc
+++ b/ms/MeasurementSets/MSSpectralWindow.cc
@@ -124,106 +124,106 @@ MSSpectralWindow& MSSpectralWindow::operator=(const MSSpectralWindow &other)
     return *this;
 }
 
-void MSSpectralWindow::init()
+void MSSpectralWindow::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-      // the PredefinedColumns
-      // 
-      // ASSOC_NATURE
-      colMapDef(ASSOC_NATURE,"ASSOC_NATURE", TpArrayString,
-		"Nature of association with other spectral window","","");
-      // ASSOC_SPW_ID
-      colMapDef(ASSOC_SPW_ID,"ASSOC_SPW_ID",TpArrayInt,
-		"Associated spectral window id","","");
-      // BBC_NO
-      colMapDef(BBC_NO,"BBC_NO",TpInt,
-		"Baseband converter number","","");
-      // BBC_SIDEBAND
-      colMapDef(BBC_SIDEBAND,"BBC_SIDEBAND",TpInt,
-		"BBC sideband","","");
-      // CHAN_FREQ
-      colMapDef(CHAN_FREQ,"CHAN_FREQ", TpArrayDouble,
-		"Center frequencies for each channel in the data matrix",
-		"Hz","Frequency");
-      // CHAN_WIDTH
-      colMapDef(CHAN_WIDTH,"CHAN_WIDTH",TpArrayDouble,
-		"Channel width for each channel","Hz","");
-      // DOPPLER_ID
-      colMapDef(DOPPLER_ID,"DOPPLER_ID",TpInt,
-		"Doppler Id, points to DOPPLER table","","");
-      // EFFECTIVE_BW
-      colMapDef(EFFECTIVE_BW,"EFFECTIVE_BW",TpArrayDouble,
-		"Effective noise bandwidth of each channel","Hz","");
-      // FLAG_ROW
-      colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
-		"Row flag","","");
-      // FREQ_GROUP
-      colMapDef(FREQ_GROUP,"FREQ_GROUP",TpInt,
-		"Frequency group","","");
-      // FREQ_GROUP_NAME
-      colMapDef(FREQ_GROUP_NAME,"FREQ_GROUP_NAME",TpString,
-		"Frequency group name","","");
-      // IF_CONV_CHAIN
-      colMapDef(IF_CONV_CHAIN, "IF_CONV_CHAIN", TpInt,
-		"The IF conversion chain number","","");
-      // MEAS_FREQ_REF
-      colMapDef(MEAS_FREQ_REF,"MEAS_FREQ_REF",TpInt,
-		"Frequency Measure reference","","");
-      // NAME
-      colMapDef(NAME,"NAME",TpString,
-		"Spectral window name","","");
-      // NET_SIDEBAND
-      colMapDef(NET_SIDEBAND,"NET_SIDEBAND",TpInt,
-		"Net sideband","","");
-      // NUM_CHAN
-      colMapDef(NUM_CHAN, "NUM_CHAN", TpInt,
-		"Number of spectral channels","","");
-      // RECEIVER_ID
-      colMapDef(RECEIVER_ID,"RECEIVER_ID",TpInt,
-		"Receiver Id for this spectral window","","");
-      // REF_FREQUENCY
-      colMapDef(REF_FREQUENCY, "REF_FREQUENCY", TpDouble,
-		"The reference frequency",
-		"Hz","Frequency");
-      // RESOLUTION
-      colMapDef(RESOLUTION, "RESOLUTION", TpArrayDouble,
-		"The effective noise bandwidth for each channel",
-		"Hz","");
-      // TOTAL_BANDWIDTH
-      colMapDef(TOTAL_BANDWIDTH, "TOTAL_BANDWIDTH", TpDouble,
-		"The total bandwidth for this window","Hz","");
-      // PredefinedKeywords
-      
-      // init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // 
+  // ASSOC_NATURE
+  colMapDef(ASSOC_NATURE,"ASSOC_NATURE", TpArrayString,
+            "Nature of association with other spectral window","","");
+  // ASSOC_SPW_ID
+  colMapDef(ASSOC_SPW_ID,"ASSOC_SPW_ID",TpArrayInt,
+            "Associated spectral window id","","");
+  // BBC_NO
+  colMapDef(BBC_NO,"BBC_NO",TpInt,
+            "Baseband converter number","","");
+  // BBC_SIDEBAND
+  colMapDef(BBC_SIDEBAND,"BBC_SIDEBAND",TpInt,
+            "BBC sideband","","");
+  // CHAN_FREQ
+  colMapDef(CHAN_FREQ,"CHAN_FREQ", TpArrayDouble,
+            "Center frequencies for each channel in the data matrix",
+            "Hz","Frequency");
+  // CHAN_WIDTH
+  colMapDef(CHAN_WIDTH,"CHAN_WIDTH",TpArrayDouble,
+            "Channel width for each channel","Hz","");
+  // DOPPLER_ID
+  colMapDef(DOPPLER_ID,"DOPPLER_ID",TpInt,
+            "Doppler Id, points to DOPPLER table","","");
+  // EFFECTIVE_BW
+  colMapDef(EFFECTIVE_BW,"EFFECTIVE_BW",TpArrayDouble,
+            "Effective noise bandwidth of each channel","Hz","");
+  // FLAG_ROW
+  colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
+            "Row flag","","");
+  // FREQ_GROUP
+  colMapDef(FREQ_GROUP,"FREQ_GROUP",TpInt,
+            "Frequency group","","");
+  // FREQ_GROUP_NAME
+  colMapDef(FREQ_GROUP_NAME,"FREQ_GROUP_NAME",TpString,
+            "Frequency group name","","");
+  // IF_CONV_CHAIN
+  colMapDef(IF_CONV_CHAIN, "IF_CONV_CHAIN", TpInt,
+            "The IF conversion chain number","","");
+  // MEAS_FREQ_REF
+  colMapDef(MEAS_FREQ_REF,"MEAS_FREQ_REF",TpInt,
+            "Frequency Measure reference","","");
+  // NAME
+  colMapDef(NAME,"NAME",TpString,
+            "Spectral window name","","");
+  // NET_SIDEBAND
+  colMapDef(NET_SIDEBAND,"NET_SIDEBAND",TpInt,
+            "Net sideband","","");
+  // NUM_CHAN
+  colMapDef(NUM_CHAN, "NUM_CHAN", TpInt,
+            "Number of spectral channels","","");
+  // RECEIVER_ID
+  colMapDef(RECEIVER_ID,"RECEIVER_ID",TpInt,
+            "Receiver Id for this spectral window","","");
+  // REF_FREQUENCY
+  colMapDef(REF_FREQUENCY, "REF_FREQUENCY", TpDouble,
+            "The reference frequency",
+            "Hz","Frequency");
+  // RESOLUTION
+  colMapDef(RESOLUTION, "RESOLUTION", TpArrayDouble,
+            "The effective noise bandwidth for each channel",
+            "Hz","");
+  // TOTAL_BANDWIDTH
+  colMapDef(TOTAL_BANDWIDTH, "TOTAL_BANDWIDTH", TpDouble,
+            "The total bandwidth for this window","Hz","");
+  // PredefinedKeywords
+}
+
+void MSSpectralWindow::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
 	
-	// all required columns 
+  // all required columns 
 
-	// set up the TableMeasure columns with variable reference
-	// first add the variable ref column
-	addColumnToDesc(requiredTD, MEAS_FREQ_REF);
-	addColumnToDesc(requiredTD, CHAN_FREQ,1,"MEAS_FREQ_REF");
-	addColumnToDesc(requiredTD, REF_FREQUENCY,-1,"MEAS_FREQ_REF");
+  // set up the TableMeasure columns with variable reference
+  // first add the variable ref column
+  addColumnToDesc(requiredTD, MEAS_FREQ_REF);
+  addColumnToDesc(requiredTD, CHAN_FREQ,1,"MEAS_FREQ_REF");
+  addColumnToDesc(requiredTD, REF_FREQUENCY,-1,"MEAS_FREQ_REF");
 
-	// define columns with known dimensionality
-	addColumnToDesc(requiredTD, CHAN_WIDTH,1);
-	addColumnToDesc(requiredTD, EFFECTIVE_BW,1);
-	addColumnToDesc(requiredTD, RESOLUTION,1);
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
+  // define columns with known dimensionality
+  addColumnToDesc(requiredTD, CHAN_WIDTH,1);
+  addColumnToDesc(requiredTD, EFFECTIVE_BW,1);
+  addColumnToDesc(requiredTD, RESOLUTION,1);
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
 
-
-	requiredTD_p=new TableDesc(requiredTD);
-	
-    }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSSpectralWindow.cc
+++ b/ms/MeasurementSets/MSSpectralWindow.cc
@@ -44,8 +44,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSSpectralWindow::MSSpectralWindow():hasBeenDestroyed_p(True) { }
 
 MSSpectralWindow::MSSpectralWindow(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSSpectralWindowEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -55,8 +54,7 @@ MSSpectralWindow::MSSpectralWindow(const String &tableName, TableOption option)
 
 MSSpectralWindow::MSSpectralWindow(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSSpectralWindowEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -67,8 +65,7 @@ MSSpectralWindow::MSSpectralWindow(const String& tableName, const String &tableD
 
 MSSpectralWindow::MSSpectralWindow(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSSpectralWindowEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -78,8 +75,7 @@ MSSpectralWindow::MSSpectralWindow(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSSpectralWindow::MSSpectralWindow(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSSpectralWindowEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -88,8 +84,7 @@ MSSpectralWindow::MSSpectralWindow(const Table &table)
 }
 
 MSSpectralWindow::MSSpectralWindow(const MSSpectralWindow &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSSpectralWindowEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -117,120 +112,115 @@ MSSpectralWindow::~MSSpectralWindow()
 MSSpectralWindow& MSSpectralWindow::operator=(const MSSpectralWindow &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSSpectralWindowEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSSpectralWindow::initMap()
+MSTableMaps MSSpectralWindow::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // 
   // ASSOC_NATURE
-  colMapDef(ASSOC_NATURE,"ASSOC_NATURE", TpArrayString,
+  colMapDef(maps, ASSOC_NATURE,"ASSOC_NATURE", TpArrayString,
             "Nature of association with other spectral window","","");
   // ASSOC_SPW_ID
-  colMapDef(ASSOC_SPW_ID,"ASSOC_SPW_ID",TpArrayInt,
+  colMapDef(maps, ASSOC_SPW_ID,"ASSOC_SPW_ID",TpArrayInt,
             "Associated spectral window id","","");
   // BBC_NO
-  colMapDef(BBC_NO,"BBC_NO",TpInt,
+  colMapDef(maps, BBC_NO,"BBC_NO",TpInt,
             "Baseband converter number","","");
   // BBC_SIDEBAND
-  colMapDef(BBC_SIDEBAND,"BBC_SIDEBAND",TpInt,
+  colMapDef(maps, BBC_SIDEBAND,"BBC_SIDEBAND",TpInt,
             "BBC sideband","","");
   // CHAN_FREQ
-  colMapDef(CHAN_FREQ,"CHAN_FREQ", TpArrayDouble,
+  colMapDef(maps, CHAN_FREQ,"CHAN_FREQ", TpArrayDouble,
             "Center frequencies for each channel in the data matrix",
             "Hz","Frequency");
   // CHAN_WIDTH
-  colMapDef(CHAN_WIDTH,"CHAN_WIDTH",TpArrayDouble,
+  colMapDef(maps, CHAN_WIDTH,"CHAN_WIDTH",TpArrayDouble,
             "Channel width for each channel","Hz","");
   // DOPPLER_ID
-  colMapDef(DOPPLER_ID,"DOPPLER_ID",TpInt,
+  colMapDef(maps, DOPPLER_ID,"DOPPLER_ID",TpInt,
             "Doppler Id, points to DOPPLER table","","");
   // EFFECTIVE_BW
-  colMapDef(EFFECTIVE_BW,"EFFECTIVE_BW",TpArrayDouble,
+  colMapDef(maps, EFFECTIVE_BW,"EFFECTIVE_BW",TpArrayDouble,
             "Effective noise bandwidth of each channel","Hz","");
   // FLAG_ROW
-  colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
+  colMapDef(maps, FLAG_ROW,"FLAG_ROW",TpBool,
             "Row flag","","");
   // FREQ_GROUP
-  colMapDef(FREQ_GROUP,"FREQ_GROUP",TpInt,
+  colMapDef(maps, FREQ_GROUP,"FREQ_GROUP",TpInt,
             "Frequency group","","");
   // FREQ_GROUP_NAME
-  colMapDef(FREQ_GROUP_NAME,"FREQ_GROUP_NAME",TpString,
+  colMapDef(maps, FREQ_GROUP_NAME,"FREQ_GROUP_NAME",TpString,
             "Frequency group name","","");
   // IF_CONV_CHAIN
-  colMapDef(IF_CONV_CHAIN, "IF_CONV_CHAIN", TpInt,
+  colMapDef(maps, IF_CONV_CHAIN, "IF_CONV_CHAIN", TpInt,
             "The IF conversion chain number","","");
   // MEAS_FREQ_REF
-  colMapDef(MEAS_FREQ_REF,"MEAS_FREQ_REF",TpInt,
+  colMapDef(maps, MEAS_FREQ_REF,"MEAS_FREQ_REF",TpInt,
             "Frequency Measure reference","","");
   // NAME
-  colMapDef(NAME,"NAME",TpString,
+  colMapDef(maps, NAME,"NAME",TpString,
             "Spectral window name","","");
   // NET_SIDEBAND
-  colMapDef(NET_SIDEBAND,"NET_SIDEBAND",TpInt,
+  colMapDef(maps, NET_SIDEBAND,"NET_SIDEBAND",TpInt,
             "Net sideband","","");
   // NUM_CHAN
-  colMapDef(NUM_CHAN, "NUM_CHAN", TpInt,
+  colMapDef(maps, NUM_CHAN, "NUM_CHAN", TpInt,
             "Number of spectral channels","","");
   // RECEIVER_ID
-  colMapDef(RECEIVER_ID,"RECEIVER_ID",TpInt,
+  colMapDef(maps, RECEIVER_ID,"RECEIVER_ID",TpInt,
             "Receiver Id for this spectral window","","");
   // REF_FREQUENCY
-  colMapDef(REF_FREQUENCY, "REF_FREQUENCY", TpDouble,
+  colMapDef(maps, REF_FREQUENCY, "REF_FREQUENCY", TpDouble,
             "The reference frequency",
             "Hz","Frequency");
   // RESOLUTION
-  colMapDef(RESOLUTION, "RESOLUTION", TpArrayDouble,
+  colMapDef(maps, RESOLUTION, "RESOLUTION", TpArrayDouble,
             "The effective noise bandwidth for each channel",
             "Hz","");
   // TOTAL_BANDWIDTH
-  colMapDef(TOTAL_BANDWIDTH, "TOTAL_BANDWIDTH", TpDouble,
+  colMapDef(maps, TOTAL_BANDWIDTH, "TOTAL_BANDWIDTH", TpDouble,
             "The total bandwidth for this window","Hz","");
-  // PredefinedKeywords
-}
 
-void MSSpectralWindow::initDesc()
-{
+  // PredefinedKeywords
+
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-	
   // all required columns 
 
   // set up the TableMeasure columns with variable reference
   // first add the variable ref column
-  addColumnToDesc(requiredTD, MEAS_FREQ_REF);
-  addColumnToDesc(requiredTD, CHAN_FREQ,1,"MEAS_FREQ_REF");
-  addColumnToDesc(requiredTD, REF_FREQUENCY,-1,"MEAS_FREQ_REF");
+  addColumnToDesc(maps, MEAS_FREQ_REF);
+  addColumnToDesc(maps, CHAN_FREQ,1,"MEAS_FREQ_REF");
+  addColumnToDesc(maps, REF_FREQUENCY,-1,"MEAS_FREQ_REF");
 
   // define columns with known dimensionality
-  addColumnToDesc(requiredTD, CHAN_WIDTH,1);
-  addColumnToDesc(requiredTD, EFFECTIVE_BW,1);
-  addColumnToDesc(requiredTD, RESOLUTION,1);
+  addColumnToDesc(maps, CHAN_WIDTH,1);
+  addColumnToDesc(maps, EFFECTIVE_BW,1);
+  addColumnToDesc(maps, RESOLUTION,1);
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
 
-  requiredTD_p=new TableDesc(requiredTD);
+  return maps;
 }
 
 	
 MSSpectralWindow MSSpectralWindow::referenceCopy(const String& newTableName, 
 				     const Block<String>& writableColumns) const
 {
-    return MSSpectralWindow(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSSpectralWindow(MSTable<MSSpectralWindowEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSSpectralWindow.h
+++ b/ms/MeasurementSets/MSSpectralWindow.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSSpectralWindow.h
+++ b/ms/MeasurementSets/MSSpectralWindow.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSSpectralWindow:public MSSpectralWindowEnums,
-                  public MSTable<MSSpectralWindowEnums::PredefinedColumns,
-		                 MSSpectralWindowEnums::PredefinedKeywords>
+                       public MSTable<MSSpectralWindowEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSState.cc
+++ b/ms/MeasurementSets/MSState.cc
@@ -125,50 +125,52 @@ MSState& MSState::operator=(const MSState &other)
     return *this;
 }
 
-void MSState::init()
+void MSState::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-        // the PredefinedColumns
-        // CAL
-	colMapDef(CAL,"CAL", TpDouble,
-		  "Noise calibration temperature","K","");
-        // FLAG_ROW
-	colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
-		  "Row flag","","");
-        // LOAD
-	colMapDef(LOAD,"LOAD", TpDouble,
-		  "Load temperature","K","");
-        // OBS_MODE
-	colMapDef(OBS_MODE,"OBS_MODE", TpString,
-		  "Observing mode, e.g., OFF_SPECTRUM","","");
-        // REF
-	colMapDef(REF,"REF", TpBool,
-		  "True for a reference observation","","");
-        // SIG
-	colMapDef(SIG,"SIG", TpBool,
-		  "True for a source observation","","");
-        // SUB_SCAN
-	colMapDef(SUB_SCAN,"SUB_SCAN", TpInt,
-		  "Sub scan number, relative to scan number","","");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // CAL
+  colMapDef(CAL,"CAL", TpDouble,
+            "Noise calibration temperature","K","");
+  // FLAG_ROW
+  colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
+            "Row flag","","");
+  // LOAD
+  colMapDef(LOAD,"LOAD", TpDouble,
+            "Load temperature","K","");
+  // OBS_MODE
+  colMapDef(OBS_MODE,"OBS_MODE", TpString,
+            "Observing mode, e.g., OFF_SPECTRUM","","");
+  // REF
+  colMapDef(REF,"REF", TpBool,
+            "True for a reference observation","","");
+  // SIG
+  colMapDef(SIG,"SIG", TpBool,
+            "True for a source observation","","");
+  // SUB_SCAN
+  colMapDef(SUB_SCAN,"SUB_SCAN", TpInt,
+            "Sub scan number, relative to scan number","","");
+  
+  // PredefinedKeywords
+}
 
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSState::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 	

--- a/ms/MeasurementSets/MSState.cc
+++ b/ms/MeasurementSets/MSState.cc
@@ -45,8 +45,7 @@ MSState::MSState():hasBeenDestroyed_p(True) { }
 
 MSState::MSState(const String &tableName, 
 				     TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSStateEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -56,8 +55,7 @@ MSState::MSState(const String &tableName,
 
 MSState::MSState(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSStateEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -68,8 +66,7 @@ MSState::MSState(const String& tableName, const String &tableDescName,
 
 MSState::MSState(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSStateEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -79,8 +76,7 @@ MSState::MSState(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSState::MSState(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSStateEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -89,8 +85,7 @@ MSState::MSState(const Table &table)
 }
 
 MSState::MSState(const MSState &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSStateEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -118,66 +113,61 @@ MSState::~MSState()
 MSState& MSState::operator=(const MSState &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSStateEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSState::initMap()
+MSTableMaps MSState::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // CAL
-  colMapDef(CAL,"CAL", TpDouble,
+  colMapDef(maps, CAL,"CAL", TpDouble,
             "Noise calibration temperature","K","");
   // FLAG_ROW
-  colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
+  colMapDef(maps, FLAG_ROW,"FLAG_ROW", TpBool,
             "Row flag","","");
   // LOAD
-  colMapDef(LOAD,"LOAD", TpDouble,
+  colMapDef(maps, LOAD,"LOAD", TpDouble,
             "Load temperature","K","");
   // OBS_MODE
-  colMapDef(OBS_MODE,"OBS_MODE", TpString,
+  colMapDef(maps, OBS_MODE,"OBS_MODE", TpString,
             "Observing mode, e.g., OFF_SPECTRUM","","");
   // REF
-  colMapDef(REF,"REF", TpBool,
+  colMapDef(maps, REF,"REF", TpBool,
             "True for a reference observation","","");
   // SIG
-  colMapDef(SIG,"SIG", TpBool,
+  colMapDef(maps, SIG,"SIG", TpBool,
             "True for a source observation","","");
   // SUB_SCAN
-  colMapDef(SUB_SCAN,"SUB_SCAN", TpInt,
+  colMapDef(maps, SUB_SCAN,"SUB_SCAN", TpInt,
             "Sub scan number, relative to scan number","","");
   
   // PredefinedKeywords
-}
 
-void MSState::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 	
 MSState MSState::referenceCopy(const String& newTableName, 
 		    const Block<String>& writableColumns) const
 {
-    return MSState(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSState(MSTable<MSStateEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSState.h
+++ b/ms/MeasurementSets/MSState.h
@@ -77,8 +77,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 
 class MSState:public MSStateEnums,
-                public MSTable<MSStateEnums::PredefinedColumns,
-		               MSStateEnums::PredefinedKeywords>
+              public MSTable<MSStateEnums>
 {
 public:
     // This constructs an empty MSState
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSState.h
+++ b/ms/MeasurementSets/MSState.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSSysCal.cc
+++ b/ms/MeasurementSets/MSSysCal.cc
@@ -124,109 +124,111 @@ MSSysCal& MSSysCal::operator=(const MSSysCal &other)
     return *this;
 }
 
-void MSSysCal::init()
+void MSSysCal::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// ANTENNA_ID
-	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
-		  "ID of antenna in this array","","");
-	// FEED_ID
-	colMapDef(FEED_ID,"FEED_ID",TpInt,
-		  "Feed id","","");
-	// INTERVAL
-	colMapDef(INTERVAL,"INTERVAL",TpDouble,
-		  "Interval for which this set of parameters is accurate",
-		  "s","");
-	// SPECTRAL_WINDOW_ID
-	colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
-		  "ID for this spectral window setup","","");
-	// TIME
-	colMapDef(TIME,"TIME",TpDouble,
-		  "Midpoint of time for which this set of "
-		  "parameters is accurate","s","Epoch");
-	// PHASE_DIFF
-	colMapDef(PHASE_DIFF,"PHASE_DIFF",TpFloat,
-		  "Phase difference between receptor 2 and receptor 1",
-		  "rad","");
-	// PHASE_DIFF_FLAG
-	colMapDef(PHASE_DIFF_FLAG,"PHASE_DIFF_FLAG",TpBool,
-		  "Flag for PHASE_DIFF","","");
-	// TANT
-	colMapDef(TANT,"TANT",TpArrayFloat,
-		  "Antenna temperature for each receptor","K","");
-	// TANT_FLAG
-	colMapDef(TANT_FLAG,"TANT_FLAG",TpBool,
-		  "Flag for TANT","","");
-	// TANT_SPECTRUM
-	colMapDef(TANT_SPECTRUM,"TANT_SPECTRUM",TpArrayFloat,
-		  "Antenna temperature for each channel and receptor","K","");
-	// TANT_TSYS
-	colMapDef(TANT_TSYS,"TANT_TSYS",TpArrayFloat,
-		  "Ratio of Antenna & system temperature for each receptor",
-		  "","");
-	// TANT_TSYS_FLAG
-	colMapDef(TANT_TSYS_FLAG,"TANT_TSYS_FLAG",TpBool,
-		  "Flag for TANT_TSYS","","");
-	// TANT_TSYS_SPECTRUM
-	colMapDef(TANT_TSYS_SPECTRUM,"TANT_TSYS_SPECTRUM",TpArrayFloat,
-		  "Ratio of Antenna & system temperature for each channel "
-		  "and receptor","","");
-	// TCAL
-	colMapDef(TCAL,"TCAL",TpArrayFloat,
-		  "Calibration temperature for each receptor","K","");
-	// TCAL_FLAG
-	colMapDef(TCAL_FLAG,"TCAL_FLAG",TpBool,
-		  "Flag for TCAL","","");
-	// TCAL_SPECTRUM
-	colMapDef(TCAL_SPECTRUM,"TCAL_SPECTRUM",TpArrayFloat,
-		  "Calibration temperature for each channel and receptor","K","");
-	// TRX 
-	colMapDef(TRX,"TRX",TpArrayFloat,
-		  "Receiver temperature for each of the two receptors","K","");
-	// TRX_FLAG
-	colMapDef(TRX_FLAG,"TRX_FLAG",TpBool,
-		  "Flag for TRX","","");
-	// TRX_SPECTRUM
-	colMapDef(TRX_SPECTRUM,"TRX_SPECTRUM",TpArrayFloat,
-		  "Receiver temperature for each channel and receptor","K","");
-	// TSKY 
-	colMapDef(TSKY,"TSKY",TpArrayFloat,
-		  "Sky temperature for each of the two receptors","K","");
-	// TSKY_FLAG
-	colMapDef(TSKY_FLAG,"TSKY_FLAG",TpBool,
-		  "Flag for TSKY","","");
-	// TSKY_SPECTRUM
-	colMapDef(TSKY_SPECTRUM,"TSKY_SPECTRUM",TpArrayFloat,
-		  "Sky temperature for each channel and receptor","K","");
-	// TSYS
-	colMapDef(TSYS,"TSYS",TpArrayFloat,
-		  "System temp. for each of the two receptors","K","");
-	// TSYS_FLAG
-	colMapDef(TSYS_FLAG,"TSYS_FLAG",TpBool,
-		  "Flag for TSYS","","");
-	// TSYS_SPECTRUM
-	colMapDef(TSYS_SPECTRUM,"TSYS_SPECTRUM",TpArrayFloat,
-		  "System temperature for each channel and receptor","K","");
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // ANTENNA_ID
+  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+            "ID of antenna in this array","","");
+  // FEED_ID
+  colMapDef(FEED_ID,"FEED_ID",TpInt,
+            "Feed id","","");
+  // INTERVAL
+  colMapDef(INTERVAL,"INTERVAL",TpDouble,
+            "Interval for which this set of parameters is accurate",
+            "s","");
+  // SPECTRAL_WINDOW_ID
+  colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
+            "ID for this spectral window setup","","");
+  // TIME
+  colMapDef(TIME,"TIME",TpDouble,
+            "Midpoint of time for which this set of "
+            "parameters is accurate","s","Epoch");
+  // PHASE_DIFF
+  colMapDef(PHASE_DIFF,"PHASE_DIFF",TpFloat,
+            "Phase difference between receptor 2 and receptor 1",
+            "rad","");
+  // PHASE_DIFF_FLAG
+  colMapDef(PHASE_DIFF_FLAG,"PHASE_DIFF_FLAG",TpBool,
+            "Flag for PHASE_DIFF","","");
+  // TANT
+  colMapDef(TANT,"TANT",TpArrayFloat,
+            "Antenna temperature for each receptor","K","");
+  // TANT_FLAG
+  colMapDef(TANT_FLAG,"TANT_FLAG",TpBool,
+            "Flag for TANT","","");
+  // TANT_SPECTRUM
+  colMapDef(TANT_SPECTRUM,"TANT_SPECTRUM",TpArrayFloat,
+            "Antenna temperature for each channel and receptor","K","");
+  // TANT_TSYS
+  colMapDef(TANT_TSYS,"TANT_TSYS",TpArrayFloat,
+            "Ratio of Antenna & system temperature for each receptor",
+            "","");
+  // TANT_TSYS_FLAG
+  colMapDef(TANT_TSYS_FLAG,"TANT_TSYS_FLAG",TpBool,
+            "Flag for TANT_TSYS","","");
+  // TANT_TSYS_SPECTRUM
+  colMapDef(TANT_TSYS_SPECTRUM,"TANT_TSYS_SPECTRUM",TpArrayFloat,
+            "Ratio of Antenna & system temperature for each channel "
+            "and receptor","","");
+  // TCAL
+  colMapDef(TCAL,"TCAL",TpArrayFloat,
+            "Calibration temperature for each receptor","K","");
+  // TCAL_FLAG
+  colMapDef(TCAL_FLAG,"TCAL_FLAG",TpBool,
+            "Flag for TCAL","","");
+  // TCAL_SPECTRUM
+  colMapDef(TCAL_SPECTRUM,"TCAL_SPECTRUM",TpArrayFloat,
+            "Calibration temperature for each channel and receptor","K","");
+  // TRX 
+  colMapDef(TRX,"TRX",TpArrayFloat,
+            "Receiver temperature for each of the two receptors","K","");
+  // TRX_FLAG
+  colMapDef(TRX_FLAG,"TRX_FLAG",TpBool,
+            "Flag for TRX","","");
+  // TRX_SPECTRUM
+  colMapDef(TRX_SPECTRUM,"TRX_SPECTRUM",TpArrayFloat,
+            "Receiver temperature for each channel and receptor","K","");
+  // TSKY 
+  colMapDef(TSKY,"TSKY",TpArrayFloat,
+            "Sky temperature for each of the two receptors","K","");
+  // TSKY_FLAG
+  colMapDef(TSKY_FLAG,"TSKY_FLAG",TpBool,
+            "Flag for TSKY","","");
+  // TSKY_SPECTRUM
+  colMapDef(TSKY_SPECTRUM,"TSKY_SPECTRUM",TpArrayFloat,
+            "Sky temperature for each channel and receptor","K","");
+  // TSYS
+  colMapDef(TSYS,"TSYS",TpArrayFloat,
+            "System temp. for each of the two receptors","K","");
+  // TSYS_FLAG
+  colMapDef(TSYS_FLAG,"TSYS_FLAG",TpBool,
+            "Flag for TSYS","","");
+  // TSYS_SPECTRUM
+  colMapDef(TSYS_SPECTRUM,"TSYS_SPECTRUM",TpArrayFloat,
+            "System temperature for each channel and receptor","K","");
+  
+  // PredefinedKeywords
+}
 
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MSSysCal::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
 }
 
 MSSysCal MSSysCal::referenceCopy(const String& newTableName, 

--- a/ms/MeasurementSets/MSSysCal.cc
+++ b/ms/MeasurementSets/MSSysCal.cc
@@ -44,8 +44,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSSysCal::MSSysCal():hasBeenDestroyed_p(True) { }
 
 MSSysCal::MSSysCal(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+  : MSTable<MSSysCalEnums>(tableName, option),
+    hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -55,8 +55,7 @@ MSSysCal::MSSysCal(const String &tableName, TableOption option)
 
 MSSysCal::MSSysCal(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSSysCalEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -67,8 +66,7 @@ MSSysCal::MSSysCal(const String& tableName, const String &tableDescName,
 
 MSSysCal::MSSysCal(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSSysCalEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -78,8 +76,7 @@ MSSysCal::MSSysCal(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSSysCal::MSSysCal(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSSysCalEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -88,8 +85,7 @@ MSSysCal::MSSysCal(const Table &table)
 }
 
 MSSysCal::MSSysCal(const MSSysCal &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSSysCalEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -117,124 +113,120 @@ MSSysCal::~MSSysCal()
 MSSysCal& MSSysCal::operator=(const MSSysCal &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSSysCalEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSSysCal::initMap()
+MSTableMaps MSSysCal::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
+  AlwaysAssert (maps.columnMap_p.empty(), AipsError);
   // the PredefinedColumns
   // ANTENNA_ID
-  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+  colMapDef(maps, ANTENNA_ID, "ANTENNA_ID", TpInt,
             "ID of antenna in this array","","");
   // FEED_ID
-  colMapDef(FEED_ID,"FEED_ID",TpInt,
+  colMapDef(maps, FEED_ID,"FEED_ID",TpInt,
             "Feed id","","");
   // INTERVAL
-  colMapDef(INTERVAL,"INTERVAL",TpDouble,
+  colMapDef(maps, INTERVAL,"INTERVAL",TpDouble,
             "Interval for which this set of parameters is accurate",
             "s","");
   // SPECTRAL_WINDOW_ID
-  colMapDef(SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
+  colMapDef(maps, SPECTRAL_WINDOW_ID,"SPECTRAL_WINDOW_ID",TpInt,
             "ID for this spectral window setup","","");
   // TIME
-  colMapDef(TIME,"TIME",TpDouble,
+  colMapDef(maps, TIME,"TIME",TpDouble,
             "Midpoint of time for which this set of "
             "parameters is accurate","s","Epoch");
   // PHASE_DIFF
-  colMapDef(PHASE_DIFF,"PHASE_DIFF",TpFloat,
+  colMapDef(maps, PHASE_DIFF,"PHASE_DIFF",TpFloat,
             "Phase difference between receptor 2 and receptor 1",
             "rad","");
   // PHASE_DIFF_FLAG
-  colMapDef(PHASE_DIFF_FLAG,"PHASE_DIFF_FLAG",TpBool,
+  colMapDef(maps, PHASE_DIFF_FLAG,"PHASE_DIFF_FLAG",TpBool,
             "Flag for PHASE_DIFF","","");
   // TANT
-  colMapDef(TANT,"TANT",TpArrayFloat,
+  colMapDef(maps, TANT,"TANT",TpArrayFloat,
             "Antenna temperature for each receptor","K","");
   // TANT_FLAG
-  colMapDef(TANT_FLAG,"TANT_FLAG",TpBool,
+  colMapDef(maps, TANT_FLAG,"TANT_FLAG",TpBool,
             "Flag for TANT","","");
   // TANT_SPECTRUM
-  colMapDef(TANT_SPECTRUM,"TANT_SPECTRUM",TpArrayFloat,
+  colMapDef(maps, TANT_SPECTRUM,"TANT_SPECTRUM",TpArrayFloat,
             "Antenna temperature for each channel and receptor","K","");
   // TANT_TSYS
-  colMapDef(TANT_TSYS,"TANT_TSYS",TpArrayFloat,
+  colMapDef(maps, TANT_TSYS,"TANT_TSYS",TpArrayFloat,
             "Ratio of Antenna & system temperature for each receptor",
             "","");
   // TANT_TSYS_FLAG
-  colMapDef(TANT_TSYS_FLAG,"TANT_TSYS_FLAG",TpBool,
+  colMapDef(maps, TANT_TSYS_FLAG,"TANT_TSYS_FLAG",TpBool,
             "Flag for TANT_TSYS","","");
   // TANT_TSYS_SPECTRUM
-  colMapDef(TANT_TSYS_SPECTRUM,"TANT_TSYS_SPECTRUM",TpArrayFloat,
+  colMapDef(maps, TANT_TSYS_SPECTRUM,"TANT_TSYS_SPECTRUM",TpArrayFloat,
             "Ratio of Antenna & system temperature for each channel "
             "and receptor","","");
   // TCAL
-  colMapDef(TCAL,"TCAL",TpArrayFloat,
+  colMapDef(maps, TCAL,"TCAL",TpArrayFloat,
             "Calibration temperature for each receptor","K","");
   // TCAL_FLAG
-  colMapDef(TCAL_FLAG,"TCAL_FLAG",TpBool,
+  colMapDef(maps, TCAL_FLAG,"TCAL_FLAG",TpBool,
             "Flag for TCAL","","");
   // TCAL_SPECTRUM
-  colMapDef(TCAL_SPECTRUM,"TCAL_SPECTRUM",TpArrayFloat,
+  colMapDef(maps, TCAL_SPECTRUM,"TCAL_SPECTRUM",TpArrayFloat,
             "Calibration temperature for each channel and receptor","K","");
   // TRX 
-  colMapDef(TRX,"TRX",TpArrayFloat,
+  colMapDef(maps, TRX,"TRX",TpArrayFloat,
             "Receiver temperature for each of the two receptors","K","");
   // TRX_FLAG
-  colMapDef(TRX_FLAG,"TRX_FLAG",TpBool,
+  colMapDef(maps, TRX_FLAG,"TRX_FLAG",TpBool,
             "Flag for TRX","","");
   // TRX_SPECTRUM
-  colMapDef(TRX_SPECTRUM,"TRX_SPECTRUM",TpArrayFloat,
+  colMapDef(maps, TRX_SPECTRUM,"TRX_SPECTRUM",TpArrayFloat,
             "Receiver temperature for each channel and receptor","K","");
   // TSKY 
-  colMapDef(TSKY,"TSKY",TpArrayFloat,
+  colMapDef(maps, TSKY,"TSKY",TpArrayFloat,
             "Sky temperature for each of the two receptors","K","");
   // TSKY_FLAG
-  colMapDef(TSKY_FLAG,"TSKY_FLAG",TpBool,
+  colMapDef(maps, TSKY_FLAG,"TSKY_FLAG",TpBool,
             "Flag for TSKY","","");
   // TSKY_SPECTRUM
-  colMapDef(TSKY_SPECTRUM,"TSKY_SPECTRUM",TpArrayFloat,
+  colMapDef(maps, TSKY_SPECTRUM,"TSKY_SPECTRUM",TpArrayFloat,
             "Sky temperature for each channel and receptor","K","");
   // TSYS
-  colMapDef(TSYS,"TSYS",TpArrayFloat,
+  colMapDef(maps, TSYS,"TSYS",TpArrayFloat,
             "System temp. for each of the two receptors","K","");
   // TSYS_FLAG
-  colMapDef(TSYS_FLAG,"TSYS_FLAG",TpBool,
+  colMapDef(maps, TSYS_FLAG,"TSYS_FLAG",TpBool,
             "Flag for TSYS","","");
   // TSYS_SPECTRUM
-  colMapDef(TSYS_SPECTRUM,"TSYS_SPECTRUM",TpArrayFloat,
+  colMapDef(maps, TSYS_SPECTRUM,"TSYS_SPECTRUM",TpArrayFloat,
             "System temperature for each channel and receptor","K","");
   
   // PredefinedKeywords
-}
 
-void MSSysCal::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 MSSysCal MSSysCal::referenceCopy(const String& newTableName, 
 				 const Block<String>& writableColumns) const
 {
-    return MSSysCal(MSTable<PredefinedColumns,PredefinedKeywords>::referenceCopy
+    return MSSysCal(MSTable<MSSysCalEnums>::referenceCopy
 		    (newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSSysCal.h
+++ b/ms/MeasurementSets/MSSysCal.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSSysCal.h
+++ b/ms/MeasurementSets/MSSysCal.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSSysCal:public MSSysCalEnums,
-                public MSTable<MSSysCalEnums::PredefinedColumns,
-		               MSSysCalEnums::PredefinedKeywords>
+               public MSTable<MSSysCalEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 

--- a/ms/MeasurementSets/MSTable.cc
+++ b/ms/MeasurementSets/MSTable.cc
@@ -25,64 +25,44 @@
 //#
 //# $Id$
 
-#include <casacore/ms/MeasurementSets/MSTable.h>
-#include <casacore/ms/MeasurementSets/MSAntennaEnums.h>
-#include <casacore/ms/MeasurementSets/MSDataDescEnums.h>
-#include <casacore/ms/MeasurementSets/MSDopplerEnums.h>
-#include <casacore/ms/MeasurementSets/MSFeedEnums.h>
-#include <casacore/ms/MeasurementSets/MSFieldEnums.h>
-#include <casacore/ms/MeasurementSets/MSFlagCmdEnums.h>
-#include <casacore/ms/MeasurementSets/MSFreqOffEnums.h>
-#include <casacore/ms/MeasurementSets/MSHistoryEnums.h>
-#include <casacore/ms/MeasurementSets/MSMainEnums.h>
-#include <casacore/ms/MeasurementSets/MSObsEnums.h>
-#include <casacore/ms/MeasurementSets/MSPointingEnums.h>
-#include <casacore/ms/MeasurementSets/MSPolEnums.h>
-#include <casacore/ms/MeasurementSets/MSProcessorEnums.h>
-#include <casacore/ms/MeasurementSets/MSSourceEnums.h>
-#include <casacore/ms/MeasurementSets/MSSpWindowEnums.h>
-#include <casacore/ms/MeasurementSets/MSStateEnums.h>
-#include <casacore/ms/MeasurementSets/MSSysCalEnums.h>
-#include <casacore/ms/MeasurementSets/MSWeatherEnums.h>
+#include <casacore/ms/MeasurementSets/MSTable.tcc>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-  template class MSTable<MSAntennaEnums::PredefinedColumns,
-                         MSAntennaEnums::PredefinedKeywords> ;
-  template class MSTable<MSDataDescriptionEnums::PredefinedColumns,
-                         MSDataDescriptionEnums::PredefinedKeywords> ;
-  template class MSTable<MSDopplerEnums::PredefinedColumns,
-                         MSDopplerEnums::PredefinedKeywords> ;
-  template class MSTable<MSFeedEnums::PredefinedColumns,
-                         MSFeedEnums::PredefinedKeywords> ;
-  template class MSTable<MSFieldEnums::PredefinedColumns,
-                         MSFieldEnums::PredefinedKeywords> ;
-  template class MSTable<MSFlagCmdEnums::PredefinedColumns,
-                         MSFlagCmdEnums::PredefinedKeywords> ;
-  template class MSTable<MSFreqOffsetEnums::PredefinedColumns,
-                         MSFreqOffsetEnums::PredefinedKeywords> ;
-  template class MSTable<MSHistoryEnums::PredefinedColumns,
-                         MSHistoryEnums::PredefinedKeywords> ;
-  template class MSTable<MSMainEnums::PredefinedColumns,
-                         MSMainEnums::PredefinedKeywords> ;
-  template class MSTable<MSObservationEnums::PredefinedColumns,
-                         MSObservationEnums::PredefinedKeywords> ;
-  template class MSTable<MSPointingEnums::PredefinedColumns,
-                         MSPointingEnums::PredefinedKeywords> ;
-  template class MSTable<MSPolarizationEnums::PredefinedColumns,
-                         MSPolarizationEnums::PredefinedKeywords> ;
-  template class MSTable<MSProcessorEnums::PredefinedColumns,
-                         MSProcessorEnums::PredefinedKeywords> ;
-  template class MSTable<MSSourceEnums::PredefinedColumns,
-                         MSSourceEnums::PredefinedKeywords> ;
-  template class MSTable<MSSpectralWindowEnums::PredefinedColumns,
-                         MSSpectralWindowEnums::PredefinedKeywords> ;
-  template class MSTable<MSStateEnums::PredefinedColumns,
-                         MSStateEnums::PredefinedKeywords> ;
-  template class MSTable<MSSysCalEnums::PredefinedColumns,
-                         MSSysCalEnums::PredefinedKeywords> ;
-  template class MSTable<MSWeatherEnums::PredefinedColumns,
-                         MSWeatherEnums::PredefinedKeywords> ;
+  Int MSTableMaps::mapType (const std::map<Int,String>& nameMap, const String& name) const
+  {
+    // find first occurrence of name in the map (should be only occurrence)
+    Int type = 0; //# 0=UNDEFINED_COLUMN for all enums
+    for (auto kv : nameMap) {
+      if (kv.second == name) {
+        type = kv.first;
+        break;
+      }
+    }
+    return type;
+  }
+
+
+  // Instantiate the templates.
+  template class MSTable<MSMainEnums>;
+
+  template class MSTable<MSAntennaEnums>;
+  template class MSTable<MSDataDescriptionEnums>;
+  template class MSTable<MSDopplerEnums>;
+  template class MSTable<MSFeedEnums>;
+  template class MSTable<MSFieldEnums>;
+  template class MSTable<MSFlagCmdEnums>;
+  template class MSTable<MSFreqOffsetEnums>;
+  template class MSTable<MSHistoryEnums>;
+  template class MSTable<MSObservationEnums>;
+  template class MSTable<MSPointingEnums>;
+  template class MSTable<MSPolarizationEnums>;
+  template class MSTable<MSProcessorEnums>;
+  template class MSTable<MSSourceEnums>;
+  template class MSTable<MSSpectralWindowEnums>;
+  template class MSTable<MSStateEnums>;
+  template class MSTable<MSSysCalEnums>;
+  template class MSTable<MSWeatherEnums>;
 
 } //# NAMESPACE CASACORE - END
 

--- a/ms/MeasurementSets/MSTable.h
+++ b/ms/MeasurementSets/MSTable.h
@@ -32,10 +32,10 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/tables/Tables/Table.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/tables/Tables/ColumnDesc.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -244,27 +244,27 @@ protected:
  
     // These are the static ordered maps which contain the above info
     // ColEnum -> name
-    static SimpleOrderedMap<Int, String> columnMap_p;
+    static std::map<Int, String> columnMap_p;
     // ColEnum -> DataType
-    static SimpleOrderedMap<Int, Int> colDTypeMap_p;
+    static std::map<Int, Int> colDTypeMap_p;
     // ColEnum -> comment string
-    static SimpleOrderedMap<Int, String> colCommentMap_p;
+    static std::map<Int, String> colCommentMap_p;
     // ColEnum -> UNIT string
-    static SimpleOrderedMap<Int, String> colUnitMap_p;
+    static std::map<Int, String> colUnitMap_p;
     // ColEnum -> MEASURE_TYPE string
-    static SimpleOrderedMap<Int, String> colMeasureTypeMap_p;
+    static std::map<Int, String> colMeasureTypeMap_p;
  
 
     // KeyEnum -> name
-    static SimpleOrderedMap<Int, String> keywordMap_p;
+    static std::map<Int, String> keywordMap_p;
     // KeyEnum -> DataType
-    static SimpleOrderedMap<Int, Int> keyDTypeMap_p;
+    static std::map<Int, Int> keyDTypeMap_p;
     // KeyEnum -> comment string
-    static SimpleOrderedMap<Int, String> keyCommentMap_p;
+    static std::map<Int, String> keyCommentMap_p;
 
     // The required TableDesc
     //# following fails in static initialization (segm. fault).
-    //    static TableDesc requiredTD_p;
+    ///static TableDesc requiredTD_p;
     static CountedPtr<TableDesc> requiredTD_p;
  
     // Define an entry in the column maps
@@ -291,20 +291,7 @@ protected:
 
 } //# NAMESPACE CASACORE - END
 
-// The CASACORE_NO_AUTO_TEMPLATES block had been commented out, and it's not clear
-// why it was since this is the standard pattern used in practically every other
-// case like this. Furthermore, when it was commented out, the CLANG compiler
-// produced copious warnings of the form:
-// /Users/dmehring/casa/casa-git/casacore/ms/MeasurementSets/MSFreqOffset.cc:128:11: warning: instantiation of variable 'casacore::MSTable<casacore::MSFreqOffsetEnums::PredefinedColumns, casacore::MSFreqOffsetEnums::PredefinedKeywords>::columnMap_p' required here, but no definition is available [-Wundefined-var-template]
-//    if (! columnMap_p.ndefined()) {
-//                  ^
-//                      /Users/dmehring/casa/casa-git/casacore/casacore/ms/MeasurementSets/MSTable.h:272:42: note: forward declaration of template entity is here 
-//                          static SimpleOrderedMap<Int, String> columnMap_p;
-//                                                           ^
-//                                                               /Users/dmehring/casa/casa-git/casacore/ms/MeasurementSets/MSFreqOffset.cc:128:11: note: add an explicit instantiation declaration to suppress this warning if 'casacore::MSTable<casacore::MSFreqOffsetEnums::PredefinedColumns, casacore::MSFreqOffsetEnums::PredefinedKeywords>::columnMap_p' is explicitly instantiated in another translation unit
-//                                                                   if (! columnMap_p.ndefined()) {
-//
-// which are no longer emitted when this standard template include block is present
+
 #ifndef CASACORE_NO_AUTO_TEMPLATES
 #include <casacore/ms/MeasurementSets/MSTable.tcc>
 #endif //# CASACORE_NO_AUTO_TEMPLATES

--- a/ms/MeasurementSets/MSTable.h
+++ b/ms/MeasurementSets/MSTable.h
@@ -44,6 +44,40 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 class TableRecord;
 template <class T> class Block;
 
+
+// <summary> 
+// A struct holding the maps used in MSTable.
+// </summary>
+struct MSTableMaps
+{
+  // ColEnum -> name
+  std::map<Int, String> columnMap_p;
+  // ColEnum -> DataType
+  std::map<Int, Int> colDTypeMap_p;
+  // ColEnum -> comment string
+  std::map<Int, String> colCommentMap_p;
+  // ColEnum -> UNIT string
+  std::map<Int, String> colUnitMap_p;
+  // ColEnum -> MEASURE_TYPE string
+  std::map<Int, String> colMeasureTypeMap_p;
+  // KeyEnum -> name
+  std::map<Int, String> keywordMap_p;
+  // KeyEnum -> DataType
+  std::map<Int, Int> keyDTypeMap_p;
+  // KeyEnum -> comment string
+  std::map<Int, String> keyCommentMap_p;
+  // The required TableDesc
+  TableDesc requiredTD_p;
+
+  // Convert a name to a ColEnum or KeyEnum.
+  Int columnType (const String& name) const
+    { return mapType (columnMap_p, name); }
+  Int keywordType (const String& name) const
+    { return mapType (keywordMap_p, name); }
+  Int mapType (const std::map<Int,String>&, const String& name) const;
+};
+
+
 // <summary> 
 // A Table intended to hold astronomical data
 // </summary>
@@ -109,9 +143,13 @@ template <class T> class Block;
 //      be necessary to modify referenceCopy().
 // </todo>
 
-template <class ColEnum, class KeyEnum> class MSTable : public Table 
+template <class MSEnum> class MSTable : public Table 
 {
 public:
+    // Define the column and keyword enuym types.
+    typedef typename MSEnum::PredefinedColumns ColEnum;
+    typedef typename MSEnum::PredefinedKeywords KeyEnum;
+  
     // ColEnum convenience functions
     // <group name=columns>
     // check to see if a column exists
@@ -166,7 +204,15 @@ public:
     // the ColumnDesc option (Fixed, Undefined, Direct) 
     // For Measure columns you can define a variable reference column.
     static void addColumnToDesc(TableDesc & tabDesc, ColEnum which,
-			  const IPosition& shape, ColumnDesc::Option option,
+                                const IPosition& shape, ColumnDesc::Option option,
+				const String& refCol="");
+    static void addColumnToDesc(MSTableMaps&, ColEnum which,
+				Int ndim=-1,const String& refCol="");
+    // add a column to a TableDesc, defining the shape and setting
+    // the ColumnDesc option (Fixed, Undefined, Direct) 
+    // For Measure columns you can define a variable reference column.
+    static void addColumnToDesc(MSTableMaps&, ColEnum which,
+                                const IPosition& shape, ColumnDesc::Option option,
 				const String& refCol="");
 
     // </group>
@@ -187,7 +233,8 @@ public:
     // <thrown>
     //   <li> AipsError
     // </thrown>
-    static void addKeyToDesc(TableDesc & tabDesc, KeyEnum key);
+    static void addKeyToDesc(TableDesc&, KeyEnum key);
+    static void addKeyToDesc(MSTableMaps&, KeyEnum key);
 
     // </group>
 
@@ -235,40 +282,19 @@ protected:
     MSTable (SetupNewTable &newTab, const TableLock& lockOptions, uInt nrrow,
 	     Bool initialize);
     MSTable (const Table &table);
-    MSTable (const MSTable<ColEnum,KeyEnum> &other);
+    MSTable (const MSTable<MSEnum> &other);
     // </group>
     ~MSTable();
 
     //  Assignment operator, reference semantics
-    MSTable& operator=(const MSTable<ColEnum,KeyEnum>&);
- 
-    // These are the static ordered maps which contain the above info
-    // ColEnum -> name
-    static std::map<Int, String> columnMap_p;
-    // ColEnum -> DataType
-    static std::map<Int, Int> colDTypeMap_p;
-    // ColEnum -> comment string
-    static std::map<Int, String> colCommentMap_p;
-    // ColEnum -> UNIT string
-    static std::map<Int, String> colUnitMap_p;
-    // ColEnum -> MEASURE_TYPE string
-    static std::map<Int, String> colMeasureTypeMap_p;
- 
+    MSTable& operator=(const MSTable<MSEnum>&);
 
-    // KeyEnum -> name
-    static std::map<Int, String> keywordMap_p;
-    // KeyEnum -> DataType
-    static std::map<Int, Int> keyDTypeMap_p;
-    // KeyEnum -> comment string
-    static std::map<Int, String> keyCommentMap_p;
+    // Get the static struct containing all column and keyword mappings.
+    static MSTableMaps& getMaps();
 
-    // The required TableDesc
-    //# following fails in static initialization (segm. fault).
-    ///static TableDesc requiredTD_p;
-    static CountedPtr<TableDesc> requiredTD_p;
- 
     // Define an entry in the column maps
-    static void colMapDef(ColEnum col,
+    static void colMapDef(MSTableMaps& maps,
+                          ColEnum col,
 			  const String& colName,
 			  DataType colType,
 			  const String& colComment,
@@ -276,7 +302,8 @@ protected:
 			  const String& colMeasureType="");
 
     // Define an entry in the keyword maps
-    static void keyMapDef(KeyEnum key,
+    static void keyMapDef(MSTableMaps& maps,
+                          KeyEnum key,
 			  const String& keyName,
 			  DataType keyType,
 			  const String& keyComment);
@@ -286,13 +313,57 @@ protected:
     Table referenceCopy(const String& newTableName, 
 			const Block<String>& writableColumns) const;
 
+  // Convert a ColEnum to the actual column name.
+  inline static
+  const String& columnName(const MSTableMaps& maps,
+                           ColEnum which)
+    { return maps.columnMap_p.at(which); }
+
+  inline static
+  DataType columnDataType(const MSTableMaps& maps,
+                          ColEnum which)
+    { return DataType(maps.colDTypeMap_p.at(which)); }
+
+  inline static
+  const String& columnStandardComment(const MSTableMaps& maps,
+                                      ColEnum which)
+    { return maps.colCommentMap_p.at(which); }
+  
+  inline static
+  const String& columnUnit(const MSTableMaps& maps,
+                           ColEnum which)
+    { return maps.colUnitMap_p.at(which); }
+
+  inline static
+  const String& columnMeasureType(const MSTableMaps& maps,
+                                  ColEnum which)
+    { return maps.colMeasureTypeMap_p.at(which); }
+
+  inline static
+  const String& keywordName(const MSTableMaps& maps,
+                            KeyEnum which)
+    { return maps.keywordMap_p.at(which); }
+
+  inline static
+  DataType keywordDataType(const MSTableMaps& maps,
+                           KeyEnum which)
+    { return DataType(maps.keyDTypeMap_p.at(which)); }
+
+  inline static
+  const String& keywordStandardComment(const MSTableMaps& maps,
+                                       KeyEnum which)
+    { return maps.keyCommentMap_p.at(which); }
+
 };
 
 
 } //# NAMESPACE CASACORE - END
 
 
-#ifndef CASACORE_NO_AUTO_TEMPLATES
-#include <casacore/ms/MeasurementSets/MSTable.tcc>
-#endif //# CASACORE_NO_AUTO_TEMPLATES
+//# Do not instantiate the templates automatically, because it means that the static
+//# in function getMaps() might be instantiated in many compilation units.
+//# The templates are instantiated in MSTable.cc.
+//#ifndef CASACORE_NO_AUTO_TEMPLATES
+//#include <casacore/ms/MeasurementSets/MSTable.tcc>
+//#endif //# CASACORE_NO_AUTO_TEMPLATES
 #endif

--- a/ms/MeasurementSets/MSTable.tcc
+++ b/ms/MeasurementSets/MSTable.tcc
@@ -34,166 +34,156 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template <class ColEnum, class KeyEnum> 
-std::map<Int, String> MSTable<ColEnum,KeyEnum>::columnMap_p;
-template <class ColEnum, class KeyEnum> 
-std::map<Int, Int> MSTable<ColEnum,KeyEnum>::colDTypeMap_p;
-template <class ColEnum, class KeyEnum> 
-std::map<Int, String> MSTable<ColEnum,KeyEnum>::colCommentMap_p;
-template <class ColEnum, class KeyEnum> 
-std::map<Int, String> MSTable<ColEnum,KeyEnum>::colUnitMap_p;
-template <class ColEnum, class KeyEnum> 
-std::map<Int, String> MSTable<ColEnum,KeyEnum>::colMeasureTypeMap_p;
 
-template <class ColEnum, class KeyEnum> 
-std::map<Int, String> MSTable<ColEnum,KeyEnum>::keywordMap_p;
-template <class ColEnum, class KeyEnum> 
-std::map<Int, Int> MSTable<ColEnum,KeyEnum>::keyDTypeMap_p;
-template <class ColEnum, class KeyEnum> 
-std::map<Int, String> MSTable<ColEnum,KeyEnum>::keyCommentMap_p;
-template <class ColEnum, class KeyEnum> 
-CountedPtr<TableDesc> MSTable<ColEnum,KeyEnum>::requiredTD_p;
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable()
+{}
 
-
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable() {}
-
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(const String &tableName, 
-				  Table::TableOption option) 
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(const String &tableName, 
+                         Table::TableOption option) 
     : Table(tableName, option)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(const String &tableName, 
-				  const TableLock& lockOptions,
-				  Table::TableOption option) 
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(const String &tableName, 
+                         const TableLock& lockOptions,
+                         Table::TableOption option) 
     : Table(tableName, lockOptions, option)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(const String& tableName, 
-				  const String &tableDescName,
-				  Table::TableOption option)
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(const String& tableName, 
+                         const String &tableDescName,
+                         Table::TableOption option)
     : Table(tableName, tableDescName, option)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(const String& tableName, 
-				  const String &tableDescName,
-				  const TableLock& lockOptions,
-				  Table::TableOption option)
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(const String& tableName, 
+                         const String &tableDescName,
+                         const TableLock& lockOptions,
+                         Table::TableOption option)
     : Table(tableName, tableDescName, lockOptions, option)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(SetupNewTable &newTab, uInt nrrow,
-				  Bool initialize)
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(SetupNewTable &newTab, uInt nrrow,
+                         Bool initialize)
     : Table(MSTableImpl::setupCompression(newTab),
 	    nrrow, initialize)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(SetupNewTable &newTab,
-				  const TableLock& lockOptions,
-				  uInt nrrow,  Bool initialize)
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(SetupNewTable &newTab,
+                         const TableLock& lockOptions,
+                         uInt nrrow,  Bool initialize)
     : Table(MSTableImpl::setupCompression(newTab),
 	    lockOptions, nrrow, initialize)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(const Table &table)
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(const Table &table)
     : Table(table)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::MSTable(const MSTable<ColEnum,KeyEnum> &other)
+template <class MSEnum> 
+MSTable<MSEnum>::MSTable(const MSTable<MSEnum> &other)
     : Table(other)
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>::~MSTable()
+template <class MSEnum> 
+MSTable<MSEnum>::~MSTable()
 {}
 
-template <class ColEnum, class KeyEnum> 
-MSTable<ColEnum,KeyEnum>& MSTable<ColEnum,KeyEnum>::
-operator=(const MSTable<ColEnum,KeyEnum>& other)
+template <class MSEnum> 
+MSTable<MSEnum>& MSTable<MSEnum>::
+operator=(const MSTable<MSEnum>& other)
 {
     if (this != &other) Table::operator=(other);
     return *this;
 }
 
 
-template <class ColEnum, class KeyEnum> 
-const String& MSTable<ColEnum,KeyEnum>::columnName(ColEnum which)
-{ 
-    MSTableImpl::initMap(); return columnMap_p[which]; 
+template <class MSEnum> 
+MSTableMaps& MSTable<MSEnum>::getMaps()
+{
+  // Create the static and fill it.
+  // Note that C++11 guarantees that it is called once and is thread-safe.
+  static MSTableMaps maps(MSTableImpl::initMaps(static_cast<MSEnum*>(0)));
+  return maps;
 }
 
-template <class ColEnum, class KeyEnum> 
-ColEnum MSTable<ColEnum,KeyEnum>::columnType(const String &name)
-{ MSTableImpl::initMap(); return ColEnum(MSTableImpl::mapType(columnMap_p,name)); }
+template <class MSEnum> 
+const String& MSTable<MSEnum>::columnName(MSTable<MSEnum>::ColEnum which)
+{ 
+  return getMaps().columnMap_p.at(which); 
+}
 
-template <class ColEnum, class KeyEnum> 
-DataType MSTable<ColEnum,KeyEnum>::columnDataType(ColEnum which)
-{ MSTableImpl::initMap(); return DataType(colDTypeMap_p[which]); }
+template <class MSEnum> 
+typename MSTable<MSEnum>::ColEnum MSTable<MSEnum>::columnType(const String &name)
+{ return ColEnum(getMaps().columnType(name)); }
 
-template <class ColEnum, class KeyEnum> 
-const String& MSTable<ColEnum,KeyEnum>::columnStandardComment(ColEnum which)
-{ MSTableImpl::initMap(); return colCommentMap_p[which]; }
-template <class ColEnum, class KeyEnum> 
+template <class MSEnum> 
+DataType MSTable<MSEnum>::columnDataType(MSTable<MSEnum>::ColEnum which)
+{ return DataType(getMaps().colDTypeMap_p.at(which)); }
 
-const String& MSTable<ColEnum,KeyEnum>::columnUnit(ColEnum which)
-{ MSTableImpl::initMap(); return colUnitMap_p[which]; }
+template <class MSEnum> 
+const String& MSTable<MSEnum>::columnStandardComment(MSTable<MSEnum>::ColEnum which)
+{ return getMaps().colCommentMap_p.at(which); }
+template <class MSEnum> 
 
-template <class ColEnum, class KeyEnum> 
-const String& MSTable<ColEnum,KeyEnum>::columnMeasureType(ColEnum which)
-{ MSTableImpl::initMap(); return colMeasureTypeMap_p[which]; }
+const String& MSTable<MSEnum>::columnUnit(MSTable<MSEnum>::ColEnum which)
+{ return getMaps().colUnitMap_p.at(which); }
 
-template <class ColEnum, class KeyEnum> 
-const String& MSTable<ColEnum,KeyEnum>::keywordName(KeyEnum which)
-{ MSTableImpl::initMap(); return keywordMap_p[which]; }
+template <class MSEnum> 
+const String& MSTable<MSEnum>::columnMeasureType(MSTable<MSEnum>::ColEnum which)
+{ return getMaps().colMeasureTypeMap_p.at(which); }
 
-template <class ColEnum, class KeyEnum> 
-KeyEnum MSTable<ColEnum,KeyEnum>::keywordType(const String &name)
-{ MSTableImpl::initMap(); return KeyEnum(MSTableImpl::mapType(keywordMap_p,name)); }
+template <class MSEnum> 
+const String& MSTable<MSEnum>::keywordName(MSTable<MSEnum>::KeyEnum which)
+{ return getMaps().keywordMap_p.at(which); }
 
-template <class ColEnum, class KeyEnum> 
-DataType MSTable<ColEnum,KeyEnum>::keywordDataType(KeyEnum which)
-{ MSTableImpl::initMap(); return DataType(keyDTypeMap_p[which]); }
+template <class MSEnum> 
+typename MSTable<MSEnum>::KeyEnum MSTable<MSEnum>::keywordType(const String &name)
+{ return KeyEnum(getMaps().keywordType(name)); }
 
-template <class ColEnum, class KeyEnum> 
-const String& MSTable<ColEnum,KeyEnum>::keywordStandardComment(KeyEnum which)
-{ MSTableImpl::initMap(); return keyCommentMap_p[which]; }
+template <class MSEnum> 
+DataType MSTable<MSEnum>::keywordDataType(MSTable<MSEnum>::KeyEnum which)
+{ return DataType(getMaps().keyDTypeMap_p.at(which)); }
 
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::isColumn(ColEnum which) const
+template <class MSEnum> 
+const String& MSTable<MSEnum>::keywordStandardComment(MSTable<MSEnum>::KeyEnum which)
+{ return getMaps().keyCommentMap_p.at(which); }
+
+template <class MSEnum> 
+Bool MSTable<MSEnum>::isColumn(MSTable<MSEnum>::ColEnum which) const
 { return tableDesc().isColumn(columnName(which)); }
 
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::isColumnWritable(ColEnum which) const
+template <class MSEnum> 
+Bool MSTable<MSEnum>::isColumnWritable(MSTable<MSEnum>::ColEnum which) const
 { return Table::isColumnWritable(columnName(which)); }
 
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::isKeyword(KeyEnum which) const
+template <class MSEnum> 
+Bool MSTable<MSEnum>::isKeyword(MSTable<MSEnum>::KeyEnum which) const
 { return keywordSet().isDefined(keywordName(which)); }
 
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::isScalar(ColEnum which) const
+template <class MSEnum> 
+Bool MSTable<MSEnum>::isScalar(MSTable<MSEnum>::ColEnum which) const
 { return tableDesc().columnDesc(columnName(which)).isScalar(); }
 
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::isArray(ColEnum which) const
+template <class MSEnum> 
+Bool MSTable<MSEnum>::isArray(MSTable<MSEnum>::ColEnum which) const
 { return tableDesc().columnDesc(columnName(which)).isArray(); }
 
-template <class ColEnum, class KeyEnum> 
-const String& MSTable<ColEnum,KeyEnum>::unit(const String& which) const
+template <class MSEnum> 
+const String& MSTable<MSEnum>::unit(const String& which) const
 { return tableDesc().columnDesc(which).keywordSet().
     asArrayString("QuantumUnits")(IPosition(1,0)); }
 
-template <class ColEnum, class KeyEnum> 
-void MSTable<ColEnum,KeyEnum>::addColumnToDesc(TableDesc &td, ColEnum which,
-					       Int ndim, const String& refCol)
+template <class MSEnum> 
+void MSTable<MSEnum>::addColumnToDesc(TableDesc &td, MSTable<MSEnum>::ColEnum which,
+                                      Int ndim, const String& refCol)
 {
     MSTableImpl::addColumnToDesc(td,columnName(which),columnDataType(which),
 				 columnStandardComment(which),
@@ -202,11 +192,11 @@ void MSTable<ColEnum,KeyEnum>::addColumnToDesc(TableDesc &td, ColEnum which,
 				 ndim,IPosition(),0,refCol);
 }
 
-template <class ColEnum, class KeyEnum> 
-void MSTable<ColEnum,KeyEnum>::addColumnToDesc(TableDesc &td, ColEnum which,
-					       const IPosition& shape,
-					       ColumnDesc::Option option,
-					       const String& refCol)
+template <class MSEnum> 
+void MSTable<MSEnum>::addColumnToDesc(TableDesc &td, MSTable<MSEnum>::ColEnum which,
+                                      const IPosition& shape,
+                                      ColumnDesc::Option option,
+                                      const String& refCol)
 {
     MSTableImpl::addColumnToDesc(td,columnName(which),columnDataType(which),
 				 columnStandardComment(which),
@@ -215,65 +205,104 @@ void MSTable<ColEnum,KeyEnum>::addColumnToDesc(TableDesc &td, ColEnum which,
 				 -1,shape,option,refCol);
 }
 
-template <class ColEnum, class KeyEnum> 
-void MSTable<ColEnum,KeyEnum>::addKeyToDesc(TableDesc& td, KeyEnum key)
+template <class MSEnum> 
+void MSTable<MSEnum>::addColumnToDesc(MSTableMaps& maps, MSTable<MSEnum>::ColEnum which,
+                                      Int ndim, const String& refCol)
+{
+  MSTableImpl::addColumnToDesc(maps.requiredTD_p,
+                               columnName(maps, which),
+                               columnDataType(maps, which),
+                               columnStandardComment(maps, which),
+                               columnUnit(maps, which),
+                               columnMeasureType(maps, which),
+                               ndim, IPosition(), 0, refCol);
+}
+
+template <class MSEnum> 
+void MSTable<MSEnum>::addColumnToDesc(MSTableMaps& maps, MSTable<MSEnum>::ColEnum which,
+                                      const IPosition& shape,
+                                      ColumnDesc::Option option,
+                                      const String& refCol)
+{
+  MSTableImpl::addColumnToDesc(maps.requiredTD_p,
+                               columnName(maps, which),
+                               columnDataType(maps, which),
+                               columnStandardComment(maps, which),
+                               columnUnit(maps, which),
+                               columnMeasureType(maps, which),
+                               -1, shape, option, refCol);
+}
+
+template <class MSEnum> 
+void MSTable<MSEnum>::addKeyToDesc(TableDesc& td, MSTable<MSEnum>::KeyEnum key)
 {
     MSTableImpl::addKeyToDesc(td,keywordName(key),keywordDataType(key),
 			      keywordStandardComment(key));
 }
 
-template <class ColEnum, class KeyEnum> 
-void MSTable<ColEnum,KeyEnum>::addColumnCompression (TableDesc& td,
-						     ColEnum which,
-						     Bool autoScale,
-						     const String& type)
+template <class MSEnum> 
+void MSTable<MSEnum>::addKeyToDesc(MSTableMaps& maps, MSTable<MSEnum>::KeyEnum key)
+{
+  MSTableImpl::addKeyToDesc(maps.requiredTD_p,
+                            keywordName(maps, key),
+                            keywordDataType(maps, key),
+                            keywordStandardComment(maps, key));
+}
+
+template <class MSEnum> 
+void MSTable<MSEnum>::addColumnCompression (TableDesc& td,
+                                            MSTable<MSEnum>::ColEnum which,
+                                            Bool autoScale,
+                                            const String& type)
 {
     MSTableImpl::addColumnCompression (td, columnName(which), autoScale, type);
 }
 
-template <class ColEnum, class KeyEnum> 
-void MSTable<ColEnum,KeyEnum>::colMapDef(ColEnum col,
-					 const String& colName,
-					 DataType colType,
-					 const String& colComment,
-					 const String& colUnit,
-					 const String& colMeasureType)
+template <class MSEnum> 
+void MSTable<MSEnum>::colMapDef(MSTableMaps& maps,
+                                MSTable<MSEnum>::ColEnum col,
+                                const String& colName,
+                                DataType colType,
+                                const String& colComment,
+                                const String& colUnit,
+                                const String& colMeasureType)
 {
-    MSTableImpl::colMapDef(columnMap_p,colDTypeMap_p,colCommentMap_p,
-			   colUnitMap_p,colMeasureTypeMap_p,col,colName,
-			   colType,colComment,colUnit,colMeasureType);
+    MSTableImpl::colMapDef(maps.columnMap_p, maps.colDTypeMap_p, maps.colCommentMap_p,
+			   maps.colUnitMap_p, maps.colMeasureTypeMap_p,
+                           col,colName,colType,colComment,colUnit,colMeasureType);
 }
 
-template <class ColEnum, class KeyEnum> 
-void MSTable<ColEnum,KeyEnum>::keyMapDef(KeyEnum key,
-					 const String& keyName,
-					 DataType keyType,
-					 const String& keyComment)
+template <class MSEnum> 
+void MSTable<MSEnum>::keyMapDef(MSTableMaps& maps,
+                                MSTable<MSEnum>::KeyEnum key,
+                                const String& keyName,
+                                DataType keyType,
+                                const String& keyComment)
 {
-    MSTableImpl::keyMapDef(keywordMap_p,keyDTypeMap_p,keyCommentMap_p,
+    MSTableImpl::keyMapDef(maps.keywordMap_p, maps.keyDTypeMap_p, maps.keyCommentMap_p,
 			   key,keyName,keyType,keyComment);
 }
 
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::validate(const TableDesc& tabDesc)
+template <class MSEnum> 
+Bool MSTable<MSEnum>::validate(const TableDesc& tabDesc)
 {
-    MSTableImpl::init(); return MSTableImpl::validate(tabDesc,*requiredTD_p);
+  return MSTableImpl::validate(tabDesc, getMaps().requiredTD_p);
 }
  
-template <class ColEnum, class KeyEnum> 
-Bool MSTable<ColEnum,KeyEnum>::validate(const TableRecord& tabKeySet)
+template <class MSEnum> 
+Bool MSTable<MSEnum>::validate(const TableRecord& tabKeySet)
 {
-    MSTableImpl::init(); return MSTableImpl::validate(tabKeySet,*requiredTD_p);
+  return MSTableImpl::validate(tabKeySet, getMaps().requiredTD_p);
 }
 
-template <class ColEnum, class KeyEnum> 
-const TableDesc& MSTable<ColEnum,KeyEnum>::requiredTableDesc()
+template <class MSEnum> 
+const TableDesc& MSTable<MSEnum>::requiredTableDesc()
 {
-    MSTableImpl::init(); return *requiredTD_p;
+  return getMaps().requiredTD_p;
 }
 
-template <class ColEnum, class KeyEnum> 
-Table MSTable<ColEnum,KeyEnum>::referenceCopy(const String& newTableName, 
+template <class MSEnum> 
+Table MSTable<MSEnum>::referenceCopy(const String& newTableName, 
 			        const Block<String>& writableColumns) const
 {
     return MSTableImpl::referenceCopy(*this, newTableName, writableColumns);

--- a/ms/MeasurementSets/MSTable.tcc
+++ b/ms/MeasurementSets/MSTable.tcc
@@ -34,28 +34,25 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# These statics cannot be compiled with egcs 1.0.3a.
-#if !defined(__GNUG__) || (defined(__GNUG__) && (__GNUG__ == 2) && (__GNUC_MINOR__ >= 91)) || defined(AIPS_GCC)
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::columnMap_p("");
+std::map<Int, String> MSTable<ColEnum,KeyEnum>::columnMap_p;
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, Int> MSTable<ColEnum,KeyEnum>::colDTypeMap_p(TpOther);
+std::map<Int, Int> MSTable<ColEnum,KeyEnum>::colDTypeMap_p;
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::colCommentMap_p("");
+std::map<Int, String> MSTable<ColEnum,KeyEnum>::colCommentMap_p;
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::colUnitMap_p("");
+std::map<Int, String> MSTable<ColEnum,KeyEnum>::colUnitMap_p;
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::colMeasureTypeMap_p("");
+std::map<Int, String> MSTable<ColEnum,KeyEnum>::colMeasureTypeMap_p;
 
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::keywordMap_p("");
+std::map<Int, String> MSTable<ColEnum,KeyEnum>::keywordMap_p;
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, Int> MSTable<ColEnum,KeyEnum>::keyDTypeMap_p(TpOther);
+std::map<Int, Int> MSTable<ColEnum,KeyEnum>::keyDTypeMap_p;
 template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::keyCommentMap_p("");
+std::map<Int, String> MSTable<ColEnum,KeyEnum>::keyCommentMap_p;
 template <class ColEnum, class KeyEnum> 
 CountedPtr<TableDesc> MSTable<ColEnum,KeyEnum>::requiredTD_p;
-#endif
 
 
 template <class ColEnum, class KeyEnum> 
@@ -130,44 +127,44 @@ operator=(const MSTable<ColEnum,KeyEnum>& other)
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::columnName(ColEnum which)
 { 
-    MSTableImpl::init(); return columnMap_p(which); 
+    MSTableImpl::initMap(); return columnMap_p[which]; 
 }
 
 template <class ColEnum, class KeyEnum> 
 ColEnum MSTable<ColEnum,KeyEnum>::columnType(const String &name)
-{ MSTableImpl::init(); return ColEnum(MSTableImpl::mapType(columnMap_p,name)); }
+{ MSTableImpl::initMap(); return ColEnum(MSTableImpl::mapType(columnMap_p,name)); }
 
 template <class ColEnum, class KeyEnum> 
 DataType MSTable<ColEnum,KeyEnum>::columnDataType(ColEnum which)
-{ MSTableImpl::init(); return DataType(colDTypeMap_p(which)); }
+{ MSTableImpl::initMap(); return DataType(colDTypeMap_p[which]); }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::columnStandardComment(ColEnum which)
-{ MSTableImpl::init(); return colCommentMap_p(which); }
+{ MSTableImpl::initMap(); return colCommentMap_p[which]; }
 template <class ColEnum, class KeyEnum> 
 
 const String& MSTable<ColEnum,KeyEnum>::columnUnit(ColEnum which)
-{ MSTableImpl::init(); return colUnitMap_p(which); }
+{ MSTableImpl::initMap(); return colUnitMap_p[which]; }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::columnMeasureType(ColEnum which)
-{ MSTableImpl::init(); return colMeasureTypeMap_p(which); }
+{ MSTableImpl::initMap(); return colMeasureTypeMap_p[which]; }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::keywordName(KeyEnum which)
-{ MSTableImpl::init(); return keywordMap_p(which); }
+{ MSTableImpl::initMap(); return keywordMap_p[which]; }
 
 template <class ColEnum, class KeyEnum> 
 KeyEnum MSTable<ColEnum,KeyEnum>::keywordType(const String &name)
-{ MSTableImpl::init(); return KeyEnum(MSTableImpl::mapType(keywordMap_p,name)); }
+{ MSTableImpl::initMap(); return KeyEnum(MSTableImpl::mapType(keywordMap_p,name)); }
 
 template <class ColEnum, class KeyEnum> 
 DataType MSTable<ColEnum,KeyEnum>::keywordDataType(KeyEnum which)
-{ MSTableImpl::init(); return DataType(keyDTypeMap_p(which)); }
+{ MSTableImpl::initMap(); return DataType(keyDTypeMap_p[which]); }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::keywordStandardComment(KeyEnum which)
-{ MSTableImpl::init(); return keyCommentMap_p(which); }
+{ MSTableImpl::initMap(); return keyCommentMap_p[which]; }
 
 template <class ColEnum, class KeyEnum> 
 Bool MSTable<ColEnum,KeyEnum>::isColumn(ColEnum which) const

--- a/ms/MeasurementSets/MSTableImpl.cc
+++ b/ms/MeasurementSets/MSTableImpl.cc
@@ -43,7 +43,6 @@
 #include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
-#include <casacore/ms/MeasurementSets/MeasurementSet.h>
 
 #include <casacore/measures/TableMeasures/TableMeasRefDesc.h>
 #include <casacore/measures/TableMeasures/TableMeasValueDesc.h>
@@ -62,10 +61,6 @@
 #include <casacore/casa/iostream.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
-
-// Initialize statics.
-CallOnce0 MSTableImpl::onceInitMap_p;
-CallOnce0 MSTableImpl::onceInitDesc_p;
 
   
 void MSTableImpl::addMeasColumn(TableDesc& td, const String& column, 
@@ -112,21 +107,6 @@ void MSTableImpl::addMeasColumn(TableDesc& td, const String& column,
     TableMeasDesc<MEarthMagnetic> measCol(measVal, measRef);
     measCol.write(td);
   }
-}
-
-Int MSTableImpl::mapType(const std::map<Int,String>& columnMap,
-			 const String &name)
-{
-    // find first occurrance of name in the map (must be only occurrance)
- 
-    Int type = 0; //# 0=UNDEFINED_COLUMN for all enums
-    for (auto kv : columnMap) {
-        if (kv.second == name) {
-          type = kv.first;
-            break;
-        }
-    }
-    return type;
 }
 
 void MSTableImpl::addColumnToDesc(TableDesc &td, const String& colName,
@@ -453,10 +433,8 @@ void MSTableImpl::colMapDef(std::map<Int,String>& columnMap,
     columnMap[col] = colName;
     colDTypeMap[col] = colType;
     colCommentMap[col] = colComment;
-    // no need to define these unless they are different from the
-    // default, which is an empty string
-    if (colUnit != "") colUnitMap[col] = colUnit;
-    if (colMeasureType != "") colMeasureTypeMap[col] = colMeasureType;
+    colUnitMap[col] = colUnit;
+    colMeasureTypeMap[col] = colMeasureType;
 }
 
 void MSTableImpl::keyMapDef(std::map<Int,String>& keywordMap,
@@ -568,66 +546,44 @@ Table MSTableImpl::referenceCopy(const Table& tab, const String& newTableName,
   return msTab;
 }
 
-void MSTableImpl::initMap()
-{
-  onceInitMap_p(doInitMap);
-}
 
-void MSTableImpl::init()
-{
-  onceInitMap_p(doInitMap);
-  onceInitDesc_p(doInitDesc);
-}
-
-void MSTableImpl::doInitMap()
-{
-  // Initialize column/keyword maps
-  MeasurementSet::initMap();
-  MSAntenna::initMap();
-  MSDataDescription::initMap();
-  MSDoppler::initMap();
-  MSFeed::initMap();
-  MSField::initMap();
-  MSFlagCmd::initMap();
-  MSFreqOffset::initMap();
-  MSHistory::initMap();
-  MSObservation::initMap();
-  MSPointing::initMap();
-  MSPolarization::initMap();
-  MSProcessor::initMap();
-  MSSource::initMap();
-  MSSpectralWindow::initMap();
-  MSState::initMap();
-  MSSysCal::initMap();
-  MSWeather::initMap();
-}
-
-void MSTableImpl::doInitDesc()
-{
-  // Initialize (sub)table descriptions
-  MeasurementSet::initDesc();
-  MSAntenna::initDesc();
-  MSDataDescription::initDesc();
-  MSDoppler::initDesc();
-  MSFeed::initDesc();
-  MSField::initDesc();
-  MSFlagCmd::initDesc();
-  MSFreqOffset::initDesc();
-  MSHistory::initDesc();
-  MSObservation::initDesc();
-  MSPointing::initDesc();
-  MSPolarization::initDesc();
-  MSProcessor::initDesc();
-  MSSource::initDesc();
-  MSSpectralWindow::initDesc();
-  MSState::initDesc();
-  MSSysCal::initDesc();
-  MSWeather::initDesc();
-}
-
-
-
-
+MSTableMaps MSTableImpl::initMaps(MSMainEnums*)
+  { return MeasurementSet::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSAntennaEnums*)
+  { return MSAntenna::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSDataDescriptionEnums*)
+  { return MSDataDescription::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSDopplerEnums*)
+  { return MSDoppler::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSFeedEnums*)
+  { return MSFeed::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSFieldEnums*)
+  { return MSField::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSFlagCmdEnums*)
+  { return MSFlagCmd::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSFreqOffsetEnums*)
+  { return MSFreqOffset::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSHistoryEnums*)
+  { return MSHistory::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSObservationEnums*)
+  { return MSObservation::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSPointingEnums*)
+  { return MSPointing::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSPolarizationEnums*)
+  { return MSPolarization::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSProcessorEnums*)
+  { return MSProcessor::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSSourceEnums*)
+  { return MSSource::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSSpectralWindowEnums*)
+  { return MSSpectralWindow::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSStateEnums*)
+  { return MSState::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSSysCalEnums*)
+  { return MSSysCal::initMaps(); }
+MSTableMaps MSTableImpl::initMaps(MSWeatherEnums*)
+  { return MSWeather::initMaps(); }
 
 } //# NAMESPACE CASACORE - END
+
 

--- a/ms/MeasurementSets/MSTableImpl.h
+++ b/ms/MeasurementSets/MSTableImpl.h
@@ -33,11 +33,12 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/tables/Tables/Table.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/tables/Tables/TableDesc.h>
 #include <casacore/casa/Utilities/Fallible.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <casacore/casa/OS/Mutex.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -83,7 +84,7 @@ class MSTableImpl
 {
 public:
     // Convert a name to a ColEnum, 
-    static Int mapType(const SimpleOrderedMap<Int,String>& map,
+    static Int mapType(const std::map<Int,String>& map,
 		       const String &name);
 
     // add a column to a TableDesc
@@ -126,11 +127,11 @@ public:
     static SetupNewTable& setupCompression (SetupNewTable&);
 
     // Define an entry in the column maps
-    static void colMapDef(SimpleOrderedMap<Int,String>& colMap,
-			  SimpleOrderedMap<Int,Int>& colDTypeMap,
-			  SimpleOrderedMap<Int,String>& colCommentMap,
-			  SimpleOrderedMap<Int,String>& colUnitMap,
-			  SimpleOrderedMap<Int,String>& colMeasureTypeMap,
+    static void colMapDef(std::map<Int,String>& colMap,
+			  std::map<Int,Int>& colDTypeMap,
+			  std::map<Int,String>& colCommentMap,
+			  std::map<Int,String>& colUnitMap,
+			  std::map<Int,String>& colMeasureTypeMap,
 			  Int col,
 			  const String& colName,
 			  Int colType,
@@ -139,9 +140,9 @@ public:
 			  const String& colMeasureType);
 
     // Define an entry in the keyword maps
-    static void keyMapDef(SimpleOrderedMap<Int,String>& keyMap,
-			  SimpleOrderedMap<Int,Int>& keyDTypeMap,
-			  SimpleOrderedMap<Int,String>& keyCommentMap,
+    static void keyMapDef(std::map<Int,String>& keyMap,
+			  std::map<Int,Int>& keyDTypeMap,
+			  std::map<Int,String>& keyCommentMap,
 			  Int key,
 			  const String& keyName,
 			  Int keyType,
@@ -165,7 +166,15 @@ public:
     static Table referenceCopy(const Table& tab, const String& newTableName, 
 			       const Block<String>& writableColumns);
     // Initialize all MeasurementSet static mappings
+    static void initMap();
     static void init();
+
+private:
+    static void doInitMap();
+    static void doInitDesc();
+
+    static CallOnce0 onceInitMap_p;
+    static CallOnce0 onceInitDesc_p;
 };
 
 

--- a/ms/MeasurementSets/MSTableImpl.h
+++ b/ms/MeasurementSets/MSTableImpl.h
@@ -31,13 +31,12 @@
 
 //# Includes
 #include <casacore/casa/aips.h>
+#include <casacore/ms/MeasurementSets/MeasurementSet.h>
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/tables/Tables/TableDesc.h>
-#include <casacore/casa/Utilities/Fallible.h>
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/OS/Mutex.h>
 #include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -83,10 +82,6 @@ class SetupNewTable;
 class MSTableImpl 
 {
 public:
-    // Convert a name to a ColEnum, 
-    static Int mapType(const std::map<Int,String>& map,
-		       const String &name);
-
     // add a column to a TableDesc
     // An exception is thrown for an invalid data type.  This indicates a 
     // programming error in this class when this occurs.
@@ -165,16 +160,28 @@ public:
     // those given in writableColumns, those are empty and writable.
     static Table referenceCopy(const Table& tab, const String& newTableName, 
 			       const Block<String>& writableColumns);
-    // Initialize all MeasurementSet static mappings
-    static void initMap();
-    static void init();
 
-private:
-    static void doInitMap();
-    static void doInitDesc();
-
-    static CallOnce0 onceInitMap_p;
-    static CallOnce0 onceInitDesc_p;
+    // Define the initialization function for each MS table type.
+    // <group>
+    static MSTableMaps initMaps(MSMainEnums*);
+    static MSTableMaps initMaps(MSAntennaEnums*);
+    static MSTableMaps initMaps(MSDataDescriptionEnums*);
+    static MSTableMaps initMaps(MSDopplerEnums*);
+    static MSTableMaps initMaps(MSFeedEnums*);
+    static MSTableMaps initMaps(MSFieldEnums*);
+    static MSTableMaps initMaps(MSFlagCmdEnums*);
+    static MSTableMaps initMaps(MSFreqOffsetEnums*);
+    static MSTableMaps initMaps(MSHistoryEnums*);
+    static MSTableMaps initMaps(MSObservationEnums*);
+    static MSTableMaps initMaps(MSPointingEnums*);
+    static MSTableMaps initMaps(MSPolarizationEnums*);
+    static MSTableMaps initMaps(MSProcessorEnums*);
+    static MSTableMaps initMaps(MSSourceEnums*);
+    static MSTableMaps initMaps(MSSpectralWindowEnums*);
+    static MSTableMaps initMaps(MSStateEnums*);
+    static MSTableMaps initMaps(MSSysCalEnums*);
+    static MSTableMaps initMaps(MSWeatherEnums*);
+    // </group>
 };
 
 

--- a/ms/MeasurementSets/MSWeather.cc
+++ b/ms/MeasurementSets/MSWeather.cc
@@ -123,88 +123,90 @@ MSWeather& MSWeather::operator=(const MSWeather &other)
     return *this;
 }
 
-void MSWeather::init()
+void MSWeather::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// ANTENNA_ID
-	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
-		  "Antenna number","","");
-	// INTERVAL
-	colMapDef(INTERVAL, "INTERVAL", TpDouble,
-		  "Interval over which data is relevant","s","");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble,
-		  "An MEpoch specifying the midpoint of the time for"
-		  "which data is relevant","s","Epoch");
-	// DEW_POINT
-	colMapDef(DEW_POINT, "DEW_POINT", TpFloat,
-		  "Dew point","K","");
-	// DEW_POINT_FLAG
-	colMapDef(DEW_POINT_FLAG, "DEW_POINT_FLAG", TpBool,
-		  "Flag for dew point","","");
-	// H2O 
-	colMapDef(H2O, "H2O", TpFloat,
-		  "Average column density of water-vapor","m-2","");
-	// H2O_FLAG
-	colMapDef(H2O_FLAG, "H2O_FLAG", TpBool,
-		  "Flag for average column density of water-vapor","","");
-	// IONOS_ELECTRON
-	colMapDef(IONOS_ELECTRON, "IONOS_ELECTRON", TpFloat,
-		  "Average column density of electrons","m-2","");
-	// IONOS_ELECTRON_FLAG
-	colMapDef(IONOS_ELECTRON_FLAG, "IONOS_ELECTRON_FLAG", TpBool,
-		  "Flag for average column density of electrons","","");
-	// PRESSURE
-	colMapDef(PRESSURE, "PRESSURE", TpFloat,
-		  "Ambient atmospheric pressure","hPa","");
-	// PRESSURE_FLAG
-	colMapDef(PRESSURE_FLAG, "PRESSURE_FLAG", TpBool,
-		  "Flag for ambient atmospheric pressure","","");
-	// REL_HUMIDITY
-	colMapDef(REL_HUMIDITY, "REL_HUMIDITY", TpFloat,
-		  "Ambient relative humidity","%","");
-	// REL_HUMIDITY_FLAG
-	colMapDef(REL_HUMIDITY_FLAG, "REL_HUMIDITY_FLAG", TpBool,
-		  "Flag for ambient relative humidity","","");
-	// TEMPERATURE
-	colMapDef(TEMPERATURE, "TEMPERATURE", TpFloat,
-		  "Ambient Air Temperature for an antenna","K","");
-	// TEMPERATURE_FLAG
-	colMapDef(TEMPERATURE_FLAG, "TEMPERATURE_FLAG", TpBool,
-		  "Flag for ambient Air Temperature for an antenna","","");
-	// WIND_DIRECTION
-	colMapDef(WIND_DIRECTION, "WIND_DIRECTION", TpFloat,
-		  "Average wind direction","rad","");
-	// WIND_DIRECTION_FLAG
-	colMapDef(WIND_DIRECTION_FLAG, "WIND_DIRECTION_FLAG", TpBool,
-		  "Flag for wind direction","","");
-	// WIND_SPEED
-	colMapDef(WIND_SPEED, "WIND_SPEED", TpFloat,
-		  "Average wind speed","m/s","");
-	// WIND_SPEED_FLAG
-	colMapDef(WIND_SPEED_FLAG, "WIND_SPEED_FLAG", TpBool,
-		  "Flag for wind speed","","");
-	// PredefinedKeywords
-
-	// init requiredTableDesc
-	TableDesc requiredTD;
-	// all required keywords
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	
-	// all required columns 
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // ANTENNA_ID
+  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+            "Antenna number","","");
+  // INTERVAL
+  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+            "Interval over which data is relevant","s","");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble,
+            "An MEpoch specifying the midpoint of the time for"
+            "which data is relevant","s","Epoch");
+  // DEW_POINT
+  colMapDef(DEW_POINT, "DEW_POINT", TpFloat,
+            "Dew point","K","");
+  // DEW_POINT_FLAG
+  colMapDef(DEW_POINT_FLAG, "DEW_POINT_FLAG", TpBool,
+            "Flag for dew point","","");
+  // H2O 
+  colMapDef(H2O, "H2O", TpFloat,
+            "Average column density of water-vapor","m-2","");
+  // H2O_FLAG
+  colMapDef(H2O_FLAG, "H2O_FLAG", TpBool,
+            "Flag for average column density of water-vapor","","");
+  // IONOS_ELECTRON
+  colMapDef(IONOS_ELECTRON, "IONOS_ELECTRON", TpFloat,
+            "Average column density of electrons","m-2","");
+  // IONOS_ELECTRON_FLAG
+  colMapDef(IONOS_ELECTRON_FLAG, "IONOS_ELECTRON_FLAG", TpBool,
+            "Flag for average column density of electrons","","");
+  // PRESSURE
+  colMapDef(PRESSURE, "PRESSURE", TpFloat,
+            "Ambient atmospheric pressure","hPa","");
+  // PRESSURE_FLAG
+  colMapDef(PRESSURE_FLAG, "PRESSURE_FLAG", TpBool,
+            "Flag for ambient atmospheric pressure","","");
+  // REL_HUMIDITY
+  colMapDef(REL_HUMIDITY, "REL_HUMIDITY", TpFloat,
+            "Ambient relative humidity","%","");
+  // REL_HUMIDITY_FLAG
+  colMapDef(REL_HUMIDITY_FLAG, "REL_HUMIDITY_FLAG", TpBool,
+            "Flag for ambient relative humidity","","");
+  // TEMPERATURE
+  colMapDef(TEMPERATURE, "TEMPERATURE", TpFloat,
+            "Ambient Air Temperature for an antenna","K","");
+  // TEMPERATURE_FLAG
+  colMapDef(TEMPERATURE_FLAG, "TEMPERATURE_FLAG", TpBool,
+            "Flag for ambient Air Temperature for an antenna","","");
+  // WIND_DIRECTION
+  colMapDef(WIND_DIRECTION, "WIND_DIRECTION", TpFloat,
+            "Average wind direction","rad","");
+  // WIND_DIRECTION_FLAG
+  colMapDef(WIND_DIRECTION_FLAG, "WIND_DIRECTION_FLAG", TpBool,
+            "Flag for wind direction","","");
+  // WIND_SPEED
+  colMapDef(WIND_SPEED, "WIND_SPEED", TpFloat,
+            "Average wind speed","m/s","");
+  // WIND_SPEED_FLAG
+  colMapDef(WIND_SPEED_FLAG, "WIND_SPEED_FLAG", TpBool,
+            "Flag for wind speed","","");
+  // PredefinedKeywords
 }
-	
+
+void MSWeather::initDesc()
+{
+  // init requiredTableDesc
+  TableDesc requiredTD;
+  // all required keywords
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  
+  // all required columns 
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  requiredTD_p=new TableDesc(requiredTD);
+}
+
 MSWeather MSWeather::referenceCopy(const String& newTableName, 
 				   const Block<String>& writableColumns) const
 {

--- a/ms/MeasurementSets/MSWeather.cc
+++ b/ms/MeasurementSets/MSWeather.cc
@@ -43,8 +43,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MSWeather::MSWeather():hasBeenDestroyed_p(True) { }
 
 MSWeather::MSWeather(const String &tableName, TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option),hasBeenDestroyed_p(False)
+    : MSTable<MSWeatherEnums>(tableName, option),hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -54,8 +53,7 @@ MSWeather::MSWeather(const String &tableName, TableOption option)
 
 MSWeather::MSWeather(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName,option),
+    : MSTable<MSWeatherEnums>(tableName, tableDescName,option),
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -66,8 +64,7 @@ MSWeather::MSWeather(const String& tableName, const String &tableDescName,
 
 MSWeather::MSWeather(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSWeatherEnums>(newTab, nrrow, initialize), 
       hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
@@ -77,8 +74,7 @@ MSWeather::MSWeather(SetupNewTable &newTab, uInt nrrow,
 }
 
 MSWeather::MSWeather(const Table &table)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(table), hasBeenDestroyed_p(False)
+    : MSTable<MSWeatherEnums>(table), hasBeenDestroyed_p(False)
 {
     // verify that the now opened table is valid
     if (! validate(this->tableDesc()))
@@ -87,8 +83,7 @@ MSWeather::MSWeather(const Table &table)
 }
 
 MSWeather::MSWeather(const MSWeather &other)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(other), 
+    : MSTable<MSWeatherEnums>(other), 
       hasBeenDestroyed_p(False)
 {
     // verify that other is valid
@@ -116,101 +111,96 @@ MSWeather::~MSWeather()
 MSWeather& MSWeather::operator=(const MSWeather &other)
 {
     if (&other != this) {
-	MSTable<PredefinedColumns,
-	PredefinedKeywords>::operator=(other);
+	MSTable<MSWeatherEnums>::operator=(other);
 	hasBeenDestroyed_p=other.hasBeenDestroyed_p;
     }
     return *this;
 }
 
-void MSWeather::initMap()
+MSTableMaps MSWeather::initMaps()
 {
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
   // the PredefinedColumns
   // ANTENNA_ID
-  colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
+  colMapDef(maps, ANTENNA_ID, "ANTENNA_ID", TpInt,
             "Antenna number","","");
   // INTERVAL
-  colMapDef(INTERVAL, "INTERVAL", TpDouble,
+  colMapDef(maps, INTERVAL, "INTERVAL", TpDouble,
             "Interval over which data is relevant","s","");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble,
+  colMapDef(maps, TIME, "TIME", TpDouble,
             "An MEpoch specifying the midpoint of the time for"
             "which data is relevant","s","Epoch");
   // DEW_POINT
-  colMapDef(DEW_POINT, "DEW_POINT", TpFloat,
+  colMapDef(maps, DEW_POINT, "DEW_POINT", TpFloat,
             "Dew point","K","");
   // DEW_POINT_FLAG
-  colMapDef(DEW_POINT_FLAG, "DEW_POINT_FLAG", TpBool,
+  colMapDef(maps, DEW_POINT_FLAG, "DEW_POINT_FLAG", TpBool,
             "Flag for dew point","","");
   // H2O 
-  colMapDef(H2O, "H2O", TpFloat,
+  colMapDef(maps, H2O, "H2O", TpFloat,
             "Average column density of water-vapor","m-2","");
   // H2O_FLAG
-  colMapDef(H2O_FLAG, "H2O_FLAG", TpBool,
+  colMapDef(maps, H2O_FLAG, "H2O_FLAG", TpBool,
             "Flag for average column density of water-vapor","","");
   // IONOS_ELECTRON
-  colMapDef(IONOS_ELECTRON, "IONOS_ELECTRON", TpFloat,
+  colMapDef(maps, IONOS_ELECTRON, "IONOS_ELECTRON", TpFloat,
             "Average column density of electrons","m-2","");
   // IONOS_ELECTRON_FLAG
-  colMapDef(IONOS_ELECTRON_FLAG, "IONOS_ELECTRON_FLAG", TpBool,
+  colMapDef(maps, IONOS_ELECTRON_FLAG, "IONOS_ELECTRON_FLAG", TpBool,
             "Flag for average column density of electrons","","");
   // PRESSURE
-  colMapDef(PRESSURE, "PRESSURE", TpFloat,
+  colMapDef(maps, PRESSURE, "PRESSURE", TpFloat,
             "Ambient atmospheric pressure","hPa","");
   // PRESSURE_FLAG
-  colMapDef(PRESSURE_FLAG, "PRESSURE_FLAG", TpBool,
+  colMapDef(maps, PRESSURE_FLAG, "PRESSURE_FLAG", TpBool,
             "Flag for ambient atmospheric pressure","","");
   // REL_HUMIDITY
-  colMapDef(REL_HUMIDITY, "REL_HUMIDITY", TpFloat,
+  colMapDef(maps, REL_HUMIDITY, "REL_HUMIDITY", TpFloat,
             "Ambient relative humidity","%","");
   // REL_HUMIDITY_FLAG
-  colMapDef(REL_HUMIDITY_FLAG, "REL_HUMIDITY_FLAG", TpBool,
+  colMapDef(maps, REL_HUMIDITY_FLAG, "REL_HUMIDITY_FLAG", TpBool,
             "Flag for ambient relative humidity","","");
   // TEMPERATURE
-  colMapDef(TEMPERATURE, "TEMPERATURE", TpFloat,
+  colMapDef(maps, TEMPERATURE, "TEMPERATURE", TpFloat,
             "Ambient Air Temperature for an antenna","K","");
   // TEMPERATURE_FLAG
-  colMapDef(TEMPERATURE_FLAG, "TEMPERATURE_FLAG", TpBool,
+  colMapDef(maps, TEMPERATURE_FLAG, "TEMPERATURE_FLAG", TpBool,
             "Flag for ambient Air Temperature for an antenna","","");
   // WIND_DIRECTION
-  colMapDef(WIND_DIRECTION, "WIND_DIRECTION", TpFloat,
+  colMapDef(maps, WIND_DIRECTION, "WIND_DIRECTION", TpFloat,
             "Average wind direction","rad","");
   // WIND_DIRECTION_FLAG
-  colMapDef(WIND_DIRECTION_FLAG, "WIND_DIRECTION_FLAG", TpBool,
+  colMapDef(maps, WIND_DIRECTION_FLAG, "WIND_DIRECTION_FLAG", TpBool,
             "Flag for wind direction","","");
   // WIND_SPEED
-  colMapDef(WIND_SPEED, "WIND_SPEED", TpFloat,
+  colMapDef(maps, WIND_SPEED, "WIND_SPEED", TpFloat,
             "Average wind speed","m/s","");
   // WIND_SPEED_FLAG
-  colMapDef(WIND_SPEED_FLAG, "WIND_SPEED_FLAG", TpBool,
+  colMapDef(maps, WIND_SPEED_FLAG, "WIND_SPEED_FLAG", TpBool,
             "Flag for wind speed","","");
   // PredefinedKeywords
-}
 
-void MSWeather::initDesc()
-{
   // init requiredTableDesc
-  TableDesc requiredTD;
   // all required keywords
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
-  
   // all required columns 
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 
 MSWeather MSWeather::referenceCopy(const String& newTableName, 
 				   const Block<String>& writableColumns) const
 {
-    return MSWeather(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MSWeather(MSTable<MSWeatherEnums>::
 		     referenceCopy(newTableName,writableColumns));
 }
 

--- a/ms/MeasurementSets/MSWeather.h
+++ b/ms/MeasurementSets/MSWeather.h
@@ -125,7 +125,8 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void init();
+    static void initMap();
+    static void initDesc();
 
 private:
 

--- a/ms/MeasurementSets/MSWeather.h
+++ b/ms/MeasurementSets/MSWeather.h
@@ -76,8 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </todo>
 
 class MSWeather:public MSWeatherEnums,
-                public MSTable<MSWeatherEnums::PredefinedColumns,
-		               MSWeatherEnums::PredefinedKeywords>
+                public MSTable<MSWeatherEnums>
 {
 public:
 
@@ -125,8 +124,7 @@ public:
     // Initialize the statics appropriately. This does not need to be
     // called by users, it is called by the implementation class
     // MSTableImpl.
-    static void initMap();
-    static void initDesc();
+    static MSTableMaps initMaps();
 
 private:
 
@@ -138,8 +136,3 @@ private:
 } //# NAMESPACE CASACORE - END
 
 #endif
-
-
-
-
-

--- a/ms/MeasurementSets/MeasurementSet.cc
+++ b/ms/MeasurementSets/MeasurementSet.cc
@@ -72,8 +72,7 @@ MeasurementSet::MeasurementSet()
 
 MeasurementSet::MeasurementSet(const String &tableName,
 			       TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, option), 
+    : MSTable<MSMainEnums>(tableName, option), 
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -105,8 +104,7 @@ void MeasurementSet::addCat()
 
 MeasurementSet::MeasurementSet (const String &tableName, const TableLock& lockOptions,
                                 bool doNotLockSubtables, TableOption option)
-: MSTable<PredefinedColumns,
-  PredefinedKeywords>(tableName, lockOptions, option),
+: MSTable<MSMainEnums>(tableName, lockOptions, option),
   doNotLockSubtables_p (doNotLockSubtables),
   hasBeenDestroyed_p(False)
 {
@@ -126,8 +124,7 @@ MeasurementSet::MeasurementSet (const String &tableName, const TableLock& lockOp
 MeasurementSet::MeasurementSet(const String &tableName,
 			       const TableLock& lockOptions,
 			       TableOption option) 
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, lockOptions, option), 
+    : MSTable<MSMainEnums>(tableName, lockOptions, option), 
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -144,8 +141,7 @@ MeasurementSet::MeasurementSet(const String &tableName,
 
 MeasurementSet::MeasurementSet(const String& tableName, const String &tableDescName,
 			       TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName, option),
+    : MSTable<MSMainEnums>(tableName, tableDescName, option),
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -161,8 +157,7 @@ MeasurementSet::MeasurementSet(const String& tableName, const String &tableDescN
 
 MeasurementSet::MeasurementSet(const String& tableName, const String &tableDescName,
 			       const TableLock& lockOptions, TableOption option)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(tableName, tableDescName, lockOptions, option),
+    : MSTable<MSMainEnums>(tableName, tableDescName, lockOptions, option),
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -178,8 +173,7 @@ MeasurementSet::MeasurementSet(const String& tableName, const String &tableDescN
 
 MeasurementSet::MeasurementSet(SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, nrrow, initialize), 
+    : MSTable<MSMainEnums>(newTab, nrrow, initialize), 
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -194,8 +188,7 @@ MeasurementSet::MeasurementSet(SetupNewTable &newTab, uInt nrrow,
 MeasurementSet::MeasurementSet(SetupNewTable &newTab,
 			       const TableLock& lockOptions, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(newTab, lockOptions, nrrow, initialize), 
+    : MSTable<MSMainEnums>(newTab, lockOptions, nrrow, initialize), 
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -208,7 +201,7 @@ MeasurementSet::MeasurementSet(SetupNewTable &newTab,
 }
 
 MeasurementSet::MeasurementSet(const Table &table, const MeasurementSet * otherMs)
-: MSTable<PredefinedColumns, PredefinedKeywords>(table),
+: MSTable<MSMainEnums>(table),
   doNotLockSubtables_p (False),
   hasBeenDestroyed_p(False)
 {
@@ -231,8 +224,7 @@ MeasurementSet::MeasurementSet(const Table &table, const MeasurementSet * otherM
 }
 
 MeasurementSet::MeasurementSet(const MeasurementSet &other)
-: MSTable<PredefinedColumns,
-  PredefinedKeywords>(other),
+: MSTable<MSMainEnums>(other),
   hasBeenDestroyed_p(False)
 {
   doNotLockSubtables_p = other.doNotLockSubtables_p;
@@ -275,7 +267,7 @@ MeasurementSet::operator=(const MeasurementSet &other)
 
         clearSubtables ();  // Make all subtables refer to null tables
 
-	MSTable<PredefinedColumns,PredefinedKeywords>::operator=(other);
+	MSTable<MSMainEnums>::operator=(other);
 
 	// MRS related components
 
@@ -336,209 +328,206 @@ MeasurementSet::getMrsEligibility () const {
 }
 
 
-void MeasurementSet::initMap()
+MSTableMaps MeasurementSet::initMaps()
 {
   // This function is called once (by MSTableImpl::doInitMap),
   // so the map should be empty.
-  AlwaysAssert (columnMap_p.empty(), AipsError);
+  MSTableMaps maps;
+  AlwaysAssert (maps.columnMap_p.empty(), AipsError);
   // the PredefinedColumns
   // ANTENNA1
-  colMapDef(ANTENNA1, "ANTENNA1", TpInt,
+  colMapDef(maps, ANTENNA1, "ANTENNA1", TpInt,
             "ID of first antenna in interferometer","","");
   // ANTENNA2
-  colMapDef(ANTENNA2, "ANTENNA2", TpInt,
+  colMapDef(maps, ANTENNA2, "ANTENNA2", TpInt,
             "ID of second antenna in interferometer","","");
   // ANTENNA3
-  colMapDef(ANTENNA3, "ANTENNA3", TpInt,
+  colMapDef(maps, ANTENNA3, "ANTENNA3", TpInt,
             "ID of third antenna in interferometer","","");
   // ARRAY_ID
-  colMapDef(ARRAY_ID, "ARRAY_ID", TpInt, 
+  colMapDef(maps, ARRAY_ID, "ARRAY_ID", TpInt, 
             "ID of array or subarray","","");
   // BASELINE_REF
-  colMapDef(BASELINE_REF,"BASELINE_REF",TpBool,
+  colMapDef(maps, BASELINE_REF,"BASELINE_REF",TpBool,
             "Reference antenna for this baseline, True for ANTENNA1","",
             "");
   // the CORRECTED_DATA column,
-  colMapDef(CORRECTED_DATA,"CORRECTED_DATA",TpArrayComplex,
+  colMapDef(maps, CORRECTED_DATA,"CORRECTED_DATA",TpArrayComplex,
             "The corrected data column","","");
   // the DATA columns,
-  colMapDef(DATA,"DATA",TpArrayComplex,"The data column","","");
+  colMapDef(maps, DATA,"DATA",TpArrayComplex,"The data column","","");
   // the DATA_DESC_ID
-  colMapDef(DATA_DESC_ID,"DATA_DESC_ID",TpInt,
+  colMapDef(maps, DATA_DESC_ID,"DATA_DESC_ID",TpInt,
             "The data description table index","","");
   // EXPOSURE
-  colMapDef(EXPOSURE, "EXPOSURE", TpDouble,
+  colMapDef(maps, EXPOSURE, "EXPOSURE", TpDouble,
             "The effective integration time","s","");
   // FEED1
-  colMapDef(FEED1, "FEED1", TpInt, "The feed index for ANTENNA1","","");
+  colMapDef(maps, FEED1, "FEED1", TpInt, "The feed index for ANTENNA1","","");
   // FEED2
-  colMapDef(FEED2, "FEED2", TpInt, "The feed index for ANTENNA2","","");
+  colMapDef(maps, FEED2, "FEED2", TpInt, "The feed index for ANTENNA2","","");
   // FEED3
-  colMapDef(FEED3, "FEED3", TpInt, "The feed index for ANTENNA3","","");
+  colMapDef(maps, FEED3, "FEED3", TpInt, "The feed index for ANTENNA3","","");
   // FIELD_ID
-  colMapDef(FIELD_ID,"FIELD_ID", TpInt, "Unique id for this pointing","","");
+  colMapDef(maps, FIELD_ID,"FIELD_ID", TpInt, "Unique id for this pointing","","");
   // FLAG
-  colMapDef(FLAG,"FLAG", TpArrayBool, 
+  colMapDef(maps, FLAG,"FLAG", TpArrayBool, 
             "The data flags, array of bools with same shape as data","","");
   // FLAG_CATEGORY
-  colMapDef(FLAG_CATEGORY,"FLAG_CATEGORY", TpArrayBool, 
+  colMapDef(maps, FLAG_CATEGORY,"FLAG_CATEGORY", TpArrayBool, 
             "The flag category, NUM_CAT flags for each datum","","");
   // FLAG_ROW
-  colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
+  colMapDef(maps, FLAG_ROW,"FLAG_ROW", TpBool,
             "Row flag - flag all data in this row if True","","");
   // FLOAT_DATA
-  colMapDef(FLOAT_DATA,"FLOAT_DATA",TpArrayFloat,
+  colMapDef(maps, FLOAT_DATA,"FLOAT_DATA",TpArrayFloat,
             "Floating point data - for single dish","","");
   // IMAGING_WEIGHT
-  colMapDef(IMAGING_WEIGHT,"IMAGING_WEIGHT",TpArrayFloat,
+  colMapDef(maps, IMAGING_WEIGHT,"IMAGING_WEIGHT",TpArrayFloat,
             "Weight set by imaging task (e.g. uniform weighting)","","");
   // INTERVAL
-  colMapDef(INTERVAL, "INTERVAL", TpDouble, 
+  colMapDef(maps, INTERVAL, "INTERVAL", TpDouble, 
             "The sampling interval","s","");
   // the LAG_DATA column,
-  colMapDef(LAG_DATA,"LAG_DATA",TpArrayComplex,
+  colMapDef(maps, LAG_DATA,"LAG_DATA",TpArrayComplex,
             "The lag data column","","");
   // the MODEL_DATA column,
-  colMapDef(MODEL_DATA,"MODEL_DATA",TpArrayComplex,
+  colMapDef(maps, MODEL_DATA,"MODEL_DATA",TpArrayComplex,
             "The model data column","","");
   // OBSERVATION_ID
-  colMapDef(OBSERVATION_ID, "OBSERVATION_ID", TpInt,
+  colMapDef(maps, OBSERVATION_ID, "OBSERVATION_ID", TpInt,
             "ID for this observation, index in OBSERVATION table","",""); 
   // PHASE_ID
-  colMapDef(PHASE_ID,"PHASE_ID",TpInt,
+  colMapDef(maps, PHASE_ID,"PHASE_ID",TpInt,
             "Id for phase switching","","");
   // PROCESSOR_ID
-  colMapDef(PROCESSOR_ID,"PROCESSOR_ID",TpInt,
+  colMapDef(maps, PROCESSOR_ID,"PROCESSOR_ID",TpInt,
             "Id for backend processor, index in PROCESSOR table","","");
   // PULSAR_BIN
-  colMapDef(PULSAR_BIN, "PULSAR_BIN", TpInt,
+  colMapDef(maps, PULSAR_BIN, "PULSAR_BIN", TpInt,
             "Pulsar pulse-phase bin for this DATA","",""); 
   // PULSAR_GATE_ID
-  colMapDef(PULSAR_GATE_ID, "PULSAR_GATE_ID", TpInt,
+  colMapDef(maps, PULSAR_GATE_ID, "PULSAR_GATE_ID", TpInt,
             "ID for this gate, index into PULSAR_GATE table","","");
   // SCAN_NUMBER
-  colMapDef(SCAN_NUMBER, "SCAN_NUMBER", TpInt,
+  colMapDef(maps, SCAN_NUMBER, "SCAN_NUMBER", TpInt,
             "Sequential scan number from on-line system","","");
   // STATE_ID
-  colMapDef(STATE_ID,"STATE_ID",TpInt,
+  colMapDef(maps, STATE_ID,"STATE_ID",TpInt,
             "ID for this observing state","","");
   // SIGMA
-  colMapDef(SIGMA, "SIGMA", TpArrayFloat,
+  colMapDef(maps, SIGMA, "SIGMA", TpArrayFloat,
             "Estimated rms noise for channel with unity bandpass response","","");
   // SIGMA_SPECTRUM
-  colMapDef(SIGMA_SPECTRUM, "SIGMA_SPECTRUM", TpArrayFloat,
+  colMapDef(maps, SIGMA_SPECTRUM, "SIGMA_SPECTRUM", TpArrayFloat,
             "Estimated rms noise for each data point","","");
   // TIME
-  colMapDef(TIME, "TIME", TpDouble, "Modified Julian Day","s","Epoch");
+  colMapDef(maps, TIME, "TIME", TpDouble, "Modified Julian Day","s","Epoch");
   // TIME_CENTROID
-  colMapDef(TIME_CENTROID, "TIME_CENTROID", TpDouble, 
+  colMapDef(maps, TIME_CENTROID, "TIME_CENTROID", TpDouble, 
             "Modified Julian Day","s","Epoch");
   // TIME_EXTRA_PREC
-  colMapDef(TIME_EXTRA_PREC, "TIME_EXTRA_PREC", TpDouble,
+  colMapDef(maps, TIME_EXTRA_PREC, "TIME_EXTRA_PREC", TpDouble,
             "Additional precision for TIME","s","");
   // UVW
-  colMapDef(UVW, "UVW", TpArrayDouble, 
+  colMapDef(maps, UVW, "UVW", TpArrayDouble, 
             "Vector with uvw coordinates (in meters)","m","uvw");
   // UVW2
-  colMapDef(UVW2,"UVW2",TpArrayDouble,
+  colMapDef(maps, UVW2,"UVW2",TpArrayDouble,
             "uvw coordinates for second pair of triple corr product",
             "m","uvw");
   // VIDEO_POINT
-  colMapDef(VIDEO_POINT,"VIDEO_POINT",TpArrayComplex,
+  colMapDef(maps, VIDEO_POINT,"VIDEO_POINT",TpArrayComplex,
             "zero frequency point, needed for transform to lag","","");
   // WEIGHT
-  colMapDef(WEIGHT, "WEIGHT", TpArrayFloat,
+  colMapDef(maps, WEIGHT, "WEIGHT", TpArrayFloat,
             "Weight for each polarization spectrum","","");
   // WEIGHT_SPECTRUM
-  colMapDef(WEIGHT_SPECTRUM, "WEIGHT_SPECTRUM", TpArrayFloat,
+  colMapDef(maps, WEIGHT_SPECTRUM, "WEIGHT_SPECTRUM", TpArrayFloat,
             "Weight for each data point","","");
   // CORRECTED_WEIGHT_SPECTRUM
-  colMapDef(CORRECTED_WEIGHT_SPECTRUM, "CORRECTED_WEIGHT_SPECTRUM", TpArrayFloat,
+  colMapDef(maps, CORRECTED_WEIGHT_SPECTRUM, "CORRECTED_WEIGHT_SPECTRUM", TpArrayFloat,
             "Weight for each corrected data point","","");
 
 
   // PredefinedKeywords
-
   // ANTENNA
-  keyMapDef(ANTENNA,"ANTENNA", TpTable,
+  keyMapDef(maps, ANTENNA,"ANTENNA", TpTable,
             "Antenna subtable. Antenna positions, mount-types etc.");
   // DATA_DESCRIPTION
-  keyMapDef(DATA_DESCRIPTION,"DATA_DESCRIPTION", TpTable,
+  keyMapDef(maps, DATA_DESCRIPTION,"DATA_DESCRIPTION", TpTable,
             "DATA_DESCRIPTION subtable. Points to freq and pol layout"
             "in subtables");
   // FEED
-  keyMapDef(FEED,"FEED", TpTable,
+  keyMapDef(maps, FEED,"FEED", TpTable,
             "Feed subtable. Responses, offsets, beams etc.");
   // FIELD
-  keyMapDef(FIELD,"FIELD",TpTable,
+  keyMapDef(maps, FIELD,"FIELD",TpTable,
             "Field subtable. Position etc. for each pointing.");
   // FLAG_CMD
-  keyMapDef(FLAG_CMD,"FLAG_CMD",TpTable,
+  keyMapDef(maps, FLAG_CMD,"FLAG_CMD",TpTable,
             "Flag command subtable. Stores global flagging commands");
   // HISTORY
-  keyMapDef(HISTORY,"HISTORY",TpTable,
+  keyMapDef(maps, HISTORY,"HISTORY",TpTable,
             "Observation and processing history");
   // MS_VERSION
-  keyMapDef(MS_VERSION,"MS_VERSION",TpFloat,
+  keyMapDef(maps, MS_VERSION,"MS_VERSION",TpFloat,
             "MS version number, i.e., 2.0");
   // OBSERVATION
-  keyMapDef(OBSERVATION,"OBSERVATION",TpTable,
+  keyMapDef(maps, OBSERVATION,"OBSERVATION",TpTable,
             "Observation subtable. Project, observer, schedule.");
   // POINTING
-  keyMapDef(POINTING,"POINTING",TpTable,
+  keyMapDef(maps, POINTING,"POINTING",TpTable,
             "Pointing subtable. Antenna pointing info.");
   // POLARIZATION
-  keyMapDef(POLARIZATION,"POLARIZATION",TpTable,
+  keyMapDef(maps, POLARIZATION,"POLARIZATION",TpTable,
             "Polarization set up subtable");
   // PROCESSOR
-  keyMapDef(PROCESSOR,"PROCESSOR",TpTable,
+  keyMapDef(maps, PROCESSOR,"PROCESSOR",TpTable,
             "Backend Processor information subtable");
   // SPECTRAL_WINDOW
-  keyMapDef(SPECTRAL_WINDOW,"SPECTRAL_WINDOW",TpTable,
+  keyMapDef(maps, SPECTRAL_WINDOW,"SPECTRAL_WINDOW",TpTable,
             "Spectral window subtable. Frequencies, bandwidths,"
             " polarizations");
   // STATE
-  keyMapDef(STATE,"STATE",TpTable,
+  keyMapDef(maps, STATE,"STATE",TpTable,
             "State subtable. State information (cal, ref etc.)");
   // CAL_TABLES
-  keyMapDef(CAL_TABLES,"CAL_TABLES",TpTable,
+  keyMapDef(maps, CAL_TABLES,"CAL_TABLES",TpTable,
             "Associated calibration tables, one per row");
   // DOPPLER
-  keyMapDef(DOPPLER,"DOPPLER",TpTable,
+  keyMapDef(maps, DOPPLER,"DOPPLER",TpTable,
             "Doppler tracking info");
   // FREQ_OFFSET
-  keyMapDef(FREQ_OFFSET,"FREQ_OFFSET",TpTable,
+  keyMapDef(maps, FREQ_OFFSET,"FREQ_OFFSET",TpTable,
             "Frequency offset information");
   // SORT_COLUMNS
-  keyMapDef(SORT_COLUMNS,"SORT_COLUMNS",TpArrayString,
+  keyMapDef(maps, SORT_COLUMNS,"SORT_COLUMNS",TpArrayString,
             "Listing of sort columns for each sorted table");
   // SORT_ORDER
-  keyMapDef(SORT_ORDER,"SORT_ORDER",TpArrayString,
+  keyMapDef(maps, SORT_ORDER,"SORT_ORDER",TpArrayString,
             "Listing of sort orders for each sorted table");
   // SORTED_TABLES
-  keyMapDef(SORTED_TABLES,"SORTED_TABLES",TpTable,
+  keyMapDef(maps, SORTED_TABLES,"SORTED_TABLES",TpTable,
             "Sorted reference tables of the main table, first one is"
             " main table");
   // SOURCE
-  keyMapDef(SOURCE,"SOURCE",TpTable,
+  keyMapDef(maps, SOURCE,"SOURCE",TpTable,
             "Source subtable. Positions etc. for each source.");
   // SYSCAL
-  keyMapDef(SYSCAL,"SYSCAL",TpTable,
+  keyMapDef(maps, SYSCAL,"SYSCAL",TpTable,
             "SysCal subtable. System calibration data (Tsys etc.).");
   // WEATHER
-  keyMapDef(WEATHER,"WEATHER",TpTable,
+  keyMapDef(maps, WEATHER,"WEATHER",TpTable,
             "Weather subtable. Weather info for each antenna.");
-}
 
-void MeasurementSet::initDesc()
-{
   // define required keywords and columns
-  TableDesc requiredTD;
+  TableDesc& requiredTD = maps.requiredTD_p;
   // all required keywords 
   uInt i;
   for (i = UNDEFINED_KEYWORD+1;
        i <= NUMBER_REQUIRED_KEYWORDS; i++) {
-    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+    addKeyToDesc(maps, PredefinedKeywords(i));
   }
   // Set MS_VERSION number
   requiredTD.rwKeywordSet().define("MS_VERSION",Float(2.0));
@@ -547,29 +536,28 @@ void MeasurementSet::initDesc()
   // First define the columns with fixed size arrays
   IPosition shape(1,3);
   ColumnDesc::Option option=ColumnDesc::Direct;
-  addColumnToDesc(requiredTD, UVW, shape, option);
+  addColumnToDesc(maps, UVW, shape, option);
   // Also define columns with Arrays with their correct dimensionality
-  addColumnToDesc(requiredTD, FLAG, 2);
-  addColumnToDesc(requiredTD, FLAG_CATEGORY, 3);
-  addColumnToDesc(requiredTD, WEIGHT, 1);
-  addColumnToDesc(requiredTD, SIGMA, 1);
+  addColumnToDesc(maps, FLAG, 2);
+  addColumnToDesc(maps, FLAG_CATEGORY, 3);
+  addColumnToDesc(maps, WEIGHT, 1);
+  addColumnToDesc(maps, SIGMA, 1);
   // Now define all other columns (duplicates are skipped)
   for (i = UNDEFINED_COLUMN+1; 
        i <= NUMBER_REQUIRED_COLUMNS; i++) {
-    addColumnToDesc(requiredTD, PredefinedColumns(i));
+    addColumnToDesc(maps, PredefinedColumns(i));
   }
   // Add the column keyword for the FLAG_CATEGORY column
   requiredTD.rwColumnDesc("FLAG_CATEGORY").rwKeywordSet().
     define("CATEGORY",Vector<String>(0));
-  
-  // init counted pointer to requiredTableDesc 
-  requiredTD_p=new TableDesc(requiredTD);
+
+  return maps;
 }
 	
 MeasurementSet MeasurementSet::referenceCopy(const String& newTableName, 
 			       const Block<String>& writableColumns) const
 {
-    return MeasurementSet(MSTable<PredefinedColumns,PredefinedKeywords>::
+    return MeasurementSet(MSTable<MSMainEnums>::
 			  referenceCopy(newTableName,writableColumns));
 }
 
@@ -991,7 +979,7 @@ Bool MeasurementSet::validateMeasureRefs()
 }
 
 void MeasurementSet::flush(Bool sync) {
-  MSTable<MSMainEnums::PredefinedColumns, MSMainEnums::PredefinedKeywords>::flush(sync);
+  MSTable<MSMainEnums>::flush(sync);
   antenna_p.flush(sync);
   dataDesc_p.flush(sync);
   if (!doppler_p.isNull()) doppler_p.flush(sync);

--- a/ms/MeasurementSets/MeasurementSet.cc
+++ b/ms/MeasurementSets/MeasurementSet.cc
@@ -336,230 +336,234 @@ MeasurementSet::getMrsEligibility () const {
 }
 
 
-void MeasurementSet::init()
+void MeasurementSet::initMap()
 {
-    if (! columnMap_p.ndefined()) {
-	// the PredefinedColumns
-	// ANTENNA1
-	colMapDef(ANTENNA1, "ANTENNA1", TpInt,
-		"ID of first antenna in interferometer","","");
-	// ANTENNA2
-	colMapDef(ANTENNA2, "ANTENNA2", TpInt,
-		  "ID of second antenna in interferometer","","");
-	// ANTENNA3
-	colMapDef(ANTENNA3, "ANTENNA3", TpInt,
-		  "ID of third antenna in interferometer","","");
-	// ARRAY_ID
-	colMapDef(ARRAY_ID, "ARRAY_ID", TpInt, 
-		  "ID of array or subarray","","");
-	// BASELINE_REF
-	colMapDef(BASELINE_REF,"BASELINE_REF",TpBool,
-		  "Reference antenna for this baseline, True for ANTENNA1","",
-		  "");
-	// the CORRECTED_DATA column,
-	colMapDef(CORRECTED_DATA,"CORRECTED_DATA",TpArrayComplex,
-		  "The corrected data column","","");
-	// the DATA columns,
-	colMapDef(DATA,"DATA",TpArrayComplex,"The data column","","");
-	// the DATA_DESC_ID
-	colMapDef(DATA_DESC_ID,"DATA_DESC_ID",TpInt,
-		  "The data description table index","","");
-	// EXPOSURE
-	colMapDef(EXPOSURE, "EXPOSURE", TpDouble,
-		  "The effective integration time","s","");
-	// FEED1
-	colMapDef(FEED1, "FEED1", TpInt, "The feed index for ANTENNA1","","");
-	// FEED2
-	colMapDef(FEED2, "FEED2", TpInt, "The feed index for ANTENNA2","","");
-	// FEED3
-	colMapDef(FEED3, "FEED3", TpInt, "The feed index for ANTENNA3","","");
-	// FIELD_ID
-	colMapDef(FIELD_ID,"FIELD_ID", TpInt, "Unique id for this pointing","","");
-	// FLAG
-	colMapDef(FLAG,"FLAG", TpArrayBool, 
-		  "The data flags, array of bools with same shape as data","","");
-	// FLAG_CATEGORY
-	colMapDef(FLAG_CATEGORY,"FLAG_CATEGORY", TpArrayBool, 
-		  "The flag category, NUM_CAT flags for each datum","","");
-	// FLAG_ROW
-	colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
-		  "Row flag - flag all data in this row if True","","");
-	// FLOAT_DATA
-	colMapDef(FLOAT_DATA,"FLOAT_DATA",TpArrayFloat,
-		  "Floating point data - for single dish","","");
-        // IMAGING_WEIGHT
-        colMapDef(IMAGING_WEIGHT,"IMAGING_WEIGHT",TpArrayFloat,
-                  "Weight set by imaging task (e.g. uniform weighting)","","");
-	// INTERVAL
-	colMapDef(INTERVAL, "INTERVAL", TpDouble, 
-		  "The sampling interval","s","");
-	// the LAG_DATA column,
-	colMapDef(LAG_DATA,"LAG_DATA",TpArrayComplex,
-		  "The lag data column","","");
-	// the MODEL_DATA column,
-	colMapDef(MODEL_DATA,"MODEL_DATA",TpArrayComplex,
-		  "The model data column","","");
-	// OBSERVATION_ID
-	colMapDef(OBSERVATION_ID, "OBSERVATION_ID", TpInt,
-		  "ID for this observation, index in OBSERVATION table","",""); 
-	// PHASE_ID
-	colMapDef(PHASE_ID,"PHASE_ID",TpInt,
-		  "Id for phase switching","","");
-	// PROCESSOR_ID
-	colMapDef(PROCESSOR_ID,"PROCESSOR_ID",TpInt,
-		  "Id for backend processor, index in PROCESSOR table","","");
-	// PULSAR_BIN
-	colMapDef(PULSAR_BIN, "PULSAR_BIN", TpInt,
-		  "Pulsar pulse-phase bin for this DATA","",""); 
-	// PULSAR_GATE_ID
-	colMapDef(PULSAR_GATE_ID, "PULSAR_GATE_ID", TpInt,
-		  "ID for this gate, index into PULSAR_GATE table","","");
-	// SCAN_NUMBER
-	colMapDef(SCAN_NUMBER, "SCAN_NUMBER", TpInt,
-		  "Sequential scan number from on-line system","","");
-	// STATE_ID
-	colMapDef(STATE_ID,"STATE_ID",TpInt,
-		  "ID for this observing state","","");
-	// SIGMA
-	colMapDef(SIGMA, "SIGMA", TpArrayFloat,
-		  "Estimated rms noise for channel with unity bandpass response","","");
-	// SIGMA_SPECTRUM
-	colMapDef(SIGMA_SPECTRUM, "SIGMA_SPECTRUM", TpArrayFloat,
-		  "Estimated rms noise for each data point","","");
-	// TIME
-	colMapDef(TIME, "TIME", TpDouble, "Modified Julian Day","s","Epoch");
-	// TIME_CENTROID
-	colMapDef(TIME_CENTROID, "TIME_CENTROID", TpDouble, 
-		  "Modified Julian Day","s","Epoch");
-	// TIME_EXTRA_PREC
-	colMapDef(TIME_EXTRA_PREC, "TIME_EXTRA_PREC", TpDouble,
-		  "Additional precision for TIME","s","");
-	// UVW
-	colMapDef(UVW, "UVW", TpArrayDouble, 
-		  "Vector with uvw coordinates (in meters)","m","uvw");
-	// UVW2
-	colMapDef(UVW2,"UVW2",TpArrayDouble,
-		  "uvw coordinates for second pair of triple corr product",
-		  "m","uvw");
-	// VIDEO_POINT
-	colMapDef(VIDEO_POINT,"VIDEO_POINT",TpArrayComplex,
-		  "zero frequency point, needed for transform to lag","","");
-	// WEIGHT
-	colMapDef(WEIGHT, "WEIGHT", TpArrayFloat,
-		  "Weight for each polarization spectrum","","");
-	// WEIGHT_SPECTRUM
-	colMapDef(WEIGHT_SPECTRUM, "WEIGHT_SPECTRUM", TpArrayFloat,
-		  "Weight for each data point","","");
-	// CORRECTED_WEIGHT_SPECTRUM
-	colMapDef(CORRECTED_WEIGHT_SPECTRUM, "CORRECTED_WEIGHT_SPECTRUM", TpArrayFloat,
-		  "Weight for each corrected data point","","");
+  // This function is called once (by MSTableImpl::doInitMap),
+  // so the map should be empty.
+  AlwaysAssert (columnMap_p.empty(), AipsError);
+  // the PredefinedColumns
+  // ANTENNA1
+  colMapDef(ANTENNA1, "ANTENNA1", TpInt,
+            "ID of first antenna in interferometer","","");
+  // ANTENNA2
+  colMapDef(ANTENNA2, "ANTENNA2", TpInt,
+            "ID of second antenna in interferometer","","");
+  // ANTENNA3
+  colMapDef(ANTENNA3, "ANTENNA3", TpInt,
+            "ID of third antenna in interferometer","","");
+  // ARRAY_ID
+  colMapDef(ARRAY_ID, "ARRAY_ID", TpInt, 
+            "ID of array or subarray","","");
+  // BASELINE_REF
+  colMapDef(BASELINE_REF,"BASELINE_REF",TpBool,
+            "Reference antenna for this baseline, True for ANTENNA1","",
+            "");
+  // the CORRECTED_DATA column,
+  colMapDef(CORRECTED_DATA,"CORRECTED_DATA",TpArrayComplex,
+            "The corrected data column","","");
+  // the DATA columns,
+  colMapDef(DATA,"DATA",TpArrayComplex,"The data column","","");
+  // the DATA_DESC_ID
+  colMapDef(DATA_DESC_ID,"DATA_DESC_ID",TpInt,
+            "The data description table index","","");
+  // EXPOSURE
+  colMapDef(EXPOSURE, "EXPOSURE", TpDouble,
+            "The effective integration time","s","");
+  // FEED1
+  colMapDef(FEED1, "FEED1", TpInt, "The feed index for ANTENNA1","","");
+  // FEED2
+  colMapDef(FEED2, "FEED2", TpInt, "The feed index for ANTENNA2","","");
+  // FEED3
+  colMapDef(FEED3, "FEED3", TpInt, "The feed index for ANTENNA3","","");
+  // FIELD_ID
+  colMapDef(FIELD_ID,"FIELD_ID", TpInt, "Unique id for this pointing","","");
+  // FLAG
+  colMapDef(FLAG,"FLAG", TpArrayBool, 
+            "The data flags, array of bools with same shape as data","","");
+  // FLAG_CATEGORY
+  colMapDef(FLAG_CATEGORY,"FLAG_CATEGORY", TpArrayBool, 
+            "The flag category, NUM_CAT flags for each datum","","");
+  // FLAG_ROW
+  colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
+            "Row flag - flag all data in this row if True","","");
+  // FLOAT_DATA
+  colMapDef(FLOAT_DATA,"FLOAT_DATA",TpArrayFloat,
+            "Floating point data - for single dish","","");
+  // IMAGING_WEIGHT
+  colMapDef(IMAGING_WEIGHT,"IMAGING_WEIGHT",TpArrayFloat,
+            "Weight set by imaging task (e.g. uniform weighting)","","");
+  // INTERVAL
+  colMapDef(INTERVAL, "INTERVAL", TpDouble, 
+            "The sampling interval","s","");
+  // the LAG_DATA column,
+  colMapDef(LAG_DATA,"LAG_DATA",TpArrayComplex,
+            "The lag data column","","");
+  // the MODEL_DATA column,
+  colMapDef(MODEL_DATA,"MODEL_DATA",TpArrayComplex,
+            "The model data column","","");
+  // OBSERVATION_ID
+  colMapDef(OBSERVATION_ID, "OBSERVATION_ID", TpInt,
+            "ID for this observation, index in OBSERVATION table","",""); 
+  // PHASE_ID
+  colMapDef(PHASE_ID,"PHASE_ID",TpInt,
+            "Id for phase switching","","");
+  // PROCESSOR_ID
+  colMapDef(PROCESSOR_ID,"PROCESSOR_ID",TpInt,
+            "Id for backend processor, index in PROCESSOR table","","");
+  // PULSAR_BIN
+  colMapDef(PULSAR_BIN, "PULSAR_BIN", TpInt,
+            "Pulsar pulse-phase bin for this DATA","",""); 
+  // PULSAR_GATE_ID
+  colMapDef(PULSAR_GATE_ID, "PULSAR_GATE_ID", TpInt,
+            "ID for this gate, index into PULSAR_GATE table","","");
+  // SCAN_NUMBER
+  colMapDef(SCAN_NUMBER, "SCAN_NUMBER", TpInt,
+            "Sequential scan number from on-line system","","");
+  // STATE_ID
+  colMapDef(STATE_ID,"STATE_ID",TpInt,
+            "ID for this observing state","","");
+  // SIGMA
+  colMapDef(SIGMA, "SIGMA", TpArrayFloat,
+            "Estimated rms noise for channel with unity bandpass response","","");
+  // SIGMA_SPECTRUM
+  colMapDef(SIGMA_SPECTRUM, "SIGMA_SPECTRUM", TpArrayFloat,
+            "Estimated rms noise for each data point","","");
+  // TIME
+  colMapDef(TIME, "TIME", TpDouble, "Modified Julian Day","s","Epoch");
+  // TIME_CENTROID
+  colMapDef(TIME_CENTROID, "TIME_CENTROID", TpDouble, 
+            "Modified Julian Day","s","Epoch");
+  // TIME_EXTRA_PREC
+  colMapDef(TIME_EXTRA_PREC, "TIME_EXTRA_PREC", TpDouble,
+            "Additional precision for TIME","s","");
+  // UVW
+  colMapDef(UVW, "UVW", TpArrayDouble, 
+            "Vector with uvw coordinates (in meters)","m","uvw");
+  // UVW2
+  colMapDef(UVW2,"UVW2",TpArrayDouble,
+            "uvw coordinates for second pair of triple corr product",
+            "m","uvw");
+  // VIDEO_POINT
+  colMapDef(VIDEO_POINT,"VIDEO_POINT",TpArrayComplex,
+            "zero frequency point, needed for transform to lag","","");
+  // WEIGHT
+  colMapDef(WEIGHT, "WEIGHT", TpArrayFloat,
+            "Weight for each polarization spectrum","","");
+  // WEIGHT_SPECTRUM
+  colMapDef(WEIGHT_SPECTRUM, "WEIGHT_SPECTRUM", TpArrayFloat,
+            "Weight for each data point","","");
+  // CORRECTED_WEIGHT_SPECTRUM
+  colMapDef(CORRECTED_WEIGHT_SPECTRUM, "CORRECTED_WEIGHT_SPECTRUM", TpArrayFloat,
+            "Weight for each corrected data point","","");
 
 
-	// PredefinedKeywords
+  // PredefinedKeywords
 
-	// ANTENNA
-	keyMapDef(ANTENNA,"ANTENNA", TpTable,
-		  "Antenna subtable. Antenna positions, mount-types etc.");
-        // DATA_DESCRIPTION
-	keyMapDef(DATA_DESCRIPTION,"DATA_DESCRIPTION", TpTable,
-		  "DATA_DESCRIPTION subtable. Points to freq and pol layout"
-		  "in subtables");
-	// FEED
-	keyMapDef(FEED,"FEED", TpTable,
-		  "Feed subtable. Responses, offsets, beams etc.");
-	// FIELD
-	keyMapDef(FIELD,"FIELD",TpTable,
-		  "Field subtable. Position etc. for each pointing.");
-	// FLAG_CMD
-	keyMapDef(FLAG_CMD,"FLAG_CMD",TpTable,
-		  "Flag command subtable. Stores global flagging commands");
-	// HISTORY
-	keyMapDef(HISTORY,"HISTORY",TpTable,
-		  "Observation and processing history");
-	// MS_VERSION
-	keyMapDef(MS_VERSION,"MS_VERSION",TpFloat,
-		  "MS version number, i.e., 2.0");
-	// OBSERVATION
-	keyMapDef(OBSERVATION,"OBSERVATION",TpTable,
-		  "Observation subtable. Project, observer, schedule.");
-	// POINTING
-	keyMapDef(POINTING,"POINTING",TpTable,
-		  "Pointing subtable. Antenna pointing info.");
-	// POLARIZATION
-	keyMapDef(POLARIZATION,"POLARIZATION",TpTable,
-		  "Polarization set up subtable");
-	// PROCESSOR
-	keyMapDef(PROCESSOR,"PROCESSOR",TpTable,
-		  "Backend Processor information subtable");
-	// SPECTRAL_WINDOW
-	keyMapDef(SPECTRAL_WINDOW,"SPECTRAL_WINDOW",TpTable,
-		  "Spectral window subtable. Frequencies, bandwidths,"
-		  " polarizations");
-	// STATE
-	keyMapDef(STATE,"STATE",TpTable,
-		  "State subtable. State information (cal, ref etc.)");
-	// CAL_TABLES
-	keyMapDef(CAL_TABLES,"CAL_TABLES",TpTable,
-		  "Associated calibration tables, one per row");
-	// DOPPLER
-	keyMapDef(DOPPLER,"DOPPLER",TpTable,
-		  "Doppler tracking info");
-	// FREQ_OFFSET
-	keyMapDef(FREQ_OFFSET,"FREQ_OFFSET",TpTable,
-		  "Frequency offset information");
-	// SORT_COLUMNS
-	keyMapDef(SORT_COLUMNS,"SORT_COLUMNS",TpArrayString,
-		  "Listing of sort columns for each sorted table");
-	// SORT_ORDER
-	keyMapDef(SORT_ORDER,"SORT_ORDER",TpArrayString,
-		  "Listing of sort orders for each sorted table");
-	// SORTED_TABLES
-	keyMapDef(SORTED_TABLES,"SORTED_TABLES",TpTable,
-		  "Sorted reference tables of the main table, first one is"
-		  " main table");
-	// SOURCE
-	keyMapDef(SOURCE,"SOURCE",TpTable,
-		  "Source subtable. Positions etc. for each source.");
-	// SYSCAL
-	keyMapDef(SYSCAL,"SYSCAL",TpTable,
-		  "SysCal subtable. System calibration data (Tsys etc.).");
-	// WEATHER
-	keyMapDef(WEATHER,"WEATHER",TpTable,
-		  "Weather subtable. Weather info for each antenna.");
+  // ANTENNA
+  keyMapDef(ANTENNA,"ANTENNA", TpTable,
+            "Antenna subtable. Antenna positions, mount-types etc.");
+  // DATA_DESCRIPTION
+  keyMapDef(DATA_DESCRIPTION,"DATA_DESCRIPTION", TpTable,
+            "DATA_DESCRIPTION subtable. Points to freq and pol layout"
+            "in subtables");
+  // FEED
+  keyMapDef(FEED,"FEED", TpTable,
+            "Feed subtable. Responses, offsets, beams etc.");
+  // FIELD
+  keyMapDef(FIELD,"FIELD",TpTable,
+            "Field subtable. Position etc. for each pointing.");
+  // FLAG_CMD
+  keyMapDef(FLAG_CMD,"FLAG_CMD",TpTable,
+            "Flag command subtable. Stores global flagging commands");
+  // HISTORY
+  keyMapDef(HISTORY,"HISTORY",TpTable,
+            "Observation and processing history");
+  // MS_VERSION
+  keyMapDef(MS_VERSION,"MS_VERSION",TpFloat,
+            "MS version number, i.e., 2.0");
+  // OBSERVATION
+  keyMapDef(OBSERVATION,"OBSERVATION",TpTable,
+            "Observation subtable. Project, observer, schedule.");
+  // POINTING
+  keyMapDef(POINTING,"POINTING",TpTable,
+            "Pointing subtable. Antenna pointing info.");
+  // POLARIZATION
+  keyMapDef(POLARIZATION,"POLARIZATION",TpTable,
+            "Polarization set up subtable");
+  // PROCESSOR
+  keyMapDef(PROCESSOR,"PROCESSOR",TpTable,
+            "Backend Processor information subtable");
+  // SPECTRAL_WINDOW
+  keyMapDef(SPECTRAL_WINDOW,"SPECTRAL_WINDOW",TpTable,
+            "Spectral window subtable. Frequencies, bandwidths,"
+            " polarizations");
+  // STATE
+  keyMapDef(STATE,"STATE",TpTable,
+            "State subtable. State information (cal, ref etc.)");
+  // CAL_TABLES
+  keyMapDef(CAL_TABLES,"CAL_TABLES",TpTable,
+            "Associated calibration tables, one per row");
+  // DOPPLER
+  keyMapDef(DOPPLER,"DOPPLER",TpTable,
+            "Doppler tracking info");
+  // FREQ_OFFSET
+  keyMapDef(FREQ_OFFSET,"FREQ_OFFSET",TpTable,
+            "Frequency offset information");
+  // SORT_COLUMNS
+  keyMapDef(SORT_COLUMNS,"SORT_COLUMNS",TpArrayString,
+            "Listing of sort columns for each sorted table");
+  // SORT_ORDER
+  keyMapDef(SORT_ORDER,"SORT_ORDER",TpArrayString,
+            "Listing of sort orders for each sorted table");
+  // SORTED_TABLES
+  keyMapDef(SORTED_TABLES,"SORTED_TABLES",TpTable,
+            "Sorted reference tables of the main table, first one is"
+            " main table");
+  // SOURCE
+  keyMapDef(SOURCE,"SOURCE",TpTable,
+            "Source subtable. Positions etc. for each source.");
+  // SYSCAL
+  keyMapDef(SYSCAL,"SYSCAL",TpTable,
+            "SysCal subtable. System calibration data (Tsys etc.).");
+  // WEATHER
+  keyMapDef(WEATHER,"WEATHER",TpTable,
+            "Weather subtable. Weather info for each antenna.");
+}
 
-	// define required keywords and columns
-	TableDesc requiredTD;
-	// all required keywords 
-	uInt i;
-	for (i = UNDEFINED_KEYWORD+1;
-	     i <= NUMBER_REQUIRED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
-	}
-	// Set MS_VERSION number
-	requiredTD.rwKeywordSet().define("MS_VERSION",Float(2.0));
-	
-	// all required columns 
-	// First define the columns with fixed size arrays
-	IPosition shape(1,3);
-	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, UVW, shape, option);
-	// Also define columns with Arrays with their correct dimensionality
-	addColumnToDesc(requiredTD, FLAG, 2);
-	addColumnToDesc(requiredTD, FLAG_CATEGORY, 3);
-	addColumnToDesc(requiredTD, WEIGHT, 1);
-	addColumnToDesc(requiredTD, SIGMA, 1);
-	// Now define all other columns (duplicates are skipped)
-	for (i = UNDEFINED_COLUMN+1; 
-	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
-	}
-        // Add the column keyword for the FLAG_CATEGORY column
-        requiredTD.rwColumnDesc("FLAG_CATEGORY").rwKeywordSet().
-	  define("CATEGORY",Vector<String>(0));
-
-	// init counted pointer to requiredTableDesc 
-	requiredTD_p=new TableDesc(requiredTD);
-    }
+void MeasurementSet::initDesc()
+{
+  // define required keywords and columns
+  TableDesc requiredTD;
+  // all required keywords 
+  uInt i;
+  for (i = UNDEFINED_KEYWORD+1;
+       i <= NUMBER_REQUIRED_KEYWORDS; i++) {
+    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+  }
+  // Set MS_VERSION number
+  requiredTD.rwKeywordSet().define("MS_VERSION",Float(2.0));
+  
+  // all required columns 
+  // First define the columns with fixed size arrays
+  IPosition shape(1,3);
+  ColumnDesc::Option option=ColumnDesc::Direct;
+  addColumnToDesc(requiredTD, UVW, shape, option);
+  // Also define columns with Arrays with their correct dimensionality
+  addColumnToDesc(requiredTD, FLAG, 2);
+  addColumnToDesc(requiredTD, FLAG_CATEGORY, 3);
+  addColumnToDesc(requiredTD, WEIGHT, 1);
+  addColumnToDesc(requiredTD, SIGMA, 1);
+  // Now define all other columns (duplicates are skipped)
+  for (i = UNDEFINED_COLUMN+1; 
+       i <= NUMBER_REQUIRED_COLUMNS; i++) {
+    addColumnToDesc(requiredTD, PredefinedColumns(i));
+  }
+  // Add the column keyword for the FLAG_CATEGORY column
+  requiredTD.rwColumnDesc("FLAG_CATEGORY").rwKeywordSet().
+    define("CATEGORY",Vector<String>(0));
+  
+  // init counted pointer to requiredTableDesc 
+  requiredTD_p=new TableDesc(requiredTD);
 }
 	
 MeasurementSet MeasurementSet::referenceCopy(const String& newTableName, 

--- a/ms/MeasurementSets/MeasurementSet.h
+++ b/ms/MeasurementSets/MeasurementSet.h
@@ -238,8 +238,7 @@ typedef MeasurementSet MS;
 //      be necessary to modify referenceCopy().
 // </todo>
 
-class MeasurementSet : public MSTable<MSMainEnums::PredefinedColumns,
-                                      MSMainEnums::PredefinedKeywords>,
+class MeasurementSet : public MSTable<MSMainEnums>,
 		       public MSMainEnums
 {
 
@@ -383,8 +382,7 @@ public:
   // Initialize the statics appropriately. This does not need to be
   // called by users, it is called by the implementation class
   // MSTableImpl.
-  static void initMap();
-  static void initDesc();
+  static MSTableMaps initMaps();
 
   // Create DATA column from existing FLOAT_DATA column. Noop if DATA already
   // exists or neither exists (returns False in that case).

--- a/ms/MeasurementSets/MeasurementSet.h
+++ b/ms/MeasurementSets/MeasurementSet.h
@@ -383,7 +383,8 @@ public:
   // Initialize the statics appropriately. This does not need to be
   // called by users, it is called by the implementation class
   // MSTableImpl.
-  static void init();
+  static void initMap();
+  static void initDesc();
 
   // Create DATA column from existing FLOAT_DATA column. Noop if DATA already
   // exists or neither exists (returns False in that case).

--- a/ms/MeasurementSets/test/tMeasurementSet.cc
+++ b/ms/MeasurementSets/test/tMeasurementSet.cc
@@ -54,7 +54,7 @@ uInt tColumnStatics()
     // ensure that the conversions are consistent
     uInt errCount = 0;
 
-    for (Int i=0;i<MS::NUMBER_PREDEFINED_COLUMNS;i++) {
+    for (Int i=1;i<MS::NUMBER_PREDEFINED_COLUMNS;i++) {
 	MS::PredefinedColumns pdcol = MS::PredefinedColumns(i);
 	MS::columnDataType(pdcol);
 	String pdname = MS::columnName(pdcol);
@@ -94,7 +94,7 @@ uInt tKeywordStatics()
 
     // MS::PredefinedKeywords
 
-    for (uInt i=0;i<MS::NUMBER_PREDEFINED_KEYWORDS;i++) {
+    for (uInt i=1;i<MS::NUMBER_PREDEFINED_KEYWORDS;i++) {
 	MS::PredefinedKeywords pdkey = MS::PredefinedKeywords(i);
 	String pdname = MS::keywordName(pdkey);
 	MS::PredefinedKeywords pdtype = MS::keywordType(pdname);


### PR DESCRIPTION
The Apertif software creates many MSs in parallel. Sometimes it stalled at the beginning of creating the MSs, which is most likely due to a race condition in the static initialization of UnitMap or MS::requiredTableDesc resulting in a deadlock. A potential problem in these initializations is the recursion that can take place for which special code constructs had to develoiped.
The implementation has been simplified considerably by removing the MS recursion and by solving the UnitMap recursion in a different way. Furthermore, the UnitMap statics are now contained in a function static variable to solve the problem of the static initialization order.
Note that C++11 guarantees that a function static is initialized only once, also in a multi-threaded program.

Close #865 