### PR TITLE
fix osx w/g++ single library segv

### DIFF
--- a/ms/MeasurementSets/MSAntenna.cc
+++ b/ms/MeasurementSets/MSAntenna.cc
@@ -126,7 +126,7 @@ MSAntenna& MSAntenna::operator=(const MSAntenna &other)
 
 void MSAntenna::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// DISH_DIAMETER
 	colMapDef(DISH_DIAMETER, "DISH_DIAMETER", TpDouble,
@@ -166,27 +166,24 @@ void MSAntenna::init()
 		  "index into PHASED_ARRAY table","","");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// First define the columns with fixed size arrays
 	IPosition shape(1,3);
 	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, OFFSET, shape, option);
-	addColumnToDesc(requiredTD, POSITION, shape, option);
+	addColumnToDesc(requiredTD_p(), OFFSET, shape, option);
+	addColumnToDesc(requiredTD_p(), POSITION, shape, option);
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSDataDescription.cc
+++ b/ms/MeasurementSets/MSDataDescription.cc
@@ -127,7 +127,7 @@ MSDataDescription& MSDataDescription::operator=(const MSDataDescription &other)
 
 void MSDataDescription::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
         // FLAG_ROW
 	colMapDef(FLAG_ROW,"FLAG_ROW", TpBool,
@@ -143,21 +143,18 @@ void MSDataDescription::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSDoppler.cc
+++ b/ms/MeasurementSets/MSDoppler.cc
@@ -154,7 +154,7 @@ MSDoppler& MSDoppler::operator=(const MSDoppler &other)
 
 void MSDoppler::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
         // the PredefinedColumns
         // 
 	colMapDef(DOPPLER_ID,"DOPPLER_ID", TpInt,
@@ -170,21 +170,18 @@ void MSDoppler::init()
 		  "Velocity Definition for Doppler shift","m/s","Doppler");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSFeed.cc
+++ b/ms/MeasurementSets/MSFeed.cc
@@ -125,7 +125,7 @@ MSFeed& MSFeed::operator=(const MSFeed &other)
 
 void MSFeed::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// ANTENNA_ID
 	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
@@ -177,31 +177,28 @@ void MSFeed::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// First define the columns with fixed size arrays
 	IPosition shape(1,3);
 	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, POSITION, shape, option);
+	addColumnToDesc(requiredTD_p(), POSITION, shape, option);
 	// define the columns with known dimensionality
-	addColumnToDesc(requiredTD, BEAM_OFFSET, 2);
-	addColumnToDesc(requiredTD, POLARIZATION_TYPE, 1);
-	addColumnToDesc(requiredTD, POL_RESPONSE, 2);
-	addColumnToDesc(requiredTD, RECEPTOR_ANGLE, 1);
+	addColumnToDesc(requiredTD_p(), BEAM_OFFSET, 2);
+	addColumnToDesc(requiredTD_p(), POLARIZATION_TYPE, 1);
+	addColumnToDesc(requiredTD_p(), POL_RESPONSE, 2);
+	addColumnToDesc(requiredTD_p(), RECEPTOR_ANGLE, 1);
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSField.cc
+++ b/ms/MeasurementSets/MSField.cc
@@ -127,7 +127,7 @@ MSField& MSField::operator=(const MSField &other)
 
 void MSField::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// CODE
 	colMapDef(CODE, "CODE", TpString,
@@ -166,26 +166,23 @@ void MSField::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// First define the columns with known dimensionality
-	addColumnToDesc(requiredTD, DELAY_DIR, 2);
-	addColumnToDesc(requiredTD, PHASE_DIR, 2);
-	addColumnToDesc(requiredTD, REFERENCE_DIR, 2);
+	addColumnToDesc(requiredTD_p(), DELAY_DIR, 2);
+	addColumnToDesc(requiredTD_p(), PHASE_DIR, 2);
+	addColumnToDesc(requiredTD_p(), REFERENCE_DIR, 2);
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSFlagCmd.cc
+++ b/ms/MeasurementSets/MSFlagCmd.cc
@@ -125,7 +125,7 @@ MSFlagCmd& MSFlagCmd::operator=(const MSFlagCmd &other)
 
 void MSFlagCmd::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// APPLIED
 	colMapDef(APPLIED, "APPLIED", TpBool,
@@ -155,22 +155,19 @@ void MSFlagCmd::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSFreqOffset.cc
+++ b/ms/MeasurementSets/MSFreqOffset.cc
@@ -125,7 +125,7 @@ MSFreqOffset& MSFreqOffset::operator=(const MSFreqOffset &other)
 
 void MSFreqOffset::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// ANTENNA1
 	colMapDef(ANTENNA1, "ANTENNA1", TpInt,
@@ -151,22 +151,19 @@ void MSFreqOffset::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSHistory.cc
+++ b/ms/MeasurementSets/MSHistory.cc
@@ -125,7 +125,7 @@ MSHistory& MSHistory::operator=(const MSHistory &other)
 
 void MSHistory::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
       // the PredefinedColumns
       // APPLICATION
       colMapDef(APPLICATION,"APPLICATION",TpString,
@@ -156,23 +156,20 @@ void MSHistory::init()
 		"Timestamp of message","s","Epoch");
       // PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	// define the columns with known dimensionality
-	addColumnToDesc(requiredTD, APP_PARAMS, 1);
-	addColumnToDesc(requiredTD, CLI_COMMAND, 1);
+	addColumnToDesc(requiredTD_p(), APP_PARAMS, 1);
+	addColumnToDesc(requiredTD_p(), CLI_COMMAND, 1);
 	// all required columns 
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSObservation.cc
+++ b/ms/MeasurementSets/MSObservation.cc
@@ -125,7 +125,7 @@ MSObservation& MSObservation::operator=(const MSObservation &other)
 
 void MSObservation::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// FLAG_ROW
 	colMapDef(FLAG_ROW,"FLAG_ROW",TpBool,
@@ -156,27 +156,24 @@ void MSObservation::init()
 		  "Start and end of observation","s","Epoch");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
         // Define the columns with fixed size arrays
         IPosition shape(1,2);
         ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, TIME_RANGE, shape, option);
+	addColumnToDesc(requiredTD_p(), TIME_RANGE, shape, option);
 	// Define the columns with known dimensionality
-	addColumnToDesc(requiredTD, LOG, 1);
-	addColumnToDesc(requiredTD, SCHEDULE, 1);
+	addColumnToDesc(requiredTD_p(), LOG, 1);
+	addColumnToDesc(requiredTD_p(), SCHEDULE, 1);
 	for (Int i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	for (Int i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSPointing.cc
+++ b/ms/MeasurementSets/MSPointing.cc
@@ -125,7 +125,7 @@ MSPointing& MSPointing::operator=(const MSPointing &other)
 
 void MSPointing::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// ANTENNA_ID
 	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
@@ -177,24 +177,21 @@ void MSPointing::init()
 		  "Offset from source as polynomial in time","rad","Direction");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	// First define the columns with known dimensionality
-	addColumnToDesc(requiredTD, DIRECTION, 2);
+	addColumnToDesc(requiredTD_p(), DIRECTION, 2);
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSPolarization.cc
+++ b/ms/MeasurementSets/MSPolarization.cc
@@ -125,7 +125,7 @@ MSPolarization& MSPolarization::operator=(const MSPolarization &other)
 
 void MSPolarization::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// CORR_PRODUCT
 	colMapDef(CORR_PRODUCT, "CORR_PRODUCT", TpArrayInt,
@@ -142,25 +142,22 @@ void MSPolarization::init()
 		  "Number of correlation products","","");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// First define the columns with known dimensionality
-	addColumnToDesc(requiredTD, CORR_TYPE, 1);
-	addColumnToDesc(requiredTD, CORR_PRODUCT, 2);
+	addColumnToDesc(requiredTD_p(), CORR_TYPE, 1);
+	addColumnToDesc(requiredTD_p(), CORR_PRODUCT, 2);
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSProcessor.cc
+++ b/ms/MeasurementSets/MSProcessor.cc
@@ -125,7 +125,7 @@ MSProcessor& MSProcessor::operator=(const MSProcessor &other)
 
 void MSProcessor::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// FLAG_ROW
 	colMapDef(FLAG_ROW, "FLAG_ROW", TpBool,
@@ -147,22 +147,19 @@ void MSProcessor::init()
 		  "Processor sub type","","");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSSource.cc
+++ b/ms/MeasurementSets/MSSource.cc
@@ -125,7 +125,7 @@ MSSource& MSSource::operator=(const MSSource &other)
 
 void MSSource::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// CALIBRATION_GROUP 
 	colMapDef(CALIBRATION_GROUP, "CALIBRATION_GROUP", TpInt,
@@ -181,27 +181,24 @@ void MSSource::init()
 		  "Line Transition name","","");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	// First define the columns with fixed size arrays
 	IPosition shape(1,2);
 	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, DIRECTION, shape, option);
-	addColumnToDesc(requiredTD, PROPER_MOTION, shape, option);
+	addColumnToDesc(requiredTD_p(), DIRECTION, shape, option);
+	addColumnToDesc(requiredTD_p(), PROPER_MOTION, shape, option);
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSSpectralWindow.cc
+++ b/ms/MeasurementSets/MSSpectralWindow.cc
@@ -126,7 +126,7 @@ MSSpectralWindow& MSSpectralWindow::operator=(const MSSpectralWindow &other)
 
 void MSSpectralWindow::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
       // the PredefinedColumns
       // 
       // ASSOC_NATURE
@@ -194,35 +194,30 @@ void MSSpectralWindow::init()
 		"The total bandwidth for this window","Hz","");
       // PredefinedKeywords
       
-      // init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 
 	// set up the TableMeasure columns with variable reference
 	// first add the variable ref column
-	addColumnToDesc(requiredTD, MEAS_FREQ_REF);
-	addColumnToDesc(requiredTD, CHAN_FREQ,1,"MEAS_FREQ_REF");
-	addColumnToDesc(requiredTD, REF_FREQUENCY,-1,"MEAS_FREQ_REF");
+	addColumnToDesc(requiredTD_p(), MEAS_FREQ_REF);
+	addColumnToDesc(requiredTD_p(), CHAN_FREQ,1,"MEAS_FREQ_REF");
+	addColumnToDesc(requiredTD_p(), REF_FREQUENCY,-1,"MEAS_FREQ_REF");
 
 	// define columns with known dimensionality
-	addColumnToDesc(requiredTD, CHAN_WIDTH,1);
-	addColumnToDesc(requiredTD, EFFECTIVE_BW,1);
-	addColumnToDesc(requiredTD, RESOLUTION,1);
+	addColumnToDesc(requiredTD_p(), CHAN_WIDTH,1);
+	addColumnToDesc(requiredTD_p(), EFFECTIVE_BW,1);
+	addColumnToDesc(requiredTD_p(), RESOLUTION,1);
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
 
-
-	requiredTD_p=new TableDesc(requiredTD);
-	
     }
 }
 

--- a/ms/MeasurementSets/MSState.cc
+++ b/ms/MeasurementSets/MSState.cc
@@ -127,7 +127,7 @@ MSState& MSState::operator=(const MSState &other)
 
 void MSState::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
         // the PredefinedColumns
         // CAL
 	colMapDef(CAL,"CAL", TpDouble,
@@ -153,21 +153,18 @@ void MSState::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSSysCal.cc
+++ b/ms/MeasurementSets/MSSysCal.cc
@@ -126,7 +126,7 @@ MSSysCal& MSSysCal::operator=(const MSSysCal &other)
 
 void MSSysCal::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// ANTENNA_ID
 	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
@@ -211,21 +211,18 @@ void MSSysCal::init()
 
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 

--- a/ms/MeasurementSets/MSTable.h
+++ b/ms/MeasurementSets/MSTable.h
@@ -244,29 +244,53 @@ protected:
  
     // These are the static ordered maps which contain the above info
     // ColEnum -> name
-    static SimpleOrderedMap<Int, String> columnMap_p;
+    static SimpleOrderedMap<Int, String> &columnMap_p( ) {
+        static SimpleOrderedMap<Int, String> map("");
+        return map;
+    }
     // ColEnum -> DataType
-    static SimpleOrderedMap<Int, Int> colDTypeMap_p;
+    static SimpleOrderedMap<Int, Int> &colDTypeMap_p( ) {
+        static SimpleOrderedMap<Int, Int> map(TpOther);
+        return map;
+    }
     // ColEnum -> comment string
-    static SimpleOrderedMap<Int, String> colCommentMap_p;
+    static SimpleOrderedMap<Int, String> &colCommentMap_p( ) {
+        static SimpleOrderedMap<Int, String> map("");
+        return map;
+    }
     // ColEnum -> UNIT string
-    static SimpleOrderedMap<Int, String> colUnitMap_p;
+    static SimpleOrderedMap<Int, String> &colUnitMap_p( ) {
+        static SimpleOrderedMap<Int, String> map("");
+        return map;
+    }
     // ColEnum -> MEASURE_TYPE string
-    static SimpleOrderedMap<Int, String> colMeasureTypeMap_p;
- 
-
-    // KeyEnum -> name
-    static SimpleOrderedMap<Int, String> keywordMap_p;
+    static SimpleOrderedMap<Int, String> &colMeasureTypeMap_p( ) {
+        static SimpleOrderedMap<Int, String> map("");
+        return map;
+    }
+    
+     // KeyEnum -> name
+    static SimpleOrderedMap<Int, String> &keywordMap_p( ) {
+        static SimpleOrderedMap<Int, String> map("");
+        return map;
+    }
     // KeyEnum -> DataType
-    static SimpleOrderedMap<Int, Int> keyDTypeMap_p;
+    static SimpleOrderedMap<Int, Int> &keyDTypeMap_p( ) {
+        static SimpleOrderedMap<Int, Int> map(TpOther);
+        return map;
+    }
     // KeyEnum -> comment string
-    static SimpleOrderedMap<Int, String> keyCommentMap_p;
+    static SimpleOrderedMap<Int, String> &keyCommentMap_p( ) {
+        static SimpleOrderedMap<Int, String> map("");
+        return map;
+    }
 
     // The required TableDesc
-    //# following fails in static initialization (segm. fault).
-    //    static TableDesc requiredTD_p;
-    static CountedPtr<TableDesc> requiredTD_p;
- 
+    static TableDesc &requiredTD_p( ) {
+        static TableDesc desc;
+        return desc;
+    }
+    
     // Define an entry in the column maps
     static void colMapDef(ColEnum col,
 			  const String& colName,

--- a/ms/MeasurementSets/MSTable.tcc
+++ b/ms/MeasurementSets/MSTable.tcc
@@ -34,30 +34,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# These statics cannot be compiled with egcs 1.0.3a.
-#if !defined(__GNUG__) || (defined(__GNUG__) && (__GNUG__ == 2) && (__GNUC_MINOR__ >= 91)) || defined(AIPS_GCC)
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::columnMap_p("");
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, Int> MSTable<ColEnum,KeyEnum>::colDTypeMap_p(TpOther);
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::colCommentMap_p("");
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::colUnitMap_p("");
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::colMeasureTypeMap_p("");
-
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::keywordMap_p("");
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, Int> MSTable<ColEnum,KeyEnum>::keyDTypeMap_p(TpOther);
-template <class ColEnum, class KeyEnum> 
-SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::keyCommentMap_p("");
-template <class ColEnum, class KeyEnum> 
-CountedPtr<TableDesc> MSTable<ColEnum,KeyEnum>::requiredTD_p;
-#endif
-
-
 template <class ColEnum, class KeyEnum> 
 MSTable<ColEnum,KeyEnum>::MSTable() {}
 
@@ -130,44 +106,44 @@ operator=(const MSTable<ColEnum,KeyEnum>& other)
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::columnName(ColEnum which)
 { 
-    MSTableImpl::init(); return columnMap_p(which); 
+    MSTableImpl::init(); return columnMap_p( )(which); 
 }
 
 template <class ColEnum, class KeyEnum> 
 ColEnum MSTable<ColEnum,KeyEnum>::columnType(const String &name)
-{ MSTableImpl::init(); return ColEnum(MSTableImpl::mapType(columnMap_p,name)); }
+{ MSTableImpl::init(); return ColEnum(MSTableImpl::mapType(columnMap_p( ),name)); }
 
 template <class ColEnum, class KeyEnum> 
 DataType MSTable<ColEnum,KeyEnum>::columnDataType(ColEnum which)
-{ MSTableImpl::init(); return DataType(colDTypeMap_p(which)); }
+{ MSTableImpl::init(); return DataType(colDTypeMap_p( )(which)); }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::columnStandardComment(ColEnum which)
-{ MSTableImpl::init(); return colCommentMap_p(which); }
+{ MSTableImpl::init(); return colCommentMap_p( )(which); }
 template <class ColEnum, class KeyEnum> 
 
 const String& MSTable<ColEnum,KeyEnum>::columnUnit(ColEnum which)
-{ MSTableImpl::init(); return colUnitMap_p(which); }
+{ MSTableImpl::init(); return colUnitMap_p( )(which); }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::columnMeasureType(ColEnum which)
-{ MSTableImpl::init(); return colMeasureTypeMap_p(which); }
+{ MSTableImpl::init(); return colMeasureTypeMap_p( )(which); }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::keywordName(KeyEnum which)
-{ MSTableImpl::init(); return keywordMap_p(which); }
+{ MSTableImpl::init(); return keywordMap_p( )(which); }
 
 template <class ColEnum, class KeyEnum> 
 KeyEnum MSTable<ColEnum,KeyEnum>::keywordType(const String &name)
-{ MSTableImpl::init(); return KeyEnum(MSTableImpl::mapType(keywordMap_p,name)); }
+{ MSTableImpl::init(); return KeyEnum(MSTableImpl::mapType(keywordMap_p( ),name)); }
 
 template <class ColEnum, class KeyEnum> 
 DataType MSTable<ColEnum,KeyEnum>::keywordDataType(KeyEnum which)
-{ MSTableImpl::init(); return DataType(keyDTypeMap_p(which)); }
+{ MSTableImpl::init(); return DataType(keyDTypeMap_p( )(which)); }
 
 template <class ColEnum, class KeyEnum> 
 const String& MSTable<ColEnum,KeyEnum>::keywordStandardComment(KeyEnum which)
-{ MSTableImpl::init(); return keyCommentMap_p(which); }
+{ MSTableImpl::init(); return keyCommentMap_p( )(which); }
 
 template <class ColEnum, class KeyEnum> 
 Bool MSTable<ColEnum,KeyEnum>::isColumn(ColEnum which) const
@@ -242,8 +218,8 @@ void MSTable<ColEnum,KeyEnum>::colMapDef(ColEnum col,
 					 const String& colUnit,
 					 const String& colMeasureType)
 {
-    MSTableImpl::colMapDef(columnMap_p,colDTypeMap_p,colCommentMap_p,
-			   colUnitMap_p,colMeasureTypeMap_p,col,colName,
+    MSTableImpl::colMapDef(columnMap_p( ),colDTypeMap_p( ),colCommentMap_p( ),
+			   colUnitMap_p( ),colMeasureTypeMap_p( ),col,colName,
 			   colType,colComment,colUnit,colMeasureType);
 }
 
@@ -253,26 +229,26 @@ void MSTable<ColEnum,KeyEnum>::keyMapDef(KeyEnum key,
 					 DataType keyType,
 					 const String& keyComment)
 {
-    MSTableImpl::keyMapDef(keywordMap_p,keyDTypeMap_p,keyCommentMap_p,
+    MSTableImpl::keyMapDef(keywordMap_p( ),keyDTypeMap_p( ),keyCommentMap_p( ),
 			   key,keyName,keyType,keyComment);
 }
 
 template <class ColEnum, class KeyEnum> 
 Bool MSTable<ColEnum,KeyEnum>::validate(const TableDesc& tabDesc)
 {
-    MSTableImpl::init(); return MSTableImpl::validate(tabDesc,*requiredTD_p);
+    MSTableImpl::init(); return MSTableImpl::validate(tabDesc,requiredTD_p());
 }
  
 template <class ColEnum, class KeyEnum> 
 Bool MSTable<ColEnum,KeyEnum>::validate(const TableRecord& tabKeySet)
 {
-    MSTableImpl::init(); return MSTableImpl::validate(tabKeySet,*requiredTD_p);
+    MSTableImpl::init(); return MSTableImpl::validate(tabKeySet,requiredTD_p());
 }
 
 template <class ColEnum, class KeyEnum> 
 const TableDesc& MSTable<ColEnum,KeyEnum>::requiredTableDesc()
 {
-    MSTableImpl::init(); return *requiredTD_p;
+    MSTableImpl::init(); return requiredTD_p();
 }
 
 template <class ColEnum, class KeyEnum> 

--- a/ms/MeasurementSets/MSTable2.cc
+++ b/ms/MeasurementSets/MSTable2.cc
@@ -42,7 +42,6 @@ SimpleOrderedMap<Int, String> \
 SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::keywordMap_p(""); \
 SimpleOrderedMap<Int, Int> MSTable<ColEnum,KeyEnum>::keyDTypeMap_p(TpOther); \
 SimpleOrderedMap<Int, String> MSTable<ColEnum,KeyEnum>::keyCommentMap_p(""); \
-SimpleCountedConstPtr<TableDesc> MSTable<ColEnum,KeyEnum>::requiredTD_p;
  
 MSTableStatics(MS::PredefinedColumns,MS::PredefinedKeywords)
 MSTableStatics(MSAntenna::PredefinedColumns,MSAntenna::PredefinedKeywords)

--- a/ms/MeasurementSets/MSWeather.cc
+++ b/ms/MeasurementSets/MSWeather.cc
@@ -125,7 +125,7 @@ MSWeather& MSWeather::operator=(const MSWeather &other)
 
 void MSWeather::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// ANTENNA_ID
 	colMapDef(ANTENNA_ID, "ANTENNA_ID", TpInt,
@@ -187,21 +187,18 @@ void MSWeather::init()
 		  "Flag for wind speed","","");
 	// PredefinedKeywords
 
-	// init requiredTableDesc
-	TableDesc requiredTD;
 	// all required keywords
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_PREDEFINED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	
 	// all required columns 
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 	

--- a/ms/MeasurementSets/MeasurementSet.cc
+++ b/ms/MeasurementSets/MeasurementSet.cc
@@ -338,7 +338,7 @@ MeasurementSet::getMrsEligibility () const {
 
 void MeasurementSet::init()
 {
-    if (! columnMap_p.ndefined()) {
+    if (! columnMap_p().ndefined()) {
 	// the PredefinedColumns
 	// ANTENNA1
 	colMapDef(ANTENNA1, "ANTENNA1", TpInt,
@@ -528,37 +528,34 @@ void MeasurementSet::init()
 		  "Weather subtable. Weather info for each antenna.");
 
 	// define required keywords and columns
-	TableDesc requiredTD;
 	// all required keywords 
 	uInt i;
 	for (i = UNDEFINED_KEYWORD+1;
 	     i <= NUMBER_REQUIRED_KEYWORDS; i++) {
-	    addKeyToDesc(requiredTD, PredefinedKeywords(i));
+	    addKeyToDesc(requiredTD_p(), PredefinedKeywords(i));
 	}
 	// Set MS_VERSION number
-	requiredTD.rwKeywordSet().define("MS_VERSION",Float(2.0));
+	requiredTD_p().rwKeywordSet().define("MS_VERSION",Float(2.0));
 	
 	// all required columns 
 	// First define the columns with fixed size arrays
 	IPosition shape(1,3);
 	ColumnDesc::Option option=ColumnDesc::Direct;
-	addColumnToDesc(requiredTD, UVW, shape, option);
+	addColumnToDesc(requiredTD_p(), UVW, shape, option);
 	// Also define columns with Arrays with their correct dimensionality
-	addColumnToDesc(requiredTD, FLAG, 2);
-	addColumnToDesc(requiredTD, FLAG_CATEGORY, 3);
-	addColumnToDesc(requiredTD, WEIGHT, 1);
-	addColumnToDesc(requiredTD, SIGMA, 1);
+	addColumnToDesc(requiredTD_p(), FLAG, 2);
+	addColumnToDesc(requiredTD_p(), FLAG_CATEGORY, 3);
+	addColumnToDesc(requiredTD_p(), WEIGHT, 1);
+	addColumnToDesc(requiredTD_p(), SIGMA, 1);
 	// Now define all other columns (duplicates are skipped)
 	for (i = UNDEFINED_COLUMN+1; 
 	     i <= NUMBER_REQUIRED_COLUMNS; i++) {
-	    addColumnToDesc(requiredTD, PredefinedColumns(i));
+	    addColumnToDesc(requiredTD_p(), PredefinedColumns(i));
 	}
         // Add the column keyword for the FLAG_CATEGORY column
-        requiredTD.rwColumnDesc("FLAG_CATEGORY").rwKeywordSet().
+        requiredTD_p().rwColumnDesc("FLAG_CATEGORY").rwKeywordSet().
 	  define("CATEGORY",Vector<String>(0));
 
-	// init counted pointer to requiredTableDesc 
-	requiredTD_p=new TableDesc(requiredTD);
     }
 }
 	


### PR DESCRIPTION
Using statics is problematic. This change modifies MSTable statics to protect object initialization within a function context. The function scope ensures proper initialization. In one case, a static shared pointer was introduced to fix an earlier SEGV (i.e. requiredTD_p). Unfortunately, this does not resolve the general problem but rather a particular SEGV instance. Fixing this case was also required because my use case also encountered an exception with this.

My use case is casacore compiled into a single library on OSX with libraries built with g++ 5.5.