### PR TITLE
Fix thread safety of bulk allocator

### DIFF
--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -310,21 +310,8 @@ class Allocator_private {
   };
   template<typename Allocator>
   static BulkAllocatorImpl<Allocator> *get_allocator_raw() {
-    static union {
-      void *dummy;
-      char alloc_obj[sizeof(BulkAllocatorImpl<Allocator> )];
-    } u;
-    static BulkAllocatorImpl<Allocator> *ptr = 0;
-    // Probably this method is called from BulkAllocatorInitializer<Allocator> first
-    // while static initialization
-    // and other threads are not started yet.
-    if (ptr == 0) {
-      // Use construct below to avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42032 
-      ::new (reinterpret_cast<BulkAllocatorImpl<Allocator>*>(u.alloc_obj)) BulkAllocatorImpl<Allocator>(); // this instance will never be destructed.
-      //      ::new (u.alloc_obj) BulkAllocatorImpl<Allocator>(); // this instance will never be destructed.
-      ptr = reinterpret_cast<BulkAllocatorImpl<Allocator> *>(u.alloc_obj);
-    }
-    return ptr;
+    static BulkAllocatorImpl<Allocator> allocator;
+    return &allocator;
   }
 
   // <summary>Allocator specifier</summary>


### PR DESCRIPTION
I'm having trouble getting casacore to open different measurement sets from multiple (~20) threads, resulting in crashes and messages that say that tables cannot be removed from the table cache. Helgrind identifies several race conditions, one of them being in the bulk allocator. This commit solves those race conditions. On a simple test application that opens two different measurement sets in two different threads, this fix decreases the number of helgrind errors from 124 to 71 in this test application.

When I run `make check` (somewhat to my surprise) I see several failures because of this edit. I'm quite confused why this is, but the old code generates a race condition so needs some kind of change, so I'm posting this for now as a pull request -- maybe someone else can comment on why apparently other code is depending on the non-thread-safe initialization of this static.