### PR TITLE
adds accessor to underlying HDF5DataSet to HDF5Lattice

### DIFF
--- a/lattices/Lattices/HDF5Lattice.h
+++ b/lattices/Lattices/HDF5Lattice.h
@@ -194,7 +194,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       { return itsGroup; }
 
 	// Returns the current HDF5DataSet object
-	const CountedPtr<HDF5DataSet> array() const
+	const CountedPtr<HDF5DataSet>& array() const
 	{ return itsDataSet; }
 
     // Returns the name of this HDF5Lattice.

--- a/lattices/Lattices/HDF5Lattice.h
+++ b/lattices/Lattices/HDF5Lattice.h
@@ -193,6 +193,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     const CountedPtr<HDF5Group>& group() const
       { return itsGroup; }
 
+	// Returns the current HDF5DataSet object
+	const CountedPtr<HDF5DataSet> array() const
+	{ return itsDataSet; }
+
     // Returns the name of this HDF5Lattice.
     const String& arrayName() const
       { return itsDataSet->getName(); }


### PR DESCRIPTION
For some of our work on CARTA, we need to read large slices of data to an allocated memory buffer directly (in this case, managed by a `std::vector`). The HDF5DataSet object's `get` method allows us to do so, but the HDF5Lattice currently does not expose the underlying HDF5DataSet object associated with that lattice. This PR adds a single accessor function which returns the HDF5DataSet. I have used `array()` rather than `dataset()` to be consistent with the existing `arrayName()` function. 