### PR TITLE
Fix reading of contiguous HDF5 datasets

### DIFF
--- a/casa/HDF5/HDF5DataSet.cc
+++ b/casa/HDF5/HDF5DataSet.cc
@@ -275,11 +275,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (itsPLid.getHid() < 0) {
       throw HDF5Error("Data set array " + name + " does not have properties");
     }
-    // Get tile shape and check if its rank matches.
-    if (H5Pget_chunk(itsPLid, rank, shp.storage()) != rank) {
-      throw HDF5Error("Data set array " + name + " tile shape error");
+    H5D_layout_t layout = H5Pget_layout(itsPLid);
+    if (layout != H5D_CONTIGUOUS) {
+      // Get tile shape and check if its rank matches.
+      if (H5Pget_chunk(itsPLid, rank, shp.storage()) != rank) {
+        throw HDF5Error("Data set array " + name + " tile shape error");
+      }
+      itsTileShape = HDF5DataType::toShape(shp);
     }
-    itsTileShape = HDF5DataType::toShape(shp);
   }
 
   void HDF5DataSet::closeDataSet()


### PR DESCRIPTION
Currently, attempting to read a contiguous HDF5 dataset will always throw an error, because `H5Pget_chunk` returns an error value (-1) when a dataset does not have a chunk size. This PR modifies the `HDF5DataSet::open` function to skip reading of the chunk size for contiguous datasets.