### PR TITLE
Catch all polymorphic exceptions by reference

### DIFF
--- a/casa/Arrays/ArrayIO.tcc
+++ b/casa/Arrays/ArrayIO.tcc
@@ -497,7 +497,7 @@ Bool read(istream &s, Array<T> &x,
     try {
       x.resize (tx.shape());
       x = tx;
-    } catch (AipsError) {
+    } catch (AipsError&) {
       IPosition first;
       IPosition last;
       if (x.ndim() >= tx.ndim()) {

--- a/casa/Arrays/test/dArrayAccessor.cc
+++ b/casa/Arrays/test/dArrayAccessor.cc
@@ -68,7 +68,7 @@ int main() {
 	  cout << "t2: " << *ab << endl;;
 	  ab++;
 	  cout << "t3: " << *ab << endl;;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
 
@@ -91,7 +91,7 @@ int main() {
 	cout << *j << ", " << j.index<Axis<1> >(1) << endl;
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
 
@@ -349,7 +349,7 @@ int main() {
     }
     timer.show("getStorage    part ");
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   }

--- a/casa/Arrays/test/tArray.cc
+++ b/casa/Arrays/test/tArray.cc
@@ -1369,7 +1369,7 @@ int main()
 		caught = False;                  // check for leaks
 		try {
 		    seeIfWeMakeMemoryLeak();
-		} catch (ArrayError x) {
+		} catch (ArrayError& x) {
 		    caught = True;
 		} 
 		AlwaysAssertExit(caught);
@@ -1530,7 +1530,7 @@ int main()
 	  Bool exc = False;
 	  try {
 	    mi.assign (ai);
-	  } catch (AipsError) {
+	  } catch (AipsError&) {
 	    exc = True;
 	  }
 	  AlwaysAssertExit (exc);

--- a/casa/Arrays/test/tArrayAccessor.cc
+++ b/casa/Arrays/test/tArrayAccessor.cc
@@ -365,7 +365,7 @@ int main() {
     cout << "ok" << endl <<
       "--------------------------------------------------" << endl;
  
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   }

--- a/casa/Arrays/test/tArrayIO2.cc
+++ b/casa/Arrays/test/tArrayIO2.cc
@@ -51,7 +51,7 @@ int main (int argc, const char*[])
 	doBin ( (argc<2));
 	doMat();
 	doVec();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "\nCaught an exception: " << x.getMesg() << endl;
         return 1;
     } 

--- a/casa/Arrays/test/tArrayIO3.cc
+++ b/casa/Arrays/test/tArrayIO3.cc
@@ -82,7 +82,7 @@ int main()
 	cout << "--------------------------------------" << endl;
 	ins >> as;
 	cout << as << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "\nCaught an exception: " << x.getMesg() << endl;
         return 1;
     } 

--- a/casa/Arrays/test/tArrayIter1.cc
+++ b/casa/Arrays/test/tArrayIter1.cc
@@ -429,7 +429,7 @@ int main()
       checkIter (array, IPosition(5,5,2,3,4,5),
 		 IPosition(5,5,2,9,11,13), IPosition(5,1,1,1,1,1));
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   }

--- a/casa/Arrays/test/tArrayLogical.cc
+++ b/casa/Arrays/test/tArrayLogical.cc
@@ -167,7 +167,7 @@ int main()
 
             cout << endl << "OK" << endl;
         }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tArrayMath.cc
+++ b/casa/Arrays/test/tArrayMath.cc
@@ -699,7 +699,7 @@ int main()
     testMakeComplex<Double,DComplex>();
     testMinMax1();
     testExpand();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   }

--- a/casa/Arrays/test/tArrayMathTransform.cc
+++ b/casa/Arrays/test/tArrayMathTransform.cc
@@ -137,7 +137,7 @@ int main()
 {
   try {
     doIt();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   }

--- a/casa/Arrays/test/tArrayOpsDiffShapes.cc
+++ b/casa/Arrays/test/tArrayOpsDiffShapes.cc
@@ -142,7 +142,7 @@ int main()
 	test_binOpExpanders(1 + i, 2 + j, 4);
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Error: " << x.getMesg() << endl;
     return 1;
   } catch (...) {

--- a/casa/Arrays/test/tArrayUtil.cc
+++ b/casa/Arrays/test/tArrayUtil.cc
@@ -198,13 +198,13 @@ Bool testConcatenateArray (Bool doExcp)
 	    concatenateArray (matrix1, matrix3);
 	    ok = False;             // should not get here
 	    cout << "1st concatenateArray exception not thrown" << endl;
-	} catch (ArrayConformanceError x) {
+	} catch (ArrayConformanceError& x) {
 	} 
 	try {
 	    concatenateArray (matrix1, vector1);
 	    ok = False;             // should not get here
 	    cout << "2nd concatenateArray exception not thrown" << endl;
-	} catch (ArrayConformanceError x) {
+	} catch (ArrayConformanceError& x) {
 	} 
     }
 
@@ -337,13 +337,13 @@ Bool testReorderArray (Bool doExcp)
       reorderArray (Array<Int>(IPosition(2,3,4)), IPosition(2,1,1));
       ok = False;        // should not get here
       cout << "1st reorderArray exception not thrown" << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
     } 
     try {
       reorderArray (Array<Int>(IPosition(2,3,4)), IPosition(2,1,2));
       ok = False;        // should not get here
       cout << "2nd reorderArray exception not thrown" << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
     } 
   }
   return ok;
@@ -490,7 +490,7 @@ int main (int argc, const char*[])
     if (! testReverseArray()) {
     	ok = False;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     ok = False;
   } 

--- a/casa/Arrays/test/tConvertArray.cc
+++ b/casa/Arrays/test/tConvertArray.cc
@@ -88,7 +88,7 @@ int main()
     tConvertEQ<Short,Int> (shape1);
     tConvertNear<Float,Int> (shape2);
     tConvertNear<Complex,Float> (shape2);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   }

--- a/casa/Arrays/test/tLinAlgebra.cc
+++ b/casa/Arrays/test/tLinAlgebra.cc
@@ -394,7 +394,7 @@ int main()
     AlwaysAssertExit(allEQ(Rz, Rot3D(2,alpha)));
 
 
-  } catch(AipsError x) {
+  } catch(AipsError& x) {
     cout << "Caught exception : " << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/Arrays/test/tMaskArrExcp.cc
+++ b/casa/Arrays/test/tMaskArrExcp.cc
@@ -69,7 +69,7 @@ int main ()
 	cout << "\nTest conformance, MaskedArray (Array, LogicalArray)";
 	MaskedArray<Int> ma (a,b);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -89,7 +89,7 @@ int main ()
 	     << " LogicalArray)";
 	MaskedArray<Int> ma (mab,b);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -107,7 +107,7 @@ int main ()
 	cout << "\nTest conformance, MaskedArray::operator= (Array)";
 	ba(b) = a;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -128,7 +128,7 @@ int main ()
 	cout << "\nTest conformance, MaskedArray::operator= (MaskedArray)";
 	a(ab) = mbab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -147,7 +147,7 @@ int main ()
 	cout << "\nTest conformance, Array::operator= (MaskedArray)";
 	a = mbab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -164,7 +164,7 @@ int main ()
 	MaskedArray<Int> ma (a,b,True);
 	ma = 1;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -182,7 +182,7 @@ int main ()
 	MaskedArray<Int> ma (a,b,True);
 	a(b) = a;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -201,7 +201,7 @@ int main ()
 	ma.setReadOnly();
 	ma = mma;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -218,7 +218,7 @@ int main ()
 	MaskedArray<Int> ma (a,b,True);
 	Vector<Int> aa (ma.getRWArray());
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -236,7 +236,7 @@ int main ()
 	Bool deleteIt;
 	ma.getRWArrayStorage(deleteIt);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -256,7 +256,7 @@ int main ()
 	Int *arrRWS ((Int *) arrS);
 	ma.putArrayStorage (arrRWS, deleteIt);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -275,7 +275,7 @@ int main ()
 	IPosition shape (2,2,5);
 	Matrix<Int> c (ma.getCompressedArray(shape));
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -295,7 +295,7 @@ int main ()
 	Matrix<Int> c (IPosition (2,2,5));
 	ma.getCompressedArray(c);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -315,13 +315,13 @@ int main ()
 	c = 1;
 	ma.setCompressedArray(c);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "\nERROR.  Caught an uncaught exception:\n";
     cout << x.getMesg() << "\n";
   } 
@@ -343,7 +343,7 @@ int main ()
 	cout << "\nTest conformance, ::operator+= (MaskedArray, Array)";
 	ba(b) += a;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -362,7 +362,7 @@ int main ()
 	MaskedArray<Int> bab (ba,b,True);
 	bab += a;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -381,7 +381,7 @@ int main ()
 	cout << "\nTest conformance, ::operator+= (Array, MaskedArray)";
 	a += mbab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -403,7 +403,7 @@ int main ()
 	     << " MaskedArray)";
 	a(ab) += mbab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -422,7 +422,7 @@ int main ()
 	MaskedArray<Int> bab (ba,b,True);
 	bab += bab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -443,7 +443,7 @@ int main ()
 	cout << "\nTest conformance, ::operator+ (MaskedArray, Array)";
 	c = mbab + a;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -464,7 +464,7 @@ int main ()
 	cout << "\nTest conformance, ::operator+ (Array, MaskedArray)";
 	c = a + mbab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -489,7 +489,7 @@ int main ()
 	     << " MaskedArray)";
 	c = maab + mbab;
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -510,7 +510,7 @@ int main ()
 	cout << "\nTest conformance, ::pow (MaskedArray, Array)";
 	c = pow (mbab, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -531,7 +531,7 @@ int main ()
 	cout << "\nTest conformance, ::pow (Array, MaskedArray)";
 	c = pow (a, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -556,7 +556,7 @@ int main ()
 	     << " MaskedArray)";
 	c = pow (maab, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -577,7 +577,7 @@ int main ()
 	cout << "\nTest conformance, ::atan2 (MaskedArray, Array)";
 	c = atan2 (mbab, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -598,7 +598,7 @@ int main ()
 	cout << "\nTest conformance, ::atan2 (Array, MaskedArray)";
 	c = atan2 (a, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -623,7 +623,7 @@ int main ()
 	     << " MaskedArray)";
 	c = atan2 (maab, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -645,7 +645,7 @@ int main ()
 	     << " const MaskedArray &)";
 	minMax (minVal, maxVal, minPos, maxPos, ma);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -662,7 +662,7 @@ int main ()
 	cout << "\nTest insufficient elements, ::min (MaskedArray)";
 	min (mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -684,7 +684,7 @@ int main ()
 	     << " ::min (MaskedArray, Array)";
 	c = min (mbab, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -705,7 +705,7 @@ int main ()
 	cout << "\nTest conformance, ::min (Array, MaskedArray)";
 	c = min (a, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -730,7 +730,7 @@ int main ()
 	     << " MaskedArray)";
 	c = min (maab, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -751,7 +751,7 @@ int main ()
 	     << " MaskedArray)";
 	::min (a, ba, c);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -772,7 +772,7 @@ int main ()
 	     << " MaskedArray)";
 	::min (ba, a, c);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -790,7 +790,7 @@ int main ()
 	     << " ::sum (const MaskedArray &)";
         sum (ma);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -808,7 +808,7 @@ int main ()
 	     << " ::sumsquares (const MaskedArray &)";
 	sumsquares (ma);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -826,7 +826,7 @@ int main ()
 	     << " ::product (const MaskedArray &)";
 	product (ma);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -844,7 +844,7 @@ int main ()
 	     << " ::mean (const MaskedArray &)";
 	mean (ma);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -864,7 +864,7 @@ int main ()
 	     << " ::variance (const MaskedArray &, T)";
 	variance (ma, mean);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -883,7 +883,7 @@ int main ()
 	     << " ::avdev (const MaskedArray &, T)";
 	avdev (ma, mean);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -901,13 +901,13 @@ int main ()
 	     << " ::median (const MaskedArray &, Bool)";
         median (ma, False);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "\nERROR.  Caught an uncaught exception:\n";
     cout << x.getMesg() << "\n";
   }
@@ -930,7 +930,7 @@ int main ()
 	cout << "\nTest conformance, ::allLE (MaskedArray, Array)";
 	allLE (mbab, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -950,7 +950,7 @@ int main ()
 	  " ::allLE (MaskedArray, Array)";
 	allLE (mbab, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -969,7 +969,7 @@ int main ()
 	cout << "\nTest conformance, ::allLE (Array, MaskedArray)";
         allLE (a, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -989,7 +989,7 @@ int main ()
 	  " ::allLE (Array, MaskedArray)";
 	allLE (a, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1012,7 +1012,7 @@ int main ()
 	     << " MaskedArray)";
 	allLE (maab, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1035,7 +1035,7 @@ int main ()
 	  " ::allLE (MaskedArray, MaskedArray)";
 	allLE (maab, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1054,7 +1054,7 @@ int main ()
 	cout << "\nTest conformance, ::anyAND (MaskedArray, Array)";
 	anyAND (mcb, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1074,7 +1074,7 @@ int main ()
 	  " ::anyAND (MaskedArray, Array)";
 	anyAND (mcb, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1093,7 +1093,7 @@ int main ()
 	cout << "\nTest conformance, ::anyAND (Array, MaskedArray)";
 	anyAND (a, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1113,7 +1113,7 @@ int main ()
 	  " ::anyAND (Array, MaskedArray)";
 	anyAND (a, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1136,7 +1136,7 @@ int main ()
 	     << " MaskedArray)";
 	anyAND (maab, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1159,7 +1159,7 @@ int main ()
 	  " ::anyAND (MaskedArray, MaskedArray)";
 	anyAND (maab, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1178,7 +1178,7 @@ int main ()
 	cout << "\nTest conformance, ::anyOR (MaskedArray, Array)";
         anyOR (mcb, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1198,7 +1198,7 @@ int main ()
 	  " ::anyOR (MaskedArray, Array)";
         anyOR (mcb, a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1217,7 +1217,7 @@ int main ()
 	cout << "\nTest conformance, ::anyOR (Array, MaskedArray)";
 	anyOR (a, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1237,7 +1237,7 @@ int main ()
 	  " ::anyOR (Array, MaskedArray)";
 	anyOR (a, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1260,7 +1260,7 @@ int main ()
 	     << " MaskedArray)";
 	anyOR (maab, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1283,7 +1283,7 @@ int main ()
 	  " ::anyOR (MaskedArray, MaskedArray)";
 	anyOR (maab, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1304,7 +1304,7 @@ int main ()
 	cout << "\nTest conformance, ::operator<= (MaskedArray, Array)";
 	cb = (mbab <= a);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1325,7 +1325,7 @@ int main ()
 	cout << "\nTest conformance, ::operator<= (Array, MaskedArray)";
 	cb = (a <= mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1350,7 +1350,7 @@ int main ()
 	     << " MaskedArray)";
 	cb = (maab <= mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayConformanceError e) {
+      } catch (ArrayConformanceError& e) {
 	cout << "\nCaught an ArrayConformanceError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1370,7 +1370,7 @@ int main ()
 	  " ::allAND (MaskedArray, scalar)";
         allAND (mcb, True);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1390,7 +1390,7 @@ int main ()
 	  " ::allAND (scalar, MaskedArray)";
 	allAND (True, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1410,7 +1410,7 @@ int main ()
 	  " ::allOR (MaskedArray, scalar)";
         allOR (mcb, False);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1430,7 +1430,7 @@ int main ()
 	  " ::allOR (scalar, MaskedArray)";
         allOR (False, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1450,7 +1450,7 @@ int main ()
 	  " ::allLE (MaskedArray, scalar)";
         allLE (mbab, 7);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1470,7 +1470,7 @@ int main ()
 	  " ::allLE (scalar, MaskedArray)";
         allLE (7, mbab);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError &e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1490,7 +1490,7 @@ int main ()
 	  " ::anyAND (MaskedArray, scalar)";
         anyAND (mcb, True);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1510,7 +1510,7 @@ int main ()
 	  " ::anyAND (scalar, MaskedArray)";
         anyAND (True, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1530,7 +1530,7 @@ int main ()
 	  " ::anyOR (MaskedArray, scalar)";
         anyOR (mcb, False);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
@@ -1550,13 +1550,13 @@ int main ()
 	  " ::anyOR (scalar, MaskedArray)";
         anyOR (False, mcb);
 	cout << "\nFAILED" << endl;
-      } catch (ArrayError e) {
+      } catch (ArrayError& e) {
 	cout << "\nCaught an ArrayError:\n";
 	cout << e.getMesg() << "\n";
       } 
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "\nERROR.  Caught an uncaught exception:\n";
     cout << x.getMesg() << "\n";
   } 

--- a/casa/Arrays/test/tMaskArrIO.cc
+++ b/casa/Arrays/test/tMaskArrIO.cc
@@ -98,7 +98,7 @@ int main ()
             cout << endl;
         }
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tMaskArrLogi.cc
+++ b/casa/Arrays/test/tMaskArrLogi.cc
@@ -523,7 +523,7 @@ int main()
                  << anyOR (True, b(y<3)) << endl;
         }
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tMaskArrMath0.cc
+++ b/casa/Arrays/test/tMaskArrMath0.cc
@@ -226,7 +226,7 @@ int main()
 
             cout << endl << "OK" << endl;
         }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tMaskArrMath1.cc
+++ b/casa/Arrays/test/tMaskArrMath1.cc
@@ -448,7 +448,7 @@ int main()
 
             cout << endl << "OK" << endl;
         }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tMaskArrMath2.cc
+++ b/casa/Arrays/test/tMaskArrMath2.cc
@@ -370,7 +370,7 @@ int main()
 
             cout << endl << "OK" << endl;
         }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tMaskedArray.cc
+++ b/casa/Arrays/test/tMaskedArray.cc
@@ -708,7 +708,7 @@ int main()
 
             cout << endl << "OK" << endl;
         }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
 

--- a/casa/Arrays/test/tMatrixMath.cc
+++ b/casa/Arrays/test/tMatrixMath.cc
@@ -75,7 +75,7 @@ int main()
 
 
 
-  } catch(AipsError x) {
+  } catch(AipsError& x) {
     cout << "Caught exception : " << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/Arrays/test/tSlicer.cc
+++ b/casa/Arrays/test/tSlicer.cc
@@ -44,7 +44,7 @@ int main()
 {
     try {
 	a();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -168,32 +168,32 @@ void a()
     // Do some erroneous constructions.
     try {
 	Slicer ns(IPosition(2,0,0), IPosition(3,0,0,0));
-    }catch (AipsError x) {                   // different lengths
+    }catch (AipsError& x) {                   // different lengths
 	cout << x.getMesg() << endl;
     } 
     try {
 	Slicer ns(IPosition(2,0,0), IPosition(3,0,0,0), Slicer::endIsLast);
-    }catch (AipsError x) {                   // different lengths
+    }catch (AipsError& x) {                   // different lengths
 	cout << x.getMesg() << endl;
     } 
     try {
 	Slicer ns(IPosition(2,0,1), IPosition(2,0,0), Slicer::endIsLast);
-    }catch (AipsError x) {                   // trc < blc
+    }catch (AipsError& x) {                   // trc < blc
 	cout << x.getMesg() << endl;
     } 
     try {
 	Slicer ns(IPosition(2,0,1), IPosition(2,0,-1), Slicer::endIsLength);
-    }catch (AipsError x) {                   // length < 0
+    }catch (AipsError& x) {                   // length < 0
 	cout << x.getMesg() << endl;
     } 
     try {
 	Slicer ns(IPosition(2,0,1), IPosition(2,1,1), IPosition(2,-1,0));
-    }catch (AipsError x) {                   // inc < 0
+    }catch (AipsError& x) {                   // inc < 0
 	cout << x.getMesg() << endl;
     } 
     try {
 	Slicer ns(IPosition(2,0,1), IPosition(2,1,1), IPosition(2,0,0));
-    }catch (AipsError x) {                   // inc < 0
+    }catch (AipsError& x) {                   // inc < 0
 	cout << x.getMesg() << endl;
     } 
 
@@ -206,7 +206,7 @@ void a()
     // Do some erroneous infers.
     try {
 	ns90.inferShapeFromSource (shape, blc, trc, inc);
-    }catch (AipsError x) {                   // shape length invalid
+    }catch (AipsError& x) {                   // shape length invalid
 	cout << x.getMesg() << endl;
     } 
     

--- a/casa/Arrays/test/tVectorSTLIterator.cc
+++ b/casa/Arrays/test/tVectorSTLIterator.cc
@@ -73,7 +73,7 @@ int main()
 {
   try {
     test1();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "\nCaught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/BasicMath/test/tMath.cc
+++ b/casa/BasicMath/test/tMath.cc
@@ -116,7 +116,7 @@ int main() {
       AlwaysAssert(max(a,b) == b, AipsError);
     }
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/casa/BasicMath/test/tRNG.cc
+++ b/casa/BasicMath/test/tRNG.cc
@@ -117,7 +117,7 @@ int main() {
       }
     }
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/casa/Containers/test/tList.cc
+++ b/casa/Containers/test/tList.cc
@@ -346,7 +346,7 @@ int main() {
       cout << onePd.getRight() << " ";
       onePd++;
     }
-  } catch (IterError xx) {
+  } catch (IterError& xx) {
     cout << endl << "IterError: " << xx.getMesg() << endl;
   } 
 
@@ -356,7 +356,7 @@ int main() {
       cout << onePd.getRight() << " ";
       onePd--;
     }
-  } catch (IterError xx) {
+  } catch (IterError& xx) {
     cout << endl << "IterError: " << xx.getMesg() << endl;
   } 
 
@@ -382,7 +382,7 @@ int main() {
       cout << onePd.getRight() << " ";
       onePd++;
     }
-  } catch (IterError xx) {
+  } catch (IterError& xx) {
     cout << endl << ">>> Instance-specific assertion error message:" << endl
          << "#X# IterError: " << xx.getMesg() << endl
          << "<<< End of assertion error message." << endl;
@@ -403,7 +403,7 @@ int main() {
     cout << ">>> Instance-specific assertion error message:" << endl;
     t4 = &onePd;
     show(t4);
-  } catch (IterError xx) {
+  } catch (IterError& xx) {
     cout << endl
          << "#X# IterError: " << xx.getMesg() << endl
          << "<<< End of assertion error message." << endl;

--- a/casa/Containers/test/tObjectStack.cc
+++ b/casa/Containers/test/tObjectStack.cc
@@ -83,7 +83,7 @@ int main() {
 	ObjectStack<vector<Double> >::stack().put(list[9-j]);
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     ok = False;
   }

--- a/casa/Containers/test/tQueue.cc
+++ b/casa/Containers/test/tQueue.cc
@@ -63,7 +63,7 @@ int main()
     Bool caught = False;
     try {
 	(void) qi(); // Should cause an exception - queue is empty
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	caught = True;
     } 
     AlwaysAssertExit(caught);

--- a/casa/Containers/test/tRecord.cc
+++ b/casa/Containers/test/tRecord.cc
@@ -61,7 +61,7 @@ int main (int argc, const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -110,12 +110,12 @@ void doDefineAssign (const Record& inrecord)
 			     stringToVector ("abc,dghij,klmn")));
     try {
 	*rfstr2 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     try {
 	*rfstr3 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     record.get (record.fieldNumber ("TpArrayString2"), vec);
@@ -127,12 +127,12 @@ void doDefineAssign (const Record& inrecord)
 
     try {
 	*rfstr2 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     try {
 	*rfstr3 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     record.get (record.fieldNumber ("TpArrayString2"), vec);
@@ -144,7 +144,7 @@ void doDefineAssign (const Record& inrecord)
 
     try {
 	rfstr2.define (stringToVector ("abc"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     rfstr3.define (stringToVector ("a"));
@@ -178,7 +178,7 @@ void doDefineAssign (const Record& inrecord)
 
     try {
         record.define ("TpBool", Vector<Bool>(2, False));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << x.getMesg() << endl;
     } 
 }
@@ -223,7 +223,7 @@ void doSubRecord (Bool doExcp, const RecordDesc& desc)
     if (doExcp) {
 	try {
 	    record1 = record;
-	} catch (AipsError x) {                    // not conforming
+	} catch (AipsError& x) {                    // not conforming
 	    cout << ">>> Instance-specific assertion error message:" << endl
 		 << x.getMesg() << endl
 		 << "<<<" << endl;
@@ -300,36 +300,36 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record.define (record.nfields()+1, (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // index too high
 	} 
 	try {
 	    record.define ("", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // empty name
 	} 
 	try {
 	    record.define ("aB", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // first no uppercase
 	} 
 	extraArgument = 10;
 	try {
 	    record.define ("A", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // extra argument = 10
 	} 
 	extraArgument = 0;
 	try {
 	    record.define ("TpShort", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // invalid type
 	} 
 	RecordDesc rd1;
 	rd1.addField ("TpTable", TpTable);
 	try {
 	    Record rec(rd1);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // invalid field type
 	} 
     }
@@ -404,7 +404,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record2a.restructure(subDesc);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;  // fixed, not empty ->impossible
 	} 
     }
@@ -414,7 +414,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record2a = record2b;
-	} catch (AipsError x) {           // fixed; non-conforming
+	} catch (AipsError& x) {           // fixed; non-conforming
 	    cout << ">>> Instance-specific assertion error message:" << endl
 		 << x.getMesg() << endl
 		 << "<<<" << endl;
@@ -503,7 +503,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record.asComplex ("TpBool");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // fixed -> add not possible
 	} 
     }
@@ -690,7 +690,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record.merge (record, RecordInterface::SkipDuplicates);
-	} catch (AipsError x) {              // merge of itself
+	} catch (AipsError& x) {              // merge of itself
 	    cout << ">>> Instance-specific assertion error message:" << endl
 		 << x.getMesg() << endl
 		 << "<<<" << endl;
@@ -698,18 +698,18 @@ void doIt (Bool doExcp)
 	try {
 	    record.mergeField (record5, "TpBool",
 			       RecordInterface::ThrowOnDuplicates);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // duplicate field
 	} 
 	try {
 	    record2a.merge (record, RecordInterface::SkipDuplicates);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // fixed structure
 	} 
 	try {
 	    record2a.mergeField (record5, "TpBool",
 				 RecordInterface::ThrowOnDuplicates);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // fixed structure
 	} 
     }

--- a/casa/Containers/test/tRecordDesc.cc
+++ b/casa/Containers/test/tRecordDesc.cc
@@ -38,7 +38,7 @@ int main (int argc, const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -116,28 +116,28 @@ void doIt (Bool doExcp)
 	Bool caught = False;
 	try {
 	    a.addField("a", TpDouble); // already exists
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssertExit(caught);
 	caught = False;
 	try {
 	    a.addField("a", TpDouble, IPosition(1,1)); // already exists
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssertExit(caught);
 	caught = False;
 	try {
 	    a.addField("a", TpDouble, IPosition(1,1)); // already exists
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssertExit(caught);
 	caught = False;
 	try {
 	    a.addField("aaa", TpOther);                // invalid type
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssertExit(caught);
@@ -206,7 +206,7 @@ void doIt (Bool doExcp)
 	    try {
 		ab.mergeField(cd, cd.fieldNumber("a"), 
 			      RecordInterface::ThrowOnDuplicates);
-	    } catch (AipsError x) {
+	    } catch (AipsError& x) {
 		caught = True;
 	    } 
 	    AlwaysAssertExit(caught);
@@ -283,14 +283,14 @@ void doIt (Bool doExcp)
 	Bool caught = False;
 	try {
 	    g.addField("Other", TpRecord, IPosition(1,1));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssertExit(caught);
         caught = False;
 	try {
 	    g.addField("Other", TpTable, IPosition(1,1));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssertExit(caught);

--- a/casa/Containers/test/tSimOrdMap.cc
+++ b/casa/Containers/test/tSimOrdMap.cc
@@ -45,7 +45,7 @@ void doit();
 int main () {
     try {
        doit();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "\nCaught an exception: " << x.getMesg() << endl;
         return 1;
     } 
@@ -99,7 +99,7 @@ void doit()
     name.rename (30,36);
     try {
 	name.rename (30,36);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     AlwaysAssert(name.ok(),AipsError);

--- a/casa/Containers/test/tStack.cc
+++ b/casa/Containers/test/tStack.cc
@@ -97,9 +97,9 @@ int main() {
     while(1) {
       two.push(one.popVal());
     }
-  } catch (EmptyStackError x) {
+  } catch (EmptyStackError& x) {
     cout << "EmptyStackError: " << x.getMesg() << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "AipsError: " << x.getMesg() << endl;
   } 
 
@@ -108,17 +108,17 @@ int main() {
     while(1) {
       two.pop();
     }
-  } catch (EmptyStackError x) {
+  } catch (EmptyStackError& x) {
     cout << "EmptyStackError: " <<  x.getMesg() << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "AipsError: " << x.getMesg() << endl;
   } 
 
   try {
     one.top();
-  } catch (EmptyStackError x) {
+  } catch (EmptyStackError& x) {
     cout << "EmptyStackError: " << x.getMesg() << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "AipsError: " << x.getMesg() << endl;
   } 
 

--- a/casa/IO/test/tAipsIOCarray.cc
+++ b/casa/IO/test/tAipsIOCarray.cc
@@ -47,7 +47,7 @@ int main (int argc, const char*[])
 {
     try {
 	doit ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "\nCaught an exception: " << x.getMesg() << endl;
         return 1;
     } 

--- a/casa/IO/test/tBucketBuffered.cc
+++ b/casa/IO/test/tBucketBuffered.cc
@@ -45,7 +45,7 @@ int main (int argc, const char*[])
   try {
     a (argc<2);
     b (argc<2);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/IO/test/tBucketCache.cc
+++ b/casa/IO/test/tBucketCache.cc
@@ -54,7 +54,7 @@ int main (int argc, const char*[])
 //	d (1024);
 //	d (32768);
 //	d (327680);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/IO/test/tBucketMapped.cc
+++ b/casa/IO/test/tBucketMapped.cc
@@ -45,7 +45,7 @@ int main (int argc, const char*[])
   try {
     a (argc<2);
     b (argc<2);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/IO/test/tByteIO.cc
+++ b/casa/IO/test/tByteIO.cc
@@ -184,7 +184,7 @@ void checkReopen()
     Bool flag = False;
     try {
 	fio2.reopenRW();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	flag = True;
     } 
     AlwaysAssertExit (flag);
@@ -213,12 +213,12 @@ void testMemoryIO()
 	}
 	try {
 	    membuf.read (1, &val);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;         // read beyond object
 	} 
 	try {
 	    membuf.seek (Int(-(length + incr + 1)), ByteIO::Current);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;         // negative seek
 	} 
 	membuf.seek (Int(-(length + incr)), ByteIO::Current);
@@ -228,12 +228,12 @@ void testMemoryIO()
 	MemoryIO membuf (buf, sizeof(buf), ByteIO::New, 0);
 	try {
 	    doIt (membuf);
-	} catch (AipsError x) {                   // not expandable
+	} catch (AipsError& x) {                   // not expandable
 	    cout << x.getMesg() << endl;
 	} 
 	try {
 	    membuf.seek (10, ByteIO::End);
-	} catch (AipsError x) {                   // not expandable
+	} catch (AipsError& x) {                   // not expandable
 	    cout << x.getMesg() << endl;
 	} 
 	AlwaysAssertExit (membuf.getBuffer() == (const uChar*)buf);
@@ -243,12 +243,12 @@ void testMemoryIO()
 	MemoryIO membuf (buf, 10, ByteIO::Scratch, 0, True);
 	try {
 	    doIt (membuf);
-	} catch (AipsError x) {                   // not expandable
+	} catch (AipsError& x) {                   // not expandable
 	    cout << x.getMesg() << endl;
 	} 
 	try {
 	    membuf.seek (10, ByteIO::End);
-	} catch (AipsError x) {                   // not expandable
+	} catch (AipsError& x) {                   // not expandable
 	    cout << x.getMesg() << endl;
 	} 
 	AlwaysAssertExit (membuf.getBuffer() == (const uChar*)buf);
@@ -267,7 +267,7 @@ int main()
 	MemoryIO file3 (file2.getBuffer(), file2.length());
 	try {
 	    file3.write (0, 0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;          // readonly
 	} 
 	checkValues (file3, 100);
@@ -321,7 +321,7 @@ int main()
 	}
 	FiledesIO file6 (fd2, "");
 	close (fd2);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/IO/test/tByteSinkSource.cc
+++ b/casa/IO/test/tByteSinkSource.cc
@@ -189,7 +189,7 @@ int main ()
 	    RegularFileIO regularFileIO (Path("tByteSinkSource_tmp.dat"),
 					 ByteIO::NewNoReplace);
 	} 
-	catch (AipsError x)  {
+	catch (AipsError& x)  {
 	    cout << x.getMesg () << endl;
 	} 
     }

--- a/casa/IO/test/tLargeFileIO.cc
+++ b/casa/IO/test/tLargeFileIO.cc
@@ -111,7 +111,7 @@ int main (int argc, const char* argv[])
     delete [] buf;
     return 0;                           // exit with success status
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   }  

--- a/casa/IO/test/tLockFile.cc
+++ b/casa/IO/test/tLockFile.cc
@@ -217,7 +217,7 @@ int main (int argc, const char* argv[])
 		 << endl;
 	    cout << "Default inspection interval is 5 seconds." << endl;
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/IO/test/tTapeIO.cc
+++ b/casa/IO/test/tTapeIO.cc
@@ -129,7 +129,7 @@ int main(int argc, const char* argv[])
     }
     delete [] writeBuffer;
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/casa/Inputs/test/tInput.cc
+++ b/casa/Inputs/test/tInput.cc
@@ -119,7 +119,7 @@ int main(int argc, const char* argv[])
     // Announce program and version.
     prgInput.announce();
     
-  } catch(AipsError x) {
+  } catch(AipsError& x) {
     cout << "Caught exception" << endl;
     cout << "Message is: " << x.getMesg() << endl;
   } 

--- a/casa/Inputs/test/tParam.cc
+++ b/casa/Inputs/test/tParam.cc
@@ -128,7 +128,7 @@ int main()
 
     cout << "OK" << endl;
 
-  } catch(AipsError x) {
+  } catch(AipsError& x) {
     cout << "Caught exception" << endl;
     cout << "Message is: " << x.getMesg() << endl;
   }    

--- a/casa/OS/test/tDirectory.cc
+++ b/casa/OS/test/tDirectory.cc
@@ -187,7 +187,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    newDir.create();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // not writable
 	} 
     }
@@ -204,12 +204,12 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    Directory file1("tDirectory_tmp/test1/testLink2");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // symlink, no directory
 	} 
 	try {
 	    Directory file1("tDirectory_tmp/test1/testFile2");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // symlink, no directory
 	} 
     }
@@ -217,7 +217,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    Directory file1("tDirectory_tmp/something");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // not writable
 	} 
     }
@@ -252,7 +252,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    test3.remove();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // not empty
 	} 
     }
@@ -294,7 +294,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    test6.create (False);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // already existing
 	} 
     }
@@ -307,7 +307,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    test7.create (False);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // already existing
 	} 
     }
@@ -341,7 +341,7 @@ int main (int argc, const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/OS/test/tDirectoryIterator.cc
+++ b/casa/OS/test/tDirectoryIterator.cc
@@ -86,12 +86,12 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    iter.name();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // past end
 	} 
 	try {
 	    iter++;
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // past end
 	} 
     }
@@ -115,7 +115,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    DirectoryIterator iter1 (Directory("tDirectoryIterator_tmp/sub"));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // not existing
 	} 
     }
@@ -126,7 +126,7 @@ int main (int argc, const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/OS/test/tEnvVar.cc
+++ b/casa/OS/test/tEnvVar.cc
@@ -42,7 +42,7 @@ int main ()
     AlwaysAssertExit (EnvironmentVariable::isDefined ("crazyHOMExyz"));
     AlwaysAssertExit (EnvironmentVariable::get("crazyHOMExyz").length() != 0);
     AlwaysAssertExit (EnvironmentVariable::get("crazyHOMExyz") == "abc");
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/OS/test/tFile.cc
+++ b/casa/OS/test/tFile.cc
@@ -101,7 +101,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    exist2.userID();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -179,7 +179,7 @@ int main (int argc, const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/OS/test/tModcompConversion.cc
+++ b/casa/OS/test/tModcompConversion.cc
@@ -685,7 +685,7 @@ int main()
     checkFloat (error);
     checkDouble (error);
   } 
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/casa/OS/test/tPath.cc
+++ b/casa/OS/test/tPath.cc
@@ -138,7 +138,7 @@ void doIt (Bool doExcp, Bool& success)
       Bool ok = True;
 	try {
             Path("/a/b").resolvedName();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
             cout << ">>> " << x.getMesg() << endl << "<<<" << endl;
             ok = False;
 	}
@@ -171,7 +171,7 @@ void doIt (Bool doExcp, Bool& success)
     if (doExcp) {
 	try {
 	    test1.expandedName ();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg () << endl;
 	} 
     }
@@ -262,7 +262,7 @@ int main (int argc, const char*[])
     Bool success = True;
     try {
 	doIt ( (argc<2), success);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/OS/test/tRegularFile.cc
+++ b/casa/OS/test/tRegularFile.cc
@@ -64,17 +64,17 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    RegularFile rf ("tRegularFile_tmp/a/b");         // not creatable
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
 	try {
 	    RegularFile rf ("tRegularFile_tmp");             // directory
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
 	try {
 	    RegularFile rf ("tRegularFile_tmp/isLink2");     // symlink to dir
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -91,7 +91,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    risFile.create (False);                         // already exists
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -117,12 +117,12 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    risFile1.copy (Path("tRegularFile_tmp/aa/bb/cc"));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;         // non-writable directory
 	} 
 	try {
 	    risFile1.copy (Path("tRegularFile_tmp/isFile"), False);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;         // already exists
 	} 
     }
@@ -130,7 +130,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    risFile1.copy (Path("tRegularFile_tmp/moveto/isFile1"));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;         // exists, non-writable
 	} 
     }
@@ -144,7 +144,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    file2.move ("tRegularFile_tmp/moveto/isFile1", False);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;         // already exists
 	} 
     }
@@ -179,7 +179,7 @@ int main (int argc,const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/OS/test/tSymLink.cc
+++ b/casa/OS/test/tSymLink.cc
@@ -56,13 +56,13 @@ void doIt (Bool doExcp)
 	try {
 	    SymLink symLink1(Path("tSymLink_tmp/isFile"));
 	}
-	catch (AipsError x) {                                   // regular file
+	catch (AipsError& x) {                                   // regular file
 	    cout << x.getMesg () << endl;
 	} 
 	try {
 	    SymLink symLink1(Path("tSymLink_tmp/isDir"));
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 	    cout << x.getMesg () << endl;                       // directory
 	} 
     }
@@ -77,13 +77,13 @@ void doIt (Bool doExcp)
 	try {
 	    SymLink symLink1(Path("tSymLink_tmp/isDir/newB"));
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 	    cout << x.getMesg () << endl;                    // cannot create
 	} 
 	try {
 	    newLink2.create("a");
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 	    cout << x.getMesg () << endl;                    // cannot create
 	} 
     }
@@ -118,7 +118,7 @@ void doIt (Bool doExcp)
 	try {
 	    linkA.followSymLink();
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 	    cout << x.getMesg () << endl;                       // endless loop
 	} 
     }
@@ -133,7 +133,7 @@ void doIt (Bool doExcp)
 	try {
 	    linkI.followSymLink();
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 	    cout << x.getMesg () << endl;                       // endless loop
 	} 
     }
@@ -178,7 +178,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    test6.create ("a", False);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // already existing
 	} 
     }
@@ -188,7 +188,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    test7.create ("a");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;               // already existing
 	} 
     }
@@ -204,7 +204,7 @@ int main (int argc, const char*[])
 {
     try {
 	doIt ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/Quanta/test/tQVector.cc
+++ b/casa/Quanta/test/tQVector.cc
@@ -93,7 +93,7 @@ int main () {
 		        // quantities don't have conformant units
 		        QVector<Double> qv(vq);
 		    }
-		    catch (const AipsError x) {
+		    catch (const AipsError& x) {
 		        thrown = True;
 		    }
 		    AlwaysAssert(thrown, AipsError);

--- a/casa/Quanta/test/tQuantum.cc
+++ b/casa/Quanta/test/tQuantum.cc
@@ -188,7 +188,7 @@ try {
     Quantum<Int> ll5(5,Quantum<Double>(7.,"mm/s"));
     cout << "Mixed Quantity/Quantum<Int>  " << ll5 << endl;
     
-} catch (AipsError x) {
+} catch (AipsError& x) {
   cout << x.getMesg() << endl;
 } 
     
@@ -197,13 +197,13 @@ try {
     
     try {
 	Quantity loc(5,"KpH");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
     try {
 	Quantity loc(A+D);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
@@ -211,37 +211,37 @@ try {
         // put in conditional so result is used,
         // so compiler won't emit warning of unused result
         if(A<D) {}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
     try {
 	l4=pow(A,200);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
     try {
 	A.convert("JY");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
     try {
 	l4 = sin(A);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
     try {
 	l4 = log(A);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     
     try {
 	l4 = sqrt(A);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     

--- a/casa/Quanta/test/tQuantumHolder.cc
+++ b/casa/Quanta/test/tQuantumHolder.cc
@@ -164,7 +164,7 @@ int main() {
     }
     cout << "----------------------------------------------------" << endl;
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/Quanta/test/tUnit.cc
+++ b/casa/Quanta/test/tUnit.cc
@@ -171,7 +171,7 @@ int main () {
 	cout << "User list after FITS removal:" << endl;
 	UnitMap::listUser();	
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Unexpected: " << x.getMesg() << endl;
     } 
     
@@ -180,13 +180,13 @@ int main () {
 
     try {
 	Unit ca="Kpm/s";
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
     try {
 	UnitVal errval(2.,"KpH");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     

--- a/casa/System/test/tObjectID.cc
+++ b/casa/System/test/tObjectID.cc
@@ -65,7 +65,7 @@ int main()
     AlwaysAssertExit(ID1 == ID1copy);
     ID1.toString(copied);
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/Utilities/test/dMUString.cc
+++ b/casa/Utilities/test/dMUString.cc
@@ -74,7 +74,7 @@ int main()
 	in = "15 s";
 	cout << MVAngle::read(res, in) << endl;
 	cout << in << " = " << res << endl;
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -83,7 +83,7 @@ int main()
 	Quantity res;
 	cout << MVAngle::read(res, in) << endl;
 	cout << in << " = " << res << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -111,7 +111,7 @@ int main()
 	 cout << "Pos1: " << instr.tellg()-stt << endl;
 	 cout << in << " = " << res << " : " << bb << endl;
        }
-     } catch (AipsError x) {
+     } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
   

--- a/casa/Utilities/test/tBitVector.cc
+++ b/casa/Utilities/test/tBitVector.cc
@@ -143,7 +143,7 @@ void doIt()
 int main () {
     try {
 	doIt();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/Utilities/test/tCOWPtr.cc
+++ b/casa/Utilities/test/tCOWPtr.cc
@@ -230,7 +230,7 @@ int main()
 
     cout << "OK" << endl;
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg () << endl;
   } 
   

--- a/casa/Utilities/test/tDataType.cc
+++ b/casa/Utilities/test/tDataType.cc
@@ -317,7 +317,7 @@ void excpAsScalar(DataType type)
     Bool hadExcp = False;
     try {
 	asScalar(type);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	hadExcp = True;
     } 
     AlwaysAssert(hadExcp, AipsError);
@@ -328,7 +328,7 @@ void excpAsArray(DataType type)
     Bool hadExcp = False;
     try {
 	asArray(type);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	hadExcp = True;
     } 
     AlwaysAssert(hadExcp, AipsError);
@@ -349,7 +349,7 @@ int main()
     try {
 	simpleTests();
 	excpTests();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/casa/Utilities/test/tDefaultValue.cc
+++ b/casa/Utilities/test/tDefaultValue.cc
@@ -62,7 +62,7 @@ int main()
     defaultValue(foo3);
     AlwaysAssert(foo3 == String("defaultval"), AipsError);
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "\nCaught an exception: " << x.getMesg() << endl;
     } 
  

--- a/casa/Utilities/test/tFallible.cc
+++ b/casa/Utilities/test/tFallible.cc
@@ -60,14 +60,14 @@ int main()
     Bool caught = False;
     try {
 	Foo(fi4);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	caught = True;
     } 
     AlwaysAssertExit(caught);
     caught = False;
     try {
         fi5.value();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	caught = True;
     } 
     AlwaysAssertExit(caught);

--- a/casa/Utilities/test/tPrecision.cc
+++ b/casa/Utilities/test/tPrecision.cc
@@ -123,7 +123,7 @@ int main () {
 	  testit(x, y, expected);
 
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/Utilities/test/tPtrHolder.cc
+++ b/casa/Utilities/test/tPtrHolder.cc
@@ -65,7 +65,7 @@ void tSPtr()
 	    Int *ip = new Int;
 	    SPtrHolder<Int> ph(ip);
 	    throw(AipsError("testing..."));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    isCaught = True;
 	} 
 	AlwaysAssertExit(isCaught);
@@ -115,7 +115,7 @@ int main()
 	    Int *ip = new Int[1000];
 	    PtrHolder<Int> ph(ip, True);
 	    throw(AipsError("testing..."));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    isCaught = True;
 	} 
 	AlwaysAssertExit(isCaught);

--- a/casa/Utilities/test/tRegex.cc
+++ b/casa/Utilities/test/tRegex.cc
@@ -51,7 +51,7 @@ int main () {
   try {
     a();
     b();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   } 

--- a/casa/Utilities/test/tRegex2.cc
+++ b/casa/Utilities/test/tRegex2.cc
@@ -49,7 +49,7 @@ void a();
 int main () {
   try {
     a();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   } 

--- a/coordinates/Coordinates/CoordinateUtil.cc
+++ b/coordinates/Coordinates/CoordinateUtil.cc
@@ -666,7 +666,7 @@ Bool CoordinateUtil::makeDirectionMachine(LogIO& os, MDirection::Convert& machin
    Bool ok = True;
    try {
       MDirection toMD = machine(fromMD);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       ok = False;
    }
    if (ok) {
@@ -699,7 +699,7 @@ Bool CoordinateUtil::makeDirectionMachine(LogIO& os, MDirection::Convert& machin
       ok = True;
       try {
          MDirection toMD = machine(fromMD);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
          ok = False;
       }
       if (ok) return True;
@@ -735,7 +735,7 @@ Bool CoordinateUtil::makeDirectionMachine(LogIO& os, MDirection::Convert& machin
       ok = True;
       try {
          MDirection toMD = machine(fromMD);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
          ok = False;
       }
       if (ok) return True;
@@ -754,7 +754,7 @@ Bool CoordinateUtil::makeDirectionMachine(LogIO& os, MDirection::Convert& machin
       ok = True;
       try {
          MDirection toMD = machine(fromMD);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
          ok = False;
       }
       if (!ok) {
@@ -904,7 +904,7 @@ Bool CoordinateUtil::makeFrequencyMachine(LogIO& os, MFrequency::Convert& machin
    MFrequency freqFrom(freq, typeFrom);
    try {
       freqTo = machine(freqFrom);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       ok = False;
    }
    if (!ok) {

--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -878,7 +878,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //
 		    fixCoordinate (c, os);
 		    cSys.addCoordinate(c);
-		} catch (AipsError x) {
+		} catch (AipsError& x) {
 		    os << LogIO::WARN << x.getMesg() << LogIO::POST;
 		    ok = False;
 		}
@@ -932,7 +932,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //
 		    fixCoordinate (c, os);
 		    cSys.addCoordinate(c);
-		} catch (AipsError x) {
+		} catch (AipsError& x) {
 		    os << LogIO::WARN << x.getMesg() << LogIO::POST;
 		    ok = False;
 		}
@@ -1098,7 +1098,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 		try {
 		    cSys.addCoordinate(c);
-		} catch (AipsError x) {
+		} catch (AipsError& x) {
 		    os << LogIO::WARN << x.getMesg() << LogIO::POST;
 		    ok = False;
 		}     
@@ -1159,7 +1159,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		
 		try {
 		    cSys.addCoordinate(c);
-		} catch (AipsError x) {
+		} catch (AipsError& x) {
 		    os << LogIO::WARN << x.getMesg() << LogIO::POST;
 		    ok = False;
 		}     
@@ -1237,7 +1237,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			
 			fixCoordinate (c, os);
 			cSys.addCoordinate(c);
-		    } catch (AipsError x) {
+		    } catch (AipsError& x) {
 			os << LogIO::WARN << x.getMesg() << LogIO::POST;
 			ok = False;
 		    }     
@@ -1598,7 +1598,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 	try {
 	    coord = StokesCoordinate(stokes);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    errMsg = x.getMesg();
 	    return False;
 	} 

--- a/coordinates/Coordinates/test/dCoordinates.cc
+++ b/coordinates/Coordinates/test/dCoordinates.cc
@@ -202,7 +202,7 @@ int main()
        delete pCoordSys;
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      return 1;
   }

--- a/coordinates/Coordinates/test/dRemoveAxes.cc
+++ b/coordinates/Coordinates/test/dRemoveAxes.cc
@@ -257,7 +257,7 @@ try {
 
 
 }
-   catch (AipsError x) {
+   catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return 1;
   }

--- a/coordinates/Coordinates/test/dWorldMap.cc
+++ b/coordinates/Coordinates/test/dWorldMap.cc
@@ -214,7 +214,7 @@ try {
       cout << endl << endl;
    }
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return 1;
 }

--- a/coordinates/Coordinates/test/tCoordinate.cc
+++ b/coordinates/Coordinates/test/tCoordinate.cc
@@ -74,7 +74,7 @@ int main()
      }
 
   
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
   }

--- a/coordinates/Coordinates/test/tCoordinateSystem.cc
+++ b/coordinates/Coordinates/test/tCoordinateSystem.cc
@@ -2449,7 +2449,7 @@ void doit6 ()
       Bool failed = False;
       try {
          pC = cSys.makeFourierCoordinate (axes, shape);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
         failed = True;
       } 
       if (!failed) {
@@ -2466,7 +2466,7 @@ void doit6 ()
       Vector<Bool> axes2(20, True);
       try {
          pC = cSys.makeFourierCoordinate (axes2, shape);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
         failed = True;
       } 
       if (!failed) {
@@ -2483,7 +2483,7 @@ void doit6 ()
       Vector<Int> shape2(20, 100);
       try {
          pC = cSys.makeFourierCoordinate (axes, shape2);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
         failed = True;
       } 
       if (!failed) {

--- a/coordinates/Coordinates/test/tFrequencyAligner.cc
+++ b/coordinates/Coordinates/test/tFrequencyAligner.cc
@@ -265,7 +265,7 @@ int main()
                                 useCachedX, method, extrapolate),AipsError); // Recompute
          AlwaysAssert (allNear(yOut3, yOut, 1e-6), AipsError);
       }
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }

--- a/coordinates/Coordinates/test/tGaussianConvert.cc
+++ b/coordinates/Coordinates/test/tGaussianConvert.cc
@@ -127,7 +127,7 @@ int main()
          Vector<Double> pixel(cSys.referencePixel().copy());
          doit2 (pixel, cSys, worldAxes);
       }
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return 1;
    }

--- a/coordinates/Coordinates/test/tLinearCoordinate.cc
+++ b/coordinates/Coordinates/test/tLinearCoordinate.cc
@@ -477,7 +477,7 @@ int main()
       }
 
        
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }

--- a/coordinates/Coordinates/test/tLinearXform.cc
+++ b/coordinates/Coordinates/test/tLinearXform.cc
@@ -288,7 +288,7 @@ int main()
             throw(AipsError("Conversion reflection failed"));
          }
       }
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }

--- a/coordinates/Coordinates/test/tObsInfo.cc
+++ b/coordinates/Coordinates/test/tObsInfo.cc
@@ -259,7 +259,7 @@ int main()
 	rec4.defineRecord("telescop", recnum);
 	try {
 	  rval = oi5.fromFITS(error2, rec4);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  cerr << (rval==True) << endl;
 	  AlwaysAssertExit(!rval);
 	}

--- a/coordinates/Coordinates/test/tProjection.cc
+++ b/coordinates/Coordinates/test/tProjection.cc
@@ -135,7 +135,7 @@ int main()
          }
       }
 
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }

--- a/coordinates/Coordinates/test/tQualityCoordinate.cc
+++ b/coordinates/Coordinates/test/tQualityCoordinate.cc
@@ -109,7 +109,7 @@ int main()
          QualityCoordinate lc  = makeCoordinate(whichQuality, qualityStrings);
          doit6(lc, verbose);
       }
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }
@@ -494,7 +494,7 @@ void doit4(QualityCoordinate& lc, Bool verbose)
 	Coordinate* pC = 0;
 	try {
 		pC = lc.makeFourierCoordinate (axes, shape);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 		failed = True;
 	}
 	if (!failed) {

--- a/coordinates/Coordinates/test/tStokesCoordinate.cc
+++ b/coordinates/Coordinates/test/tStokesCoordinate.cc
@@ -383,7 +383,7 @@ void doit4(StokesCoordinate& lc)
    Coordinate* pC = 0;
    try {
       pC = lc.makeFourierCoordinate (axes, shape);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      failed = True;
    } 
    if (!failed) {

--- a/coordinates/Coordinates/test/tTabularCoordinate.cc
+++ b/coordinates/Coordinates/test/tTabularCoordinate.cc
@@ -163,7 +163,7 @@ int main()
          doitNonLinear(pixelValues, worldValues, lc);
       }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       return (1);
    }

--- a/fits/FITS/hdu.tcc
+++ b/fits/FITS/hdu.tcc
@@ -376,7 +376,7 @@ OFF_T PrimaryArray<TYPE>::set_next(OFF_T ne) {
 	   delete [] array;
 		try{
          array = new TYPE [ne];
-      }catch( std::bad_alloc ){ // out of storage exception.
+      }catch( std::bad_alloc& ){ // out of storage exception.
         cerr << "\narray is too big to fit into memory."<< endl;
 		  errmsg(BADOPER,"Error allocating Array.");
 		  alloc_elems = 0;

--- a/fits/FITS/test/tBinTable.cc
+++ b/fits/FITS/test/tBinTable.cc
@@ -133,7 +133,7 @@ int main(int argc, const char* argv[])
 	    }
 	}
 	cout << "At end of file" << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Unexpected exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/fits/FITS/test/tFITSDateUtil.cc
+++ b/fits/FITS/test/tFITSDateUtil.cc
@@ -125,7 +125,7 @@ int main()
 	if (FITSDateUtil::findPrecision("2001-06-01T05:30:20.25") != 8) {
 	    throw(AipsError("FITSDateUtil::findPrecision - didn't return 8 as expected"));
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     }

--- a/fits/FITS/test/tFITSHistoryUtil.cc
+++ b/fits/FITS/test/tFITSHistoryUtil.cc
@@ -127,7 +127,7 @@ int main()
 		}
 	    }
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     }

--- a/fits/FITS/test/tFITSKeywordUtil.cc
+++ b/fits/FITS/test/tFITSKeywordUtil.cc
@@ -313,7 +313,7 @@ int main()
 						      ignore));
 	AlwaysAssertExit(myNewKeywords.nfields()==0);
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cerr << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     }

--- a/fits/FITS/test/tFITSSpectralUtil.cc
+++ b/fits/FITS/test/tFITSSpectralUtil.cc
@@ -168,7 +168,7 @@ int main()
 	    }
 
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     }
@@ -269,7 +269,7 @@ int main()
 	AlwaysAssertExit(refFrame==refFrameOut);
 	AlwaysAssertExit(near(restFreq,restFreqOut));
 	
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     }
@@ -370,7 +370,7 @@ int main()
     	AlwaysAssertExit(refFrame==refFrameOut);
     	AlwaysAssertExit(near(restFreq,restFreqOut));
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
     	cout << "Caught an exception: " << x.getMesg() << endl;
     	return 1;
     }

--- a/fits/apps/fits2table/fits2table.cc
+++ b/fits/apps/fits2table/fits2table.cc
@@ -142,7 +142,7 @@ int main(int argc, const char* argv[])
 	}
 
 	cout << "done." << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/images/Images/ImageConcat.tcc
+++ b/images/Images/ImageConcat.tcc
@@ -853,7 +853,7 @@ Vector<Int> ImageConcat<T>::makeNewStokes(const Vector<Int>& stokes1,
    Bool ok = True;
    try {
       StokesCoordinate tmp(stokes);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       ok = False;
    } 
 //

--- a/images/Images/ImageExprParse.cc
+++ b/images/Images/ImageExprParse.cc
@@ -228,7 +228,7 @@ LatticeExprNode ImageExprParse::command
 	if (imageExprGramParseCommand(command) != 0) {
 	    throw (AipsError("Parse error in image expression " + str));
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	message = x.getMesg();
 	error = True;
     } 

--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -758,7 +758,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
           } else {
             msg = "Cannot remove file - unknown file type";
           }
-        } catch (AipsError x) {
+        } catch (AipsError& x) {
           msg = x.getMesg();
         }
         //

--- a/images/Images/MIRIADImage.cc
+++ b/images/Images/MIRIADImage.cc
@@ -671,7 +671,7 @@ void MIRIADImage::getImageAttributes (CoordinateSystem& cSys,
 
     try {
       projn = Projection(ptype, projp);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       os << LogIO::SEVERE << "Error forming projection, maybe the "
 	"wrong number of parameters\n(" << x.getMesg() << ")" << 
 	LogIO::POST;
@@ -1022,7 +1022,7 @@ void MIRIADImage::getImageAttributes (CoordinateSystem& cSys,
       try {
 	StokesCoordinate sc(stokes);
 	cSys.addCoordinate(sc);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	os << LogIO::SEVERE << "Error forming stokes axis : " << x.getMesg() << LogIO::POST;
 	//return False;
       } 

--- a/images/Images/test/dImageStatistics.cc
+++ b/images/Images/test/dImageStatistics.cc
@@ -453,7 +453,7 @@ try {
 	 << " not yet supported" << LogIO::POST;
       return 1;
    }
-} catch (AipsError x) {
+} catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      return 1;
   }

--- a/images/Images/test/dImageSummary.cc
+++ b/images/Images/test/dImageSummary.cc
@@ -98,7 +98,7 @@ try {
    }
 
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      return 1;
   } 

--- a/images/Images/test/tExtendImage.cc
+++ b/images/Images/test/tExtendImage.cc
@@ -217,7 +217,7 @@ int main ()
     testRest();
     // Test the axes removal..
     testMask();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/images/Images/test/tFITSErrorImage.cc
+++ b/images/Images/test/tFITSErrorImage.cc
@@ -309,7 +309,7 @@ try {
 
    cerr << "ok " << endl;
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
    cerr << "aipserror: error " << x.getMesg() << endl;
    return 1;
 }

--- a/images/Images/test/tFITSExtImage.cc
+++ b/images/Images/test/tFITSExtImage.cc
@@ -154,7 +154,7 @@ try {
 //
    cerr << "ok " << endl;
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
    cerr << "aipserror: error " << x.getMesg() << endl;
    return 1;
 }

--- a/images/Images/test/tFITSExtImageII.cc
+++ b/images/Images/test/tFITSExtImageII.cc
@@ -156,7 +156,7 @@ try {
 
    cerr << "ok " << endl;
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
    cerr << "aipserror: error " << x.getMesg() << endl;
    return 1;
 }

--- a/images/Images/test/tFITSImage.cc
+++ b/images/Images/test/tFITSImage.cc
@@ -160,7 +160,7 @@ try {
    delete pLoadImage;
 
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
    cout << "aipserror: error " << x.getMesg() << endl;
    return 1;
 }

--- a/images/Images/test/tFITSImgParser.cc
+++ b/images/Images/test/tFITSImgParser.cc
@@ -295,7 +295,7 @@ int main (int argc, const char* argv[])
 		   cerr << "File contains quality image: " << fitsImg.has_qualityimg() << "\n";
 		   cerr << "String representation of all extensions with data:\n" << fitsImg.get_extlist_string(String("<A>")) << endl;
 	   }
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	   cerr << "aipserror: error " << x.getMesg() << endl;
 	   return 1;
 	}

--- a/images/Images/test/tFITSQualityImage.cc
+++ b/images/Images/test/tFITSQualityImage.cc
@@ -180,7 +180,7 @@ try {
 
    cerr << "ok " << endl;
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
    cerr << "aipserror: error " << x.getMesg() << endl;
    return 1;
 }

--- a/images/Images/test/tHDF5Image.cc
+++ b/images/Images/test/tHDF5Image.cc
@@ -337,7 +337,7 @@ int main()
     }
 
     cout<< "ok"<< endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Exception caught: " << x.getMesg() << endl;
     return 1;
   } 

--- a/images/Images/test/tImageConcat.cc
+++ b/images/Images/test/tImageConcat.cc
@@ -386,7 +386,7 @@ int main() {
          try {
             lc.setImage(im1, True);
             ok = False;
-         } catch (AipsError x) {
+         } catch (AipsError& x) {
          } 
          if (!ok) {
             throw (AipsError("set forced failure did not work - this was unexpected"));  
@@ -398,7 +398,7 @@ int main() {
                                "tImageConcat_tmp3.img");
             lc.setImage(ml4, True);
             ok = False;
-         } catch (AipsError x) {;} 
+         } catch (AipsError& x) {;} 
          if (!ok) {
             throw (AipsError("set forced failure did not work - this was unexpected"));  
          }

--- a/images/Images/test/tImageExpr2Gram.cc
+++ b/images/Images/test/tImageExpr2Gram.cc
@@ -380,7 +380,7 @@ int main (int argc, const char* argv[])
       delete tempRegs[i];
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     foundError = True;
   } 

--- a/images/Images/test/tImageExpr3Gram.cc
+++ b/images/Images/test/tImageExpr3Gram.cc
@@ -164,7 +164,7 @@ int main (int argc, const char* argv[])
       }
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     foundError = True;
   } 

--- a/images/Images/test/tImageExprGram.cc
+++ b/images/Images/test/tImageExprGram.cc
@@ -168,27 +168,27 @@ int main (int argc, const char* argv[])
     cout << endl;
     try {
       doExpr ("xxx", Record());
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
     try {
       LatticeExpr<Double> expr (ImageExprParse::command ("b/a1"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
     try {
       LatticeExpr<Double> expr (ImageExprParse::command ("a1/b"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
     try {
       LatticeExpr<Double> expr (ImageExprParse::command ("b/b*"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
     try {
       LatticeExpr<Double> expr (ImageExprParse::command ("min(b,b,b)"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
   }
@@ -688,7 +688,7 @@ int main (int argc, const char* argv[])
 
   cout << endl;
 
- } catch (AipsError x) {
+ } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     foundError = True;
  } 

--- a/images/Images/test/tImageExprParse_addDir.cc
+++ b/images/Images/test/tImageExprParse_addDir.cc
@@ -42,7 +42,7 @@ int main()
     AlwaysAssertExit (ImageExprParse::setAddDir("", "/a/b") == "/a/b");
     AlwaysAssertExit (ImageExprParse::setAddDir("", "$HOME") == "$HOME");
     cout<< "ok"<< endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Exception caught: " << x.getMesg() << endl;
     return 1;
   } 

--- a/images/Images/test/tImageInfo.cc
+++ b/images/Images/test/tImageInfo.cc
@@ -196,7 +196,7 @@ try {
     		myinfo.setBeam(2, 1, majAx, minAx, pa);
     		ok = False;
     	}
-    	catch (AipsError x) {
+    	catch (AipsError& x) {
     		cout << "Exception thrown as expected: "
     			<< x.getMesg() << endl;
     	}
@@ -208,7 +208,7 @@ try {
     		myinfo.setBeam(0, 0, minAx, majAx, pa);
     		ok = False;
     	}
-    	catch (AipsError x) {
+    	catch (AipsError& x) {
     		cout << "Exception thrown as expected: "
     			<< x.getMesg() << endl;
     	}

--- a/images/Images/test/tImageRegrid.cc
+++ b/images/Images/test/tImageRegrid.cc
@@ -315,7 +315,7 @@ try {
 //
     delete pIm;
     cout << "OK" << endl;
-} catch (AipsError x) {
+} catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      return 1;
 } 

--- a/images/Images/test/tLELSpectralIndex.cc
+++ b/images/Images/test/tLELSpectralIndex.cc
@@ -177,7 +177,7 @@ int main ()
   Bool ok = True;
   try {
     ok = doIt();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     ok = False;
   } 

--- a/images/Images/test/tMIRIADImage.cc
+++ b/images/Images/test/tMIRIADImage.cc
@@ -158,7 +158,7 @@ try {
    cerr << "ok " << endl;
 
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
    cerr << "aipserror: error " << x.getMesg() << endl;
    return 1;
 }

--- a/images/Images/test/tPagedImage2.cc
+++ b/images/Images/test/tPagedImage2.cc
@@ -174,7 +174,7 @@ int main()
     }
 
     cout<< "ok"<< endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Exception caught: " << x.getMesg() << endl;
     return 1;
   } 

--- a/images/Images/test/tRebinImage.cc
+++ b/images/Images/test/tRebinImage.cc
@@ -156,7 +156,7 @@ try {
    }
     delete pIm;
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      cout << "FAIL" << endl;
      return 1;

--- a/images/Images/test/tSubImage.cc
+++ b/images/Images/test/tSubImage.cc
@@ -373,7 +373,7 @@ int main ()
     // test per plane beams
     testBeams();
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/images/Images/test/tTempImage.cc
+++ b/images/Images/test/tTempImage.cc
@@ -262,7 +262,7 @@ int main()
     	try {
     		temp.setImageInfo(info);
     	}
-    	catch (AipsError x) {
+    	catch (AipsError& x) {
     		cout << "Exception thrown as expected: "
     			<< x.getMesg() << endl;
     	}
@@ -270,7 +270,7 @@ int main()
     	try {
     		temp.setImageInfo(info);
     	}
-    	catch (AipsError x) {}
+    	catch (AipsError& x) {}
     	for (uInt i=0; i<4; i++) {
     		for (uInt j=0; j<16; j++) {
     			info.setBeam(j, i, maj, min, pa);

--- a/images/Regions/RegionHandlerHDF5.cc
+++ b/images/Regions/RegionHandlerHDF5.cc
@@ -202,7 +202,7 @@ Bool RegionHandlerHDF5::removeRegion (const String& name,
       Bool error = False;
       try {
 	lcPtr->handleDelete();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	error = True;
 	msg = x.getMesg();
       }

--- a/images/Regions/RegionHandlerMemory.cc
+++ b/images/Regions/RegionHandlerMemory.cc
@@ -200,7 +200,7 @@ Bool RegionHandlerMemory::removeRegion (const String& name,
       Bool error = False;
       try {
 	lcPtr->handleDelete();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	error = True;
 	msg = x.getMesg();
       }

--- a/images/Regions/RegionHandlerTable.cc
+++ b/images/Regions/RegionHandlerTable.cc
@@ -225,7 +225,7 @@ Bool RegionHandlerTable::removeRegion (const String& name,
       Bool error = False;
       try {
 	lcPtr->handleDelete();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	error = True;
 	msg = x.getMesg();
       }

--- a/images/Regions/RegionManager.cc
+++ b/images/Regions/RegionManager.cc
@@ -814,7 +814,7 @@ namespace casacore { //# name space casa begins
 	myimage.defineRegion (newName, mask, RegionHandler::Masks);
 	retval=myimage.hasRegion(newName);
       }
-      catch(AipsError x){
+      catch(AipsError& x){
 	throw(AipsError("Could not write mask in image "+tabName+" because "+x.getMesg()));
       }
       catch(...){

--- a/images/Regions/WCEllipsoid.cc
+++ b/images/Regions/WCEllipsoid.cc
@@ -592,7 +592,7 @@ void WCEllipsoid::_checkUnits() const {
 	try {
 		checkAxes(_pixelAxes, _csys, units);
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 		throw AipsError(
 			x.getMesg() + " Checking radii units"
 		);
@@ -603,7 +603,7 @@ void WCEllipsoid::_checkUnits() const {
 	try {
 		checkAxes(_pixelAxes, _csys, units);
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 		throw AipsError(
 			x.getMesg() + " Checking center units"
 		);

--- a/images/Regions/WCLELMask.cc
+++ b/images/Regions/WCLELMask.cc
@@ -113,7 +113,7 @@ void WCLELMask::processCommand()
   try {
     LatticeExprNode expr = ImageExprParse::command (itsCommand);
     init (expr);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     throw AipsError (x.getMesg() + "\n  Error in creating WCLELMask");
   }
 }

--- a/images/Regions/test/tRegionHandler.cc
+++ b/images/Regions/test/tRegionHandler.cc
@@ -165,7 +165,7 @@ int main()
       RegionHandlerHDF5 reghdf5 (getHDF5File, 0);
       doIt (reghdf5);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/images/Regions/test/tWCBox.cc
+++ b/images/Regions/test/tWCBox.cc
@@ -249,7 +249,7 @@ try {
       try {
          LCRegion* pLCRegion = box3.toLCRegion(cSys2, shape2);
          if (pLCRegion != 0) delete pLCRegion;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 //         cout << "aipserror: caught error " << x.getMesg() << endl;
          ok = True;
       } 
@@ -279,7 +279,7 @@ try {
       try {
          pLCRegion =  box.toLCRegion(cSys2, shape);
          if (pLCRegion != 0) delete pLCRegion;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 //         cout << "aipserror: caught error " << x.getMesg() << endl;
          ok = True;
       } 
@@ -374,7 +374,7 @@ try {
       try {
          pLCRegion = box1.toLCRegion(cSys2, shape2);
          if (pLCRegion != 0) delete pLCRegion;
-       } catch (AipsError x) {
+       } catch (AipsError& x) {
 //          cout << "aipserror: caught error " << x.getMesg() << endl;
           ok = True;
        } 
@@ -401,7 +401,7 @@ try {
 //         cout << "toLCRegion called with shape = " << shape2 << endl;
          pLCRegion = box1.toLCRegion(cSys2, shape2);
          if (pLCRegion != 0) delete pLCRegion;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 //         cout << "aipserror: caught expected error " << x.getMesg() << endl;
          ok = True;
       } 
@@ -450,7 +450,7 @@ try {
 //   cout << endl;
 
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
       cerr << "aipserror: error " << x.getMesg() << endl;
       cout << "not ok" << endl; 
       return 1;

--- a/images/Regions/test/tWCEllipsoid.cc
+++ b/images/Regions/test/tWCEllipsoid.cc
@@ -95,7 +95,7 @@ int main()
         WCEllipsoid(center, radius, pixelAxes, csys);
         AlwaysAssert(False, AipsError);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       radius[2] = Quantity(50, "MHz");
@@ -103,7 +103,7 @@ int main()
         WCEllipsoid(center, radius, pixelAxes, csys);
         AlwaysAssert(False, AipsError);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       center[2] = Quantity(1415, "GHz");
@@ -112,7 +112,7 @@ int main()
         WCEllipsoid(center, radius, pixelAxes, csys);
         AlwaysAssert(False, AipsError);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       pixelAxes = IPosition(3, 0, 0, 1);
@@ -120,7 +120,7 @@ int main()
         WCEllipsoid(center, radius, pixelAxes, csys);
         AlwaysAssert(False, AipsError);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       pixelAxes = IPosition(3, 0, 1, 2);
@@ -129,7 +129,7 @@ int main()
         WCEllipsoid(center, radius, pixelAxes, csys);
         AlwaysAssert(False, AipsError);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
 
@@ -254,7 +254,7 @@ int main()
                            );
         AlwaysAssert(False, AipsError);
       }
-      catch(AipsError x) {
+      catch(AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       pixelAxes.resize(2, True);
@@ -289,7 +289,7 @@ int main()
                             );
         AlwaysAssert(False, AipsError);
       }
-      catch(AipsError x) {
+      catch(AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       try {
@@ -301,7 +301,7 @@ int main()
                             );
         AlwaysAssert(False, AipsError);
       }
-      catch(AipsError x) {
+      catch(AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       radius[0].setValue(2);
@@ -331,7 +331,7 @@ int main()
                               );
         AlwaysAssert(False, AipsError);
       }
-      catch(AipsError x) {
+      catch(AipsError& x) {
         cout << "Caught as expected " << x.getMesg() << endl;
       }
       ellipse = WCEllipsoid(
@@ -350,7 +350,7 @@ int main()
       delete ellipse3;
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/images/Regions/test/tWCExtension.cc
+++ b/images/Regions/test/tWCExtension.cc
@@ -369,7 +369,7 @@ int main ()
   try {
     doIt();
     testAll();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/images/Regions/test/tWCLELMask.cc
+++ b/images/Regions/test/tWCLELMask.cc
@@ -127,7 +127,7 @@ int main ()
       try {
 	LCRegion* lc = mask.toLCRegion (cSys, latticeShape-1);
 	delete lc;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "Expected exception: " << x.getMesg() << endl;
       }
     }
@@ -146,7 +146,7 @@ int main ()
       try {
 	LCRegion* lc = mask.toLCRegion (cSys, latticeShape-1);
 	delete lc;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "Expected exception: " << x.getMesg() << endl;
       }
     }
@@ -174,7 +174,7 @@ int main ()
       testVectorROIter (*lc, True, True);
       delete lc;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/images/Regions/test/tWCUnion.cc
+++ b/images/Regions/test/tWCUnion.cc
@@ -119,7 +119,7 @@ int main()
 {
   try {
     doIt();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/images/apps/imagecalc.cc
+++ b/images/apps/imagecalc.cc
@@ -86,7 +86,7 @@ int main(int argc, const char* argv[])
       ImageProxy img(imgin, String(), vector<ImageProxy>());
       img.saveAs (outName, True, hdf5, True);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LEL/test/tLEL.cc
+++ b/lattices/LEL/test/tLEL.cc
@@ -2341,7 +2341,7 @@ int main (int argc, const char* argv[])
     cout << endl << "ok" << endl;
   }
 
- } catch (AipsError x) {
+ } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     return 1;
  } 
@@ -2384,7 +2384,7 @@ Bool checkFloat (LELInterface<Float>& expr,
       }
       try {
         expr.eval(Arr, region);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
         if (!suppress) cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     } else {
@@ -2404,7 +2404,7 @@ Bool checkFloat (LELInterface<Float>& expr,
       }
       try {
        expr.getScalar();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     }
@@ -2449,7 +2449,7 @@ Bool checkDouble (LELInterface<Double>& expr,
       }
       try {
         expr.eval(Arr, region);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     } else {
@@ -2469,7 +2469,7 @@ Bool checkDouble (LELInterface<Double>& expr,
       }
       try {
        expr.getScalar();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     }
@@ -2514,7 +2514,7 @@ Bool checkComplex (LELInterface<Complex>& expr,
       }
       try {
         expr.eval(Arr, region);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     } else {
@@ -2534,7 +2534,7 @@ Bool checkComplex (LELInterface<Complex>& expr,
       }
       try {
        expr.getScalar();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     }
@@ -2579,7 +2579,7 @@ Bool checkDComplex (LELInterface<DComplex>& expr,
       }
       try {
         expr.eval(Arr, region);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     } else {
@@ -2599,7 +2599,7 @@ Bool checkDComplex (LELInterface<DComplex>& expr,
       }
       try {
        expr.getScalar();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     }
@@ -2645,7 +2645,7 @@ Bool checkBool (LELInterface<Bool>& expr,
       }
       try {
         expr.eval(Arr, region);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     } else {
@@ -2672,7 +2672,7 @@ Bool checkBool (LELInterface<Bool>& expr,
       }
       try {
        expr.getScalar();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
        if (!suppress)  cout << "      Caught expected exception; message is: " << x.getMesg() << endl;
       } 
     }

--- a/lattices/LEL/test/tLatticeExpr.cc
+++ b/lattices/LEL/test/tLatticeExpr.cc
@@ -237,7 +237,7 @@ int main (int argc, const char* argv[])
      cout << "ok" << endl;
   }
 
- } catch (AipsError x) {
+ } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     return 1;
  } 
@@ -270,12 +270,12 @@ Bool checkFloat(Lattice<Float>& expr,
 
    try {
      expr.putSlice(outArr, origin, stride);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
    try {
      expr.putSlice(outArr, origin);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
 
@@ -355,12 +355,12 @@ Bool checkDouble(Lattice<Double>& expr,
 
    try {
      expr.putSlice(outArr, origin, stride);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
    try {
      expr.putSlice(outArr, origin);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
 
@@ -440,12 +440,12 @@ Bool checkComplex(Lattice<Complex>& expr,
 
    try {
      expr.putSlice(outArr, origin, stride);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
    try {
      expr.putSlice(outArr, origin);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
 
@@ -526,12 +526,12 @@ Bool checkDComplex(Lattice<DComplex>& expr,
 
    try {
      expr.putSlice(outArr, origin, stride);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
    try {
      expr.putSlice(outArr, origin);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
 
@@ -613,12 +613,12 @@ Bool checkBool(Lattice<Bool>& expr,
 
    try {
      expr.putSlice(outArr, origin, stride);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
    try {
      expr.putSlice(outArr, origin);
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
      if (!supress)  cout << "   Caught expected exception; message is: " << x.getMesg() << endl;
    } 
 

--- a/lattices/LEL/test/tLatticeExpr2.cc
+++ b/lattices/LEL/test/tLatticeExpr2.cc
@@ -270,7 +270,7 @@ int main(int argc, const char* argv[])
       timer.show ("as lattice");
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LEL/test/tLatticeExpr2Node.cc
+++ b/lattices/LEL/test/tLatticeExpr2Node.cc
@@ -815,7 +815,7 @@ int main() {
 	if (!doIt(SubLattice<Float>(aF,mask2), SubLattice<Float>(bF,mask1))) {
 	    ok = False;
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	ok = False;
     } 

--- a/lattices/LEL/test/tLatticeExpr3.cc
+++ b/lattices/LEL/test/tLatticeExpr3.cc
@@ -341,7 +341,7 @@ int main(int argc, const char* argv[])
       timer.show ("+= sca mem");
       AlwaysAssertExit (allEQ(pa1.get(), float(12)));
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LEL/test/tLatticeExpr3Node.cc
+++ b/lattices/LEL/test/tLatticeExpr3Node.cc
@@ -154,7 +154,7 @@ int main()
 	if (!doIt(sublat, box2, cir2)) {
 	    ok = False;
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	ok = False;
     } 

--- a/lattices/LEL/test/tLatticeExprNode.cc
+++ b/lattices/LEL/test/tLatticeExprNode.cc
@@ -3563,7 +3563,7 @@ int main (int argc, const char* argv[])
     }
 
 
- } catch (AipsError x) {
+ } catch (AipsError& x) {
     cerr << "aipserror: error " << x.getMesg() << endl;
     ok = False;
  } 

--- a/lattices/LRegions/test/tLCComplement.cc
+++ b/lattices/LRegions/test/tLCComplement.cc
@@ -124,7 +124,7 @@ int main()
 	doIt (IPosition (2,10,20),
 	      IPosition (2,3,4), IPosition (2,7,8),
 	      IPosition (2,4,16), 5.);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCConcatenation.cc
+++ b/lattices/LRegions/test/tLCConcatenation.cc
@@ -170,7 +170,7 @@ int main()
 	doIt (IPosition (2,10,20),
 	      IPosition (2,3,4), IPosition (2,7,8),
 	      IPosition (2,4,16), 5.);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCDifference.cc
+++ b/lattices/LRegions/test/tLCDifference.cc
@@ -131,7 +131,7 @@ int main()
 	doIt (IPosition (2,10,20),
 	      IPosition (2,3,4), IPosition (2,7,8),
 	      IPosition (2,4,16), 5.);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCExtension.cc
+++ b/lattices/LRegions/test/tLCExtension.cc
@@ -111,7 +111,7 @@ void doIt (const LCRegion& region,
         LCExtension prism2 (region, axes, LCBox(blc-1, trc, latticeShape));
         AlwaysAssertExit (prism2 != prism);
       }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 }
@@ -150,7 +150,7 @@ int main()
 	// Error; incorrect order of extendAxes
 	doIt (polygon, IPosition(2,1), IPosition(2,2), IPosition(2,3),
 	      IPosition(2,20));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCIntersection.cc
+++ b/lattices/LRegions/test/tLCIntersection.cc
@@ -129,10 +129,10 @@ int main()
 	    doIt (IPosition (2,10,20),
 		  IPosition (2,3,4), IPosition (2,7,8),
 		  IPosition (2,4,16), 5.);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCLELMask.cc
+++ b/lattices/LRegions/test/tLCLELMask.cc
@@ -95,7 +95,7 @@ int main ()
 
       AlwaysAssertExit (mask1 != mask2);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LRegions/test/tLCMask.cc
+++ b/lattices/LRegions/test/tLCMask.cc
@@ -112,7 +112,7 @@ int main ()
       AlwaysAssertExit (mask3 != mask);
 
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LRegions/test/tLCPagedMask.cc
+++ b/lattices/LRegions/test/tLCPagedMask.cc
@@ -119,7 +119,7 @@ int main ()
       AlwaysAssertExit (mask3 != mask);
 
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LRegions/test/tLCPixelSet.cc
+++ b/lattices/LRegions/test/tLCPixelSet.cc
@@ -147,7 +147,7 @@ int main ()
 				  latticeShape-1, latticeShape));
       AlwaysAssertExit (mask3 != mask1);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/LRegions/test/tLCPolygon2.cc
+++ b/lattices/LRegions/test/tLCPolygon2.cc
@@ -75,7 +75,7 @@ int main()
       Vector<Float> yv(IPosition(1,sizeof(y)/sizeof(Float)), y, SHARE);
       doIt (shape, xv, yv);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/LRegions/test/tLCRegion.cc
+++ b/lattices/LRegions/test/tLCRegion.cc
@@ -167,7 +167,7 @@ int main()
 	radii(1) = 8;
 	center(1) = 10;
 	doIt (IPosition (2,11,20), center, radii);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCSlicer.cc
+++ b/lattices/LRegions/test/tLCSlicer.cc
@@ -222,7 +222,7 @@ int main()
 {
     try {
 	doIt();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCStretch.cc
+++ b/lattices/LRegions/test/tLCStretch.cc
@@ -116,7 +116,7 @@ void doIt (const LCRegion& region,
         LCStretch prism2 (ext2, axes, LCBox(blc-1, trc, latticeShape));
         AlwaysAssertExit (prism2 != prism);
       }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 }
@@ -130,7 +130,7 @@ void doItError (const LCRegion& region,
 {
     try {
 	LCStretch prism (region, axes, LCBox(blc, trc, latticeShape));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 }
@@ -175,7 +175,7 @@ int main()
 	// Error; stretched axis has not length 1
 	doItError (polygon, IPosition(1,0), IPosition(1,2), IPosition(1,3),
 		   IPosition(1,20));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLCUnion.cc
+++ b/lattices/LRegions/test/tLCUnion.cc
@@ -129,7 +129,7 @@ int main()
 	doIt (IPosition (2,10,20),
 	      IPosition (2,3,4), IPosition (2,7,8),
 	      IPosition (2,4,16), 5.);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LRegions/test/tLatticeRegion.cc
+++ b/lattices/LRegions/test/tLatticeRegion.cc
@@ -74,7 +74,7 @@ int main()
 	doIt (IPosition (2,11,20),
 	      IPosition (2,3,4), IPosition (2,7,8),
 	      IPosition (2,5,10), 5);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LatticeMath/Fit2D.cc
+++ b/lattices/LatticeMath/Fit2D.cc
@@ -647,7 +647,7 @@ Fit2D::ErrorTypes Fit2D::fitData(const Vector<Double>& values,
 // A valid solution includes non-convergence
 //
       itsValidSolution = True;
-   } catch (AipsError x) {
+   } catch (AipsError& x) {
       itsErrorMessage = String("Fitting failed because ") + x.getMesg();
       status = Fit2D::FAILED;
    } 

--- a/lattices/LatticeMath/LatticeFit.cc
+++ b/lattices/LatticeMath/LatticeFit.cc
@@ -199,14 +199,14 @@ uInt LatticeFit::fitProfiles (MaskedLattice<Float>* pFit,
                                     inIter.cursorShape(), True);
          try {
             sol.assign(fitter.fit(x, data, inSigma, &inMask));
-         } catch (AipsError x) {
+         } catch (AipsError& x) {
             ok = False;
          }
 
       } else {
          try {
             sol.assign(fitter.fit(x, data, &inMask));
-         } catch (AipsError x) {
+         } catch (AipsError& x) {
             ok = False;
          }
       }

--- a/lattices/LatticeMath/test/tFit2D.cc
+++ b/lattices/LatticeMath/test/tFit2D.cc
@@ -308,7 +308,7 @@ int main(int argc, const char *argv[])
    cout << "Number of points     = " << fitter.numberPoints() << endl;
 */
 
- } catch (AipsError x) {
+ } catch (AipsError& x) {
       cout << "Failed with message " << x.getMesg() << endl;
  }   
 

--- a/lattices/LatticeMath/test/tLattStatsSpecialize.cc
+++ b/lattices/LatticeMath/test/tLattStatsSpecialize.cc
@@ -121,7 +121,7 @@ int main() {
 			*/
 		}
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 		cerr << "aipserror: error " << x.getMesg() << endl;
 		return 1;
 	}

--- a/lattices/LatticeMath/test/tLatticeAddNoise.cc
+++ b/lattices/LatticeMath/test/tLatticeAddNoise.cc
@@ -84,7 +84,7 @@ int main ()
          if (type!=Random::GEOMETRIC &&
              type!=Random::UNKNOWN) test1Complex (type);
       }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/LatticeMath/test/tLatticeApply.cc
+++ b/lattices/LatticeMath/test/tLatticeApply.cc
@@ -624,7 +624,7 @@ int main (int argc, const char* argv[])
 	doIt (argc,argv);
 	cout<< "OK"<< endl;
 	return 0;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cerr << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LatticeMath/test/tLatticeApply2.cc
+++ b/lattices/LatticeMath/test/tLatticeApply2.cc
@@ -366,7 +366,7 @@ int main (int argc, const char* argv[])
 	doIt (argc,argv);
 	cout<< "OK"<< endl;
 	return 0;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cerr << "Caught exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/lattices/LatticeMath/test/tLatticeConvolver.cc
+++ b/lattices/LatticeMath/test/tLatticeConvolver.cc
@@ -606,7 +606,7 @@ int main() {
 // 	cout << "result = " << resultArray << endl;
 //       }
       }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout<< "FAIL"<< endl;
     cerr << x.getMesg() << endl;
     return 1;

--- a/lattices/LatticeMath/test/tLatticeFFT.cc
+++ b/lattices/LatticeMath/test/tLatticeFFT.cc
@@ -178,7 +178,7 @@ int main() {
     }
     cout<< "OK"<< endl;
     return 0;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout<< "FAIL"<< endl;
   } 

--- a/lattices/LatticeMath/test/tLatticeSlice1D.cc
+++ b/lattices/LatticeMath/test/tLatticeSlice1D.cc
@@ -83,7 +83,7 @@ try {
    doit3();
 
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      return 1;
 } 
@@ -175,7 +175,7 @@ void doit1 ()
       trc = shape - 1;
       try {
         slicer.getSlice (data, mask, blc, trc, nPts);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
         cerr << "Caught expected exception " << x.getMesg() << endl;
       }
    }
@@ -248,7 +248,7 @@ void doit2 ()
       LatticeSlice1D<Float> slicer2;
       try {
         slicer2.getSlice (data, mask, blc, trc, nPts);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
         cerr << "Caught expected exception " << x.getMesg() << endl;
       }
 //

--- a/lattices/LatticeMath/test/tLatticeTwoPtCorr.cc
+++ b/lattices/LatticeMath/test/tLatticeTwoPtCorr.cc
@@ -131,7 +131,7 @@ int main ()
         t = t2;
       }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/dLattice.cc
+++ b/lattices/Lattices/test/dLattice.cc
@@ -118,7 +118,7 @@ int main() {
     AlwaysAssert(near(latMean(xfr), 
 		      Complex(1.0)/Float(psfShape(2)*psfShape(3)), 1E-6), 
 		 AipsError);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl << "FAIL" << endl;		
     return 1;
   } 

--- a/lattices/Lattices/test/dPagedArray.cc
+++ b/lattices/Lattices/test/dPagedArray.cc
@@ -241,7 +241,7 @@ int main(int argc, const char* argv[])
       pa.showCacheStatistics (cout);
       pa.clearCache();
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tArrayLattice.cc
+++ b/lattices/Lattices/test/tArrayLattice.cc
@@ -324,7 +324,7 @@ int main()
     Bool caught = False;
     try {
       al6ROIter.matrixCursor();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       caught = True;
     } 
     AlwaysAssert(caught, AipsError);
@@ -332,7 +332,7 @@ int main()
     caught = False;
     try {
       al6ROIter.cubeCursor();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       caught = True;
     } 
     AlwaysAssert(caught, AipsError);
@@ -378,7 +378,7 @@ int main()
     caught = False;
     try {
       al6Iter.vectorCursor();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       caught = True;
     } 
     AlwaysAssert(caught, AipsError);
@@ -386,7 +386,7 @@ int main()
     caught = False;
     try {
       al6Iter.cubeCursor();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       caught = True;
     } 
     AlwaysAssert(caught, AipsError);
@@ -885,7 +885,7 @@ int main()
       AlwaysAssertExit (to.asArray()(IPosition(4,0,0,0,1)) == 960);
       AlwaysAssertExit (allEQ(arr, to.asArray()));
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg () << endl;
     cout << "FAIL" << endl; 
     return 1;

--- a/lattices/Lattices/test/tCurvedLattice2D.cc
+++ b/lattices/Lattices/test/tCurvedLattice2D.cc
@@ -210,7 +210,7 @@ int main (int argc, const char* argv[])
 	pa.showCacheStatistics(cout);
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tExtendLattice.cc
+++ b/lattices/Lattices/test/tExtendLattice.cc
@@ -233,7 +233,7 @@ int main ()
     testRest();
     // Test mask handling
     testMask();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tHDF5Iterator.cc
+++ b/lattices/Lattices/test/tHDF5Iterator.cc
@@ -65,7 +65,7 @@ void testVectorROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -74,7 +74,7 @@ void testVectorROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -129,7 +129,7 @@ void testMatrixROIter (const Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tHDF5Iterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -138,7 +138,7 @@ void testMatrixROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -194,7 +194,7 @@ void testCubeROIter (const Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tHDF5Iterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -203,7 +203,7 @@ void testCubeROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -253,7 +253,7 @@ void testArrayROIter (const Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tHDF5Iterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -262,7 +262,7 @@ void testArrayROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -271,7 +271,7 @@ void testArrayROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -321,7 +321,7 @@ void test8ElemROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -330,7 +330,7 @@ void test8ElemROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -625,7 +625,7 @@ void testVectorRWIter (Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -634,7 +634,7 @@ void testVectorRWIter (Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -693,7 +693,7 @@ void testMatrixRWIter (Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tHDF5Iterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -702,7 +702,7 @@ void testMatrixRWIter (Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -758,7 +758,7 @@ void testCubeRWIter (Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tHDF5Iterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -767,7 +767,7 @@ void testCubeRWIter (Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -817,7 +817,7 @@ void testArrayRWIter (Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tHDF5Iterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -826,7 +826,7 @@ void testArrayRWIter (Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tHDF5Iterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -835,7 +835,7 @@ void testArrayRWIter (Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tHDF5Iterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -1276,7 +1276,7 @@ int main (int argc, const char *argv[])
       pagedArr.put (savarr);
       testNonCongruentRWIter (pagedArr, True);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;
@@ -1446,7 +1446,7 @@ int main (int argc, const char *argv[])
       testAdd (latArr1, pagedArr2, True);
       AlwaysAssert (allEQ(latArr1.get(), 13*arr), AipsError);
     }      
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tHDF5Lattice.cc
+++ b/lattices/Lattices/test/tHDF5Lattice.cc
@@ -193,7 +193,7 @@ int main()
       indgen(arr);
       AlwaysAssertExit (allEQ(pa.get(), float(2)*arr));
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/Lattices/test/tLatticeCache.cc
+++ b/lattices/Lattices/test/tLatticeCache.cc
@@ -206,7 +206,7 @@ int main()
 
     cout<<"<<<"<<endl;
     cout<< "OK"<< endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Exception caught: " << x.getMesg() << endl;
   } 
 

--- a/lattices/Lattices/test/tLatticeConcat.cc
+++ b/lattices/Lattices/test/tLatticeConcat.cc
@@ -639,7 +639,7 @@ int main() {
          try {
             lc.pixelMask();
             ok = False;
-         } catch (AipsError x) {
+         } catch (AipsError& x) {
             ok = True;
          } 
          if (!ok) {
@@ -728,7 +728,7 @@ int main() {
          try {
             lc.setLattice(ml1);
             ok = False;
-         } catch (AipsError x) {
+         } catch (AipsError&x) {
          } 
          if (!ok) {
             throw (AipsError("setLattice forced failure did not work - this was unexpected"));  
@@ -740,13 +740,13 @@ int main() {
             SubLattice<Float> ml4(l4, True);
             lc.setLattice(ml4);
             ok = False;
-         } catch (AipsError x) {;} 
+         } catch (AipsError& x) {;} 
          if (!ok) {
             throw (AipsError("setLattice forced failure did not work - this was unexpected"));  
          }
       }
 
-  } catch(AipsError x) {
+  } catch(AipsError& x) {
     cerr << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/Lattices/test/tLatticeIndexer.cc
+++ b/lattices/Lattices/test/tLatticeIndexer.cc
@@ -330,7 +330,7 @@ int main ()
     }
     cout << "OK" << endl;
     return 0;
-  } catch   (AipsError x) {
+  } catch   (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tLatticeIterator.cc
+++ b/lattices/Lattices/test/tLatticeIterator.cc
@@ -64,7 +64,7 @@ void testVectorROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -73,7 +73,7 @@ void testVectorROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -128,7 +128,7 @@ void testMatrixROIter (const Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tLatticeIterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -137,7 +137,7 @@ void testMatrixROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -193,7 +193,7 @@ void testCubeROIter (const Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tLatticeIterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -202,7 +202,7 @@ void testCubeROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -252,7 +252,7 @@ void testArrayROIter (const Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tLatticeIterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -261,7 +261,7 @@ void testArrayROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -270,7 +270,7 @@ void testArrayROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -320,7 +320,7 @@ void test8ElemROIter (const Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -329,7 +329,7 @@ void test8ElemROIter (const Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -624,7 +624,7 @@ void testVectorRWIter (Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -633,7 +633,7 @@ void testVectorRWIter (Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -692,7 +692,7 @@ void testMatrixRWIter (Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tLatticeIterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -701,7 +701,7 @@ void testMatrixRWIter (Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -757,7 +757,7 @@ void testCubeRWIter (Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tLatticeIterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -766,7 +766,7 @@ void testCubeRWIter (Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -816,7 +816,7 @@ void testArrayRWIter (Lattice<Int>& lattice, Bool useRef)
         Vector<Int> temp(iter.vectorCursor());
         throw(AipsError("tLatticeIterator - "
                         "vectorCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("one non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -825,7 +825,7 @@ void testArrayRWIter (Lattice<Int>& lattice, Bool useRef)
         Matrix<Int> temp(iter.matrixCursor());
         throw(AipsError("tLatticeIterator - "
                         "matrixCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("two non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -834,7 +834,7 @@ void testArrayRWIter (Lattice<Int>& lattice, Bool useRef)
         Cube<Int> temp(iter.cubeCursor());
         throw(AipsError("tLatticeIterator - "
                         "cubeCursor worked where it should not have"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         if (!x.getMesg().contains("three non-degenerate")) {
 	    throw (AipsError (x.getMesg()));
         }
@@ -1271,7 +1271,7 @@ int main (int argc, const char* argv[])
       pagedArr.put (savarr);
       testNonCongruentRWIter (pagedArr, True);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;
@@ -1441,7 +1441,7 @@ int main (int argc, const char* argv[])
       testAdd (latArr1, pagedArr2, True);
       AlwaysAssert (allEQ(latArr1.get(), 13*arr), AipsError);
     }      
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << "Caught exception: " << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tLatticeLocker.cc
+++ b/lattices/Lattices/test/tLatticeLocker.cc
@@ -61,7 +61,7 @@ void b()
 		try {
 		    latlock[nrll] = new LatticeLocker (pa, FileLocker::Read, 1);
 		    nrll++;
-		} catch (AipsError x) {
+		} catch (AipsError& x) {
 		    cout << x.getMesg() << endl;
 		} 
 	    }
@@ -72,7 +72,7 @@ void b()
 		try {
 		    latlock[nrll] = new LatticeLocker (pa, FileLocker::Write,1);
 		    nrll++;
-		} catch (AipsError x) {
+		} catch (AipsError& x) {
 		    cout << x.getMesg() << endl;
 		} 
 	    }
@@ -125,7 +125,7 @@ int main (int argc, const char* argv[])
 		PagedArray<Int> pa(IPosition(2,4,4), "tLatticeLocker_tmp.data");
 	    }
 	    b();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << "Caught an exception: " << x.getMesg() << endl;
 	    return 1;
 	} 

--- a/lattices/Lattices/test/tLatticePerf.cc
+++ b/lattices/Lattices/test/tLatticePerf.cc
@@ -155,7 +155,7 @@ int main (int argc, char* argv[])
         getCube (PagedArray<Float>("tLatticePerf_tmp.tab"), argv[1]);
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/Lattices/test/tLatticeStepper.cc
+++ b/lattices/Lattices/test/tLatticeStepper.cc
@@ -55,7 +55,7 @@ int main()
  	LatticeStepper demented(smallLatticeShape, badCursor);
 	cout << "'more axes than lattice' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
  	if (!x.getMesg().contains("more axes than lattice")) {
  	  cout << x.getMesg() << endl << "FAIL" << endl;
 	  return 1;
@@ -66,7 +66,7 @@ int main()
 	LatticeStepper demented(latticeShape, bigCursor, stepperOrientation);
 	cout << "'upper bound exceeded' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	if (!x.getMesg().contains("> latticeShape")) {
 	  cout << x.getMesg() << endl << "FAIL" << endl;
 	  return 1;
@@ -77,7 +77,7 @@ int main()
 	LatticeStepper demented(latticeShape, zeroCursor,stepperOrientation);
 	cout << "'lower bound exceeded' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	if (!x.getMesg().contains("cursorShape <=0")) {
 	  cout << x.getMesg() << endl << "FAIL" << endl;
 	  return 1;
@@ -88,7 +88,7 @@ int main()
 	LatticeStepper demented(latticeShape, stepperShape, badOrientation1);
 	cout << "'bad orientation' exception 1 expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	if (!x.getMesg().contains("makeAxisPath")){
 	  cout << x.getMesg() << endl << "FAIL" << endl;
 	  return 1;
@@ -99,7 +99,7 @@ int main()
 	LatticeStepper demented(latticeShape, stepperShape, badOrientation2);
 	cout << "'bad orientation' exception 2 expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	if (!x.getMesg().contains("makeAxisPath")){
 	  cout << x.getMesg() << endl << "FAIL" << endl;
 	  return 1;
@@ -110,49 +110,49 @@ int main()
 			     IPosition(2,1,2), IPosition());
 	cout << "'no cursor shape' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
       try {
 	LatticeStepper step3(IPosition(4,2,3,4,5), IPosition(5,1),
 			     IPosition(2,1,2), IPosition());
 	cout << "'too long cursor shape' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
       try {
 	LatticeStepper step3(IPosition(4,2,3,4,5), IPosition(2,1),
 			     IPosition(5,1), IPosition());
 	cout << "'too long cursor axes' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
       try {
 	LatticeStepper step3(IPosition(4,2,3,4,5), IPosition(2,1),
 			     IPosition(3,1), IPosition());
 	cout << "'unequal cursor axes' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
       try {
 	LatticeStepper step3(IPosition(4,2,3,4,5), IPosition(2,1),
 			     IPosition(2,4), IPosition());
 	cout << "'too high cursor axes' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
       try {
 	LatticeStepper step3(IPosition(4,2,3,4,5), IPosition(4,2,3,4,1),
 			     IPosition(2,1,2), IPosition());
 	cout << "'> length 1' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
       try {
 	LatticeStepper step3(IPosition(4,2,3,4,5), IPosition(2,1),
 			     IPosition(2,2,1), IPosition());
 	cout << "'non ascending order' exception expected" << endl;
 	return 1;
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
       } 
     }
     logger << "End of section which checks error detection" 
@@ -311,7 +311,7 @@ int main()
     AlwaysAssert(stepPtr->endPosition() == IPosition(3,3,1,0), AipsError);
     delete clonePtr;
     delete stepPtr;
-  } catch  (AipsError x) {
+  } catch  (AipsError& x) {
     cout << x.getMesg() << endl << "FAIL" << endl;
     return 1;
   } 

--- a/lattices/Lattices/test/tLatticeUtilities.cc
+++ b/lattices/Lattices/test/tLatticeUtilities.cc
@@ -175,7 +175,7 @@ void doReplicate ()
       try {
          LatticeUtilities::replicate (lat, slice, arr);
          throw(AipsError("replicate unexpectedly did not fail"));
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
          cerr << "Expected error = " << x.getMesg() << endl;
       }
    }

--- a/lattices/Lattices/test/tPagedArray.cc
+++ b/lattices/Lattices/test/tPagedArray.cc
@@ -272,7 +272,7 @@ int main() {
       AlwaysAssertExit (allEQ(pa.get(), float(2)*arr));
     }
     testTempClose();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     return 1;
   } 

--- a/lattices/Lattices/test/tRebinLattice.cc
+++ b/lattices/Lattices/test/tRebinLattice.cc
@@ -186,7 +186,7 @@ try {
    doit3();
 
 
-} catch (AipsError x) {
+} catch (AipsError& x) {
      cerr << "aipserror: error " << x.getMesg() << endl;
      return 1;
 } 

--- a/lattices/Lattices/test/tTempLattice.cc
+++ b/lattices/Lattices/test/tTempLattice.cc
@@ -86,7 +86,7 @@ int main() {
       AlwaysAssertExit (! small.isPaged());
       doIt (small);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/lattices/Lattices/test/tTiledShape.cc
+++ b/lattices/Lattices/test/tTiledShape.cc
@@ -123,7 +123,7 @@ int main (int argc, const char* argv[])
 {
     try {
 	testClass();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -142,7 +142,7 @@ int main (int argc, const char* argv[])
 	istringstream istr1(argv[1]);
 	istr1 >> tileSize;
 	testTiling (tileSize);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/measures/Measures/MeasuresProxy.cc
+++ b/measures/Measures/MeasuresProxy.cc
@@ -85,7 +85,7 @@ Bool MeasuresProxy::doFrame(const String &in) {
       return False;
     }
     frame_p.set(*pcomet_p);
-  } catch (AipsError(x)) {
+  } catch (AipsError& x) {
     return False;
   } 
   return True;
@@ -342,7 +342,7 @@ Bool MeasuresProxy::makeMeasure(String &error, MeasureHolder &out,
       error += "No measure created; probably unknow measure type\n";
       return False;
     }
-  } catch (AipsError (x)) {
+  } catch (AipsError& x) {
     error += "Cannot convert due to missing frame information\n";
     return False;
   }
@@ -397,7 +397,7 @@ Bool MeasuresProxy::toUvw(String &error, MeasureHolder &out,
       dot[j] *= C::pi/180/240./1.002737909350795;
     }
 
-  } catch (AipsError(x)) {
+  } catch (AipsError& x) {
     error += "Cannot convert baseline to uvw: frame "
       "information missing";
     return False;

--- a/measures/Measures/test/dM1950_2000.cc
+++ b/measures/Measures/test/dM1950_2000.cc
@@ -257,7 +257,7 @@ int main()
     conB1950(b1950, j2000, 1979.9, &frame);
     conB1950(b1950, j2000, 2000.0, &frame);
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
     

--- a/measures/Measures/test/dMeasure.cc
+++ b/measures/Measures/test/dMeasure.cc
@@ -120,7 +120,7 @@ int main()
 	    };
 	};	    
 	    
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     

--- a/measures/Measures/test/tEarthField.cc
+++ b/measures/Measures/test/tEarthField.cc
@@ -127,7 +127,7 @@ int main() {
 
 	cout << "------------------------------------------" << endl;
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 

--- a/measures/Measures/test/tEarthMagneticMachine.cc
+++ b/measures/Measures/test/tEarthMagneticMachine.cc
@@ -233,7 +233,7 @@ int main() {
       cout << "LOS 210:       " << fm1(qhgt, "G") << endl;
     }
     
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
   

--- a/measures/Measures/test/tMBaseline.cc
+++ b/measures/Measures/test/tMBaseline.cc
@@ -213,7 +213,7 @@ int main()
 	  delete mbc;
 	}
       
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 

--- a/measures/Measures/test/tMDirection.cc
+++ b/measures/Measures/test/tMDirection.cc
@@ -114,7 +114,7 @@ int main() {
 		}
 	}
 
-	catch (AipsError x) {
+	catch (AipsError& x) {
 		cout << "tMDirection failed: " << x.getMesg() << endl;
 		return 1;
 	}

--- a/measures/Measures/test/tMEarthMagnetic.cc
+++ b/measures/Measures/test/tMEarthMagnetic.cc
@@ -244,7 +244,7 @@ int main() {
 	}
 	cout << "------------------------------------------" << endl;
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 

--- a/measures/Measures/test/tMeasComet.cc
+++ b/measures/Measures/test/tMeasComet.cc
@@ -186,7 +186,7 @@ int main()
       delete cl;
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 
@@ -197,7 +197,7 @@ int main()
     MeasComet comet;
     cout << "OK:             " << comet.ok() << endl;
     cout << "Name:           " << comet.getName() << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
 

--- a/measures/Measures/test/tMeasMath.cc
+++ b/measures/Measures/test/tMeasMath.cc
@@ -182,14 +182,14 @@ int main()
 	cout << "Length in dam:        " << pdc3.getLength("dam") << endl;
 
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
     try {
 	cout << "Euler(10 deg, 20 m): ";
 	cout << Euler(Quantity(10,"deg"), Quantity(20,"m")) << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -199,7 +199,7 @@ int main()
 	MVDirection dc10(Quantity(10,"deg"),Quantity(20,"deg"));
 	cout << "Rotate (10,20 deg) over 0,0,30 deg: " 
 	    << (rot10*dc10).getAngle("deg") << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -335,7 +335,7 @@ int main()
 		mypcd << endl;
 	}
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -346,7 +346,7 @@ int main()
 	cout << "5.3 + 10.9: " << MVEpoch(5.3)+MVEpoch(10.9) << endl;
 	cout << "1.123 years: " << MVEpoch(Quantity(1.123,"a")) << endl;
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -366,7 +366,7 @@ int main()
       cout << "Near 0.01 \" (0.1,0.2) and (0.1000001, 0.2): " <<
 	dc1.near(dc3, Quantity(0.01, "arcsec")) << endl;
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 

--- a/measures/Measures/test/tMeasure.cc
+++ b/measures/Measures/test/tMeasure.cc
@@ -398,7 +398,7 @@ int main()
 	
     };	
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -412,7 +412,7 @@ int main()
         MeasFrame mftbm(tbm);
 	cout << mftbm << endl;
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -819,7 +819,7 @@ int main()
       };
     }
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
 

--- a/measures/Measures/test/tMeasureHolder.cc
+++ b/measures/Measures/test/tMeasureHolder.cc
@@ -104,7 +104,7 @@ int main() {
       cout << "To error: " << error << endl;
     };
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 
@@ -130,7 +130,7 @@ int main() {
     cout << "As epoch:      ";
     cout << q00.asMEpoch() << endl;
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 
@@ -237,7 +237,7 @@ int main() {
       cout << "As RadialVelocity:      " << q00.asMRadialVelocity() << endl;
     }      
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 
@@ -288,7 +288,7 @@ int main() {
       cout << "To error: " << error << endl;
     };
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 

--- a/measures/Measures/test/tMuvw.cc
+++ b/measures/Measures/test/tMuvw.cc
@@ -238,7 +238,7 @@ int main()
 	  cout << "---------------------------" << endl;
 	}
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -248,7 +248,7 @@ int main()
       MEpoch x;
       Muvw::assure(x);
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 
@@ -258,7 +258,7 @@ int main()
       MVEpoch x;
       MVuvw::assure(x);
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
     cout << "---------------------------" << endl;

--- a/measures/Measures/test/tParAngleMachine.cc
+++ b/measures/Measures/test/tParAngleMachine.cc
@@ -178,7 +178,7 @@ int main() {
     cout << "---------------------------------------------" << endl;
 
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 
@@ -192,7 +192,7 @@ int main() {
     Double result = pam(52230.0);
     cout << result << endl;
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
 

--- a/measures/Measures/test/tQuality.cc
+++ b/measures/Measures/test/tQuality.cc
@@ -102,7 +102,7 @@ int main() {
 
 		cout << "ok" << endl;
 	}
-	catch (AipsError x) {
+	catch (AipsError& x) {
 		cout << "fail "<< x.getMesg()<<endl;
 		return 1;
 	}

--- a/measures/Measures/test/tRecordTransformable.cc
+++ b/measures/Measures/test/tRecordTransformable.cc
@@ -71,7 +71,7 @@ int main() {
       AlwaysAssert(md.getRef().getType() == MDirection::B1950, AipsError);
     }
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/measures/Measures/test/tStokes.cc
+++ b/measures/Measures/test/tStokes.cc
@@ -62,7 +62,7 @@ int main() {
 			cout <<  " --- receptor2 = ";
 			cout << Stokes::receptor2(Stokes::type(polint));
 			cout << endl;
-		} catch(AipsError x) {
+		} catch(AipsError& x) {
 			cout << " Caught exception of receptor correctly: "<<x.getMesg()<<endl;
 		}
 
@@ -99,7 +99,7 @@ int main() {
 			cout <<  " --- receptor2 = ";
 			cout << Stokes::receptor2(Stokes::type(polstr)) ;
 			cout << endl;
-		} catch(AipsError x) {
+		} catch(AipsError& x) {
 			cout << " Caught exception of receptor correctly: "<<x.getMesg()<<endl;
 		}
 		for (uInt i=0;i<Stokes::NumberOfTypes;i++) {
@@ -121,7 +121,7 @@ int main() {
 		AlwaysAssert(Stokes::allNames(True).size() == Stokes::NumberOfTypes, AipsError);
 		cout << "ok" << endl;
 	}
-	catch (AipsError) {
+	catch (AipsError&) {
 		cout << "fail" << endl;
 
 	}

--- a/measures/Measures/test/tUVWMachine.cc
+++ b/measures/Measures/test/tUVWMachine.cc
@@ -209,7 +209,7 @@ int main() {
       cout << "Phase: "  << ph << ", UVW: " << uvw << endl;
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 
@@ -302,7 +302,7 @@ int main() {
 
     cout << "---------------------------------------" << endl;
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
 

--- a/measures/Measures/test/tVelocityMachine.cc
+++ b/measures/Measures/test/tVelocityMachine.cc
@@ -146,7 +146,7 @@ int main() {
 
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   } 
   

--- a/measures/TableMeasures/test/tTableMeasures.cc
+++ b/measures/TableMeasures/test/tTableMeasures.cc
@@ -346,7 +346,7 @@ void testMain (Bool doExcep)
       try {
 	// test TMRefDesc no such column
 	TableMeasRefDesc tCol(td, "SillyColumnName");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report no such column ";
 	cout << " for TableMeasRefDesc.\n";
 	cout << x.getMesg() << endl;
@@ -354,7 +354,7 @@ void testMain (Bool doExcep)
       try {
 	// test TMRefDesc - column exist but is of the wrong type
 	TableMeasRefDesc tCol(td, "Time4ScaOffset");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report that the column's ";
 	cout << "type is no good.\n";
 	cout << x.getMesg() << endl;
@@ -362,7 +362,7 @@ void testMain (Bool doExcep)
       try {
 	// test TableMeasValueDesc - column doesn't exist exception
 	TableMeasValueDesc tCol(td, "SillyColumnName");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report no such column ";
 	cout << "for TableMeasValueDesc.\n";
 	cout << x.getMesg() << endl;
@@ -370,7 +370,7 @@ void testMain (Bool doExcep)
       try {
 	// test TableMeasValueDesc - column exists but not array
 	TableMeasValueDesc tCol(td, "Time4StrRef");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report that the column ";
 	cout << "is not array for TabelMeasValueDesc.\n";
 	cout << x.getMesg() << endl;
@@ -378,7 +378,7 @@ void testMain (Bool doExcep)
       try {
 	// test TableMeasValueDesc - column exists but is double
 	TableMeasValueDesc tCol(td, "Time2ArrRef");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report that the column's ";
 	cout << "type should be double for the TableMeasValueDesc.\n";
 	cout << x.getMesg() << endl;
@@ -388,7 +388,7 @@ void testMain (Bool doExcep)
 	Vector<Unit> u(2);
 	TableMeasValueDesc tCol(td, "Time2Arr");
 	TableMeasDesc<MEpoch> tmp(tCol, u);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report that the column's ";
 	cout << "unit vector is too long.\n";
 	cout << x.getMesg() << endl;
@@ -399,7 +399,7 @@ void testMain (Bool doExcep)
 	u(0) = "m";
 	TableMeasValueDesc tCol(td, "Time2Arr");
 	TableMeasDesc<MEpoch> tmp(tCol, u);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following should report that the column ";
 	cout << "has an invalid unit.\n";
 	cout << x.getMesg() << endl;
@@ -420,7 +420,7 @@ void testMain (Bool doExcep)
       try {
 	// get getOffset on a variable offset column
 	tmOsDesc.getOffset();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "Attempt to reference undefined Measure offset ";
 	cout << " exception on the TableMeasOffsetDesc object.\n";
 	cout << x.getMesg() << endl;
@@ -578,7 +578,7 @@ void testMain (Bool doExcep)
       if (doExcep) {
 	try {
 	  arrayCol.setDescUnits (u);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  cout << "The following line should report an error ";
 	  cout << "in ScalarMeasColumn::setDescUnits - invalid unit.\n";
 	  cout << x.getMesg() << endl;
@@ -648,7 +648,7 @@ void testMain (Bool doExcep)
       try {
 	// try constructing with a non MeasureColumn
 	MEpoch::ScalarColumn tScaCol(tab, "TimeRef");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should report an error ";
 	cout << "in reconstruct - invalid column exception.\n";
 	cout << x.getMesg() << endl;
@@ -657,7 +657,7 @@ void testMain (Bool doExcep)
 	// test throw if null exception
 	MEpoch::ScalarColumn nullCol;
 	nullCol.throwIfNull();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should be a ";
 	cout << "null column exception.\n";
 	cout << x.getMesg() << endl;
@@ -666,7 +666,7 @@ void testMain (Bool doExcep)
 	// try constructing a ScalarMeasColumn with an Array Offset
 	// column
 	MEpoch::ScalarColumn(tab, "SpareCol1");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should be an illegal ";
 	cout << "offset column type exception.\n";
 	cout << x.getMesg() << endl;
@@ -840,7 +840,7 @@ void testMain (Bool doExcep)
 	MeasFrame frame(epoch_frame);
 	me.getRefPtr()->set(frame);
 	meCol.put(0, me);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should report an error ";
 	cout << "in ScalarMeasColumn::put - not allowed to put a ";
 	cout << "measure with a frame in variable column.\n";
@@ -943,7 +943,7 @@ void testMain (Bool doExcep)
       try {
 	Vector<Unit> u(1);
 	arrayCol.setDescUnits (u);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should report an error ";
 	cout << "in ScalarMeasColumn::setDescUnits - not allowed to put ";
 	cout << "when the table is not empty.\n";
@@ -1036,7 +1036,7 @@ void testMain (Bool doExcep)
 	// test throw if null exception
 	MEpoch::ArrayColumn nullCol;
 	nullCol.throwIfNull();
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should be a ";
 	cout << "null column exception.\n";
 	cout << x.getMesg() << endl;
@@ -1105,14 +1105,14 @@ void testMain (Bool doExcep)
       Bool excp = False;
       try {
 	arrayCol.setDescRefCode (MEpoch::TAI);
-      } catch (AipsError) {
+      } catch (AipsError&) {
 	excp = True;
       }
       AlwaysAssertExit (excp);
       excp = False;
       try {
 	arrayCol.setDescOffset (obsTime);
-      } catch (AipsError) {
+      } catch (AipsError&) {
 	excp = True;
       }
       AlwaysAssertExit (excp);
@@ -1122,7 +1122,7 @@ void testMain (Bool doExcep)
       try {
 	Array<MEpoch> badShapeArr(IPosition(2,2));
 	scaStrRefCol.get(0, badShapeArr, False);
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "The following line should be a ";
 	cout << "Table array conformance error exception.\n";
 	cout << x.getMesg() << endl;
@@ -1437,7 +1437,7 @@ int main(int argc, const char*[])
     // Do tests where a refcode changes.
     testRefCodeChg();
     cout << "Test completed normally...bye.\n";
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "An error occurred.  The test ended early with the following";
     cout << " message:\n";
     cout << x.getMesg() << endl;

--- a/measures/TableMeasures/test/tTableQuantum.cc
+++ b/measures/TableMeasures/test/tTableQuantum.cc
@@ -141,7 +141,7 @@ int main (int argc, const char* argv[])
       try {
 	// no such column
 	TableQuantumDesc taexcep(td, "SillyName");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "A no such column message should follow\n";
 	cout << x.getMesg() << endl;
       } 
@@ -149,7 +149,7 @@ int main (int argc, const char* argv[])
       try {
 	// variable unit's column doesn't exist.
 	TableQuantumDesc taexcep(td, "ScaQuantComplex", "SillyName");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "A no such unit's column message should follow\n";
 	cout << x.getMesg() << endl;
       } 
@@ -160,7 +160,7 @@ int main (int argc, const char* argv[])
 		  "variable units column with incorrect type");
 	td.addColumn(eucol);
 	TableQuantumDesc taexcep(td, "ScaQuantComplex", "testvarcolumn");
-      } catch (AipsError x) {
+      } catch (AipsError& x) {
 	cout << "A message about an incorrect variable unit's type...\n";
 	cout << x.getMesg() << endl;
       } 
@@ -223,7 +223,7 @@ int main (int argc, const char* argv[])
 	  // test isnull exception
 	  try {
 	    sqCol.throwIfNull();
-	  } catch (AipsError x) {
+	  } catch (AipsError& x) {
 	    cout << "Catch an AipsError. Column is null...\n";
 	    cout << x.getMesg() << endl;
 	  } 
@@ -365,7 +365,7 @@ int main (int argc, const char* argv[])
       if (doExcep) {
 	try {
 	  tmpCol.throwIfNull();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  cout << "Catch an AipsError. Array column is null...\n";
 	  cout << x.getMesg() << endl;
 	} 
@@ -375,7 +375,7 @@ int main (int argc, const char* argv[])
 	  // create with a real column but not a quantum column
           // It will succeed because the QuantumDesc does not require a unit.
 	  ArrayQuantColumn<Double> testCol(qtab, "BogusQuantCol");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  cout << "Exception should not occur" << endl;
 	} 
       }
@@ -408,7 +408,7 @@ int main (int argc, const char* argv[])
 	try {
 	  Array<Quantum<Double> > badShapeArr(IPosition(2,2));
 	  roaqCol.get(0, badShapeArr, False);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  cout << "The following line should be a ";
 	  cout << "Table array conformance error exception.\n";
 	  cout << x.getMesg() << endl;
@@ -527,7 +527,7 @@ int main (int argc, const char* argv[])
         }
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception1: " << x.getMesg() << endl;
     return 1;
   } 
@@ -548,7 +548,7 @@ int main (int argc, const char* argv[])
     for (i=0; i<qtab.nrow(); i++) {
       cout << "Quantum " << i << ": " << rosqCol(i) << endl;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception2: " << x.getMesg() << endl;
     return 1;
   } 
@@ -597,7 +597,7 @@ int main (int argc, const char* argv[])
     }
     timer.show ("get tab    arrays");
     cout << "<<<" << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception3: " << x.getMesg() << endl;
     return 1;
   } 

--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -1809,7 +1809,7 @@ int main (int argc, const char** argv) {
     // Create the full properties
     makeProperties();
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     exit(1);
   } 
@@ -1854,7 +1854,7 @@ int main (int argc, const char** argv) {
 // Finish
 //*************************************************************************//
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
     exit(1);
   } 

--- a/ms/MSOper/MSConcat.cc
+++ b/ms/MSOper/MSConcat.cc
@@ -2273,7 +2273,7 @@ Block<uInt>  MSConcat::copyField(const MeasurementSet& otherms) {
       phaseDir = otherFieldCols.phaseDirMeas(f);
       refDir = otherFieldCols.referenceDirMeas(f);
     }
-    catch(AipsError x){
+    catch(AipsError& x){
       if(!ephPath.empty()){
 	LogIO os(LogOrigin("MSConcat", "copyField"));
 	os << LogIO::SEVERE << "Field " << f << " (" << otherFieldCols.name()(f) << ", to be appended)"
@@ -2308,7 +2308,7 @@ Block<uInt>  MSConcat::copyField(const MeasurementSet& otherms) {
 	    try{
 	      MDirection tMDir = fieldCols.phaseDirMeas(newFld, validityRange(i));
 	    }
-	    catch(AipsError x){
+	    catch(AipsError& x){
 	      canUseThisEntry = False;
 	      ss << validityRange(i) << ", ";
 	    }	  
@@ -2771,7 +2771,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const uInt
       try {
 	areEquivalent = areEQ(sourceCol.position(), rowi, rowj);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
 	// row has invalid data
 	areEquivalent = True;
       }
@@ -2781,7 +2781,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const uInt
       try {
 	areEquivalent = areEQ(sourceCol.pulsarId(), rowi, rowj);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
 	// row has invalid data
 	areEquivalent = True;
       }
@@ -2791,7 +2791,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const uInt
       try {
 	areEquivalent = areEQ(sourceCol.restFrequency(), rowi, rowj);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
 	// row has invalid data
 	areEquivalent = True;
       }
@@ -2801,7 +2801,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const uInt
       try {
 	areEquivalent = areEQ(sourceCol.sysvel(), rowi, rowj);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
 	// row has invalid data
 	areEquivalent = True;
       }
@@ -2811,7 +2811,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const uInt
       try {
 	areEquivalent = areEQ(sourceCol.transition(), rowi, rowj);
       }
-      catch (AipsError x) {
+      catch (AipsError& x) {
 	// row has invalid data
 	areEquivalent = True;
       }

--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -298,7 +298,7 @@ void MSLister::listHeader()
     // List the data
     listData(pagerows, listfile);
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     logStream_p << LogOrigin("MSLister","list",WHERE)
             << LogIO::SEVERE << "Caught exception: " << x.getMesg()
             << LogIO::POST;
@@ -525,7 +525,7 @@ void MSLister::selectvis(const String& timerange,
     //initialize(*pMS_p,False);
     throw(AipsError("Error in data selection specification."));
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     // Re-initialize with the existing MS
     logStream_p << LogOrigin("MSLister","selectvis",WHERE)
             << LogIO::SEVERE << "Caught exception: " << x.getMesg()
@@ -1138,7 +1138,7 @@ void MSLister::listData(const int pageRows,
     logStream_p << LogIO::DEBUG1 << "End: MSLister::listData"
                 << LogIO::POST;
   } // end try
-  catch(AipsError x){
+  catch(AipsError& x){
     logStream_p << LogIO::SEVERE << "Caught exception: " << x.getMesg()
                 << LogIO::POST;
     throw(AipsError("Error in MSLister::listData"));
@@ -1322,7 +1322,7 @@ void MSLister::polarizationParse(String correlation) {
 	} // end try
 
 	// Catch an exception if a selected correlation does not exist.
-	catch(AipsError x){
+	catch(AipsError& x){
 		logStream_p << LogIO::SEVERE << "Caught exception: " << x.getMesg()
                 		<< LogIO::POST;
 		throw(AipsError("Error in MSLister::polarizationParse"));

--- a/ms/MSOper/test/tMSDerivedValues.cc
+++ b/ms/MSOper/test/tMSDerivedValues.cc
@@ -115,7 +115,7 @@ int main()
     }
     */
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught exception " << endl;
 	cout << x.getMesg() << endl;
 	return 1;

--- a/ms/MSOper/test/tMSReader.cc
+++ b/ms/MSOper/test/tMSReader.cc
@@ -70,7 +70,7 @@ int main(int argc, const char* argv[])
 	}
 	timer.show("read to end : ");
 	cout << "done" << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cerr << "Exception : " << x.getMesg() << endl;
     } 
  

--- a/ms/MSSel/test/tMSCorrGram.cc
+++ b/ms/MSSel/test/tMSCorrGram.cc
@@ -94,7 +94,7 @@ int main(int argc, const char* argv[])
     else {
       cout << "failed to parse expression" << endl;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "ERROR: " << x.getMesg() << endl;
     return 1;
   } 

--- a/ms/MSSel/test/tMSFieldGram.cc
+++ b/ms/MSSel/test/tMSFieldGram.cc
@@ -94,7 +94,7 @@ int main(int argc, const char* argv[])
       }
     delete mssel;
   }
-  catch (AipsError x) 
+  catch (AipsError& x) 
     {
       cout << "ERROR: " << x.getMesg() << endl;
       return 1;

--- a/ms/MSSel/test/tMSScanGram.cc
+++ b/ms/MSSel/test/tMSScanGram.cc
@@ -91,7 +91,7 @@ int main(int argc, const char* argv[])
     else {
       cout << "ERROR: failed to parse expression " << endl;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "ERROR: " << x.getMesg() << endl;
     return 1;
   } 

--- a/ms/MSSel/test/tMSSpwGram.cc
+++ b/ms/MSSel/test/tMSSpwGram.cc
@@ -95,7 +95,7 @@ int main(int argc, const char* argv[])
     else {
       cout << "failed to parse expression" << endl;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "ERROR: " << x.getMesg() << endl;
     return 1;
   } 

--- a/ms/MSSel/test/tMSTimeGram.cc
+++ b/ms/MSSel/test/tMSTimeGram.cc
@@ -92,7 +92,7 @@ int main(int argc, const char* argv[])
 	cout << "selected table has rows " << mssel->nrow() << endl;
       delete mssel;
     } 
-  catch (AipsError x) 
+  catch (AipsError& x) 
     {
       cout << "ERROR: " << x.getMesg() << endl;
       return 1;

--- a/ms/MSSel/test/tMSUvDistGram.cc
+++ b/ms/MSSel/test/tMSUvDistGram.cc
@@ -93,7 +93,7 @@ int main(int argc, const char* argv[])
     else {
       cout << "failed to parse expression" << endl;
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "ERROR: " << x.getMesg() << endl;
     return 1;
   } 

--- a/ms/MeasurementSets/MSFieldColumns.cc
+++ b/ms/MeasurementSets/MSFieldColumns.cc
@@ -245,7 +245,7 @@ matchReferenceDir(uInt row, const MVDirection& dirVal, const Double& sepInRad,
   try{
     mvdir = referenceDirMeas(row, time).getAngle();
   }
-  catch(AipsError x){
+  catch(AipsError& x){
     return False;
   }
   if (dirVal.separation(mvdir) < sepInRad) {
@@ -262,7 +262,7 @@ matchDelayDir(uInt row, const MVDirection& dirVal, const Double& sepInRad,
   try{
     mvdir = delayDirMeas(row, time).getAngle();
   }
-  catch(AipsError x){
+  catch(AipsError& x){
     return False;
   }
   if (dirVal.separation(mvdir) < sepInRad) {
@@ -279,7 +279,7 @@ matchPhaseDir(uInt row, const MVDirection& dirVal, const Double& sepInRad,
   try{
     mvdir = phaseDirMeas(row, time).getAngle();
   }
-  catch(AipsError x){
+  catch(AipsError& x){
     return False;
   }
   if (dirVal.separation(mvdir) < sepInRad) {

--- a/ms/MeasurementSets/test/tMSColumns.cc
+++ b/ms/MeasurementSets/test/tMSColumns.cc
@@ -187,7 +187,7 @@ int main() {
       ms.markForDelete();
     }
     return 0;  
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() <<endl;
     return 1;
   } 

--- a/ms/MeasurementSets/test/tMSDataDescBuffer.cc
+++ b/ms/MeasurementSets/test/tMSDataDescBuffer.cc
@@ -91,7 +91,7 @@ int main() {
       table.markForDelete();
     }
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/ms/MeasurementSets/test/tMSFieldEphem.cc
+++ b/ms/MeasurementSets/test/tMSFieldEphem.cc
@@ -340,7 +340,7 @@ int main() {
 
 	try{
 	  MDirection xDir = msfc.delayDirMeas(row, 12345.); // time outside validity range
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  //cout <<  x.getMesg() <<endl;
 	  didThrow = True;
 	}
@@ -349,7 +349,7 @@ int main() {
 	didThrow = False;
 	try{
 	  MRadialVelocity xmradvel = msfc.radVelMeas(row, 12345.); // time outside validity range
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  //cout <<  x.getMesg() <<endl;
 	  didThrow = True;
 	}
@@ -358,7 +358,7 @@ int main() {
 	didThrow = False;
 	try{
 	  MRadialVelocity xrho = msfc.rho(row, 12345.); // time outside validity range
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	  //cout <<  x.getMesg() <<endl;
 	  didThrow = True;
 	}
@@ -384,7 +384,7 @@ int main() {
       ms.markForDelete();
     }
     return 0;  
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() <<endl;
     return 1;
   } 

--- a/ms/MeasurementSets/test/tMeasurementSet.cc
+++ b/ms/MeasurementSets/test/tMeasurementSet.cc
@@ -314,7 +314,7 @@ uInt tConstructors(const String& msName)
     Bool thrown=False;
     try {
 	MeasurementSet badms("tMeasurementSet_tmp.badmsTable");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	thrown = True;
     } 
     if (!thrown) errCount++;
@@ -325,7 +325,7 @@ uInt tConstructors(const String& msName)
     thrown=False;
     try {
 	MeasurementSet badms("tMeasurementSet_tmp.badmsTable","");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	thrown = True;
     } 
     if (!thrown) errCount++;
@@ -340,7 +340,7 @@ uInt tConstructors(const String& msName)
     try {
 	Table badtab("tMeasurementSet_tmp.badmsTab;e","");
 	MeasurementSet badms(badtab);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	thrown = True;
     } 
     if (!thrown) errCount++;
@@ -377,7 +377,7 @@ uInt tConstructors(const String& msName)
 	try {
 	    MSAntenna msant2b("tMeasurementSet_tmp.msant2","badAntTD",Table::Old);
 	    msant2b.markForDelete();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    thrown = True;
 	} 
 	// No exception is thrown here, even though the td name is wrong..
@@ -395,7 +395,7 @@ uInt tConstructors(const String& msName)
 	    SetupNewTable newtab("tMeasurementSet_tmp.msant3b",
 				 MSFeed::requiredTableDesc(),Table::New);
 	    MSAntenna msant3b(newtab,5);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    thrown = True;
 	} 
 	if (!thrown) errCount++;
@@ -423,7 +423,7 @@ uInt tConstructors(const String& msName)
 	    Table tab(newtab4);
 	    tab.markForDelete();
 	    MSAntenna msant4b(tab);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    thrown = True;
 	} 
 	if (!thrown) errCount++;
@@ -438,7 +438,7 @@ uInt tConstructors(const String& msName)
 		Table tab("tMeasurementSet_tmp.badmsantTable","badAntTD",Table::New);
 	    }
 	    MSAntenna msant5b("tMeasurementSet_tmp.badmsantTable");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    thrown = True;
 	} 
 	if (!thrown) errCount++;
@@ -451,7 +451,7 @@ uInt tConstructors(const String& msName)
 	    MSFeed msfeed("msfeed", Table::New);
 	    msfeed.markForDelete();
 	    MSAntenna msant6b(msfeed);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    thrown = True;
 	} 
 	if (!thrown) errCount++;
@@ -521,7 +521,7 @@ uInt tSetupNewTabError()
     Bool thrown = False;
     try {
 	MeasurementSet ms(setup,0);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	thrown = True;
     } 
     if (!thrown) {
@@ -542,7 +542,7 @@ uInt tDestructorError(const String& sdmsName)
 	MeasurementSet ms(sdmsName);
 	// remove a column
 	ms.removeColumn(MS::columnName(MS::TIME));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	thrown = True;
     } 
 
@@ -626,7 +626,7 @@ int main() {
     }
 
     return errCount;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
       cerr << x.getMesg() << endl;
   } 
   return 1;

--- a/ms/MeasurementSets/test/tStokesConverter.cc
+++ b/ms/MeasurementSets/test/tStokesConverter.cc
@@ -120,7 +120,7 @@ int main()
 	}
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Exception: "<< x.getMesg() <<endl;
   } 
   if (err==0) cout<<"OK"<<endl;

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2625,7 +2625,7 @@ void FITSIDItoMS1::fillFeedTable() {
   try{
     timeint.attach(anTab, "TIME_INTERVAL");
   }
-  catch(AipsError){
+  catch(AipsError&){
     timeintd.attach(anTab, "TIME_INTERVAL");
     *itsLog << LogIO::NORMAL << "Note: this ANTENNA table uses double precision for TIME_INTERVAL. Convention is single."
 	    << LogIO::POST;
@@ -2648,7 +2648,7 @@ void FITSIDItoMS1::fillFeedTable() {
     polaa.attach(anTab, "POLAA");
     polab.attach(anTab, "POLAB");
   }
-  catch(AipsError x){
+  catch(AipsError& x){
     polaaS.attach(anTab, "POLAA");
     polabS.attach(anTab, "POLAB");
     POLAisScalar = True;
@@ -2962,14 +2962,14 @@ void FITSIDItoMS1::fillFieldTable()
     try{
       foffset.attach(suTab,"FREQOFF"); // fq. offset  
     }
-    catch(AipsError x){
+    catch(AipsError& x){
       foffsetD.attach(suTab,"FREQOFF"); // fq. offset  
       *itsLog << LogIO::WARN << "Column FREQOFF is Double but should be Float." << LogIO::POST;
     }
     sysvel.attach(suTab,"SYSVEL"); // sys vel. (m/s)  
     restfreq.attach(suTab,"RESTFREQ"); // rest freq. (hz)  
   }
-  catch(AipsError x){
+  catch(AipsError& x){
     ifluxS.attach(suTab,"IFLUX"); // I (Jy)
     qfluxS.attach(suTab,"QFLUX"); // Q 
     ufluxS.attach(suTab,"UFLUX"); // U 
@@ -3165,7 +3165,7 @@ Bool FITSIDItoMS1::fillSysCalTable()
       dualPol=True;
     }
   }
-  catch(AipsError){
+  catch(AipsError&){
     tsys_1S.attach(tyTab, "TSYS_1");
     if(tyTab.tableDesc().isColumn("TSYS_2")) {
       tsys_2S.attach(tyTab, "TSYS_2"); // this column is optional
@@ -3255,7 +3255,7 @@ Bool FITSIDItoMS1::fillFlagCmdTable()
   try {
     bands.attach(flagTab, "BANDS");
   }
-  catch(AipsError x){
+  catch(AipsError& x){
     bandsS.attach(flagTab, "BANDS");
     BANDSisScalar = True;
   }

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -2050,7 +2050,7 @@ void MSFitsInput::fillSpectralWindowTable(BinaryTable& bt, Int nSpW)
       colIFFreq.getColumn(ifFreq);
       colChWidth.getColumn(chWidth);
       colTotalBandwidth.getColumn(totalBandwidth);
-    }catch(AipsError x) {
+    }catch(AipsError& x) {
       _log << LogOrigin("MSFitsInput", "fillSpectralWindowTable")
              << LogIO::DEBUG1 << x.getMesg() << LogIO::POST;
     }
@@ -3615,7 +3615,7 @@ void MSFitsInput::fillFieldTable(BinaryTable& bt) {
       restfreq.getColumn(_restFreq);
       sysvel.getColumn(_sysVel);
     }
-    catch (std::exception x) {
+    catch (std::exception& x) {
       if(noif>1){
 	_log << LogOrigin("MSFitsInput", __func__) << LogIO::WARN
 	       << x.what() << ": " << "Inconsistent setup of RESTFREQ and LSRVEL columns." << endl

--- a/msfits/MSFits/test/tMSConcat.cc
+++ b/msfits/MSFits/test/tMSConcat.cc
@@ -83,7 +83,7 @@ int main(int argc, const char* argv[])
     MSConcat mscat(ms);
     mscat.concatenate(appendedMS);
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/msfits/MSFits/test/tMSFitsSelection.cc
+++ b/msfits/MSFits/test/tMSFitsSelection.cc
@@ -124,7 +124,7 @@ int main(int argc, const char* argv[])
           cout << "selected table has rows " << mssel.nrow() << endl;
         }
     }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "ERROR: " << x.getMesg() << endl;
     }
 

--- a/msfits/MSFits/test/tfits2ms.cc
+++ b/msfits/MSFits/test/tfits2ms.cc
@@ -59,7 +59,7 @@ int main(int argc, const char* argv[])
       msfitsin.readFitsFile();
     }
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL!!!" << endl;
     return 1;

--- a/msfits/apps/ms2uvfits.cc
+++ b/msfits/apps/ms2uvfits.cc
@@ -123,7 +123,7 @@ int main (int argc, const char* argv[])
 				    column, -1, -1, -1,
 				    writeSyscal, multisource,
 				    combinespw, writestation, sensitivity);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
 	return 1;
     } 

--- a/scimath/Fitting/FitGaussian.tcc
+++ b/scimath/Fitting/FitGaussian.tcc
@@ -386,7 +386,7 @@ Matrix<T> FitGaussian<T>::fit(const Matrix<T>& pos, const Vector<T>& f,
     
     try {
        solution = fitter.fit(pos, f, sigma);
-    } catch (AipsError fittererror) {
+    } catch (AipsError& fittererror) {
       string errormessage;
       errormessage = fittererror.getMesg();
       os << LogIO::DEBUG1 << "Unsuccessful - Error during fitting." << LogIO::POST;

--- a/scimath/Fitting/test/dConstraints.cc
+++ b/scimath/Fitting/test/dConstraints.cc
@@ -173,7 +173,7 @@ int main (int argc, const char* argv[])
     delete gauss;
 
     cout << "---------------------------------------------------" << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
   

--- a/scimath/Fitting/test/tFitGaussian.cc
+++ b/scimath/Fitting/test/tFitGaussian.cc
@@ -77,7 +77,7 @@ int main()
 
   try {
     solution = fitgauss.fit(pos, f);
-  } catch (AipsError err) {
+  } catch (AipsError& err) {
     cout << "ERROR: " << err.getMesg() << endl;
     fail = 1;
   }
@@ -107,7 +107,7 @@ int main()
   solution.resize();
   try {
     solution = fitgauss.fit(pos, f);
-  } catch (AipsError err) {
+  } catch (AipsError& err) {
     cout << "ERROR: " << err.getMesg() << endl;
     fail = 1;
   }
@@ -148,7 +148,7 @@ int main()
   solution.resize();
   try {
     solution = fitgauss.fit(pos, f);
-  } catch (AipsError err) {
+  } catch (AipsError& err) {
     cout << "ERROR: " << err.getMesg() << endl;
     fail = 1;
   }
@@ -179,7 +179,7 @@ int main()
   solution.resize();
   try {
     solution = fitgauss.fit(pos, f, 0.001);
-  } catch (AipsError err) {
+  } catch (AipsError& err) {
     cout << "ERROR: " << err.getMesg() << endl;
     fail = 1;
   }
@@ -223,7 +223,7 @@ int main()
   solution.resize();
   try {
     solution = fitgauss.fit(pos, f, 0.01, 256);
-  } catch (AipsError err) {
+  } catch (AipsError& err) {
     cout << "ERROR: " << err.getMesg() << endl;
     fail = 1;
   }

--- a/scimath/Fitting/test/tLSQFit.cc
+++ b/scimath/Fitting/test/tLSQFit.cc
@@ -1483,7 +1483,7 @@ int main() {
     }
 
     cout << "---------------------------------------------------" << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
   return 0;

--- a/scimath/Fitting/test/tLSQaips.cc
+++ b/scimath/Fitting/test/tLSQaips.cc
@@ -1197,7 +1197,7 @@ int main() {
     }
     
     cout << "---------------------------------------------------" << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;
   }
   return 0;

--- a/scimath/Functionals/SerialHelper.cc
+++ b/scimath/Functionals/SerialHelper.cc
@@ -47,7 +47,7 @@ Bool SerialHelper::getFuncType(String& ftype) const
        if(!ftype.size() ){
 	   throw InvalidSerializationError("Empty value for functype field");
         }
-    } catch (AipsError (x)) {
+    } catch (AipsError& x) {
 	throw InvalidSerializationError("Wrong type for functype field");
     }
     return True;

--- a/scimath/Functionals/test/tChebyshev.cc
+++ b/scimath/Functionals/test/tChebyshev.cc
@@ -204,7 +204,7 @@ int main() {
 			 tmp(0) == -15.0 && tmp(1) == 15.0 &&
 			 def == 70.0);
     }
-    catch (AipsError ex) {
+    catch (AipsError& ex) {
 	cerr << "Exception: " << ex.getMesg() << endl;
 	exit(1);
     }

--- a/scimath/Functionals/test/tConstantND.cc
+++ b/scimath/Functionals/test/tConstantND.cc
@@ -156,7 +156,7 @@ int main() {
 		     near(y61(1), y51[1]) &&
 		     near(y61(2), y51[2]));
 		     */
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Exception : " << x.getMesg() << endl;
   } 
 

--- a/scimath/Functionals/test/tFuncExpression.cc
+++ b/scimath/Functionals/test/tFuncExpression.cc
@@ -124,7 +124,7 @@ int main() {
       cout << expr(3.5) << ", " << expr(0.0) << endl;
       cout << "----------------------------------------------------" << endl;
     }
-  }  catch (AipsError x) {
+  }  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/scimath/Functionals/test/tGaussian2D.cc
+++ b/scimath/Functionals/test/tGaussian2D.cc
@@ -290,7 +290,7 @@ int main() {
       return 0;
     }
 
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "Failed" << endl;
     return 1;

--- a/scimath/Functionals/test/tGaussianND.cc
+++ b/scimath/Functionals/test/tGaussianND.cc
@@ -425,7 +425,7 @@ int main(){
     return 0;
   }
 
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/scimath/Functionals/test/tHyperPlane.cc
+++ b/scimath/Functionals/test/tHyperPlane.cc
@@ -127,7 +127,7 @@ int main() {
 		     near(y61(0), y51[0]) &&
 		     near(y61(1), y51[1]) &&
 		     near(y61(2), y51[2]));
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Exception : " << x.getMesg() << endl;
   } 
 

--- a/scimath/Functionals/test/tSimButterworthBandpass.cc
+++ b/scimath/Functionals/test/tSimButterworthBandpass.cc
@@ -96,7 +96,7 @@ int main() {
 	rec2.get(RecordFieldId("maxOrder"), maxo);
 	AlwaysAssertExit(mino == 2 && maxo ==3);
     }
-    catch (AipsError ex) {
+    catch (AipsError& ex) {
 	cerr << "Exception: " << ex.getMesg() << endl;
 	exit(1);
     }

--- a/scimath/Mathematics/test/tCombinatorics.cc
+++ b/scimath/Mathematics/test/tCombinatorics.cc
@@ -50,7 +50,7 @@ int main() {
             try {
                 Combinatorics::choose(3,5);
             }
-            catch (AipsError) {
+            catch (AipsError&) {
                 res = True;
             }
             AlwaysAssert(res, AipsError);
@@ -59,7 +59,7 @@ int main() {
 
         cout << "ok" << endl;
     }
-    catch (AipsError x) {
+    catch (AipsError& x) {
         cerr << x.getMesg() << endl;
         return 1;
     }

--- a/scimath/Mathematics/test/tFFTServer.cc
+++ b/scimath/Mathematics/test/tFFTServer.cc
@@ -2304,7 +2304,7 @@ int main()
       run_tests<Double, DComplex>();
 
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/scimath/Mathematics/test/tFFTServer2.cc
+++ b/scimath/Mathematics/test/tFFTServer2.cc
@@ -1286,7 +1286,7 @@ int main() {
 			      5*FLT_EPSILON), AipsError);
     }
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/scimath/Mathematics/test/tGaussianBeam.cc
+++ b/scimath/Mathematics/test/tGaussianBeam.cc
@@ -69,7 +69,7 @@ int main() {
             GaussianBeam beam3(majAx, minAx, pa);
 
         }
-        catch (AipsError x) {
+        catch (AipsError& x) {
             cout << "Exception thrown as expected: " << x.getMesg() << endl;
             except = True;
         }
@@ -81,7 +81,7 @@ int main() {
             GaussianBeam beam3(majAx, minAx, pa);
 
         }
-        catch (AipsError x) {
+        catch (AipsError& x) {
             cout << "Exception thrown as expected: " << x.getMesg() << endl;
             except = True;
         }
@@ -97,7 +97,7 @@ int main() {
             // bogus units
             beam.getArea("arcsec");
         }
-        catch (AipsError x) {
+        catch (AipsError& x) {
             cout << "Exception thrown as expected: " << x.getMesg() << endl;
             except = True;
         }
@@ -114,7 +114,7 @@ int main() {
             beam2 = GaussianBeam::fromRecord(rec);
 
         }
-        catch (AipsError x) {
+        catch (AipsError& x) {
             cout << "Exception thrown as expected: " << x.getMesg() << endl;
             except = True;
         }
@@ -144,7 +144,7 @@ int main() {
             }
         }
     }
-    catch (AipsError x) {
+    catch (AipsError& x) {
         cout << x.getMesg() << endl;
         cout << "FAIL" << endl;
         return 1;

--- a/scimath/Mathematics/test/tHistAcc.cc
+++ b/scimath/Mathematics/test/tHistAcc.cc
@@ -109,7 +109,7 @@ int main()
 
       cout << " *** end of tHistAcc *** " << endl;  
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << x.getMesg() << endl;
         return 1;                       // unexpected error
     } 

--- a/scimath/Mathematics/test/tInterpolateArray1D.cc
+++ b/scimath/Mathematics/test/tInterpolateArray1D.cc
@@ -314,7 +314,7 @@ int main()
       run_nearest_tests<Double,Float>();
 
   }
-  catch (AipsError x) {
+  catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/scimath/Mathematics/test/tMathFunc.cc
+++ b/scimath/Mathematics/test/tMathFunc.cc
@@ -251,7 +251,7 @@ try{
    delete p1;
    delete p2;
 
- } catch(AipsError x) {
+ } catch(AipsError& x) {
    cout << "Unexpected exception: " << x.getMesg() << endl;
    return 1;
   } 

--- a/scimath/Mathematics/test/tStatAcc.cc
+++ b/scimath/Mathematics/test/tStatAcc.cc
@@ -135,7 +135,7 @@ int main()
       s.printSummaryList(cout,"Test of s.printSummaryList");
 
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << x.getMesg() << endl;
         return 1;                       // unexpected error
     } 

--- a/scimath/Mathematics/test/tVanVleck.cc
+++ b/scimath/Mathematics/test/tVanVleck.cc
@@ -540,7 +540,7 @@ int main() {
       cout << "thresh(9,zerolag) : " << vv.thresh(9,zerolag) << endl;
     }
     
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cerr << x.getMesg() << endl;
     cout << "FAIL" << endl;
     return 1;

--- a/tables/DataMan/test/dRetypedArrayEngine.cc
+++ b/tables/DataMan/test/dRetypedArrayEngine.cc
@@ -206,7 +206,7 @@ int main (int argc, const char*[])
 	a( (argc<2));
 	b();
 	c();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tBitFlagsEngine.cc
+++ b/tables/DataMan/test/tBitFlagsEngine.cc
@@ -280,7 +280,7 @@ int main ()
   try {
     createTable();
     readTable();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tCompressComplex.cc
+++ b/tables/DataMan/test/tCompressComplex.cc
@@ -487,7 +487,7 @@ int main ()
     writeData (True, True);
     if (!checkDataSD (True)) sts=1;
     testSpeed();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tCompressFloat.cc
+++ b/tables/DataMan/test/tCompressFloat.cc
@@ -339,7 +339,7 @@ int main ()
     writeData (True);
     if (! checkData (True)) sts=1;
     testSpeed();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tForwardCol.cc
+++ b/tables/DataMan/test/tForwardCol.cc
@@ -74,7 +74,7 @@ int main ()
 	check("tForwardCol_tmp.data1", 0, 10);
 	check("tForwardCol_tmp.data2", 10, 10);
 	check("tForwardCol_tmp.data3", 10, 10);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tForwardColRow.cc
+++ b/tables/DataMan/test/tForwardColRow.cc
@@ -71,7 +71,7 @@ int main ()
 	check("tForwardColRow_tmp.data1", 0, 0);
 	check("tForwardColRow_tmp.data2", 0, 0);
 	check("tForwardColRow_tmp.data3", 0, 0);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tIncrementalStMan.cc
+++ b/tables/DataMan/test/tIncrementalStMan.cc
@@ -81,7 +81,7 @@ int main (int argc, const char* argv[])
 	e (20);
 	a (nr, 0);
 	f();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -491,12 +491,12 @@ void f()
     //# Try to change some arrays (which cannot be done).
     try {
 	arr1.put (0, vecf);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;         // shape cannot change
     } 
     try {
 	arr7.put (0, vecb);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;         // shape cannot change
     } 
     Vector<Bool> removedRows(20);

--- a/tables/DataMan/test/tMappedArrayEngine.cc
+++ b/tables/DataMan/test/tMappedArrayEngine.cc
@@ -58,7 +58,7 @@ int main ()
     try {
 	a();
 	b();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tMemoryStMan.cc
+++ b/tables/DataMan/test/tMemoryStMan.cc
@@ -140,7 +140,7 @@ int main ()
 	deleteRows      (aNewNrRows);
 
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tSSMStringHandler.cc
+++ b/tables/DataMan/test/tSSMStringHandler.cc
@@ -109,7 +109,7 @@ int main (int argc, const char* argv[])
 	addSmallColumn     ();
 	deleteColumn       ("Col-1");
 	addEmptyColumn     ();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tScaledArrayEngine.cc
+++ b/tables/DataMan/test/tScaledArrayEngine.cc
@@ -57,7 +57,7 @@ int main ()
     try {
 	a();
 	b();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tScaledComplexData.cc
+++ b/tables/DataMan/test/tScaledComplexData.cc
@@ -60,7 +60,7 @@ int main () {
     try {
 	a();
 	b();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -151,7 +151,7 @@ void a()
         newtab2.bindColumn ("source2", engine1);
         try {
     	Table tab2(newtab2, 10);                // bound to incorrect column
-        } catch (AipsError x) {
+        } catch (AipsError& x) {
     	cout << x.getMesg() << endl;
         } 
     }

--- a/tables/DataMan/test/tStArrayFile.cc
+++ b/tables/DataMan/test/tStArrayFile.cc
@@ -74,7 +74,7 @@ int main (int argc, const char* argv[])
 	    c (False, off1, off2, off3, off4);
 	    c (False, offc1, offc2, offc3, offc4);
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tStMan.cc
+++ b/tables/DataMan/test/tStMan.cc
@@ -682,7 +682,7 @@ int main (int argc, const char* argv[])
     doTest (nrrow, st2);
     IncrementalStMan st3(max(bucketSize,1000u), False);
     doTest (nrrow, st3);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   }

--- a/tables/DataMan/test/tStMan1.cc
+++ b/tables/DataMan/test/tStMan1.cc
@@ -172,7 +172,7 @@ int main (int argc, const char* argv[])
     cout << endl << "IncrementalStMan" << endl;
     IncrementalStMan st3(max(bucketSize,1000u), False);
     doTest (nrrow, st3, flushnr);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tStandardStMan.cc
+++ b/tables/DataMan/test/tStandardStMan.cc
@@ -216,7 +216,7 @@ int main (int argc, const char* argv[])
         testInd();
         testInd2();
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tTiledBool.cc
+++ b/tables/DataMan/test/tTiledBool.cc
@@ -126,7 +126,7 @@ int main()
     testAll (IPosition(2,4,256), IPosition(3,4,256,1));
     testAll (IPosition(2,4,256), IPosition(3,4,257,1));
     testAll (IPosition(2,4,256), IPosition(3,4,255,1));
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tTiledCellStM_1.cc
+++ b/tables/DataMan/test/tTiledCellStM_1.cc
@@ -105,7 +105,7 @@ int main (int argc, const char* argv[])
 #ifdef PABLO_IO
         closePablo();
 #endif
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tTiledCellStMan.cc
+++ b/tables/DataMan/test/tTiledCellStMan.cc
@@ -66,7 +66,7 @@ int main () {
 	readTable(TSMOption::Buffer);
 	writeNoHyper(TSMOption::MMap);
 	readTable(TSMOption::Cache);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tTiledColumnStMan.cc
+++ b/tables/DataMan/test/tTiledColumnStMan.cc
@@ -68,7 +68,7 @@ int main () {
 	readTable(TSMOption::Buffer, False);
         writeFixed(TSMOption::Buffer);
 	readTable(TSMOption::Cache, False);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     }

--- a/tables/DataMan/test/tTiledDataStMan.cc
+++ b/tables/DataMan/test/tTiledDataStMan.cc
@@ -62,7 +62,7 @@ int main()
     try {
 	a ();
 	b ();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tTiledEmpty.cc
+++ b/tables/DataMan/test/tTiledEmpty.cc
@@ -61,7 +61,7 @@ int main() {
       readTable(TSMOption::Buffer, i==0);
       readTable(TSMOption::MMap, i==0);
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tTiledFileAccess.cc
+++ b/tables/DataMan/test/tTiledFileAccess.cc
@@ -76,7 +76,7 @@ int main()
 							 shape))));
       tfa.showCacheStatistics (cout);
       cout << tfa.cacheSize() << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }
@@ -117,7 +117,7 @@ int main()
 							 shape))));
       tfa.showCacheStatistics (cout);
       cout << tfa.cacheSize() << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }
@@ -156,7 +156,7 @@ int main()
       AlwaysAssertExit (allEQ (arr, tfal.getDComplex (slicer)));
       tfac.put (tfac.getDComplex(slicer) + DComplex(1,2), slicer);
       tfal.put (tfal.getDComplex(slicer) + DComplex(3,5), slicer);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }
@@ -181,7 +181,7 @@ int main()
 				 tfal.getDComplex (Slicer(st,leng))));
       }
       cout << end << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }
@@ -215,7 +215,7 @@ int main()
 						    uChar(255))));
       AlwaysAssertExit (tfac.shape() == shape);
       AlwaysAssertExit (tfac.tileShape() == IPosition(2,10,5));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }
@@ -249,7 +249,7 @@ int main()
 						    short(-32768))));
       AlwaysAssertExit (tfac.shape() == shape);
       AlwaysAssertExit (tfac.tileShape() == IPosition(2,17,4));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }
@@ -264,7 +264,7 @@ int main()
       cout << TiledFileAccess::makeTileShape (IPosition(2,17,40), 33) << endl;
       cout << TiledFileAccess::makeTileShape (IPosition(2,17,40), 15) << endl;
       cout << TiledFileAccess::makeTileShape (IPosition(2,17,40), 3) << endl;
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Exception: " << x.getMesg() << endl;
       return 1;
     }

--- a/tables/DataMan/test/tTiledShapeStM_1.cc
+++ b/tables/DataMan/test/tTiledShapeStM_1.cc
@@ -328,7 +328,7 @@ void writeVar (int acc, Bool chk, const IPosition& shape,
     }
     // Sync to measure true IO.
     table.flush(True);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
   }
   timer.show("Write     ");
@@ -457,7 +457,7 @@ int main (int argc, const char* argv[])
 	ok = False;
       }
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/DataMan/test/tTiledShapeStMan.cc
+++ b/tables/DataMan/test/tTiledShapeStMan.cc
@@ -617,7 +617,7 @@ int main () {
 
         writeFlags();
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tTiledStMan.cc
+++ b/tables/DataMan/test/tTiledStMan.cc
@@ -61,7 +61,7 @@ int main (int argc, const char* argv[])
 	istringstream istr1(argv[1]);
 	istr1 >> tileSize;
 	doIt (tileSize);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tVSCEngine.cc
+++ b/tables/DataMan/test/tVSCEngine.cc
@@ -59,7 +59,7 @@ int main ()
     try {
 	a();
 	b();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tVirtColEng.cc
+++ b/tables/DataMan/test/tVirtColEng.cc
@@ -72,7 +72,7 @@ int main()
     try {
 	a();
 	b();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/DataMan/test/tVirtualTaQLColumn.cc
+++ b/tables/DataMan/test/tVirtualTaQLColumn.cc
@@ -75,7 +75,7 @@ int main ()
 	check (tab2, True);
       }
       testSelect();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/LogTables/NewFile.cc
+++ b/tables/LogTables/NewFile.cc
@@ -106,7 +106,7 @@ Bool NewFile::valueOK(const String &value, String &error) const
 			    try {
 				Table::deleteTable(value);
 				removed = True;
-			    } catch (AipsError xxx) {
+			    } catch (AipsError& xxx) {
 				removed = False;
 				extra_error = String("Error deleting table ")
 				    + value + ":" + xxx.getMesg();
@@ -118,7 +118,7 @@ Bool NewFile::valueOK(const String &value, String &error) const
 		    sfile.remove();
 		    removed = True;
 		}
-	    } catch (AipsError x) {
+	    } catch (AipsError& x) {
 		extra_error = x.getMesg();
 		removed = False;
 	    } 

--- a/tables/LogTables/test/tLogging.cc
+++ b/tables/LogTables/test/tLogging.cc
@@ -366,7 +366,7 @@ void testLogSink()
     Bool caught = False;
     try {
         sink5.postThenThrow(message, AipsError());
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         caught = True;
 	AlwaysAssertExit(x.getMesg().contains("test"));
 	AlwaysAssertExit(logTable.nrow() == 5 && logTable2.nrow() == 7);
@@ -377,7 +377,7 @@ void testLogSink()
     caught = False;
     try {
         sink5.postGloballyThenThrow(message);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         caught = True;
 	AlwaysAssertExit(x.getMesg().contains("test"));
 	AlwaysAssertExit(logTable.nrow() == 5 && logTable2.nrow() == 8);
@@ -458,7 +458,7 @@ void testLogIO()
 	try {
 	    //     void postThenThrow();
 	    os << "This SHOULD post" << LogIO::EXCEPTION;
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    caught = True;
 	} 
 	AlwaysAssert(caught, AipsError);
@@ -540,7 +540,7 @@ int main()
 	testLogIO();
 	testLogMemory();
 	testLogTable();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "Caught an exception : " << x.getMesg() << endl;
 	exit(1);
     } 

--- a/tables/TaQL/test/tRecordExpr.cc
+++ b/tables/TaQL/test/tRecordExpr.cc
@@ -147,7 +147,7 @@ int main()
 {
   try {
     doIt();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   } catch (...) {

--- a/tables/TaQL/test/tRecordGram.cc
+++ b/tables/TaQL/test/tRecordGram.cc
@@ -186,7 +186,7 @@ void doIt()
     Bool err = False;
     try {
       TableExprNode expr8 (RecordGram::parse (rec, "rownumber() > 3"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << "Expected exception:\n" << x.getMesg() << endl;
       err = True;
     }
@@ -266,7 +266,7 @@ int main()
   try {
     doIt();
     testExpr2();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   } catch (...) {

--- a/tables/TaQL/test/tRecordGramTable.cc
+++ b/tables/TaQL/test/tRecordGramTable.cc
@@ -158,7 +158,7 @@ int main (int argc, const char* argv[])
   }
   try {
     doIt(argv[1]);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Unexpected exception: " << x.getMesg() << endl;
     return 1;
   } catch (...) {

--- a/tables/TaQL/test/tTableGram.cc
+++ b/tables/TaQL/test/tTableGram.cc
@@ -134,7 +134,7 @@ int main (int argc, const char* argv[])
     // Do some interactive tests.
       docomm();
     }
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "\nCaught an exception: " << x.getMesg() << endl;
     return 1;
   } 
@@ -154,7 +154,7 @@ void docomm()
       break;
     try {
       seltab (str);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     } 
   }

--- a/tables/Tables/test/ascii2Table.cc
+++ b/tables/Tables/test/ascii2Table.cc
@@ -75,7 +75,7 @@ int main (int argc, const char* argv[])
 	    cout << "Loaded " << tab.nrow() << " rows" << endl;
 	    calc (tab, argv[3]);
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "\nCaught an exception: " << x.getMesg() << endl;
         return 1;
     } 

--- a/tables/Tables/test/tColumnsIndex.cc
+++ b/tables/Tables/test/tColumnsIndex.cc
@@ -162,7 +162,7 @@ void b()
     *abool = True;
     try {
         colInx0.getRowNumber(found);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << x.getMesg() << endl;       // values are not unique
     } 
     rows = colInx0.getRowNumbers();
@@ -332,7 +332,7 @@ int main()
 	b();
 	c();
 	d();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "Exception caught: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tColumnsIndexArray.cc
+++ b/tables/Tables/test/tColumnsIndexArray.cc
@@ -122,7 +122,7 @@ void b()
   // Test a not unique index in an erroneous way.
   try {
     colInx9.getRowNumber(found);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << x.getMesg() << endl;       // values are not unique
   } 
   // Test a range.
@@ -176,7 +176,7 @@ int main()
     a();
     b();
     c();
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Exception caught: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/Tables/test/tConcatTable2.cc
+++ b/tables/Tables/test/tConcatTable2.cc
@@ -253,7 +253,7 @@ int main()
     cout<< "done check" << endl;
     checkFull("tConcatTable2_tmp.data", 0);
     cout<< "done checkFull" << endl;
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Exception caught: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/Tables/test/tConcatTable3.cc
+++ b/tables/Tables/test/tConcatTable3.cc
@@ -106,7 +106,7 @@ int main()
     createTable ("tConcatTable3_tmp.tab3", 30, 5);
     concatTables();
     checkTable (0, 35);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Exception caught: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/Tables/test/tMemoryTable.cc
+++ b/tables/Tables/test/tMemoryTable.cc
@@ -167,7 +167,7 @@ int main ()
 	deleteRows      (aNewNrRows, tab);
 
 
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tReadAsciiTable.cc
+++ b/tables/Tables/test/tReadAsciiTable.cc
@@ -95,7 +95,7 @@ int main (int argc, const char* argv[])
 	b3 (dir, IPosition(2,3,5));
 	b3 (dir, IPosition(2,0,5));
 	erroneous();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tRefRows.cc
+++ b/tables/Tables/test/tRefRows.cc
@@ -137,7 +137,7 @@ int main()
 {
     try {
 	doIt();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "\nCaught an exception: " << x.getMesg() << endl;
         return 1;
     } 

--- a/tables/Tables/test/tRefTable.cc
+++ b/tables/Tables/test/tRefTable.cc
@@ -115,7 +115,7 @@ int main()
     makeRef();
     readTab ("tRefTable_tmp.data", 10, 5);
     readTab ("tRefTable_tmp.dataref", 10, 4);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 

--- a/tables/Tables/test/tRowCopier.cc
+++ b/tables/Tables/test/tRowCopier.cc
@@ -275,7 +275,7 @@ int main()
 	Vector<String> colname(1);
 	colname(0) = "Garbage";
 	RowCopier rc(partialtab, maintab, colname, colname);
-    } catch (TableError x) {
+    } catch (TableError& x) {
 	caught = True;
     } 
     if (caught) {
@@ -293,7 +293,7 @@ int main()
 	Vector<String> inname(1), outname(1);
 	inname(0) = "FCol"; outname(0) = "DCol";
 	RowCopier rc(maintab, maintab, inname, outname);
-    } catch (TableError x) {
+    } catch (TableError& x) {
 	caught = True;
     } 
     if (caught) {
@@ -310,7 +310,7 @@ int main()
 	Vector<String> inname(1), outname(1);
 	inname(0) = "ICol1"; outname(0) = "IACol";
 	RowCopier rc(maintab, maintab, inname, outname);
-    } catch (TableError x) {
+    } catch (TableError& x) {
 	caught = True;
     } 
     if (caught) {
@@ -327,7 +327,7 @@ int main()
 	Vector<String> inname(1), outname(2);
 	inname(0) = "IACol"; outname(0) = "IACol"; outname(1) = "DCol";
 	RowCopier rc(maintab, maintab, inname, outname);
-    } catch (TableError x) {
+    } catch (TableError& x) {
 	caught = True;
     } 
     if (caught) {

--- a/tables/Tables/test/tScalarRecordColumn.cc
+++ b/tables/Tables/test/tScalarRecordColumn.cc
@@ -194,7 +194,7 @@ int main()
     try {
 	a();
 	b();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTableDesc.cc
+++ b/tables/Tables/test/tTableDesc.cc
@@ -81,7 +81,7 @@ void a (Bool doExcp)
     if (doExcp) {
 	try {
 	    td.addColumn (ScalarColumnDesc<Int> ("ab"));   // already exists
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -97,7 +97,7 @@ void a (Bool doExcp)
 	try {
 	    td.addColumn (ScalarColumnDesc<ExampleDesc>
 			                     ("af", ColumnDesc::Undefined));
-    	} catch (AipsError x) {
+    	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // undefined given
 	} 
     }
@@ -112,22 +112,22 @@ void a (Bool doExcp)
     if (doExcp) {
 	try {
 	    td.rwColumnDesc("ab").setNdim (2);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // column is a scalar
 	} 
 	try {
 	    td.rwColumnDesc("ab").setShape (IPosition());
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // column is a scalar
 	} 
 	try {
 	    td.rwColumnDesc("Arr3").setNdim (2);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // ndim already defined
 	} 
 	try {
 	    td.rwColumnDesc("Arr3").setShape (IPosition());
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // shape already defined
 	} 
     }
@@ -146,7 +146,7 @@ void a (Bool doExcp)
     if (doExcp) {
 	try {
 	    td.checkSubTableDesc();
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;     // subtable sub1 does not exist
 	} 
     }
@@ -263,7 +263,7 @@ void b (Bool doExcp) {
     if (doExcp) {
 	try {
 	    td.rwColumnDesc("Arr1").setShape (IPosition(3,4,5,6));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;        // shape mimatches ndim
 	} 
     }
@@ -272,7 +272,7 @@ void b (Bool doExcp) {
     if (doExcp) {
 	try {
 	    td["Arr1"].tableDesc();              // no subtable
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -301,7 +301,7 @@ void b (Bool doExcp) {
 	try {
 	    cout << "Tryerr update" << endl;
 	    TableDesc td1("",TableDesc::Update);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -322,7 +322,7 @@ void c (Bool doExcp) {
 	try {
 	    cout << "Tryerr update not exist" << endl;
 	    td1 = new TableDesc("tTableDescXX_tmp", TableDesc::Update);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	    td1 = 0;
 	} 
@@ -330,7 +330,7 @@ void c (Bool doExcp) {
 	try {
 	    cout << "Tryerr old not exist" << endl;
 	    td2 = new TableDesc("tTableDescXX_tmp", TableDesc::Old);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	    td2 = 0;
 	} 
@@ -338,7 +338,7 @@ void c (Bool doExcp) {
 	try {
 	    cout << "Tryerr newnoreplace" << endl;
 	    td3 = new TableDesc("tTableDesc_tmp", TableDesc::NewNoReplace);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	    td3 = 0;
 	} 
@@ -385,12 +385,12 @@ void d (Bool doExcp)
     if (doExcp) {
 	try {
 	    td.renameColumn ("colint2", "colint");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
 	try {
 	    td.renameColumn ("colintnew", "colintxxx");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;
 	} 
     }
@@ -430,7 +430,7 @@ int main (int argc, const char*[])
 	a ( (argc<2));
 	b ( (argc<2));
 	c ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTableDescHyper.cc
+++ b/tables/Tables/test/tTableDescHyper.cc
@@ -54,7 +54,7 @@ int main (int argc, const char*[])
 	if (argc < 2) {
 	    excpDesc();
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -178,14 +178,14 @@ void excpDesc()
 	td.defineHypercolumn ("TSMExample",
 			      4,
 			      stringToVector (""));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // no data columns
     } 
     try {
 	td.defineHypercolumn ("TSMExample",
 			      0,
 			      stringToVector ("Data,Weight"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // ndim < 1
     } 
     try {
@@ -193,7 +193,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // ndim != #coord
     } 
     try {
@@ -201,14 +201,14 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Timex"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Timex does not exist
     } 
     try {
 	td.defineHypercolumn ("TSMExample",
 			      4,
 			      stringToVector ("Data,Weight,Datax"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Datax does not exist
     } 
     try {
@@ -217,7 +217,7 @@ void excpDesc()
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Time"),
 			      stringToVector ("Idx"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Idx does not exist
     } 
     try {
@@ -225,7 +225,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,TimeNotNum"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // TimeNotNum not numeric
     } 
     try {
@@ -233,7 +233,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,TimeShort"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Coord short not supported
     } 
     try {
@@ -241,7 +241,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Data"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Coord Data is array > 1-dim
     } 
     try {
@@ -249,21 +249,21 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Pol"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // coord vectors not at start
     } 
     try {
 	td.defineHypercolumn ("TSMExample",
 			      4,
 			      stringToVector ("Data0,Weight"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Data #dim undefined
     } 
     try {
 	td.defineHypercolumn ("TSMExample",
 			      4,
 			      stringToVector ("Data1,Weight"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Data #dim != Weight #ndim
     } 
     try {
@@ -271,7 +271,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data1"),
 			      stringToVector ("Pol,Freq,Baseline,Time"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Data #dim != #coordVector
     } 
     try {
@@ -279,7 +279,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data"),
 			      stringToVector ("Pol,Time,Baseline,Time"));
-    } catch (AipsError x) {
+    } catch (AipsError&x) {
 	cout << x.getMesg() << endl;             // Data #dim != #coordVector
     } 
     try {
@@ -287,7 +287,7 @@ void excpDesc()
 			      4,
 			      stringToVector ("Data"),
 			      stringToVector (",,Pol,"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Data #dim != #coordVector
     } 
     try {
@@ -296,7 +296,7 @@ void excpDesc()
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Time"),
 			      stringToVector ("TimeShort"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Id short not supported
     } 
     try {
@@ -305,7 +305,7 @@ void excpDesc()
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Time"),
 			      stringToVector ("Data"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Id array not supported
     } 
     try {
@@ -314,7 +314,7 @@ void excpDesc()
 			      stringToVector ("Data,Weight"),
 			      stringToVector ("Pol,Freq,Baseline,Time"),
 			      stringToVector ("Time"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;             // Time double used 
     } 
 }

--- a/tables/Tables/test/tTableInfo.cc
+++ b/tables/Tables/test/tTableInfo.cc
@@ -68,7 +68,7 @@ int main()
     try {
 	writeInfo();
 	readInfo();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTableKeywords.cc
+++ b/tables/Tables/test/tTableKeywords.cc
@@ -105,7 +105,7 @@ void renameTables (const String& newName, const String& oldName)
     Bool excp = False;
     try {
 	Table tab1(oldName);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	excp = True;
     } 
     AlwaysAssertExit (excp);
@@ -169,7 +169,7 @@ int main()
 	readTables ("main3data", True);
 	readTables ("main4data", False);
 	readFromOtherDir();
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << "Caught an exception : " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTableLockSync.cc
+++ b/tables/Tables/test/tTableLockSync.cc
@@ -109,7 +109,7 @@ void b (Bool noReadLocking, Bool permLocking)
     Table tab("tTableLockSync_tmp.tab", lt, Table::Update);
     try {
 	TableLocker lock1 (tab, FileLocker::Write, 1);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "table is write-locked" << endl;
     } 
     ScalarColumn<Int> col1 (tab, "col1");
@@ -171,7 +171,7 @@ void b (Bool noReadLocking, Bool permLocking)
 		if (opt == 9) {
 		    col1.put (0, val);
 		}
-	    } catch (AipsError x) {
+	    } catch (AipsError& x) {
 	        cout << x.getMesg() << endl;
 		err = True;
 	    } 
@@ -226,7 +226,7 @@ void b (Bool noReadLocking, Bool permLocking)
 		if (opt == 11) {
 		    tab.rwKeywordSet().define ("k0", val);
 		}
-	    } catch (AipsError x) {
+	    } catch (AipsError& x) {
 	        cout << x.getMesg() << endl;
 		err = True;
 	    } 
@@ -279,7 +279,7 @@ int main (int argc, const char* argv[])
 		a();
 	    }
 	    b (noReadLocking, permLocking);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << "Caught an exception: " << x.getMesg() << endl;
 	    return 1;
 	} 

--- a/tables/Tables/test/tTableLockSync_2.cc
+++ b/tables/Tables/test/tTableLockSync_2.cc
@@ -343,7 +343,7 @@ int main (int argc, const char* argv[])
 	}else{
 	    c (lockMode, var[2], var[4], show);
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTableRecord.cc
+++ b/tables/Tables/test/tTableRecord.cc
@@ -103,12 +103,12 @@ void doDefineAssign (const TableRecord& inrecord)
 			     stringToVector ("abc,dghij,klmn")));
     try {
 	*rfstr2 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     try {
 	*rfstr3 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     record.get (record.fieldNumber ("TpArrayString2"), vec);
@@ -120,12 +120,12 @@ void doDefineAssign (const TableRecord& inrecord)
 
     try {
 	*rfstr2 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     try {
 	*rfstr3 = stringToVector ("abc");
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     record.get (record.fieldNumber ("TpArrayString2"), vec);
@@ -137,7 +137,7 @@ void doDefineAssign (const TableRecord& inrecord)
 
     try {
 	rfstr2.define (stringToVector ("abc"));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;           // incorrect shape
     } 
     rfstr3.define (stringToVector ("a"));
@@ -171,7 +171,7 @@ void doDefineAssign (const TableRecord& inrecord)
 
     try {
         record.define ("TpBool", Vector<Bool>(2, False));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
         cout << x.getMesg() << endl;
     } 
 }
@@ -217,7 +217,7 @@ void doSubRecord (Bool doExcp, const RecordDesc& desc)
     if (doExcp) {
 	try {
 	    record1 = record;
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << ">>> Instance-specific assertion error message:" << endl;
 	    cout << x.getMesg() << endl;           // not conforming
 	    cout << "<<<" << endl;
@@ -290,24 +290,24 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record.define ("", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // empty name
 	} 
 	try {
 	    record.define ("aB", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // first no uppercase
 	} 
 	extraArgument = 10;
 	try {
 	    record.define ("A", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // extra argument = 10
 	} 
 	extraArgument = 0;
 	try {
 	    record.define ("TpShort", (Int)0);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // invalid type
 	} 
     }
@@ -379,7 +379,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record2a.restructure(subDesc);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;  // fixed, not empty ->impossible
 	} 
     }
@@ -389,7 +389,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    record2a = record2b;
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << ">>> Instance-specific assertion error message:" << endl;
 	    cout << x.getMesg() << endl;  // fixed; non-conforming
 	    cout << "<<<" << endl;
@@ -463,7 +463,7 @@ void doIt (Bool doExcp)
     if (doExcp) {
 	try {
 	    RecordFieldPtr<Record> fld(record, "SubRecord");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // invalid type
 	} 
     }
@@ -774,12 +774,12 @@ void testTable (Bool doExcp)
     if (doExcp) {
 	try {
 	    rec1.defineTable (rec1.fieldNumber("tab1"), tab2);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // non-conforming
 	} 
 	try {
 	    RecordFieldPtr<Table> fld1 (rec1, "tab1");
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;           // invalid type
 	} 
     }    
@@ -916,7 +916,7 @@ int main (int argc, const char*[])
 	doIt ( (argc<2));
 	testTable ( (argc<2));
 	testTable2 ( (argc<2));
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTableRow.cc
+++ b/tables/Tables/test/tTableRow.cc
@@ -197,12 +197,12 @@ void b (Bool doExcp)
     if (doExcp) {
 	try {
 	    TableRow row (tab);
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;             // not writable
 	} 
 	try {
 	    ROTableRow row (tab, stringToVector("ab,abb"));
-	} catch (AipsError x) {
+	} catch (AipsError& x) {
 	    cout << x.getMesg() << endl;             // abb not exists
 	} 
     }
@@ -356,7 +356,7 @@ int main (int argc, const char* argv[])
 	a ( (argc<2));
 	b ( (argc<2));
 	c (nr);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTable_1.cc
+++ b/tables/Tables/test/tTable_1.cc
@@ -52,7 +52,7 @@ int main (int argc, const char* argv[])
     }
     try {
 	a(nr);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 
@@ -86,7 +86,7 @@ void a(uInt nrrow) {
     //# Do some erroneous things.
     try {
 	newtab.bindColumn ("ab", sm1);     // newtab is already in use
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << x.getMesg() << endl;
     } 
 ///    try {

--- a/tables/Tables/test/tTable_2.cc
+++ b/tables/Tables/test/tTable_2.cc
@@ -61,7 +61,7 @@ int main (int argc, const char* argv[])
 	for (int i=1; i<argc; i++) {
 	    doIt (argv[i]);
 	}
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTable_3.cc
+++ b/tables/Tables/test/tTable_3.cc
@@ -172,7 +172,7 @@ int main (int argc, const char* argv[])
 	}
 	cout << nrrow << " rows" << endl;
 	a (nrrow);
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;
     } 

--- a/tables/Tables/test/tTable_4.cc
+++ b/tables/Tables/test/tTable_4.cc
@@ -120,7 +120,7 @@ TableDesc makeDesc (Bool ask)
       } else {
 	break;
       }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << x.getMesg() << endl;
     }
   }
@@ -303,7 +303,7 @@ void doTable (Bool ask, const TableDesc& td)
       } else {
 	break;
       }
-    } catch (AipsError x) {
+    } catch (AipsError& x) {
       cout << removeDir(x.getMesg()) << endl;
     }
   }
@@ -316,7 +316,7 @@ int main (int argc, const char*[])
     cout << "-----------------------------------------------" << endl;
     Bool ask = argc < 2;
     doTable (ask, makeDesc(ask));
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 


### PR DESCRIPTION
Newer version of gcc will output a (correct) warning for every (polymorphic) exception catch by value.
This happens a lot in casacore, and this litters the compilation output considerably. This commit
consists purely of adding ampersands to every polymorphic exception type inside a catch, removing all of
gccs warnings about this.