### PR TITLE
Added support for O_DIRECT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required (VERSION 2.6.0)
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 include(CheckFunctionExists)
+include(CheckCXXSourceCompiles)
 
 # fixes warnings on cmake 3.x+ For now we want the old behavior to be backwards compatible
 if (POLICY CMP0048)
@@ -50,6 +51,15 @@ option (ENABLE_SHARED "Build shared libraries" YES)
 
 option (ENABLE_RPATH "Include rpath in executables and shared libraries" YES)
 
+# Check if O_DIRECT is available.
+# Note this does not work well with check_c_source_compiles.
+check_cxx_source_compiles("
+  #include <fcntl.h>
+  main() { int i = O_DIRECT; }
+  " HAVE_O_DIRECT)
+if (HAVE_O_DIRECT)
+    add_definitions(-DHAVE_O_DIRECT)
+endif()
 
 # By default do not use ADIOS2, HDF5, FFTW3
 option (ENABLE_TABLELOCKING "Make locking for concurrent table access possible" YES)
@@ -537,6 +547,7 @@ message (STATUS "USE_THREADS ........... = ${USE_THREADS}")
 message (STATUS "USE_OPENMP ............ = ${USE_OPENMP}")
 message (STATUS "USE_MPI ............... = ${USE_MPI}")
 message (STATUS "USE_STACKTRACE ........ = ${USE_STACKTRACE}")
+message (STATUS "HAVE_O_DIRECT ......... = ${HAVE_O_DIRECT}")
 message (STATUS "CMAKE_CXX_COMPILER .... = ${CMAKE_CXX_COMPILER}")
 message (STATUS "CMAKE_CXX_FLAGS ....... = ${CMAKE_CXX_FLAGS}")
 message (STATUS "DATA directory ........ = ${DATA_DIR}")

--- a/casa/IO/MultiFile.h
+++ b/casa/IO/MultiFile.h
@@ -52,12 +52,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   // reduce the number of open files (especially when concatenating tables).
   // <br>A secondary goal is offering the ability to use an IO buffer size
   // that matches the file system well (large buffer size for e.g. ZFS).
+  // <br>A third goal is offering the ability to use O_DIRECT (if supported by OS)
+  // to tell the OS kernel to bypass its file cache. It makes the I/O behaviour
+  // more predictable which a real-time system might need.
   //
   // The SetupNewTable constructor has a StorageOption argument to define
   // if a MultiFile has to be used and if so, the buffer size to use.
   // It is also possible to specify that through aipsrc variables.
   //
-
   // A virtual file is spread over multiple (fixed size) data blocks in the
   // MultiFile. A data block is never shared by multiple files.
   // For each virtual file MultiFile keeps a MultiFileInfo object telling
@@ -111,7 +113,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Open or create a MultiFile with the given name.
     // Upon creation the block size can be given. If 0, it uses the block size
     // of the file system the file is on.
-    MultiFile (const String& name, ByteIO::OpenOption, Int blockSize=0);
+    // If useODirect=True, the O_DIRECT flag in used (if supported). It tells the
+    // kernel to bypass its file cache to have more predictable I/O behaviour.
+    MultiFile (const String& name, ByteIO::OpenOption, Int blockSize=0,
+               Bool useODirect=False);
 
     // The destructor flushes and closes the file.
     virtual ~MultiFile();

--- a/casa/IO/MultiFileBase.cc
+++ b/casa/IO/MultiFileBase.cc
@@ -251,8 +251,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (inx == itsInfo.size()) {
       itsInfo.resize (inx+1);
     }
-    size_t align = (itsUseODirect ? 4096 : 0);
-    itsInfo[inx] = MultiFileInfo(itsBlockSize, align);
+    itsInfo[inx] = MultiFileInfo(itsBlockSize, itsUseODirect);
     itsInfo[inx].name = bname;
     doAddFile (itsInfo[inx]);
     itsChanged = True;

--- a/casa/IO/MultiHDF5.cc
+++ b/casa/IO/MultiHDF5.cc
@@ -36,7 +36,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   MultiHDF5::MultiHDF5 (const String& name, ByteIO::OpenOption option,
                         Int blockSize)
-    : MultiFileBase (name, blockSize),
+    : MultiFileBase (name, blockSize, False),     //# no O_DIRECT in HDF5
       itsFile       (itsName, option)
   {
     if (option == ByteIO::New  ||  option == ByteIO::NewNoReplace) {

--- a/casa/IO/RegularFileIO.h
+++ b/casa/IO/RegularFileIO.h
@@ -105,8 +105,13 @@ public:
 
     // Convenience function to open or create a file.
     // Optionally it is checked if the file does not exist yet.
+    // If useODirect=True and if supported by the OS, the file will be opened
+    // with O_DIRECT which bypasses the kernel's file cache for more predictable
+    // I/O behaviour. It requires the size and the alignment of the data to be
+    // read/written to be a multiple of the the disk's logival block size.
     // It returns the file descriptor.
-    static int openCreate (const RegularFile& file, ByteIO::OpenOption);
+    static int openCreate (const RegularFile& file, ByteIO::OpenOption,
+                           Bool useODirect=False);
 
 private:
     OpenOption  itsOption;

--- a/casa/IO/test/tMultiFile.cc
+++ b/casa/IO/test/tMultiFile.cc
@@ -48,9 +48,9 @@ void showMultiFile (MultiFile& mfile)
        << mfile.freeBlocks() << endl;
 }
 
-void makeFile (Int64 blockSize)
+void makeFile (Int64 blockSize, Bool useODirect)
 {
-  MultiFile mfile("tMultiFile_tmp.dat", ByteIO::New, blockSize);
+  MultiFile mfile("tMultiFile_tmp.dat", ByteIO::New, blockSize, useODirect);
   AlwaysAssertExit (mfile.isWritable());
   showMultiFile(mfile);
 }
@@ -254,10 +254,10 @@ void timeMove3()
   timer.show ("move3 ");
 }
 
-void doTest (Int64 blockSize)
+void doTest (Int64 blockSize, Bool useODirect=False)
 {
   cout << "MultiFile test with blockSize=" << blockSize << endl;
-  makeFile (blockSize);
+  makeFile (blockSize, useODirect);
   readFile();
   addFiles();
   readFile();
@@ -274,8 +274,9 @@ void doTest (Int64 blockSize)
 int main()
 {
   try {
-    doTest (128);     // requires extra header file
-    doTest (1024);    // no extra header file
+    doTest (128);           // requires extra header file
+    doTest (1024);          // no extra header file
+    doTest (4096, True);    // with O_DIRECT (if possible)
     timeExact();
     timeDouble();
     timePartly();

--- a/tables/Tables/ColumnSet.cc
+++ b/tables/Tables/ColumnSet.cc
@@ -191,7 +191,8 @@ void ColumnSet::openMultiFile (uInt from, const Table& tab,
     if (! multiFile_p) {
       if (storageOpt_p.option() == StorageOption::MultiFile) {
         multiFile_p = new MultiFile (tab.tableName() + "/table.mf",
-                                     opt, storageOpt_p.blockSize());
+                                     opt, storageOpt_p.blockSize(),
+                                     storageOpt_p.useODirect());
       } else {
         multiFile_p = new MultiHDF5 (tab.tableName() + "/table.mfh5",
                                      opt, storageOpt_p.blockSize());

--- a/tables/Tables/StorageOption.cc
+++ b/tables/Tables/StorageOption.cc
@@ -30,9 +30,12 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-  StorageOption::StorageOption (StorageOption::Option option, Int blockSize)
-    : itsOption    (option),
-      itsBlockSize (blockSize)
+  StorageOption::StorageOption (StorageOption::Option option, Int blockSize,
+                                Int useODirect)
+    : itsOption     (option),
+      itsBlockSize  (blockSize),
+      itsUseODirect (useODirect>0),
+      itsUseAipsrcODirect (useODirect<0)
   {}
 
   void StorageOption::fillOption()
@@ -59,10 +62,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (itsBlockSize <= 0) {
       itsBlockSize = 4*1024*1024;
     }
+    // Default O_DIRECT support is False.
+    if (itsUseAipsrcODirect) {
+      AipsrcValue<Bool>::find (itsUseODirect, "table.storage.odirect", False);
+    }
     // Default is to use separate files.
     if (itsOption == StorageOption::Default) {
       itsOption = StorageOption::SepFile;
     }
+  }
+
+  void StorageOption::setUseODirect (Bool useODirect)
+  {
+    itsUseODirect = useODirect;
+    itsUseAipsrcODirect = False;
   }
 
 } //# NAMESPACE CASACORE - END

--- a/tables/Tables/StorageOption.h
+++ b/tables/Tables/StorageOption.h
@@ -54,7 +54,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //       <br>The block size to be used in a MultiFile can be defined in
 //           this class. Default is 4 MByte.
 //  <li> Using MultiHDF5 which behaves similar to MultiFile but uses an
-//       HDF5 file instead of a regular file.
+//       HDF5 file instead of a regular file. Note that it requires that
+//       support for HDF5 has been used in the build system.
 // </ol>
 // It is possible to specify the storage type and block size using aipsrc.
 // The aipsrc variables are:
@@ -64,6 +65,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //       Another value means the old way (separate files).
 //  <li> <src>table.storage.blocksize</src> gives the default blocksize to be
 //       used for the multifile and multihdf5 option.
+// <li> <src>table.storage.odirect</src> can be true or false. It tells if the
+//       O_DIRECT option has to be used to let the kernel bypass its filecache
+//       for more predictable I/O behaviour. It's only used for MultiFile and
+//       only if the OS supports O_DIRECT.
 // </ul>
 // </synopsis>
 
@@ -79,7 +84,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       MultiHDF5,
       // Let storage managers use separate files.
       SepFile,
-      // Use default (currently MultiFile).
+      // Use default (currently SepFile).
       Default,
       // Use as defined in the aipsrc file.
       Aipsrc
@@ -90,7 +95,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // The blocksize has to be given in bytes.
     // A size value -2 means reading that size from the aipsrc file.
     // A size value -1 means use the default of 4*1024*1024.
-    StorageOption (Option option=Aipsrc, Int blockSize=-2);
+    // <br>useODirect<0 means reading the option from the aipsrc file.
+    // It is only set if the OS supports O_DIRECT.
+    StorageOption (Option option=Aipsrc, Int blockSize=-2, Int useODirect=-3);
 
     // Fill the option in case Aipsrc or Default was given.
     // It is done as explained in the synopsis.
@@ -112,9 +119,19 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     void setBlockSize (Int blockSize)
       { itsBlockSize = blockSize; }
 
+    // Get the O_DIRECT option.
+    Bool useODirect() const
+      { return itsUseODirect; }
+
+    // Set the O_DIRECT option.
+    // It is only set if the OS supports O_DIRECT.
+    void setUseODirect (Bool useODirect);
+
   private:
     Option itsOption;
     Int    itsBlockSize;
+    Bool   itsUseODirect;
+    Bool   itsUseAipsrcODirect;
   };
 
 } //# NAMESPACE CASACORE - END

--- a/tables/Tables/test/tTable.cc
+++ b/tables/Tables/test/tTable.cc
@@ -89,7 +89,7 @@ Table::EndianFormat theEndianFormat = Table::BigEndian;
 
 
 // First build a description.
-void a (Bool doExcp)
+void a (const StorageOption& stopt, Bool doExcp)
 {
     // Build the table description.
     TableDesc td("", "1", TableDesc::Scratch);
@@ -105,7 +105,7 @@ void a (Bool doExcp)
     // Now create a new table from the description.
     // Use copy constructor to test if it works fine.
     // (newtab and newtabcp have the same underlying object).
-    SetupNewTable newtab("tTable_tmp.data", td, Table::New);
+    SetupNewTable newtab("tTable_tmp.data", td, Table::New, stopt);
     SetupNewTable newtabcp(newtab);
     // Create a storage manager for it.
     StManAipsIO sm1;
@@ -578,7 +578,7 @@ void b (Bool doExcp)
 }
 
 //# Test deletion of rows, array of Strings, and some more.
-void c (Bool doExcp)
+void c (const StorageOption& stopt, Bool doExcp)
 {
     TableDesc td("", "1", TableDesc::Scratch);
     td.addColumn (ScalarColumnDesc<Int>("ab","Comment for column ab"));
@@ -592,7 +592,7 @@ void c (Bool doExcp)
     td.addColumn (ArrayColumnDesc<String>("arr3",0,ColumnDesc::Direct));
 
     // Now create a new table from the description.
-    SetupNewTable newtab("tTable_tmp.data1", td, Table::New);
+    SetupNewTable newtab("tTable_tmp.data1", td, Table::New, stopt);
     // Create a storage manager for it.
     StManAipsIO sm1;
     StManAipsIO sm2;
@@ -751,7 +751,7 @@ void c (Bool doExcp)
 }
 
 
-void d()
+void d (const StorageOption& stopt)
 {
     Vector<Complex> arrf2(100);
     indgen (arrf2);
@@ -766,7 +766,7 @@ void d()
 	td.addColumn (ArrayColumnDesc<Int>    ("arr3",0,ColumnDesc::Direct));
 	
 	// Now create a new table from the description.
-	SetupNewTable newtab("tTable_tmp.data3", td, Table::New);
+	SetupNewTable newtab("tTable_tmp.data3", td, Table::New, stopt);
 	// Create a storage manager for it.
 	StManAipsIO sm1;
 	newtab.bindAll (sm1);
@@ -913,10 +913,18 @@ int main (int argc,const char*[])
 {
     try {
 	Table::setScratchCallback (cbFunc);
-	a ( (argc<2));
+        StorageOption stopt;
+	a ( stopt, (argc<2));
 	b ( (argc<2));
-	c ( (argc<2));
-        d ();
+	c ( stopt, (argc<2));
+        d ( stopt);
+        // Also test with MultiFile (with O_DIRECT if supported).
+        cout<<endl<<endl<<"Test with MultiFile:"<<endl<<endl;
+        stopt = StorageOption (StorageOption::MultiFile, 4096, True);
+	a ( stopt, (argc<2));
+	b ( (argc<2));
+	c ( stopt, (argc<2));
+        d ( stopt);
     } catch (AipsError& x) {
 	cout << "Caught an exception: " << x.getMesg() << endl;
 	return 1;

--- a/tables/Tables/test/tTable.out
+++ b/tables/Tables/test/tTable.out
@@ -238,3 +238,247 @@ Axis Lengths: [2, 7]  (NB: Matrix in Row/Column order)
 
 ScratchCallBack:  name=tTable_tmp.data3  isScratch=1  oldName=
 ScratchCallBack:  name=tTable_tmp.data3  isScratch=0  oldName=
+
+
+Test with MultiFile:
+
+Expected exception: Invalid Table operation: SetupNewTable::setShapeColumn, column arr2 is not fixed shape
+ScratchCallBack:  name=tTable_tmp.data  isScratch=1  oldName=
+ScratchCallBack:  name=tTable_tmp.data  isScratch=0  oldName=
+stored columns: 111111
+
+TableDesc    version 1   (Directory **SCRATCH**)
+---------
+  Comment: A test of class Table
+  #Keywords = 0
+  #Columns  = 9
+   Name=ab   DataType=Int
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = Comment for column ab
+   #keywords=0
+
+   Name=ad   DataType=uInt
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = comment for ad
+   #keywords=0
+
+   Name=ag   DataType=DComplex
+   DataManager=StandardStMan/StandardStMan   Default=(0,0)
+   Comment = 
+   #keywords=0
+
+   Name=arr1   DataType=float   Nrdim=3   Shape=[2, 3, 4]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+   Name=arr2   DataType=float   Nrdim=-1   Shape=[]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+   Name=arr3   DataType=float   Nrdim=-1   Shape=[]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+   Name=ac   DataType=Int
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = 
+   #keywords=0
+
+   Name=ae   DataType=float
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = 
+   #keywords=0
+
+   Name=af   DataType=String   MaxLength=10
+   DataManager=StandardStMan/StandardStMan   Default=
+   Comment = 
+   #keywords=0
+
+Expected exception: ScalarColumn::put: string value '12345678901' exceeds maximum length
+Expected exception: ArrayColumn::put for row 0 in column arr1: Table array conformance error
+get layout in static way
+Table::getlayout #rows = 10
+TableDesc    version 1   (Directory **SCRATCH**)
+---------
+  Comment: A test of class Table
+  #Keywords = 0
+  #Columns  = 9
+   Name=ab   DataType=Int
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = Comment for column ab
+   #keywords=0
+
+   Name=ad   DataType=uInt
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = comment for ad
+   #keywords=0
+
+   Name=ag   DataType=DComplex
+   DataManager=StandardStMan/StandardStMan   Default=(0,0)
+   Comment = 
+   #keywords=0
+
+   Name=arr1   DataType=float   Nrdim=3   Shape=[2, 3, 4]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+   Name=arr2   DataType=float   Nrdim=-1   Shape=[]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+   Name=arr3   DataType=float   Nrdim=-1   Shape=[]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+   Name=ac   DataType=Int
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = 
+   #keywords=0
+
+   Name=ae   DataType=float
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = 
+   #keywords=0
+
+   Name=af   DataType=String   MaxLength=10
+   DataManager=StandardStMan/StandardStMan   Default=
+   Comment = 
+   #keywords=0
+
+
+type = testtype
+subtype = testsubtype
+first readme line
+second test readme line
+
+1100
+start reading Table
+end reading Table
+type = testtype
+subtype = testsubtype
+first readme line
+second test readme line
+
+Expected exception: Invalid Table operation: Table::addColumn; table tTable_tmp.data is not writable
+1 arr1.shapeColumn() = [2, 3, 4]
+0 arr2.shapeColumn() = []
+1 arr3.shapeColumn() = [2, 3, 4]
+datatypes ab = Int Int
+datatypes ac = Int Int
+datatypes ad = uInt uInt
+datatypes ae = float float
+datatypes af = String String
+datatypes ag = DComplex DComplex
+datatypes ar1 = float Array<float>
+datatypes arr2 = float Array<float>
+datatypes arr3 = float Array<float>
+get scalar row 0
+get array row 0
+get scalar row 1
+get array row 1
+get scalar row 2
+get array row 2
+get scalar row 3
+get array row 3
+get scalar row 4
+get array row 4
+get scalar row 5
+get array row 5
+get scalar row 6
+get array row 6
+get scalar row 7
+get array row 7
+get scalar row 8
+get array row 8
+get scalar row 9
+get array row 9
+10 10
+[12, 11, 10, 9, 8, 7, 6, 5, 4, 3]
+#columns in sortab: 9
+[2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+#columns in sortab2: 9
+sortab2 type = testtype
+sortab2 subtype = testsubtype
+first readme line
+second test readme line
+a sortab line
+
+[9, 6, 3, 1]
+[9, 6, 3, 1]
+[0, 3, 6, 8]
+[6, 8, 0, 3]
+#columns in seltab1: 9
+[6, 8, 0, 3]
+#columns in seltab2: 3
+[8, 0]
+#columns in seltab3: 3
+
+TableDesc    version 1   (Directory **SCRATCH**)
+---------
+  Comment: A test of class Table
+  #Keywords = 0
+  #Columns  = 3
+   Name=ae   DataType=float
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = 
+   #keywords=0
+
+   Name=ab   DataType=Int
+   DataManager=StandardStMan/StandardStMan   Default=0
+   Comment = Comment for column ab
+   #keywords=0
+
+   Name=arr1   DataType=float   Nrdim=3   Shape=[2, 3, 4]
+   DataManager=StandardStMan/StandardStMan
+   Comment = 
+   #keywords=0
+
+[1, 2, 4, 5, 7, 9]
+#columns in xortab: 9
+[0, 1, 2, 4, 5, 7, 8, 9]
+#columns in or1tab: 9
+[0, 1, 2, 4, 5, 7, 8, 9]
+#columns in or2tab: 3
+[9, 8, 7, 6, 5]
+[3, 5, 6, 7]
+[6, 7, 8, 9]
+>>>
+ScratchCallBack:  name=tab17115_20  isScratch=0  oldName=
+<<<
+ScratchCallBack:  name=tTable_tmp.ex1  isScratch=1  oldName=
+ScratchCallBack:  name=tTable_tmp.ex1  isScratch=0  oldName=
+ScratchCallBack:  name=tTable_tmp.data1  isScratch=1  oldName=
+ScratchCallBack:  name=tTable_tmp.data1  isScratch=0  oldName=
+ScratchCallBack:  name=tTable_tmp.data2  isScratch=1  oldName=
+ScratchCallBack:  name=tTable_tmp.data2a  isScratch=1  oldName=tTable_tmp.data2
+ScratchCallBack:  name=tTable_tmp.data2a  isScratch=0  oldName=
+ScratchCallBack:  name=tTable_tmp.data2  isScratch=1  oldName=
+ScratchCallBack:  name=tTable_tmp.data2  isScratch=0  oldName=
+Expected exception: Table tTable_tmp.file already exists (and is not a true table directory)
+Expected exception: Table tTable_tmp.data already exists
+Expected exception: Table tTable.datx does not exist
+Expected exception: Invalid description of column ab: column already exists
+[3, 5, 6, 7]
+[3, 6]
+[0, 1, 2, 4, 5, 7, 8, 9]
+Expected exception: Invalid Table operation: removeRow: rownr 7 too high in table tTable_tmp.data2a (#rows=7)
+[0, 1, 2, 4, 5, 7, 8]
+[0, 1]
+[23, 4]
+[5, 6]
+[9, 100]
+[1, 2]
+[6, 7]
+[8, 9]
+Axis Lengths: [2, 7]  (NB: Matrix in Row/Column order)
+[0, 23, 5, 9, 1, 6, 8
+ 1, 4, 6, 100, 2, 7, 9]
+
+ScratchCallBack:  name=tTable_tmp.data3  isScratch=1  oldName=
+ScratchCallBack:  name=tTable_tmp.data3  isScratch=0  oldName=


### PR DESCRIPTION
MultiFile got support for file creation with the O_DIRECT option (provided the OS supports it) to bypass the kernel's file cache. It makes the I/O behaviour much more predictable which is useful for some real-time applications. It means that new tables using the MultiFile option can be written with O_DIRECT. It is not (yet) possible to use O_DIRECT on existing tables.

Close #882