### PR TITLE
Fixed race conditions in Regex

### DIFF
--- a/casa/Utilities/Regex.cc
+++ b/casa/Utilities/Regex.cc
@@ -63,6 +63,7 @@ void Regex::create(const String& exp, Int fast, Int bufsize,
     bufsize = tlen;
   buf->allocated = bufsize;
   buf->buffer = (Char *) malloc(buf->allocated);
+  /*
   Int orig = a2_re_set_syntax(RE_NO_BK_PARENS+     // use () for grouping
 			    RE_NO_BK_VBAR+         // use | for OR
 			    RE_INTERVALS+          // intervals are possible
@@ -71,8 +72,9 @@ void Regex::create(const String& exp, Int fast, Int bufsize,
 			    RE_NO_EMPTY_BK_REF+    // backreferences possible
 			    RE_NO_EMPTY_RANGES+    // e.g. [z-a] is empty set
 			    RE_CONTEXTUAL_INVALID_OPS);
+  */
   const char* msg = a2_re_compile_pattern((Char*)(exp.chars()), tlen, buf);
-  a2_re_set_syntax(orig);
+  ///a2_re_set_syntax(orig);
   if (msg != 0) {
     throw(invalid_argument("Regex: invalid regular expression " + exp +
 			   " given (" + String(msg) + ')'));

--- a/casa/Utilities/test/tRegex.cc
+++ b/casa/Utilities/test/tRegex.cc
@@ -37,6 +37,7 @@
 #include <casacore/casa/namespace.h>
 //# Forward Declarations
 
+void testParallel();
 void a();
 void b();
 
@@ -49,6 +50,8 @@ void b();
 
 int main () {
   try {
+    // Test parallel first to ensure initialization works fine.
+    testParallel();
     a();
     b();
   } catch (AipsError& x) {
@@ -155,4 +158,16 @@ void b() {
     cout << exp5.regexp() << endl;
 
     cout << "end of b" << endl;
+}
+
+// Test a Regex in parallel.
+void testParallel()
+{
+#ifdef HAVE_OPENMP
+#pragma omp parallel
+#endif
+  for (int i=0; i<32; ++i) {
+    Regex rx(".*");
+    AlwaysAssert (String("ab").matches(rx), AipsError);
+  }
 }


### PR DESCRIPTION
This was fixed in PR #881 by using std::regex, but unfortunately gcc-4.8 has errors in the std::regex support. Hence that PR cannot be merged.
This PR fixes it in a simpler way by using a function static and presetting the syntax mode.
tRegex was extended with a parallel loop; helgrind did not report any error.
