### PR TITLE
Fixes for latest MPI-communicator-enabled MS classes

### DIFF
--- a/ms/MeasurementSets/MSTable.tcc
+++ b/ms/MeasurementSets/MSTable.tcc
@@ -84,7 +84,7 @@ MSTable<MSEnum>::MSTable(SetupNewTable &newTab,
 
 #ifdef HAVE_MPI
 template <class MSEnum>
-MSTable<MSENum>::MSTable(MPI_Comm comm,
+MSTable<MSEnum>::MSTable(MPI_Comm comm,
 				  SetupNewTable &newTab, uInt nrrow,
 				  Bool initialize)
     : Table(comm, MSTableImpl::setupCompression(newTab),

--- a/ms/MeasurementSets/MeasurementSet.cc
+++ b/ms/MeasurementSets/MeasurementSet.cc
@@ -227,8 +227,7 @@ MeasurementSet::MeasurementSet(const Table &table, const MeasurementSet * otherM
 MeasurementSet::MeasurementSet (MPI_Comm comm,
 			       SetupNewTable &newTab, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(comm, newTab, nrrow, initialize),
+    : MSTable<MSMainEnums>(comm, newTab, nrrow, initialize),
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {
@@ -244,8 +243,7 @@ MeasurementSet::MeasurementSet (MPI_Comm comm,
 			       SetupNewTable &newTab,
 			       const TableLock& lockOptions, uInt nrrow,
 			       Bool initialize)
-    : MSTable<PredefinedColumns,
-      PredefinedKeywords>(comm, newTab, lockOptions, nrrow, initialize),
+    : MSTable<MSMainEnums>(comm, newTab, lockOptions, nrrow, initialize),
       doNotLockSubtables_p (False),
       hasBeenDestroyed_p(False)
 {

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -197,7 +197,7 @@ target_link_libraries (casa_tables casa_casa ${CASACORE_ARCH_LIBS})
 if(MPI_FOUND)
     target_link_libraries(casa_tables ${MPI_C_LIBRARIES})
     if(ADIOS2_FOUND)
-        target_link_libraries(casa_tables ${ADIOS2_LIBRARIES})
+        target_link_libraries(casa_tables adios2::adios2)
     endif(ADIOS2_FOUND)
 endif(MPI_FOUND)
 


### PR DESCRIPTION
When producing the commits for my last pull request #884 I was careless and didn't double-check that my last commit (which merged the latest changes on the `master` branch with mine) was fully correct (it definitely was before that last merge). It however was incorrect, as it didn't fully take into account the changes on the changes on the `master` branch, specifically the template arguments for the `MSTable` class, and it failed to build. Since Travis doesn't build MPI-enabled builds by default it didn't catch this either.

I've now double-checked that everything *actually* builds and that all tests pass.

In merging the latest changes from the `master` branch I've also started using the new `CONFIG`-based cmake lookup for the ADIOS2 libraries introduced in b185392. This worked out of the box for ADIOS2 2.3.1, but didn't for 2.3.0 (the version I had locally installed), so I am taking the opportunity to correct that as well.