### PR TITLE
Forward declaration of operator<< overloads

### DIFF
--- a/casa/BasicSL/STLIO.h
+++ b/casa/BasicSL/STLIO.h
@@ -42,6 +42,21 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   //# Forward Declarations
   class AipsIO;
 
+  template <typename T, typename U>
+  inline ostream& operator<< (ostream& os, const std::pair<T,U>& p);
+
+  template<typename T>
+  inline ostream& operator<<(ostream& os, const std::vector<T>& v);
+
+  template<typename T>
+  inline ostream& operator<<(ostream& os, const std::set<T>& v);
+
+  template<typename T>
+  inline ostream& operator<<(ostream& os, const std::list<T>& v);
+
+  template<typename T, typename U>
+  inline ostream& operator<<(ostream& os, const std::map<T,U>& m);
+
   // <summary>
   //    Input/output operators for STL-like containers.
   // </summary>

--- a/casa/BasicSL/test/tSTLIO.cc
+++ b/casa/BasicSL/test/tSTLIO.cc
@@ -83,6 +83,16 @@ int main()
     AlwaysAssertExit (oss.str() == "[4,4,4]");
   }
 
+  // Test a map of integers to list of ints
+  std::map<Int, std::list<Int>> map2;
+  map2[0] = {1, 2};
+  map2[3] = {-1, -2};
+  {
+    ostringstream oss;
+    oss << map2;
+    AlwaysAssertExit (oss.str() == "{<0,[1,2]>, <3,[-1,-2]>}");
+  }
+
   cout << "OK\n";
   return 0;
 }


### PR DESCRIPTION
This change adds a forward declaration for all `operator<<` overloads defined in STLIO.h *before* the declaration of the `showDataIter` template function.

This makes then usable in situations when the value type of a container is a container itself (e.g., `map<int, list<int>>`). In such situations the instantiation of `showDataIter` will eventually reference to `operator<<(ostream &, T &c)` with `T` being a container type, but those template functions are declared after the declaration of `showDataIter` itself. Apparently gcc is happy with this, but clang isn't, and trying to compile such an example fails.

The pull request includes also a small use case added to the `tSTLIO` test program. The program fails to compile with clang. I tried both versions 7.0 and 3.4, so it's safe to say that all versions fail.