### PR TITLE
Replace STL-like containers by their STL counterparts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,10 @@ set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # By default build only Python2 bindings
 option (BUILD_PYTHON "Build the python bindings" YES)
 option (BUILD_PYTHON3 "Build the python3 bindings" NO)
+option (BUILD_DEPRECATED "build and install deprecated classes (such as Map)" NO)
 
 # By default build shared libraries
 option (ENABLE_SHARED "Build shared libraries" YES)
-
 option (ENABLE_RPATH "Include rpath in executables and shared libraries" YES)
 
 # Check if O_DIRECT is available.
@@ -485,6 +485,10 @@ endif (NOT DATA_DIR)
 set (DATA_DIR "${DATA_DIR}" CACHE PATH "Measures tables root")
 
 
+# Set compiler flag if deprecated Casacore header files are allowed.
+if (BUILD_DEPRECATED)
+    add_definitions(-DAIPS_USE_DEPRECATED)
+endif ()
 # Set compiler flag if no table locking.
 if (NOT ENABLE_TABLELOCKING)
     add_definitions(-DAIPS_TABLE_NOLOCKING)
@@ -563,6 +567,7 @@ message (STATUS "ADIOS2 library? ....... = ${ADIOS2_LIBRARIES}")
 message (STATUS "HDF5 library? ......... = ${HDF5_hdf5_LIBRARY}")
 message (STATUS "FFTW3 library? ........ = ${FFTW3_LIBRARIES}")
 
+message (STATUS "BUILD_DEPRECATED ...... = ${BUILD_DEPRECATED}")
 message (STATUS "BUILD_PYTHON .......... = ${BUILD_PYTHON}")
 message (STATUS "BUILD_PYTHON3 ......... = ${BUILD_PYTHON3}")
 
@@ -585,6 +590,7 @@ endif (BUILD_PYTHON3)
 # List of build variables and defaults.
 #  BUILD_PYTHON                  YES
 #  BUILD_PYTHON3                 NO
+#  BUILD_DEPRECATED            NO
 #  ENABLE_SHARED                 YES
 #  ENABLE_RPATH                  YES
 #  ENABLE_TABLELOCKING           YES

--- a/build-tools/casacore_memcheck.supp
+++ b/build-tools/casacore_memcheck.supp
@@ -68,6 +68,20 @@
    fun:???
    fun:_ZN8casacore9FilebufIO11writeBufferExPKcx
 }
+{
+   Casacore-write-not-fully-initialized-buffer-FiledesIO-dbg8
+   Memcheck:Param
+   pwrite64(buf)
+   fun:__pwrite_nocancel
+   fun:_ZN8casacore9FiledesIO6pwriteExxPKv
+}
+{
+   Casacore-write-not-fully-initialized-buffer-FiledesIO-opt8
+   Memcheck:Param
+   pwrite64(buf)
+   fun:???
+   fun:_ZN8casacore9FiledesIO6pwriteExxPKv
+}
 
 # The function strlen is optimized by testing multiple byte simultaneously.
 # This gives an uninitialized condition error for the bytes beyond the end.

--- a/casa/BasicSL/STLIO.h
+++ b/casa/BasicSL/STLIO.h
@@ -184,6 +184,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   AipsIO& operator<< (AipsIO& ios, const std::vector<T>&);
   // </group>
 
+  // Read and write the contents of a map object from/to AipsIO.
+  // It is done in the same way as the old SimpleOrderedMap class, so
+  // persistent SimpleOrderedMap objects in CTDS can be read as std::map
+  // and vice-versa.
+  template<typename K, typename V>
+  AipsIO& operator>> (AipsIO& ios, std::map<K,V>&);
+  template<typename K, typename V>
+  AipsIO& operator<< (AipsIO& ios, const std::map<K,V>&);
+  // </group>
+                      
 } //# NAMESPACE CASACORE - END
 
 #ifndef CASACORE_NO_AUTO_TEMPLATES

--- a/casa/BasicSL/STLIO.tcc
+++ b/casa/BasicSL/STLIO.tcc
@@ -71,6 +71,44 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     return ios;
   }
 
+  template<typename K, typename V>
+  AipsIO& operator>> (AipsIO& ios, std::map<K,V>& m)
+  {
+    K key;
+    V val;
+    // Start reading the object.
+    // Delete the current keys and values.
+    ios.getstart ("SimpleOrderedMap");
+    m.clear();
+    // Now read in the values and store them into the map.
+    ios >> val;    // old default value; ignored
+    uInt nr,ni;
+    ios >> nr;
+    ios >> ni;     // old incr; ignored
+    for (uInt i=0; i<nr; i++) {
+      ios >> key;
+      ios >> val;
+      m.insert (std::make_pair(key,val));
+    }
+    ios.getend();
+    return ios;
+  }
+  
+  template<typename K, typename V>
+  AipsIO& operator<< (AipsIO& ios, const std::map<K,V>& m)
+  {
+    ios.putstart ("SimpleOrderedMap", 1);
+    ios << V();       // old default value; ignored
+    ios << uInt(m.size());
+    ios << uInt(1);   // old incr; ignored
+    for (const auto& x : m) {
+      ios << x.first;
+      ios << x.second;
+    }
+    ios.putend();
+    return ios;
+  }
+
 } //# NAMESPACE CASACORE - END
 
 #endif

--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -21,7 +21,8 @@ endforeach (src)
 include_directories (${CMAKE_CURRENT_BINARY_DIR})
 
 
-add_library (casa_casa
+# Define the bfiles to build.
+set (buildfiles
 Arrays/ArrayBase.cc
 Arrays/ArrayError.cc
 Arrays/ArrayOpsDiffShapes.cc
@@ -54,10 +55,7 @@ BasicSL/String.cc
 Containers/Allocator.cc
 Containers/Block.cc
 Containers/Block_tmpl.cc
-Containers/HashMap2.cc
 Containers/IterError.cc
-Containers/List2.cc
-Containers/Map2.cc
 Containers/Record.cc
 Containers/RecordDesc.cc
 Containers/RecordDescRep.cc
@@ -67,8 +65,6 @@ Containers/RecordInterface.cc
 Containers/RecordRep.cc
 Containers/Record2.cc
 Containers/Record2Interface.cc
-Containers/StackError.cc
-Containers/Stack2.cc
 Containers/ValueHolder.cc
 Containers/ValueHolderRep.cc
 Exceptions/Error2.cc
@@ -234,6 +230,19 @@ ${BISON_JsonGram_OUTPUTS}
 ${FLEX_JsonGram_OUTPUTS}
 )
 
+if (BUILD_DEPRECATED)
+    list (APPEND buildfiles
+         Containers/HashMap2.cc
+         Containers/List2.cc
+         Containers/Map2.cc
+         Containers/Stack2.cc
+         Containers/StackError.cc
+    )
+endif ()
+
+add_library (casa_casa ${buildfiles})
+
+
 if (HDF5_FOUND)
     list (APPEND de_libraries ${HDF5_LIBRARIES})
 endif (HDF5_FOUND)
@@ -349,35 +358,11 @@ Containers/Allocator.h
 Containers/Block.h
 Containers/BlockIO.h
 Containers/BlockIO.tcc
-Containers/HashMap.h
-Containers/HashMap.tcc
-Containers/HashMapIO.h
-Containers/HashMapIO.tcc
-Containers/HashMapIter.h
-Containers/HashMapIter.tcc
 Containers/IterError.h
 Containers/Link.h
 Containers/Link.tcc
-Containers/List.h
-Containers/List.tcc
-Containers/ListIO.h
-Containers/ListIO.tcc
-Containers/Map.h
-Containers/Map.tcc
-Containers/MapIO.h
-Containers/MapIO.tcc
 Containers/ObjectStack.h
 Containers/ObjectStack.tcc
-Containers/OrderedMap.h
-Containers/OrderedMap.tcc
-Containers/OrderedPair.h
-Containers/OrderedPair.tcc
-Containers/OrdMapIO.h
-Containers/OrdMapIO.tcc
-Containers/OrdPairIO.h
-Containers/OrdPairIO.tcc
-Containers/Queue.h
-Containers/Queue.tcc
 Containers/RecordDesc.h
 Containers/RecordDescRep.h
 Containers/RecordField.h
@@ -388,17 +373,47 @@ Containers/RecordFieldWriter.tcc
 Containers/Record.h
 Containers/RecordInterface.h
 Containers/RecordRep.h
-Containers/SimOrdMap.h
-Containers/SimOrdMap.tcc
-Containers/SimOrdMapIO.h
-Containers/SimOrdMapIO.tcc
-Containers/StackError.h
-Containers/Stack.h
-Containers/Stack.tcc
 Containers/ValueHolder.h
 Containers/ValueHolderRep.h
 DESTINATION include/casacore/casa/Containers
 )
+
+if (BUILD_DEPRECATED)
+    install (FILES
+         Containers/HashMap.h
+         Containers/HashMap.tcc
+         Containers/HashMapIO.h
+         Containers/HashMapIO.tcc
+         Containers/HashMapIter.h
+         Containers/HashMapIter.tcc
+         Containers/List.h
+         Containers/List.tcc
+         Containers/ListIO.h
+         Containers/ListIO.tcc
+         Containers/Map.h
+         Containers/Map.tcc
+         Containers/MapIO.h
+         Containers/MapIO.tcc
+         Containers/OrderedMap.h
+         Containers/OrderedMap.tcc
+         Containers/OrdMapIO.h
+         Containers/OrdMapIO.tcc
+         Containers/OrdPair.h
+         Containers/OrdPair.tcc
+         Containers/OrdPairIO.h
+         Containers/OrdPairIO.tcc
+         Containers/Queue.h
+         Containers/Queue.tcc
+         Containers/SimOrdMap.h
+         Containers/SimOrdMap.tcc
+         Containers/SimOrdMapIO.h
+         Containers/SimOrdMapIO.tcc
+         Containers/Stack.h
+         Containers/Stack.tcc
+         Containers/StackError.h
+    DESTINATION include/casacore/casa/Containers
+    )
+endif ()
 
 install (FILES
 Exceptions/CasaErrorTools.h

--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -398,8 +398,8 @@ if (BUILD_DEPRECATED)
          Containers/OrderedMap.tcc
          Containers/OrdMapIO.h
          Containers/OrdMapIO.tcc
-         Containers/OrdPair.h
-         Containers/OrdPair.tcc
+         Containers/OrderedPair.h
+         Containers/OrderedPair.tcc
          Containers/OrdPairIO.h
          Containers/OrdPairIO.tcc
          Containers/Queue.h

--- a/casa/Containers.h
+++ b/casa/Containers.h
@@ -31,27 +31,11 @@
 #include <casacore/casa/aips.h>
 
 #include <casacore/casa/Containers/Block.h>
-#include <casacore/casa/Containers/Link.h>
-#include <casacore/casa/Containers/List.h>
-#include <casacore/casa/Containers/ListMap.h>
-#include <casacore/casa/Containers/Map.h>
-#include <casacore/casa/Containers/OrderedPair.h>
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Containers/RecordField.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
-#include <casacore/casa/Containers/OrderedMap.h>
-#include <casacore/casa/Containers/Queue.h>
-#include <casacore/casa/Containers/Stack.h>
 
 #include <casacore/casa/Containers/BlockIO.h>
-#include <casacore/casa/Containers/ListIO.h>
-#include <casacore/casa/Containers/ListMapIO.h>
-#include <casacore/casa/Containers/OrdPairIO.h>
-#include <casacore/casa/Containers/OrdMapIO.h>
-#include <casacore/casa/Containers/SimOrdMapIO.h>
-#include <casacore/casa/Containers/MapIO.h>
 
-#include <casacore/casa/Containers/StackError.h>
 #include <casacore/casa/Containers/IterError.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -67,13 +51,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //
 // <synopsis>
 //    This module provides non-mathematical containers. These containers are the
-//    prototypical computer science types of containers -- <linkto
-//    class=Queue>queues</linkto>, <linkto class=Stack>stacks</linkto>, <linkto
-//    class=List>lists</linkto>, <linkto class=Map>associative arrays</linkto>,
+//    prototypical computer science types of containers -- 
 //    <linkto class="Record">records</linkto> and <linkto class=Block>simple
 //    arrays</linkto>. These classes are useful for all of the various types of low
 //    level data management. In general, these classes will have familiar semantics
 //    and an unsurprising interface.
+//    Note that Casacore used to have classes such as Map and List, but they
+//    became obsolete when the Standard C++ Library was introduced. Therefore these
+//    classes have been removed.
 //
 //    Most of the important classes in this module also have IO shift operators,
 //    e.g. for <linkto file=BlockIO.h#BlockIO>writing out a Block</linkto> (simple

--- a/casa/Containers/HashMap.h
+++ b/casa/Containers/HashMap.h
@@ -28,6 +28,10 @@
 #ifndef CASA_HASHMAP_H
 #define CASA_HASHMAP_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "HashMap.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/Block.h>

--- a/casa/Containers/HashMapIO.h
+++ b/casa/Containers/HashMapIO.h
@@ -28,6 +28,9 @@
 #ifndef CASA_HASHMAPIO_H
 #define CASA_HASHMAPIO_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "HashMapIO.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/HashMapIter.h>

--- a/casa/Containers/HashMapIter.h
+++ b/casa/Containers/HashMapIter.h
@@ -27,6 +27,9 @@
 #ifndef CASA_HASHMAPITER_H
 #define CASA_HASHMAPITER_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "HashMapIter.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/HashMap.h>

--- a/casa/Containers/List.h
+++ b/casa/Containers/List.h
@@ -28,6 +28,9 @@
 #ifndef CASA_LIST_H
 #define CASA_LIST_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "List.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
 
 //# Includes
 #include <casacore/casa/aips.h>

--- a/casa/Containers/ListIO.h
+++ b/casa/Containers/ListIO.h
@@ -31,6 +31,9 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/List.h>
 
+#ifndef AIPS_USE_DEPRECATED
+#error "ListIO.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/casa/Containers/Map.h
+++ b/casa/Containers/Map.h
@@ -28,6 +28,9 @@
 #ifndef CASA_MAP_H
 #define CASA_MAP_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "Map.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
 
 //# Includes
 #include <casacore/casa/aips.h>

--- a/casa/Containers/MapIO.h
+++ b/casa/Containers/MapIO.h
@@ -31,6 +31,10 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/Map.h>
 
+#ifndef AIPS_USE_DEPRECATED
+#error "MapIO.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class AipsIO;

--- a/casa/Containers/OrdMapIO.h
+++ b/casa/Containers/OrdMapIO.h
@@ -28,6 +28,10 @@
 #ifndef CASA_ORDMAPIO_H
 #define CASA_ORDMAPIO_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "OrdMapIO.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 // <summary>
 // Input/output operators for OrderedMaps.
 // </summary>

--- a/casa/Containers/OrdPairIO.h
+++ b/casa/Containers/OrdPairIO.h
@@ -28,6 +28,10 @@
 #ifndef CASA_ORDPAIRIO_H
 #define CASA_ORDPAIRIO_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "OrdPairIO.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/OrderedPair.h>
 #include <casacore/casa/iosfwd.h>

--- a/casa/Containers/OrderedMap.h
+++ b/casa/Containers/OrderedMap.h
@@ -28,6 +28,10 @@
 #ifndef CASA_ORDEREDMAP_H
 #define CASA_ORDEREDMAP_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "OrderedMap.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Containers/Block.h>

--- a/casa/Containers/OrderedPair.h
+++ b/casa/Containers/OrderedPair.h
@@ -28,6 +28,9 @@
 #ifndef CASA_ORDEREDPAIR_H
 #define CASA_ORDEREDPAIR_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "OrderedPair.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
 
 //# Includes
 #include <casacore/casa/aips.h>

--- a/casa/Containers/Queue.h
+++ b/casa/Containers/Queue.h
@@ -28,6 +28,10 @@
 #ifndef CASA_QUEUE_H
 #define CASA_QUEUE_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "Queue.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/Block.h>
 

--- a/casa/Containers/Record.h
+++ b/casa/Containers/Record.h
@@ -235,7 +235,7 @@ public:
     Record& operator= (const Record& other);
     
     // Release resources associated with this object.
-    ~Record();
+    virtual ~Record();
 
     // Make a copy of this object.
     virtual RecordInterface* clone() const;

--- a/casa/Containers/RecordDescRep.h
+++ b/casa/Containers/RecordDescRep.h
@@ -34,9 +34,9 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/casa/Containers/Block.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/iosfwd.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -291,7 +291,7 @@ private:
     // Comments for each field.
     Block<String> comments_p;
     // Mapping of field name to field number.
-    SimpleOrderedMap<String,Int> name_map_p;
+    std::map<String,Int> name_map_p;
 };
 
 inline uInt RecordDescRep::nfields() const

--- a/casa/Containers/RecordInterface.h
+++ b/casa/Containers/RecordInterface.h
@@ -208,7 +208,7 @@ public:
 
     // Destruct the record.
     // All attached RecordFieldPtr objects are notified to detach themselves.
-    ~RecordInterface();
+    virtual ~RecordInterface();
 
     // Make a copy of this object.
     virtual RecordInterface* clone() const = 0;

--- a/casa/Containers/SimOrdMap.h
+++ b/casa/Containers/SimOrdMap.h
@@ -28,6 +28,10 @@
 #ifndef CASA_SIMORDMAP_H
 #define CASA_SIMORDMAP_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "SimOrdMap.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/OrderedPair.h>
 #include <casacore/casa/Containers/Block.h>
@@ -87,6 +91,7 @@ public:
     SimpleOrderedMap<K,V>& operator= (const SimpleOrderedMap<K,V>&);
 
     // Defines a mapping (ie. create a key value mapping)
+    // The value is replaced if the key already exists.
     V &define (const K&, const V&);
 
     // This is the mapping function which maps keys to values. If the
@@ -115,7 +120,7 @@ public:
     //-grp
 
     // These functions check to see if a mapping is defined between
-    // the specified key and some value. If one is, a pointer to
+    // the specified key and some value. If defined, a pointer to
     // the value is returned, otherwise 0 is returned.
     //+grp
     V *isDefined(const K&);

--- a/casa/Containers/SimOrdMap.tcc
+++ b/casa/Containers/SimOrdMap.tcc
@@ -167,7 +167,7 @@ const V &SimpleOrderedMap<K,V>::operator()(const K &ky) const
 template<class K, class V>
 V &SimpleOrderedMap<K,V>::define (const K& k, const V& v)
 {
-    //  Locate the key. Error if the key already exists.
+    //  Locate the key. Replace if the key already exists.
     Bool defined;
     uInt inx = findKey (k, defined);
     if (defined) {

--- a/casa/Containers/SimOrdMapIO.h
+++ b/casa/Containers/SimOrdMapIO.h
@@ -28,6 +28,10 @@
 #ifndef CASA_SIMORDMAPIO_H
 #define CASA_SIMORDMAPIO_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "SimOrdMapIO.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/iosfwd.h>

--- a/casa/Containers/Stack.h
+++ b/casa/Containers/Stack.h
@@ -28,6 +28,10 @@
 #ifndef CASA_STACK_H
 #define CASA_STACK_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "Stack.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/Link.h>
 

--- a/casa/Containers/StackError.h
+++ b/casa/Containers/StackError.h
@@ -28,6 +28,10 @@
 #ifndef CASA_STACKERROR_H
 #define CASA_STACKERROR_H
 
+#ifndef AIPS_USE_DEPRECATED
+#error "StackError.h is deprecated; use -DBUILD_DEPRECATED=ON to use it"
+#endif
+
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Exceptions/Error.h>

--- a/casa/Containers/test/CMakeLists.txt
+++ b/casa/Containers/test/CMakeLists.txt
@@ -1,20 +1,25 @@
 set (tests
 tBlock
 tBlockTrace
-tHashMap
-tHashMapIO
-tHashMapIter
-tList
 tObjectStack
-tOrdMap2
-tOrdMap
-tQueue
 tRecord
 tRecordDesc
-tSimOrdMap
-tStack
 tValueHolder
 )
+
+if (BUILD_DEPRECATED)
+   list (APPEND tests
+       tHashMap
+       tHashMapIO
+       tHashMapIter
+       tList
+       tOrdMap2
+       tOrdMap
+       tQueue
+       tSimOrdMap
+       tStack
+   )
+endif ()
 
 foreach (test ${tests})
     add_executable (${test} ${test}.cc)

--- a/casa/Inputs/Input.h
+++ b/casa/Inputs/Input.h
@@ -31,7 +31,7 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Inputs/Param.h>
-#include <casacore/casa/Containers/List.h>
+#include <vector>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -78,8 +78,7 @@ template<class T> class Vector;
 // on prompting for parameter values not specified on the command-line.  In
 // such an instance, the optional String arguments to Input::create become 
 // important.  The argument "help=keys" will print to standard output a list 
-// of all the parameters.  Finally, "help=pane" prints to standard output a
-// pane file usable as a graphic user interface within Khoros Cantata.
+// of all the parameters.
 // 
 // The default existance of the debug parameter allows the user to specify
 // levels of debugging, where 0 implies none and higher integers means more.
@@ -165,9 +164,6 @@ template<class T> class Vector;
 //  // Create a parameter with a help String which will be displayed when in
 //  // the prompted entry mode.
 //  inp.create("ubound", "1000", "The number of iterations to clean.");
-//  // Create a parameter with a type.  This is utilized to create the correct
-//  // labels on a Khoros pane.  You could do type checking yourself, as well.
-//  inp.create("baseline", "451", "The number of baselines.", "Int");
 //  // Create a parameter with a range of acceptable values.  Note: checking
 //  // must be done by the user as this isn't coded in.
 //  inp.create("gainstride", "0.5", "The factor by which the Clean strides.",
@@ -200,17 +196,8 @@ template<class T> class Vector;
 // <motivation>
 // In the earliest days of the old AIPS++ project, the desire to start coding 
 // right away led to the need for a user interface.  The preexistant C language
-// method of argc/argv was enclosed in an object for easier use.  This also
-// provided a means to output a pane file.  Pane files are used by the 
-// Cantata desktop within the Khoros system to build quick graphic user 
-// interfaces.  The Casacore code has moved on to greater heights and left the
-// Input class mostly unchanged.
+// method of argc/argv was enclosed in an object for easier use.
 // </motivation>
-//
-// <todo asof="Thu 1995/04/06 21:26:43 GMT">
-//   <li> major cleanup needed - this is the oldest code in Casacore.
-//   <li> replace List<Param> with keywords
-// </todo>
 
 
 class Input {
@@ -312,8 +299,8 @@ public:
 
 
 private:
-  // Get the index of the named parameter (0 if unknown key).
-  // Anywhere from 1.. if a key is found.
+  // Get the index of the named parameter (-1 if unknown key).
+  // Anywhere from 0.. if a key is found.
   Int getParam (const String& key) const;
 
   // Prompt the user for a value for the parameter.
@@ -327,15 +314,12 @@ private:
   void createPar (Int, const String&, const String&, const String&,
 		  const String&, const String&, const String&);
 
-  // output to stdout a Khoros Cantata pane.
-  void pane();
-
   // output to stdout a listing of all "key=value" pairs.
   void keys();
 
 
-  // linked list container of parameters
-  List<Param> parList_p;
+  // container of parameters
+  std::vector<Param> parList_p;
 
   // version id         
   String version_id;    
@@ -349,7 +333,7 @@ private:
   // threshold value for debug output
   Int debug_level;              
 
-  // "prompt", "keys", or "pane" indicates the various types of help.
+  // "prompt" or "keys" indicates the various types of help.
   String help_mode;     
 
   // count of program parameters

--- a/casa/Logging.h
+++ b/casa/Logging.h
@@ -34,7 +34,6 @@
 #include <casacore/casa/Logging/LogOrigin.h>
 #include <casacore/casa/Logging/LogSink.h>
 #include <casacore/casa/Logging/LogFilter.h>
-//#include <aips/LogTables/TableLogSink.h>
 #include <casacore/casa/Logging/LogIO.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN

--- a/casa/casa.dox
+++ b/casa/casa.dox
@@ -35,7 +35,7 @@ namespace casacore {
 //   <li> <a href="group__Quanta__module.html">Quantities</a> (values with physical units)
 //   <li> <a href="group__OS__module.html">OS</a> and
 //    <a href="group__IO__module.html">IO</a> interface classes
-//   <li> <a href="group__Containers__module.html">Container</a>s (from pre-STL era)
+//   <li> <a href="group__Containers__module.html">Container</a>s (such as Record)
 //   <li> Various <a href="group__Utilities__module.html">utilit</a>y classes
 //        and functions
 //   <li> Classes to store and retrieve Casacore data types in/from the 
@@ -52,9 +52,12 @@ namespace casacore {
 // </ul>
 // It is important to note that most of the code has been developed before STL
 // came into existence, so several classes in modules Containers
-// and Utilities are superseded by their STL counterparts. However, they
-// are still used in some Casacore code.
-// Furthermore, some classes offer some extra functionality compared
+// and Utilities are superseded by their STL counterparts. They
+// have been removed from the Casacore code.
+//
+// Note that class Regex still exists because std::regex is not supported in
+// gcc-4.8 and before; this compiler is still shipped in some distributions.
+// Furthermore, some classes (such as String) offer some extra functionality compared
 // to STL.
 
 }

--- a/fits/FITS/BasicFITS.cc
+++ b/fits/FITS/BasicFITS.cc
@@ -44,7 +44,7 @@ Array<Float> ReadFITS(const char *FileName, Bool &ok, String &ErrorMessage,
 		      Vector<Float> *refPixel,
 		      Vector<Float> *refLocation,
 		      Vector<Float> *delta,
-		      Map<String, Double> *keywords,
+		      std::map<String, Double> *keywords,
                       String *objectName)
 {
     Array<Float> data;
@@ -115,7 +115,7 @@ Bool WriteFITS(const char *FileName, const Array<Float> &array,
 	       const Vector<Float> *refPixel,
 	       const Vector<Float> *refLocation,
 	       const Vector<Float> *delta,
-	       const Map<String, double> *keywords,
+	       const std::map<String, double> *keywords,
                const char *objectName,
 	       Int BITPIX, Float minPix, Float maxPix)
 {
@@ -196,19 +196,15 @@ Bool WriteFITS(const char *FileName, const Array<Float> &array,
 	}
     }
     if (keywords) {
-	ConstMapIter<String, Double> keyiter(keywords);
-	String key;
-	Double val;
-	while (! keyiter.atEnd()) {
-	    key = keyiter.getKey();
-	    val = keyiter.getVal();
+        for (const auto& elem : *keywords) {
+            String key (elem.first);
+	    Double val (elem.second);
 	    // FITS requires upper case, length=8 (or less) keywords
 	    key.upcase();
 	    if (key.length() > 8) {
 		key = key.at(0,8);
 	    }
 	    kw.mk(key.chars(), val);
-	    ++keyiter;
 	}
     }
     if (objectName) {

--- a/fits/FITS/BasicFITS.h
+++ b/fits/FITS/BasicFITS.h
@@ -25,13 +25,13 @@
 //#
 //# $Id$
 
-#ifndef FITS_BasicFITS_H
-#define FITS_BasicFITS_H
+#ifndef FITS_BASICFITS_H
+#define FITS_BASICFITS_H
 
 #include <casacore/casa/aips.h>
 //# Would like to forward declare
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Containers/Map.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -91,7 +91,7 @@ Array<Float> ReadFITS(const char *FileName, Bool &ok, String &ErrorMessage,
 		      Vector<Float> *refPixel = 0,
 		      Vector<Float> *refLocation = 0,
 		      Vector<Float> *delta = 0,
-		      Map<String, Double> *keywords = 0,
+		      std::map<String, Double> *keywords = 0,
                       String *objectName = 0);
 //</group>
 
@@ -137,7 +137,7 @@ Bool WriteFITS(const char *FileName, const Array<Float> &array,
 	       const Vector<Float> *refPixel = 0,
 	       const Vector<Float> *refLocation = 0,
 	       const Vector<Float> *delta = 0,
-	       const Map<String, Double> *keywords = 0,
+	       const std::map<String, Double> *keywords = 0,
 	       const char *objectName = 0,
 	       Int BITPIX=-32,
 	       Float minPix = 1.0, Float maxPix = -1.0);

--- a/fits/FITS/BinTable.cc
+++ b/fits/FITS/BinTable.cc
@@ -225,7 +225,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
    //		get some things to remember
    Int nfield = (Int ) tfields();
    nelem = new Int[nfield];
-   colNames = new SimpleOrderedMap<Int, String>("");
+   colNames = new std::map<Int, String>();
 
    AlwaysAssert(nelem, AipsError);
    //		loop over the number of fields in the FITS table
@@ -252,7 +252,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
 	   td.rwKeywordSet().renameField(newname, colname);
        }
        //		enter the name in the colNames map
-       colNames->define(i, colname);
+       colNames->insert(std::make_pair(i, colname));
        //		get a shorthand Bool for array versus scalar
        //               NOTE: VADESC are always assumed to be array columns
        //               but that fact is ignored by isArray - but thats ok,
@@ -486,7 +486,7 @@ void BinaryTable::fillRow()
     //		loop over each field
     for (Int j=0;j<tfields(); j++) {
 	//		and switch on the FITS type
-	TableColumn tabcol(*currRowTab, (*colNames)(j));
+	TableColumn tabcol(*currRowTab, (*colNames)[j]);
 	switch (field(j).fieldtype()) {
 	case FITS::LOGICAL:
             {

--- a/fits/FITS/BinTable.h
+++ b/fits/FITS/BinTable.h
@@ -35,7 +35,7 @@
 #include <casacore/fits/FITS/hdu.h>
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/tables/Tables/TableRecord.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -165,7 +165,7 @@ private:
     // The number of elements for each column of the BinaryTableExtension
     Int *nelem;
     // This is a map from column number to column name
-    SimpleOrderedMap<Int, String> *colNames;
+    std::map<Int, String> *colNames;
 
     TableRecord kwSet;
 

--- a/fits/FITS/FITS2.h
+++ b/fits/FITS/FITS2.h
@@ -31,8 +31,8 @@
 #include <casacore/casa/aips.h>
 //# Would like to forward declare
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Containers/Map.h>
 #include <casacore/fits/FITS/hdu.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -57,7 +57,7 @@ void ReadFITSin(PrimaryArray<StorageType> &fitsdata,
 	      Vector<Float> *refPixel,
 	      Vector<Float> *refLocation,
 	      Vector<Float> *delta,
-	      Map<String, Double> *keywords,
+              std::map<String, Double> *keywords,
               String *objectName);
 //</group>
 

--- a/fits/FITS/FITS2.tcc
+++ b/fits/FITS/FITS2.tcc
@@ -49,7 +49,7 @@ void ReadFITSin(PrimaryArray<StorageType> &fitsdata,
 	      Vector<Float> *refPixel,
 	      Vector<Float> *refLocation,
 	      Vector<Float> *delta,
-	      Map<String, Double> *keywords,
+              std::map<String, Double> *keywords,
 	      String *objectName)
 {
 
@@ -120,9 +120,9 @@ void ReadFITSin(PrimaryArray<StorageType> &fitsdata,
 		continue;
 	    }
 	    switch (next->type()) {
-	    case  FITS::DOUBLE:  (*keywords)(kwname) = next->asDouble(); break;
-	    case FITS::FLOAT:    (*keywords)(kwname) = next->asFloat(); break;
-            case FITS::LONG:     (*keywords)(kwname) = next->asInt(); break;
+	    case  FITS::DOUBLE:  (*keywords)[kwname] = next->asDouble(); break;
+	    case FITS::FLOAT:    (*keywords)[kwname] = next->asFloat(); break;
+            case FITS::LONG:     (*keywords)[kwname] = next->asInt(); break;
             default:             break;
 			     }
 	    next = kwl.next();

--- a/fits/FITS/test/tFITS.cc
+++ b/fits/FITS/test/tFITS.cc
@@ -41,7 +41,6 @@
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
-#include <casacore/casa/Containers/OrderedMap.h>
 #include <casacore/casa/iostream.h>
 
 #include <casacore/casa/namespace.h>
@@ -57,7 +56,7 @@ int main()
     }
 
     // Create the "optional" information
-    OrderedMap<String, Double> mapout(0.0), mapin(0.0);
+    std::map<String, Double> mapout, mapin;
     String unitout, unitin;
     unitout = "Jy";
     Vector<String> namesout(2), namesin(2);
@@ -65,8 +64,8 @@ int main()
     Vector<Float> refout(2), refin(2), locout(2), locin(2), deltaout(2),
 	deltain(2);
     refout = 0.0f; locout = 1.0f; deltaout = 1.0f;
-    mapout("hello") = 1.0;
-    mapout("world") = 2.0;
+    mapout["hello"] = 1.0;
+    mapout["world"] = 2.0;
     String objectin, objectout;
     objectout  = "Testing 1.2.3.";
 
@@ -98,8 +97,8 @@ int main()
     AlwaysAssertExit(allEQ(refout , refin));
     AlwaysAssertExit(allEQ(locout , locin));
     AlwaysAssertExit(allEQ(deltaout , deltain));
-    AlwaysAssertExit(mapin("HELLO") == 1.0);
-    AlwaysAssertExit(mapin("WORLD") == 2.0);
+    AlwaysAssertExit(mapin["HELLO"] == 1.0);
+    AlwaysAssertExit(mapin["WORLD"] == 2.0);
     AlwaysAssertExit(objectout == objectin);
 
     unlink(file);

--- a/images/Images/ImageOpener.cc
+++ b/images/Images/ImageOpener.cc
@@ -49,20 +49,15 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-// Initialize registry with the unknown as the default open function.
-SimpleOrderedMap<ImageOpener::ImageTypes,ImageOpener::OpenImageFunction*>
-     ImageOpener::theirOpenFuncMap(&ImageOpener::unknownImageOpen);
+// Initialize registry.
+std::map<ImageOpener::ImageTypes,ImageOpener::OpenImageFunction*>
+     ImageOpener::theirOpenFuncMap;
 
-LatticeBase* ImageOpener::unknownImageOpen (const String&,
-					    const MaskSpecifier&)
-{
-  return 0;
-}
 
 void ImageOpener::registerOpenImageFunction (ImageTypes type,
 					     OpenImageFunction* func)
 {
-  theirOpenFuncMap.define (type, func);
+  theirOpenFuncMap[type] = func;
 }
 
 ImageOpener::ImageTypes ImageOpener::imageType (const String& name)
@@ -271,7 +266,10 @@ LatticeBase* ImageOpener::openImage (const String& fileName,
    FITSImage::registerOpenFunction();
    MIRIADImage::registerOpenFunction();
    // Try to open a foreign image.
-   return theirOpenFuncMap(type) (fileName, spec);
+   if (theirOpenFuncMap.find(type) == theirOpenFuncMap.end()) {
+     return 0;
+   }
+   return theirOpenFuncMap[type] (fileName, spec);
 }
 
 

--- a/images/Images/ImageOpener.h
+++ b/images/Images/ImageOpener.h
@@ -32,7 +32,8 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/images/Images/MaskSpecifier.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <casacore/casa/Containers/Block.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -144,13 +145,8 @@ public:
                                 const JsonKVMap&);
 
 private:
-  // The default openImage function for an unknown image type.
-  // It returns a null pointer.
-  static LatticeBase* unknownImageOpen (const String& name,
-					const MaskSpecifier&);
-
   // Mapping of the image type to an openImage function.
-  static SimpleOrderedMap<ImageTypes,OpenImageFunction*> theirOpenFuncMap;
+  static std::map<ImageTypes,OpenImageFunction*> theirOpenFuncMap;
 };
 
 

--- a/images/Images/test/dPagedImage.cc
+++ b/images/Images/test/dPagedImage.cc
@@ -28,7 +28,6 @@
 
 #include<casacore/casa/aips.h>
 #include <casacore/images/Images/PagedImage.h>
-///#include <trial/ImgCrdSys/ImageCoordinate.h>
 
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/Cube.h>

--- a/images/Regions/RegionHandlerMemory.h
+++ b/images/Regions/RegionHandlerMemory.h
@@ -33,7 +33,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/images/Regions/RegionHandler.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -182,7 +182,7 @@ private:
 
 
   String itsDefaultName;
-  SimpleOrderedMap<String, void*>* itsMaps[2];
+  std::map<String, void*> itsMaps[2];
 };
 
 

--- a/images/Regions/RegionManager.cc
+++ b/images/Regions/RegionManager.cc
@@ -31,7 +31,6 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Containers/Block.h>
-#include <casacore/casa/Containers/HashMap.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/Logging/LogFilter.h>

--- a/ms/MSOper/MSConcat.h
+++ b/ms/MSOper/MSConcat.h
@@ -139,13 +139,13 @@ private:
   Float itsWeightScale;
   Bool itsRespectForFieldName;
   Vector<Bool> itsChanReversed;
-  SimpleOrderedMap <Int, Int> newSourceIndex_p;
-  SimpleOrderedMap <Int, Int> newSourceIndex2_p;
-  SimpleOrderedMap <Int, Int> newSPWIndex_p;
-  SimpleOrderedMap <Int, Int> newObsIndexA_p;
-  SimpleOrderedMap <Int, Int> newObsIndexB_p;
-  SimpleOrderedMap <Int, Int> otherObsIdsWithCounterpart_p;
-  SimpleOrderedMap <Int, Int> solSystObjects_p;
+  std::map <Int, Int> newSourceIndex_p;
+  std::map <Int, Int> newSourceIndex2_p;
+  std::map <Int, Int> newSPWIndex_p;
+  std::map <Int, Int> newObsIndexA_p;
+  std::map <Int, Int> newObsIndexB_p;
+  std::map <Int, Int> otherObsIdsWithCounterpart_p;
+  std::map <Int, Int> solSystObjects_p;
 
   Bool doSource_p;
   Bool doSource2_p;
@@ -182,7 +182,12 @@ Bool areEQ(const ROArrayColumn<T>& col, uInt row_i, uInt row_j)
   return rval;
 }
 
-
+inline Int getMapValue (const std::map<Int,Int>& m, Int k)
+{
+  auto iter = m.find(k);
+  return (iter == m.end()  ?  -1 : iter->second);
+}
+  
 
 } //# NAMESPACE CASACORE - END
 

--- a/ms/MSOper/MSReader.cc
+++ b/ms/MSOper/MSReader.cc
@@ -40,7 +40,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 MSReader::MSReader(const MeasurementSet &ms)
-    : itsMS(ms), itsMSCols(ms), itsSecUnit("s"), itsIds(ms), itsTabId(-1),
+    : itsMS(ms), itsMSCols(ms), itsSecUnit("s"), itsIds(ms),
       itsMainId(-1), itsAnt1Id(-1), itsAnt2Id(-1), itsDDId(-1), itsDopplerId(-1),
       itsFeed1Id(-1), itsFeed2Id(-1), itsFieldId(-1), itsFlagCmdId(-1),
       itsFreqOffsetId(-1), itsObsId(-1), itsPointing1Id(-1), itsPointing2Id(-1), 
@@ -52,7 +52,7 @@ MSReader::MSReader(const MeasurementSet &ms)
     uInt idCount = 0;
     for (uInt i=0;i<kwSet.nfields();i++) {
 	if (kwSet.type(i) == TpTable) {
-	    itsTabId.define(kwSet.name(i),idCount);
+            itsTabId[kwSet.name(i)] = idCount;
 	    idCount++;
 	} // ignore all other keywords
     }
@@ -61,55 +61,55 @@ MSReader::MSReader(const MeasurementSet &ms)
 
     // ANTENNA1 == ANTENNA
     // ANTENNA is required
-    itsAnt1Id = itsTabId("ANTENNA");
+    itsAnt1Id = itsTabId.at("ANTENNA");
     DebugAssert(itsAnt1Id>=0, AipsError);
-    itsTabId.define("ANTENNA1", itsAnt1Id);
+    itsTabId["ANTENNA1"] = itsAnt1Id;
     // ANTENNA2 gets a new number
-    itsTabId.define("ANTENNA2", idCount++);
-    itsAnt2Id = itsTabId("ANTENNA2");
+    itsAnt2Id = idCount++;
+    itsTabId["ANTENNA2"] = itsAnt2Id;
     
     // FEED1 == FEED
     // FEED is required
-    itsFeed1Id = itsTabId("FEED");
+    itsFeed1Id = itsTabId.at("FEED");
     DebugAssert(itsFeed1Id>=0, AipsError);
-    itsTabId.define("FEED1", itsFeed1Id);
+    itsTabId["FEED1"] = itsFeed1Id;
     // FEED2 gets a new number
-    itsTabId.define("FEED2", idCount++);
-    itsFeed2Id = itsTabId("FEED2");
+    itsFeed2Id = idCount++;
+    itsTabId["FEED2"] = itsFeed2Id;
 
     // there are two POINTING lookups, one for each possible antenna
     // POINTING is a required table
-    itsPointing1Id = itsTabId("POINTING");
+    itsPointing1Id = itsTabId.at("POINTING");
     DebugAssert(itsPointing1Id>=0, AipsError);
-    itsTabId.define("POINTING1", itsPointing1Id);
+    itsTabId["POINTING1"] = itsPointing1Id;
 
     // POINTING2 gets a new number
-    itsTabId.define("POINTING2", idCount++);
-    itsPointing2Id = itsTabId("POINTING2");
+    itsPointing2Id = idCount++;
+    itsTabId["POINTING2"] = itsPointing2Id;
 
     // there are two SYSCAL lookups, one for each possible antenna
     // SYSCAL is an optional table
-    itsSyscal1Id = itsTabId("SYSCAL");
+    itsSyscal1Id = itsTabId.at("SYSCAL");
     if (itsSyscal1Id >= 0) {
-	itsTabId.define("SYSCAL1", itsSyscal1Id);
+	itsTabId["SYSCAL1"] = itsSyscal1Id;
 	// SYSCAL2 gets a new number
-	itsTabId.define("SYSCAL2", idCount++);
-	itsSyscal2Id = itsTabId("SYSCAL2");
+	itsSyscal2Id = idCount++;
+	itsTabId["SYSCAL2"] = itsSyscal2Id;
     }
 
     // there are two WEATHER lookups, one for each possible antenna
     // WEATHER is an optional table
-    itsWeather1Id = itsTabId("WEATHER");
+    itsWeather1Id = itsTabId.at("WEATHER");
     if (itsWeather1Id >= 0) {
-	itsTabId.define("WEATHER1", itsWeather1Id);
+	itsTabId["WEATHER1"] = itsWeather1Id;
 	// WEATHER2 gets a new number
-	itsTabId.define("WEATHER2", idCount++);
-	itsWeather2Id = itsTabId("WEATHER2");
+	itsWeather2Id = idCount++;
+	itsTabId["WEATHER2"] = itsWeather2Id;
     }
 
     // And the MAIN table needs a presence in the various blocks
-    itsTabId.define("MAIN", idCount++);
-    itsMainId = itsTabId("MAIN");
+    itsMainId = idCount++;
+    itsTabId["MAIN"] = itsMainId;
 
     // at this point, we know the size of the things we need == idCount
     Vector<Bool> handledTab(idCount, False);
@@ -134,13 +134,13 @@ MSReader::MSReader(const MeasurementSet &ms)
 
     // DATA_DESCRIPTION - no index, indexed simply via DATA_DESC_ID value
     // This table is required.
-    itsDDId = itsTabId("DATA_DESCRIPTION");
+    itsDDId = itsTabId.at("DATA_DESCRIPTION");
     DebugAssert(itsDDId>=0, AipsError);
     itsTabRows[itsDDId] = ROTableRow(itsMS.dataDescription());
     handledTab(itsDDId) = True;
 
     // DOPPLER - has a special index.  This table is OPTIONAL
-    itsDopplerId = itsTabId("DOPPLER");
+    itsDopplerId = itsTabId.at("DOPPLER");
     if (itsDopplerId >= 0) {
 	itsDopplerIndex.attach(itsMS.doppler());
 	itsTabRows[itsDopplerId] = ROTableRow(itsMS.doppler());
@@ -160,14 +160,14 @@ MSReader::MSReader(const MeasurementSet &ms)
 
     // FIELD - no index, indexed simply via FIELD_ID value
     // This table is required.
-    itsFieldId = itsTabId("FIELD");
+    itsFieldId = itsTabId.at("FIELD");
     DebugAssert(itsFieldId>=0, AipsError);
     itsTabRows[itsFieldId] = ROTableRow(itsMS.field());
     handledTab(itsFieldId) = True;
 
     // FLAG_CMD, simple time and interval MSTableIndex
     // This table is required
-    itsFlagCmdId = itsTabId("FLAG_CMD");
+    itsFlagCmdId = itsTabId.at("FLAG_CMD");
     DebugAssert(itsFlagCmdId>=0, AipsError);
     itsIndexes[itsFlagCmdId] = MSTableIndex(itsMS.flagCmd(),Vector<String>());
     itsTabRows[itsFlagCmdId] = ROTableRow(itsMS.flagCmd());
@@ -175,7 +175,7 @@ MSReader::MSReader(const MeasurementSet &ms)
 
     // FREQ_OFFSET - indexed
     // This table is optional
-    itsFreqOffsetId = itsTabId("FREQ_OFFSET");
+    itsFreqOffsetId = itsTabId.at("FREQ_OFFSET");
     if (itsFreqOffsetId >= 0) {
 	itsFreqOffIndex.attach(itsMS.freqOffset());
 	itsTabRows[itsFreqOffsetId] = ROTableRow(itsMS.freqOffset());
@@ -184,14 +184,14 @@ MSReader::MSReader(const MeasurementSet &ms)
 
     // HISTORY - not handled here, this is a required table
     // make sure its marked as undefined in the ID map and mark it as handled here
-    Int histId = itsTabId("HISTORY");
+    Int histId = itsTabId.at("HISTORY");
     if (histId >= 0) {
-	itsTabId.define("HISTORY",-1);
+	itsTabId["HISTORY"] = -1;
 	handledTab(histId) = True;
     }
 
     // OBSERVATION - not indexed, this is a required table
-    itsObsId = itsTabId("OBSERVATION");
+    itsObsId = itsTabId.at("OBSERVATION");
     DebugAssert(itsObsId>=0, AipsError);
     itsTabRows[itsObsId] = ROTableRow(itsMS.observation());
     handledTab(itsObsId) = True;
@@ -206,19 +206,19 @@ MSReader::MSReader(const MeasurementSet &ms)
     handledTab(itsPointing2Id) = True;
 
     // POLARIZATION - not indexed, this is a required table
-    itsPolId = itsTabId("POLARIZATION");
+    itsPolId = itsTabId.at("POLARIZATION");
     DebugAssert(itsPolId>=0, AipsError);
     itsTabRows[itsPolId] = ROTableRow(itsMS.polarization());
     handledTab(itsPolId) = True;
 
     // PROCESSOR - not indexed, this is a required table
-    itsProcId = itsTabId("PROCESSOR");
+    itsProcId = itsTabId.at("PROCESSOR");
     DebugAssert(itsProcId>=0, AipsError);
     itsTabRows[itsProcId] = ROTableRow(itsMS.processor());
     handledTab(itsProcId) = True;
 
     // SOURCE - indexed, this is an optional table
-    itsSourceId = itsTabId("SOURCE");
+    itsSourceId = itsTabId.at("SOURCE");
     if (itsSourceId >= 0) {
 	itsSourceIndex.attach(itsMS.source());
 	itsTabRows[itsSourceId] = ROTableRow(itsMS.source());
@@ -226,13 +226,13 @@ MSReader::MSReader(const MeasurementSet &ms)
     }
 
     // SPECTRAL_WINDOW - not indexed, this is a required table
-    itsSpwId = itsTabId("SPECTRAL_WINDOW");
+    itsSpwId = itsTabId.at("SPECTRAL_WINDOW");
     DebugAssert(itsSpwId>=0, AipsError);
     itsTabRows[itsSpwId] = ROTableRow(itsMS.spectralWindow());
     handledTab(itsSpwId) = True;
 
     // STATE - not indexed, this is an optional table
-    itsStateId = itsTabId("STATE");
+    itsStateId = itsTabId.at("STATE");
     if (itsStateId >= 0) {
 	itsTabRows[itsStateId] = ROTableRow(itsMS.state());
 	handledTab(itsStateId) = True;
@@ -264,10 +264,10 @@ MSReader::MSReader(const MeasurementSet &ms)
 
     // and now, for everything not handled above, also fill in itsTableNames
     Vector<String> tableNames(idCount);
-    for (uInt i=0; i<itsTabId.ndefined(); i++) {
-	Int tabId = itsTabId.getVal(i);
+    for (const auto& x : itsTabId) {
+        Int tabId = x.second;
 	if (tabId >= 0) {
-	    String tabName = itsTabId.getKey(i);
+	    String tabName = x.first;
 	    tableNames(tabId) = tabName;
 	    if (!handledTab(tabId)) {
 		itsIndexes[tabId].attach(kwSet.asTable(tabName), Vector<String>());
@@ -519,23 +519,23 @@ void MSReader::gotoRow(uInt which)
 
 const RecordInterface &MSReader::tableRow(const String &name) const
 {
-    if (!itsTabId.isDefined(name)) return emptyRecord;
-    Int tabId = itsTabId(name);
+    if (itsTabId.find(name) == itsTabId.end()) return emptyRecord;
+    Int tabId = itsTabId.at(name);
     return itsTabRows[tabId].record();
 }
 
 Int MSReader::rowNumber(const String &name) const
 {
-    if (!itsTabId.isDefined(name)) return -1;
-    Int tabId = itsTabId(name);
+    if (itsTabId.find(name) == itsTabId.end()) return -1;
+    Int tabId = itsTabId.at(name);
     return itsRowNumbers[tabId];
 }
 
 // Return a reference to the named subtable
 const Table &MSReader::table(const String &name) const
 {
-    if (!itsTabId.isDefined(name)) return emptyTable;
-    Int tabId = itsTabId(name);
+    if (itsTabId.find(name) == itsTabId.end()) return emptyTable;
+    Int tabId = itsTabId.at(name);
     return itsTabRows[tabId].table();
 }
 

--- a/ms/MSOper/MSReader.h
+++ b/ms/MSOper/MSReader.h
@@ -33,7 +33,6 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Containers/Record.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 #include <casacore/ms/MeasurementSets/MSColumns.h>
 #include <casacore/ms/MSSel/MSDopplerIndex.h>
@@ -48,6 +47,7 @@
 #include <casacore/tables/Tables/TableRow.h>
 #include <casacore/casa/Quanta/Unit.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -101,7 +101,7 @@ private:
     MSValidIds itsIds;
 
     // this maps table name to an index used throughout this class
-    SimpleOrderedMap<String, Int> itsTabId;
+    std::map<String, Int> itsTabId;
 
     // the indexes for the NS subtables
     Block<MSTableIndex> itsIndexes;

--- a/ms/MSSel/MSPolnGram.cc
+++ b/ms/MSSel/MSPolnGram.cc
@@ -39,7 +39,6 @@
 #include <casacore/ms/MSSel/MSSpwGram.h>
 #include <casacore/ms/MSSel/MSPolnParse.h>
 #include <casacore/measures/Measures/Stokes.h>
-#include <casacore/casa/Containers/MapIO.h>
 
 // Define the yywrap function for flex.
 int MSPolnGramwrap()
@@ -66,8 +65,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			      const String& command,
 			      TableExprNode& node,
 			      Vector<Int>& selectedDDIDs,
-			      OrderedMap<Int, Vector<Int> >& selectedPolnMap,
-			      OrderedMap<Int, Vector<Vector<Int> > >& selectedSetupMap) 
+			      std::map<Int, Vector<Int> >& selectedPolnMap,
+			      std::map<Int, Vector<Vector<Int> > >& selectedSetupMap) 
   {
     try 
       {

--- a/ms/MSSel/MSPolnGram.h
+++ b/ms/MSSel/MSPolnGram.h
@@ -34,7 +34,7 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/ms/MSSel/MSDataDescIndex.h>
 #include <casacore/ms/MSSel/MSPolIndex.h>
-#include <casacore/casa/Containers/OrderedMap.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
@@ -74,8 +74,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   int msPolnGramParseCommand (const MeasurementSet *ms, const String& command,
 			      TableExprNode& node,
 			      Vector<Int>& selectedDDIDs, 
-			      OrderedMap<Int, Vector<Int> >& selectedPolnMap,
-			      OrderedMap<Int, Vector<Vector<Int> > >& selectedSetupMap
+			      std::map<Int, Vector<Int> >& selectedPolnMap,
+			      std::map<Int, Vector<Vector<Int> > >& selectedSetupMap
 			      );
   
   // The error handler.

--- a/ms/MSSel/MSPolnParse.cc
+++ b/ms/MSSel/MSPolnParse.cc
@@ -32,15 +32,13 @@
 #include <casacore/ms/MSSel/MSSpwGram.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Logging/LogIO.h>
-#include <casacore/casa/Containers/MapIO.h>
-#include <casacore/casa/Containers/OrderedMap.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
   //  MSPolnParse* MSPolnParse::thisMSSParser = 0x0; // Global pointer to the parser object
   // TableExprNode* MSPolnParse::node_p = 0x0;
   // Vector<Int> MSPolnParse::ddIDList;
-  // OrderedMap<Int, Vector<Int> > MSPolnParse::polList(Vector<Int>(0)); 
+  // std::map<Int, Vector<Int> > MSPolnParse::polList(Vector<Int>(0)); 
   //# Constructor
   //------------------------------------------------------------------------------
   //  
@@ -48,9 +46,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   MSPolnParse::MSPolnParse ()
     : MSParse(),
       node_p(),			      //      node_p(0x0), 
-      ddIDList_p(), 
-      polMap_p(Vector<Int>(0)),
-      setupMap_p(Vector<Vector<Int> >(0))
+      ddIDList_p()
   {
     // if (MSPolnParse::node_p!=0x0) delete MSPolnParse::node_p;
     // MSPolnParse::node_p=0x0;
@@ -62,9 +58,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   MSPolnParse::MSPolnParse (const MeasurementSet* ms)
     : MSParse(ms, "Pol"),
       node_p(),			      //     node_p(0x0), 
-      ddIDList_p(), 
-      polMap_p(Vector<Int>(0)),
-      setupMap_p(Vector<Vector<Int> >(0))
+      ddIDList_p()
   {
     ddIDList_p.resize(0);
     // if(MSPolnParse::node_p) delete MSPolnParse::node_p;
@@ -193,8 +187,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		thisDDList.resize((n=thisDDList.nelements())+1,True);
 		thisDDList[n]=tmp[0];
 		setIDLists((Int)polnIDs[p],0,polnIndices);
-		polMap_p(polnIDs[p]).resize(0);
-		polMap_p(polnIDs[p])=polnIndices;
+		polMap_p[polnIDs[p]].resize(0);
+		polMap_p[polnIDs[p]]=polnIndices;
 		//		cout << "DDIDs for SPW = " << spwIDs[s] << " = " << tmp[0] << endl;
 	      }
 	  }
@@ -229,7 +223,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   //  i.e. "RR", "LL" etc.
   //
   Vector<Int> MSPolnParse::matchPolIDsToPolTableRow(const Vector<Int>& polIds,
-						    OrderedMap<Int, Vector<Int> >& /*polIndexMap*/,
+						    std::map<Int, Vector<Int> >& /*polIndexMap*/,
 						    Vector<Int>& polIndices,
 						    Bool addToMap)
   {
@@ -459,11 +453,11 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       //
       // Remove entries which did not map to any DD ID(s)
       //
-      MapIter<Int, Vector<Vector<Int> > > omi(setupMap_p);
-      for(omi.toStart(); !omi.atEnd(); omi++)
-	if (omi.getVal()[1].nelements() == 0)
-	  omi.remove(omi.getKey());
-	  //	  setupMap_p.remove(omi.getKey());
+      for (const auto& x : setupMap_p) {
+	if (x.second[1].nelements() == 0) {
+          setupMap_p.erase(x.first);
+        }
+      }
     }
     return ret;
   }
@@ -476,22 +470,23 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (ndx>1)
       throw(MSSelectionError("Internal error in MSPolnParse::setIDLists(): Index > 1"));
 
-    if (setupMap_p(key).nelements() !=2) setupMap_p(key).resize(2, True);
+    if (setupMap_p[key].nelements() !=2) setupMap_p[key].resize(2, True);
     if (val.nelements() > 0)
       {
 	Vector<Int> v0=val;
-	if (setupMap_p.isDefined(key))
+	auto elem = setupMap_p.find(key);
+        if (elem != setupMap_p.end())
 	  {
 	    Vector<Int> t0;
 	    v0.resize(0);
-	    v0 = setupMap_p(key)[ndx];
+	    v0 = elem->second[ndx];
 	    t0=set_union(val,v0);
 	    v0.resize(0);
 	    v0 = t0;
 	  }
 
-	if (setupMap_p(key)[ndx].nelements() > 0) setupMap_p(key)[ndx].resize(0);
-	setupMap_p(key)[ndx]=v0;
+	if (setupMap_p[key][ndx].nelements() > 0) setupMap_p[key][ndx].resize(0);
+	setupMap_p[key][ndx]=v0;
       }
   }
   //

--- a/ms/MSSel/MSPolnParse.h
+++ b/ms/MSSel/MSPolnParse.h
@@ -31,8 +31,6 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/ms/MSSel/MSParse.h>
-#include <casacore/casa/Containers/OrderedMap.h>
-#include <casacore/casa/Containers/MapIO.h>
 #include <casacore/ms/MeasurementSets/MSPolarization.h>
 #include <casacore/ms/MeasurementSets/MSPolColumns.h>
 #include <casacore/ms/MSSel/MSPolIndex.h>
@@ -108,15 +106,15 @@ public:
   Int theParser(const String& command); 
 		// Vector<Int>& selectedDDIDs, 
 		// Matrix<Int>& selectedSpwPolnMap);
-  OrderedMap<Int, Vector<Int> > selectedPolnMap()           {return polMap_p;}
-  OrderedMap<Int, Vector<Vector<Int> > > selectedSetupMap() {return setupMap_p;}
+  std::map<Int, Vector<Int> > selectedPolnMap()             {return polMap_p;}
+  std::map<Int, Vector<Vector<Int> > > selectedSetupMap()   {return setupMap_p;}
   Vector<Int> selectedDDIDs()                               {return ddIDList_p;}
 private:
   Vector<Int> getMapToDDIDs(MSDataDescIndex& msDDNdx, MSPolarizationIndex& msPolNdx,
 			    const Vector<Int>& spwIDs, Vector<Int>& polnIDs,
 			    Vector<Int>& polIndices);
   Vector<Int> matchPolIDsToPolTableRow(const Vector<Int>& polIds,
-				       OrderedMap<Int, Vector<Int> >& polIndexMap,
+				       std::map<Int, Vector<Int> >& polIndexMap,
 				       Vector<Int>& polIndices,
 				       Bool addToMap=False);
   Vector<Int> getPolnIDs(const String& polSpec, Vector<Int>& polIndices);
@@ -130,8 +128,8 @@ private:
 			      Vector<Int>& polnIndices);
   TableExprNode node_p;
   Vector<Int> ddIDList_p;
-  OrderedMap<Int, Vector<Int> > polMap_p;
-  OrderedMap<Int, Vector<Vector<Int> > > setupMap_p;
+  std::map<Int, Vector<Int> > polMap_p;
+  std::map<Int, Vector<Vector<Int> > > setupMap_p;
 
   void setIDLists(const Int key, const Int ndx, Vector<Int>& val);
 };

--- a/ms/MSSel/MSSelectableMainColumn.h
+++ b/ms/MSSel/MSSelectableMainColumn.h
@@ -35,8 +35,6 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Arrays/Cube.h>
-#include <casacore/casa/Containers/OrderedMap.h>
-#include <casacore/casa/Containers/MapIO.h>
 #include <casacore/tables/TaQL/ExprNode.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 #include <casacore/ms/MeasurementSets/MSMainEnums.h>

--- a/ms/MSSel/MSSelectableTable.h
+++ b/ms/MSSel/MSSelectableTable.h
@@ -35,8 +35,6 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Arrays/Cube.h>
-#include <casacore/casa/Containers/OrderedMap.h>
-#include <casacore/casa/Containers/MapIO.h>
 #include <casacore/tables/TaQL/ExprNode.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 #include <casacore/ms/MeasurementSets/MSMainEnums.h>

--- a/ms/MSSel/MSSelection.cc
+++ b/ms/MSSel/MSSelection.cc
@@ -64,7 +64,7 @@
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Utilities/GenSort.h>
 #include <casacore/ms/MeasurementSets/MSColumns.h>
-#include <casa/Utilities/CountedPtr.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
   //----------------------------------------------------------------------------
@@ -77,7 +77,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     fieldIDs_p(), spwIDs_p(), scanIDs_p(), arrayIDs_p(), ddIDs_p(), observationIDs_p(),
     feed1IDs_p(), feed2IDs_p(), baselineIDs_p(), feedPairIDs_p(),
     selectedTimesList_p(), selectedUVRange_p(),selectedUVUnits_p(),
-    selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0)),
     maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), 
     isMS_p(True), toTENCalled_p(False)
   {
@@ -112,7 +111,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     feedExpr_p(""), exprOrder_p(MAX_EXPR, NO_EXPR), antenna1IDs_p(), antenna2IDs_p(),
     fieldIDs_p(), spwIDs_p(), scanIDs_p(),ddIDs_p(),baselineIDs_p(), feedPairIDs_p(),
     selectedTimesList_p(), selectedUVRange_p(),selectedUVUnits_p(),
-    selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0)),
     maxScans_p(1000), maxObs_p(1000), maxArray_p(1000), 
     isMS_p(True), toTENCalled_p(False)
   {
@@ -281,8 +279,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     timeExpr_p(""), uvDistExpr_p(""), polnExpr_p(""),taqlExpr_p(""),stateExpr_p(""), 
     observationExpr_p(""), feedExpr_p(""),
     antenna1IDs_p(), antenna2IDs_p(), fieldIDs_p(), spwIDs_p(), ddIDs_p(),
-    feed1IDs_p(), feed2IDs_p(), baselineIDs_p(), feedPairIDs_p(),
-    selectedPolMap_p(Vector<Int>(0)), selectedSetupMap_p(Vector<Vector<Int> >(0))
+    feed1IDs_p(), feed2IDs_p(), baselineIDs_p(), feedPairIDs_p()
     
   {
     // Construct from a record representing a selection item
@@ -304,10 +301,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   
   //----------------------------------------------------------------------------
   
-  MSSelection::MSSelection (const MSSelection& other):
-    selectedPolMap_p(Vector<Int>(0)),
-    selectedSetupMap_p(Vector<Vector<Int> >(0))
-    
+  MSSelection::MSSelection (const MSSelection& other)
   {
     // Copy constructor
     // Input:
@@ -1426,13 +1420,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     corrslices.set(Vector<Slice>());
     
     // Get the corr indices as an ordered map
-    OrderedMap<Int, Vector<Vector<Int> > > corrmap(this->getCorrMap(ms));
+    std::map<Int, Vector<Vector<Int> > > corrmap(this->getCorrMap(ms));
     
     // Iterate over the ordered map to fill the slices
-    ConstMapIter<Int, Vector<Vector<Int> > > mi(corrmap);
-    for (mi.toStart(); !mi.atEnd(); mi++) {
-      Int pol=mi.getKey();
-      Vector<Int> corridx=mi.getVal()[0];
+    for (const auto& elem : corrmap) {
+      Int pol=elem.first;
+      Vector<Int> corridx=elem.second[0];
       
       Int ncorr=corridx.nelements();
       corrslices(pol).resize(ncorr);

--- a/ms/MSSel/MSSelection.h
+++ b/ms/MSSel/MSSelection.h
@@ -41,8 +41,8 @@
 #include <casacore/ms/MSSel/MSSelectionError.h>
 #include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
 #include <casacore/ms/MSSel/MSSelectableTable.h>
-#include <casacore/casa/Containers/OrderedMap.h>
-#include <casacore/casa/Containers/MapIO.h>
+#include <map>
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // <summary> 
@@ -344,7 +344,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // what the user intended (i.e., e.g. not all DD IDs due to user
     // POL expression might be selected due to SPW expressions).
     //
-    inline OrderedMap<Int, Vector<Int> > getPolMap(const MeasurementSet* ms=NULL) 
+    inline std::map<Int, Vector<Int> > getPolMap(const MeasurementSet* ms=NULL) 
     {getTEN(ms); return selectedPolMap_p;};
 
     //
@@ -420,7 +420,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     //
     // o To get a list of POLARIZATION IDs selected (rows of the POLARIZATION
     //   table), make a list of all the keys of this map.
-    inline OrderedMap<Int, Vector<Vector<Int> > > getCorrMap(const MeasurementSet* ms=NULL) 
+    inline std::map<Int, Vector<Vector<Int> > > getCorrMap(const MeasurementSet* ms=NULL) 
     {getTEN(ms); return selectedSetupMap_p;};
 
     // Methods to convert the maps return by getChanList and
@@ -631,8 +631,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Matrix<Double> selectedTimesList_p;
     Matrix<Double> selectedUVRange_p;
     Vector<Bool> selectedUVUnits_p;
-    OrderedMap<Int, Vector<Int> > selectedPolMap_p;
-    OrderedMap<Int, Vector<Vector<Int> > > selectedSetupMap_p;
+    std::map<Int, Vector<Int> > selectedPolMap_p;
+    std::map<Int, Vector<Vector<Int> > > selectedSetupMap_p;
     Int maxScans_p, maxObs_p, maxArray_p;
     Bool isMS_p,toTENCalled_p;
   };

--- a/ms/MSSel/MSSelectionKeywords.cc
+++ b/ms/MSSel/MSSelectionKeywords.cc
@@ -26,117 +26,124 @@
 //#
 //# $Id$
 #include <casacore/ms/MSSel/MSSelectionKeywords.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/Exceptions/Error.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
+std::map<String,Int>& MSSelectionKeywords::getMap()
+{
+  static std::map<String,Int> fieldMap(initMap());
+  return fieldMap;
+}
+
+Block<String>& MSSelectionKeywords::getReverseMap()
+{
+  static Block<String> reverseMap(initReverseMap());
+  return reverseMap;
+}
+
 MSSelectionKeywords::Field MSSelectionKeywords::field(const String& itemName)
 {
-  // static map with enum to string mapping for fields
-  static SimpleOrderedMap<String,Int>* fieldMap(0);
-  static Block<Int>* reverseMap(0);
-
-  if (!fieldMap) initMap(fieldMap,reverseMap);
- 
-  const Int* p=fieldMap->isDefined(itemName);
-  return p ? Field(*p) : UNDEFINED;
+  std::map<String,Int>& fieldMap = getMap();
+  std::map<String,Int>::iterator iter = fieldMap.find(itemName);
+  return iter==fieldMap.end() ?  UNDEFINED : Field(iter->second);
 }
 
 const String& MSSelectionKeywords::keyword(Field fld) 
 {
-  static SimpleOrderedMap<String,Int>* fieldMap(0);
-  static Block<Int>* reverseMap(0);
-
-  if (!reverseMap) initMap(fieldMap,reverseMap);
-
-  return fieldMap->getKey((*reverseMap)[fld]);
+  Block<String>& reverseMap = getReverseMap();
+  return reverseMap[fld];
 }
 
 
-void MSSelectionKeywords::initMap(SimpleOrderedMap<String,Int>*& fieldMap,
-				  Block<Int>*& reverseMap)
+std::map<String,Int> MSSelectionKeywords::initMap()
 {
-  static Bool initialized(False);
-  static SimpleOrderedMap<String, Int> map(UNDEFINED,NUMBER_KEYWORDS);
-  static Block<Int> revMap(NUMBER_KEYWORDS);
+  std::map<String,Int> fieldMap;
+  fieldMap.insert (std::make_pair("undefined",UNDEFINED));
+  fieldMap.insert (std::make_pair("amplitude",AMPLITUDE));
+  fieldMap.insert (std::make_pair("corrected_amplitude",CORRECTED_AMPLITUDE));
+  fieldMap.insert (std::make_pair("model_amplitude",MODEL_AMPLITUDE));
+  fieldMap.insert (std::make_pair("ratio_amplitude",RATIO_AMPLITUDE));
+  fieldMap.insert (std::make_pair("residual_amplitude",RESIDUAL_AMPLITUDE));
+  fieldMap.insert (std::make_pair("obs_residual_amplitude",OBS_RESIDUAL_AMPLITUDE));
+  fieldMap.insert (std::make_pair("antenna1",ANTENNA1));
+  fieldMap.insert (std::make_pair("antenna2",ANTENNA2));
+  fieldMap.insert (std::make_pair("antennas",ANTENNAS));
+  fieldMap.insert (std::make_pair("array_id",ARRAY_ID));
+  fieldMap.insert (std::make_pair("axis_info",AXIS_INFO));
+  fieldMap.insert (std::make_pair("chan_freq",CHAN_FREQ));
+  fieldMap.insert (std::make_pair("corr_names",CORR_NAMES));
+  fieldMap.insert (std::make_pair("corr_types",CORR_TYPES));
+  fieldMap.insert (std::make_pair("data",DATA));
+  fieldMap.insert (std::make_pair("corrected_data",CORRECTED_DATA));
+  fieldMap.insert (std::make_pair("model_data",MODEL_DATA));
+  fieldMap.insert (std::make_pair("ratio_data",RATIO_DATA));
+  fieldMap.insert (std::make_pair("residual_data",RESIDUAL_DATA));
+  fieldMap.insert (std::make_pair("obs_residual_data",OBS_RESIDUAL_DATA));
+  fieldMap.insert (std::make_pair("data_desc_id",DATA_DESC_ID));
+  fieldMap.insert (std::make_pair("feed1",FEED1));
+  fieldMap.insert (std::make_pair("feed2",FEED2));
+  fieldMap.insert (std::make_pair("field_id",FIELD_ID));
+  fieldMap.insert (std::make_pair("fields",FIELDS));
+  fieldMap.insert (std::make_pair("flag",FLAG));
+  fieldMap.insert (std::make_pair("flag_row",FLAG_ROW));
+  fieldMap.insert (std::make_pair("flag_sum",FLAG_SUM));
+  fieldMap.insert (std::make_pair("float_data",FLOAT_DATA));
+  fieldMap.insert (std::make_pair("ha",HA));
+  fieldMap.insert (std::make_pair("ifr_number",IFR_NUMBER));
+  fieldMap.insert (std::make_pair("imaginary",IMAGINARY));
+  fieldMap.insert (std::make_pair("corrected_imaginary",CORRECTED_IMAGINARY));
+  fieldMap.insert (std::make_pair("model_imaginary",MODEL_IMAGINARY));
+  fieldMap.insert (std::make_pair("ratio_imaginary",RATIO_IMAGINARY));
+  fieldMap.insert (std::make_pair("residual_imaginary",RESIDUAL_IMAGINARY));
+  fieldMap.insert (std::make_pair("obs_residual_imaginary",OBS_RESIDUAL_IMAGINARY));
+  fieldMap.insert (std::make_pair("last",LAST));
+  fieldMap.insert (std::make_pair("num_corr",NUM_CORR));
+  fieldMap.insert (std::make_pair("num_chan",NUM_CHAN));
+  fieldMap.insert (std::make_pair("phase",PHASE));
+  fieldMap.insert (std::make_pair("corrected_phase",CORRECTED_PHASE));
+  fieldMap.insert (std::make_pair("model_phase",MODEL_PHASE));
+  fieldMap.insert (std::make_pair("ratio_phase",RATIO_PHASE));
+  fieldMap.insert (std::make_pair("residual_phase",RESIDUAL_PHASE));
+  fieldMap.insert (std::make_pair("obs_residual_phase",OBS_RESIDUAL_PHASE));
+  fieldMap.insert (std::make_pair("phase_dir",PHASE_DIR));
+  fieldMap.insert (std::make_pair("real",REAL));
+  fieldMap.insert (std::make_pair("corrected_real",CORRECTED_REAL));
+  fieldMap.insert (std::make_pair("model_real",MODEL_REAL));
+  fieldMap.insert (std::make_pair("ratio_real",RATIO_REAL));
+  fieldMap.insert (std::make_pair("residual_real",RESIDUAL_REAL));
+  fieldMap.insert (std::make_pair("obs_residual_real",OBS_RESIDUAL_REAL));
+  fieldMap.insert (std::make_pair("ref_frequency",REF_FREQUENCY));
+  fieldMap.insert (std::make_pair("rows",ROWS));
+  fieldMap.insert (std::make_pair("scan_number",SCAN_NUMBER));
+  fieldMap.insert (std::make_pair("sigma",SIGMA));
+  fieldMap.insert (std::make_pair("time",TIME));
+  fieldMap.insert (std::make_pair("times",TIMES));
+  fieldMap.insert (std::make_pair("u",U));
+  fieldMap.insert (std::make_pair("v",V));
+  fieldMap.insert (std::make_pair("w",W));
+  fieldMap.insert (std::make_pair("ut",UT));
+  fieldMap.insert (std::make_pair("uvw",UVW));
+  fieldMap.insert (std::make_pair("uvdist",UVDIST));
+  fieldMap.insert (std::make_pair("weight",WEIGHT));
+  // Assure all fields are defined.
+  AlwaysAssert (fieldMap.size() == NUMBER_KEYWORDS, AipsError);
+  return fieldMap;
+}
 
-  if (!initialized) {
-    map.define("undefined",UNDEFINED);
-    map.define("amplitude",AMPLITUDE);
-    map.define("corrected_amplitude",CORRECTED_AMPLITUDE);
-    map.define("model_amplitude",MODEL_AMPLITUDE);
-    map.define("ratio_amplitude",RATIO_AMPLITUDE);
-    map.define("residual_amplitude",RESIDUAL_AMPLITUDE);
-    map.define("obs_residual_amplitude",OBS_RESIDUAL_AMPLITUDE);
-    map.define("antenna1",ANTENNA1);
-    map.define("antenna2",ANTENNA2);
-    map.define("antennas",ANTENNAS);
-    map.define("array_id",ARRAY_ID);
-    map.define("axis_info",AXIS_INFO);
-    map.define("chan_freq",CHAN_FREQ);
-    map.define("corr_names",CORR_NAMES);
-    map.define("corr_types",CORR_TYPES);
-    map.define("data",DATA);
-    map.define("corrected_data",CORRECTED_DATA);
-    map.define("model_data",MODEL_DATA);
-    map.define("ratio_data",RATIO_DATA);
-    map.define("residual_data",RESIDUAL_DATA);
-    map.define("obs_residual_data",OBS_RESIDUAL_DATA);
-    map.define("data_desc_id",DATA_DESC_ID);
-    map.define("feed1",FEED1);
-    map.define("feed2",FEED2);
-    map.define("field_id",FIELD_ID);
-    map.define("fields",FIELDS);
-    map.define("flag",FLAG);
-    map.define("flag_row",FLAG_ROW);
-    map.define("flag_sum",FLAG_SUM);
-    map.define("float_data",FLOAT_DATA);
-    map.define("ha",HA);
-    map.define("ifr_number",IFR_NUMBER);
-    map.define("imaginary",IMAGINARY);
-    map.define("corrected_imaginary",CORRECTED_IMAGINARY);
-    map.define("model_imaginary",MODEL_IMAGINARY);
-    map.define("ratio_imaginary",RATIO_IMAGINARY);
-    map.define("residual_imaginary",RESIDUAL_IMAGINARY);
-    map.define("obs_residual_imaginary",OBS_RESIDUAL_IMAGINARY);
-    map.define("last",LAST);
-    map.define("num_corr",NUM_CORR);
-    map.define("num_chan",NUM_CHAN);
-    map.define("phase",PHASE);
-    map.define("corrected_phase",CORRECTED_PHASE);
-    map.define("model_phase",MODEL_PHASE);
-    map.define("ratio_phase",RATIO_PHASE);
-    map.define("residual_phase",RESIDUAL_PHASE);
-    map.define("obs_residual_phase",OBS_RESIDUAL_PHASE);
-    map.define("phase_dir",PHASE_DIR);
-    map.define("real",REAL);
-    map.define("corrected_real",CORRECTED_REAL);
-    map.define("model_real",MODEL_REAL);
-    map.define("ratio_real",RATIO_REAL);
-    map.define("residual_real",RESIDUAL_REAL);
-    map.define("obs_residual_real",OBS_RESIDUAL_REAL);
-    map.define("ref_frequency",REF_FREQUENCY);
-    map.define("rows",ROWS);
-    map.define("scan_number",SCAN_NUMBER);
-    map.define("sigma",SIGMA);
-    map.define("time",TIME);
-    map.define("times",TIMES);
-    map.define("u",U);
-    map.define("v",V);
-    map.define("w",W);
-    map.define("ut",UT);
-    map.define("uvw",UVW);
-    map.define("uvdist",UVDIST);
-    map.define("weight",WEIGHT);
-
-    for (uInt i=0; i<NUMBER_KEYWORDS; i++) {
-      revMap[map.getVal(i)]=i;
-    }
-    initialized=True;
+Block<String> MSSelectionKeywords::initReverseMap()
+{
+  std::map<String,Int>& fieldMap = getMap();
+  Block<String> reverseMap(NUMBER_KEYWORDS);
+  for (const auto& x : fieldMap) {
+    AlwaysAssert (x.second < NUMBER_KEYWORDS, AipsError);
+    reverseMap[x.second] = x.first;
   }
-  fieldMap=&map;
-  reverseMap=&revMap;
+  return reverseMap;
 }
 
 } //# NAMESPACE CASACORE - END

--- a/ms/MSSel/MSSelectionKeywords.h
+++ b/ms/MSSel/MSSelectionKeywords.h
@@ -30,11 +30,12 @@
 #define MS_MSSELECTIONKEYWORDS_H
 
 #include <casacore/casa/aips.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template <class K, class V> class SimpleOrderedMap;
 template <class T> class Block;
+
 // forward declare the class so we can typedef it
 class MSSelectionKeywords;
 class String;
@@ -241,15 +242,23 @@ public:
   // convert an enum value to the corresponding keyword string
   static const String& keyword(Field field);
 
-protected:
+private:
   // This class is purely static, no instances are allowed.
   MSSelectionKeywords();
   MSSelectionKeywords(const MSSelectionKeywords& other);
   MSSelectionKeywords& operator=(const MSSelectionKeywords& other);
-  
-  // initialization function for the string to enum mapping
-  static void initMap(SimpleOrderedMap<String,Int>*& fieldMap,
-		      Block<Int>*& reverseMap);
+
+  // Get the static map.
+  static std::map<String,Int>& getMap();
+
+  // Get the static reverse map.
+  static Block<String>& getReverseMap();
+
+  // Create an initialized map.
+  static std::map<String,Int> initMap();
+
+    // Create an initialized reverse map.
+  static Block<String> initReverseMap();
 };
 
 

--- a/ms/MSSel/MSSelectionTools.cc
+++ b/ms/MSSel/MSSelectionTools.cc
@@ -280,8 +280,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Vector<Int> feed1List=thisSelection.getFeed1List();
     Vector<Int> feed2List=thisSelection.getFeed2List();
     Vector<Int> feedPairList=thisSelection.getFeedPairList();
-    OrderedMap<Int, Vector<Int > > polMap=thisSelection.getPolMap();
-    OrderedMap<Int, Vector<Vector<Int> > > corrMap=thisSelection.getCorrMap();
+    std::map<Int, Vector<Int > > polMap=thisSelection.getPolMap();
+    std::map<Int, Vector<Vector<Int> > > corrMap=thisSelection.getCorrMap();
     Vector<Int> allDDIDList;
     if (ddIDList.nelements() == 0) allDDIDList = spwDDIDList;
     else if (spwDDIDList.nelements() == 0) allDDIDList = ddIDList;

--- a/ms/MSSel/MSStateParse.h
+++ b/ms/MSSel/MSStateParse.h
@@ -33,7 +33,7 @@
 #include <casacore/ms/MSSel/MSParse.h>
 #include <casacore/ms/MSSel/MSSelectionError.h>
 #include <casacore/ms/MSSel/MSSelectionErrorHandler.h>
-#include <casa/Utilities/CountedPtr.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward 

--- a/ms/MSSel/test/tMSSelection.cc
+++ b/ms/MSSel/test/tMSSelection.cc
@@ -24,15 +24,16 @@
 //#
 //# $Id$
 
-#include <casa/aips.h>
-#include <ms/MSSel/MSSelection.h>
-#include <ms/MSSel/MSSelectionError.h>
-#include <ms/MSSel/MSSelectionTools.h>
-#include <ms/MSSel/MSSelectableTable.h>
-#include <tables/Tables/Table.h>
-#include <tables/Tables/TableCache.h>
-#include <tables/Tables/PlainTable.h>
+#include <casacore/casa/aips.h>
+#include <casacore/ms/MSSel/MSSelection.h>
+#include <casacore/ms/MSSel/MSSelectionError.h>
+#include <casacore/ms/MSSel/MSSelectionTools.h>
+#include <casacore/ms/MSSel/MSSelectableTable.h>
+#include <casacore/tables/Tables/Table.h>
+#include <casacore/tables/Tables/TableCache.h>
+#include <casacore/tables/Tables/PlainTable.h>
 #include <casacore/casa/Inputs.h>
+#include <casacore/casa/BasicSL/STLIO.h>
 
 using namespace std;
 using namespace casacore;

--- a/ms/MSSel/test/tMSSelection.out
+++ b/ms/MSSel/test/tMSSelection.out
@@ -24,8 +24,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -59,8 +59,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -95,8 +95,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -130,8 +130,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -166,8 +166,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -202,8 +202,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -237,8 +237,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -273,8 +273,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -308,8 +308,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -343,8 +343,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -379,8 +379,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -415,8 +415,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -451,8 +451,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -486,8 +486,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -521,8 +521,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -556,8 +556,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -597,8 +597,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -637,8 +637,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -677,8 +677,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -717,8 +717,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -761,8 +761,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -800,8 +800,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -845,8 +845,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -900,8 +900,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -943,8 +943,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -986,8 +986,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1029,8 +1029,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1076,8 +1076,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1126,8 +1126,8 @@ UVE: UVRange Expr=>1000m
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1176,8 +1176,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1222,8 +1222,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX
-	PE: PolMap       = (0,[0])(1,[0])
-	PE: CorrMap      = (0,[[0], [1, 2]])(1,[[0], [0]])
+	PE: PolMap       = {<0,[0]>, <1,[0]>}
+	PE: CorrMap      = {<0,[[0], [1, 2]]>, <1,[[0], [0]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2, 0]
@@ -1268,8 +1268,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1320,8 +1320,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1366,8 +1366,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1412,8 +1412,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1458,8 +1458,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1507,8 +1507,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1553,8 +1553,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1599,8 +1599,8 @@ UVE: UVRange Expr=>1000m:50%
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=XX,YX
-	PE: PolMap       = (0,[0, 2])
-	PE: CorrMap      = (0,[[0, 2], [1, 2]])
+	PE: PolMap       = {<0,[0, 2]>}
+	PE: CorrMap      = {<0,[[0, 2], [1, 2]]>}
 
 ===========================================================
 DDIDs(Poln)  = [1, 2]
@@ -1647,8 +1647,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1690,8 +1690,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []
@@ -1733,8 +1733,8 @@ UVE: UVRange Expr=
 OE: Observation Expr=
 	OE: ObservationIDList    = []
 PE: Poln Expr=
-	PE: PolMap       = 
-	PE: CorrMap      = 
+	PE: PolMap       = {}
+	PE: CorrMap      = {}
 
 ===========================================================
 DDIDs(Poln)  = []

--- a/ms/MeasurementSets/MSFieldColumns.cc
+++ b/ms/MeasurementSets/MSFieldColumns.cc
@@ -48,7 +48,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 ROMSFieldColumns::ROMSFieldColumns(const MSField& msField):
   measCometsPath_p(),
   measCometsV_p(),
-  ephIdToMeasComet_p(-1),
   name_p(msField, MSField::columnName(MSField::NAME)),
   code_p(msField, MSField::columnName(MSField::CODE)),
   time_p(msField, MSField::columnName(MSField::TIME)),
@@ -221,8 +220,8 @@ Int ROMSFieldColumns::measCometIndex(Int row) const
   Int rval = -1;
   if( measCometsV_p.size()>0 ){
     Int ephId = ephemerisId()(row);
-    if(ephId>=0 && ephIdToMeasComet_p.isDefined(ephId)){
-      rval = ephIdToMeasComet_p(ephId);
+    if(ephId>=0 && ephIdToMeasComet_p.find(ephId) != ephIdToMeasComet_p.end()){
+      rval = ephIdToMeasComet_p.at(ephId);
     }
   }
   return rval;
@@ -359,7 +358,6 @@ Int ROMSFieldColumns::matchDirection(const MDirection& referenceDirection,
 ROMSFieldColumns::ROMSFieldColumns():
   measCometsPath_p(),
   measCometsV_p(),
-  ephIdToMeasComet_p(-1),
   name_p(),
   code_p(),
   time_p(),
@@ -430,7 +428,7 @@ void ROMSFieldColumns::updateMeasComets()
     Int theEphId = ephId(i);
     //cout << "updateMeasComet: processing row " << i << ", found eph id " << theEphId << endl;
     if(theEphId>=0 
-       && !ephIdToMeasComet_p.isDefined(theEphId)){
+       && ephIdToMeasComet_p.find(theEphId) == ephIdToMeasComet_p.end()){
       // the id is not yet in use, need to create a new MeasComet object
       
       // find the table belonging to this id
@@ -452,7 +450,7 @@ void ROMSFieldColumns::updateMeasComets()
       measCometsV_p.resize(nMeasCom+1, True);
       measCometsV_p(nMeasCom) = mC;
       // remember the connection ephId to the measCometsV_p index
-      ephIdToMeasComet_p.define(theEphId, nMeasCom); 
+      ephIdToMeasComet_p.insert(std::make_pair(theEphId, nMeasCom)); 
       //cout << "Found and successfully opened ephemeris table " << ephemTablePath << endl;
     }
   }

--- a/ms/MeasurementSets/MSFieldColumns.h
+++ b/ms/MeasurementSets/MSFieldColumns.h
@@ -41,6 +41,7 @@
 #include <casacore/tables/Tables/ArrayColumn.h>
 #include <casacore/tables/Tables/ScalarColumn.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -190,7 +191,7 @@ protected:
   Int measCometIndex(int row) const;
   String measCometsPath_p;
   Vector<MeasComet*> measCometsV_p;
-  SimpleOrderedMap <Int, Int> ephIdToMeasComet_p;
+  std::map<Int, Int> ephIdToMeasComet_p;
 
   // Extract the direction Measure from the corresponding ephemeris
   // using the nominal position as an offset.

--- a/ms/MeasurementSets/MSTable.cc
+++ b/ms/MeasurementSets/MSTable.cc
@@ -33,7 +33,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     // find first occurrence of name in the map (should be only occurrence)
     Int type = 0; //# 0=UNDEFINED_COLUMN for all enums
-    for (auto kv : nameMap) {
+    for (const auto& kv : nameMap) {
       if (kv.second == name) {
         type = kv.first;
         break;

--- a/ms/MeasurementSets/MSTableImpl.cc
+++ b/ms/MeasurementSets/MSTableImpl.cc
@@ -40,7 +40,6 @@
 #include <casacore/tables/DataMan/CompressComplex.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
 
@@ -410,8 +409,8 @@ SetupNewTable& MSTableImpl::setupCompression (SetupNewTable& newtab)
     // If the column is used in a hypercolumn definition, change it
     // to contain the compressed column.
     if (! cname.empty()) {
-      SimpleOrderedMap<String,String> old2new("");
-      old2new.define (cdesc.name(), cname);
+      std::map<String,String> old2new;
+      old2new.insert (std::make_pair(cdesc.name(), cname));
       newtab.adjustHypercolumns (old2new, True);
     }
   }

--- a/ms/MeasurementSets/MeasurementSet.cc
+++ b/ms/MeasurementSets/MeasurementSet.cc
@@ -1098,8 +1098,8 @@ Record MeasurementSet::msseltoindex(const String& spw, const String& field,
   Matrix<Int> baselinelist=thisSelection.getBaselineList();
   Vector<Int> ddIDList=thisSelection.getDDIDList();
   Vector<Int> spwDDIDList=thisSelection.getSPWDDIDList();
-  OrderedMap<Int, Vector<Int > > polMap=thisSelection.getPolMap();
-  OrderedMap<Int, Vector<Vector<Int> > > corrMap=thisSelection.getCorrMap();
+  std::map<Int, Vector<Int > > polMap=thisSelection.getPolMap();
+  std::map<Int, Vector<Vector<Int> > > corrMap=thisSelection.getCorrMap();
   Vector<Int> allDDIDList;
   if (ddIDList.nelements() == 0) allDDIDList = spwDDIDList;
   else if (spwDDIDList.nelements() == 0) allDDIDList = ddIDList;

--- a/ms/MeasurementSets/test/tMSFieldBuffer.cc
+++ b/ms/MeasurementSets/test/tMSFieldBuffer.cc
@@ -28,12 +28,12 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/namespace.h>
 // #include <casacore/casa/Exceptions/Error.h>
-// #include <aips/Exceptions/Excp.h>
+// #include <casacore/casa/Exceptions/Excp.h>
 // #include <casacore/casa/Utilities/Assert.h>
 // #include <casacore/casa/BasicSL/String.h>
 // #include <casacore/casa/iostream.h>
 
-// #include <trial/MeasurementSets/MSFieldBuffer.h>
+// #include <casacore/ms/MeasurementSets/MSFieldBuffer.h>
 // #include <casacore/casa/Arrays/ArrayLogical.h>
 // #include <casacore/casa/Arrays/IPosition.h>
 // #include <casacore/casa/Arrays/Matrix.h>

--- a/ms/MeasurementSets/test/tMSMainBuffer.cc
+++ b/ms/MeasurementSets/test/tMSMainBuffer.cc
@@ -27,7 +27,7 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/namespace.h>
-// #include <trial/MeasurementSets/MSMainBuffer.h>
+// #include <casacore/ms/MeasurementSets/MSMainBuffer.h>
 // #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 // #include <casacore/casa/Arrays/ArrayLogical.h>
 // #include <casacore/casa/Arrays/Vector.h>
@@ -36,7 +36,7 @@
 // #include <casacore/casa/Exceptions/Error.h>
 // #include <casacore/casa/BasicSL/Constants.h>
 // #include <casacore/casa/BasicMath/Math.h>
-// #include <aips/Exceptions/Excp.h>
+// #include <casacore/casa/Exceptions/Excp.h>
 // #include <casacore/tables/Tables/Table.h>
 // #include <casacore/casa/Utilities/Assert.h>
 // #include <casacore/casa/BasicSL/String.h>

--- a/ms/MeasurementSets/test/tMSPolBuffer.cc
+++ b/ms/MeasurementSets/test/tMSPolBuffer.cc
@@ -28,12 +28,12 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/namespace.h>
 // #include <casacore/casa/Exceptions/Error.h>
-// #include <aips/Exceptions/Excp.h>
+// #include <casacore/casa/Exceptions/Excp.h>
 // #include <casacore/casa/Utilities/Assert.h>
 // #include <casacore/casa/BasicSL/String.h>
 // #include <casacore/casa/iostream.h>
 
-// #include <trial/MeasurementSets/MSPolBuffer.h>
+// #include <casacore/ms/MeasurementSets/MSPolBuffer.h>
 // #include <casacore/casa/Arrays/ArrayLogical.h>
 // #include <casacore/casa/Arrays/IPosition.h>
 // #include <casacore/casa/Arrays/Matrix.h>

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -157,8 +157,8 @@ Bool FITSIDItoMS1::firstSyscal = True; // initialize the class variable firstSys
 Bool FITSIDItoMS1::firstWeather = True; // initialize the class variable firstWeather
 Double FITSIDItoMS1::rdate = 0.; // initialize the class variable rdate
 String FITSIDItoMS1::array_p = ""; // initialize the class variable array_p
-SimpleOrderedMap<Int,Int> FITSIDItoMS1::antIdFromNo(-1); // initialize the class variable antIdFromNo
-SimpleOrderedMap<Int,Int> FITSIDItoMS1::digiLevels(0); // initialize the class variable digiLevels
+std::map<Int,Int> FITSIDItoMS1::antIdFromNo; // initialize the class variable antIdFromNo
+std::map<Int,Int> FITSIDItoMS1::digiLevels; // initialize the class variable digiLevels
 Vector<Double> FITSIDItoMS1::effChBw;
 
 //	
@@ -2009,15 +2009,15 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
     Int array = Int(100.0*(baseline - Int(baseline)+0.001));
     Int ant1 = Int(baseline)/256; 
     Int ant2 = Int(baseline) - ant1*256; 
-    if(antIdFromNo.isDefined(ant1)){
-    	ant1 = antIdFromNo(ant1);
+    if(antIdFromNo.find(ant1) != antIdFromNo.end()){
+    	ant1 = antIdFromNo[ant1];
     }
     else{
     	*itsLog << LogIO::SEVERE << "Inconsistent input dataset: unknown ANTENNA_NO "
     			<< ant1 << " in baseline used in UV_DATA table." << LogIO::EXCEPTION;
     }
-    if(antIdFromNo.isDefined(ant2)){
-    	ant2 = antIdFromNo(ant2);
+    if(antIdFromNo.find(ant2) != antIdFromNo.end()){
+    	ant2 = antIdFromNo[ant2];
     }
     else{
     	*itsLog << LogIO::SEVERE << "Inconsistent input dataset: unknown ANTENNA_NO "
@@ -2141,18 +2141,18 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
 	Double Rm, gamma, alfa;
 	Double (*rho)(Double) = NULL;
 
-	if (digiLevels(ant1) == 4 && digiLevels(ant2) == 4) {
+	if (digiLevels[ant1] == 4 && digiLevels[ant2] == 4) {
 	  Rm = 4.3048;
 	  alfa = 0.882518;
 	  gamma = 3.335875 * 64.0 / 63.0;
 	  rho = rho_4;
-	} else if (digiLevels(ant1) == 2 && digiLevels(ant2) == 2) {
+	} else if (digiLevels[ant1] == 2 && digiLevels[ant2] == 2) {
 	  Rm = 1.0;
 	  alfa = 2.0 / C::pi;
 	  gamma = 1.0 * 64.0 / 63.0;
 	  rho = rho_2;
-	} else if ((digiLevels(ant1) == 2 && digiLevels(ant2) == 4) ||
-		   (digiLevels(ant1) == 4 && digiLevels(ant2) == 2)) {
+	} else if ((digiLevels[ant1] == 2 && digiLevels[ant2] == 4) ||
+		   (digiLevels[ant1] == 4 && digiLevels[ant2] == 2)) {
 	  Rm = 5.8784;
 	  alfa = 0.882518;
 	  gamma = 3.335875 * 64.0 / 63.0;
@@ -2513,9 +2513,10 @@ void FITSIDItoMS1::fillAntennaTable()
    // continue definition of antenna number to antenna id mapping 
    for (Int inRow=0; inRow<nAnt; inRow++) {
      Int ii = anNo(inRow);
-     if(!antIdFromNo.isDefined(ii)){
-       antIdFromNo.define(ii, antIdFromNo.ndefined()); // append assuming uniqueness
-       *itsLog << LogIO::NORMAL << "   antenna_no " << ii << " -> antenna ID " << antIdFromNo(ii) << endl;
+     if(antIdFromNo.find(ii) == antIdFromNo.end()){
+       Int sz = antIdFromNo.size();
+       antIdFromNo[ii] = sz; // append assuming uniqueness
+       *itsLog << LogIO::NORMAL << "   antenna_no " << ii << " -> antenna ID " << antIdFromNo[ii] << endl;
      }
    }
 
@@ -2523,13 +2524,13 @@ void FITSIDItoMS1::fillAntennaTable()
    ant.setPositionRef(MPosition::ITRF);
 
    // take into account that the ANTENNA table may already contain rows 
-   Int newRows = antIdFromNo.ndefined() - ms_p.antenna().nrow();
+   Int newRows = antIdFromNo.size() - ms_p.antenna().nrow();
    ms_p.antenna().addRow(newRows);
 
    Int row=0;
    for (Int i=0; i<newRows; i++) {
      
-     row = antIdFromNo(anNo(i));
+     row = antIdFromNo[anNo(i)];
 
      if(diam.isNull()){ // no DIAMETER column available
        ant.dishDiameter().put(row,diameter);
@@ -2710,15 +2711,16 @@ void FITSIDItoMS1::fillFeedTable() {
   // start/continue definition of antenna number to ID mapping in case this table is read before the MS Antenna table is filled
   for (Int inRow=0; inRow<nAnt; inRow++) {
     Int ii = anNo(inRow);
-    if(!antIdFromNo.isDefined(ii)){
-      antIdFromNo.define(ii, antIdFromNo.ndefined()); // append assuming uniqueness
-       *itsLog << LogIO::NORMAL << "   antenna_no " << ii << " -> antenna ID " << antIdFromNo(ii) << endl;
+    if(antIdFromNo.find(ii) == antIdFromNo.end()){
+      Int sz = antIdFromNo.size();
+      antIdFromNo[ii] = sz; // append assuming uniqueness
+       *itsLog << LogIO::NORMAL << "   antenna_no " << ii << " -> antenna ID " << antIdFromNo[ii] << endl;
     }
   }
 
   // record number of digitizer levels for each antenna
   for (Int inRow=0; inRow<nAnt; inRow++) {
-    digiLevels.define(antIdFromNo(anNo(inRow)),digLev(inRow));
+    digiLevels[antIdFromNo[anNo(inRow)]] = digLev(inRow);
     if (itsCorrelat == "DIFX" && digLev(inRow) != 2 && digLev(inRow) != 4) {
       *itsLog << LogIO::SEVERE << "unsupported number of digitizer levels for ANTENNA_NO " << anNo(inRow) << "."
 	      << endl << " Digital corrections and amplitude scaling will not be applied to"
@@ -2732,8 +2734,8 @@ void FITSIDItoMS1::fillFeedTable() {
     for (Int inIF=0; inIF<nIF; inIF++) { 
       Int k = inRow*nIF + inIF;
       ms_p.feed().addRow(); outRow++;
-      if(antIdFromNo.isDefined(anNo(inRow))){
-    	msfc.antennaId().put(outRow,antIdFromNo(anNo(inRow)));
+      if(antIdFromNo.find(anNo(inRow)) != antIdFromNo.end()){
+    	msfc.antennaId().put(outRow,antIdFromNo[anNo(inRow)]);
       }
       else{
     	*itsLog << LogIO::SEVERE << "Internal error: no mapping for ANTENNA_NO "
@@ -3181,8 +3183,8 @@ Bool FITSIDItoMS1::fillSysCalTable()
   for (Int inRow=0; inRow<nVal; inRow++) {
     for (Int inIF=0; inIF<nIF; inIF++) {
       ms_p.sysCal().addRow(); outRow++;
-      if (antIdFromNo.isDefined(anNo(inRow))) {
-	msSysCal.antennaId().put(outRow, antIdFromNo(anNo(inRow)));
+      if (antIdFromNo.find(anNo(inRow)) != antIdFromNo.end()) {
+	msSysCal.antennaId().put(outRow, antIdFromNo[anNo(inRow)]);
       } else {
     	*itsLog << LogIO::SEVERE << "Internal error: no mapping for ANTENNA_NO "
 				<< anNo(inRow) << LogIO::EXCEPTION;
@@ -3277,11 +3279,11 @@ Bool FITSIDItoMS1::fillFlagCmdTable()
     // Check antenna numbers; fail if there are inconsistencies.
     Int ant1 = ants(inRow)(IPosition(1, 0));
     Int ant2 = ants(inRow)(IPosition(1, 1));
-    if (ant1 != 0 && !antIdFromNo.isDefined(ant1)) {
+    if (ant1 != 0 && antIdFromNo.find(ant1) == antIdFromNo.end()) {
     	*itsLog << LogIO::SEVERE << "No mapping for antenna "
 				<< ant1 << LogIO::EXCEPTION;
     }
-    if (ant2 != 0 && !antIdFromNo.isDefined(ant2)) {
+    if (ant2 != 0 && antIdFromNo.find(ant2) == antIdFromNo.end()) {
     	*itsLog << LogIO::SEVERE << "No mapping for antenna "
 				<< ant2 << LogIO::EXCEPTION;
     }
@@ -3309,8 +3311,8 @@ Bool FITSIDItoMS1::fillFlagCmdTable()
     ostringstream cmd;
 
     // antenna selection
-    ant1 = (ant1 == 0) ? -1 : antIdFromNo(ant1);
-    ant2 = (ant2 == 0) ? -1 : antIdFromNo(ant2);
+    ant1 = (ant1 == 0) ? -1 : antIdFromNo[ant1];
+    ant2 = (ant2 == 0) ? -1 : antIdFromNo[ant2];
     if (ant1 != -1) {
       cmd << "antenna='" << ant1;
       if (ant2 != -1)
@@ -3405,8 +3407,8 @@ Bool FITSIDItoMS1::fillWeatherTable()
   Int outRow=-1;
   for (Int inRow=0; inRow<nVal; inRow++) {
       ms_p.weather().addRow(); outRow++;
-      if (antIdFromNo.isDefined(anNo(inRow))) {
-	msWeather.antennaId().put(outRow, antIdFromNo(anNo(inRow)));
+      if (antIdFromNo.find(anNo(inRow)) != antIdFromNo.end()) {
+	msWeather.antennaId().put(outRow, antIdFromNo[anNo(inRow)]);
       } else {
     	*itsLog << LogIO::SEVERE << "Internal error: no mapping for ANTENNA_NO "
 				<< anNo(inRow) << LogIO::EXCEPTION;

--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -35,14 +35,15 @@
 #include <casacore/tables/Tables/TableDesc.h> //
 #include <casacore/tables/Tables/TableRecord.h> //
 #include <casacore/tables/Tables/TableColumn.h> //
-#include <casacore/casa/Containers/SimOrdMap.h> //
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/measures/Measures/MFrequency.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
-#include <casacore/casa/BasicSL/String.h> 
+#include <casacore/casa/BasicSL/String.h>
+#include <map>
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class MSColumns;
@@ -310,8 +311,8 @@ protected:
   String weightyp_p;
   Int nStokes_p;
   Int nBand_p;
-  static SimpleOrderedMap<Int,Int> antIdFromNo;
-  static SimpleOrderedMap<Int,Int> digiLevels;
+  static std::map<Int,Int> antIdFromNo;
+  static std::map<Int,Int> digiLevels;
   static Vector<Double> effChBw;
 
   //

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -96,6 +96,7 @@
 #include <casacore/casa/iostream.h>
 #include <casacore/casa/iomanip.h>
 #include <casacore/casa/OS/Directory.h>
+#include <map>
 
 using std::make_pair;
 
@@ -2467,7 +2468,7 @@ void MSFitsInput::fillExtraTables() {
       ddId = _msc->dataDescId().getColumn();
     }
 
-    SimpleOrderedMap <pair<Int,Int>, Int> sourceFieldIndex(-1); // for the case we need to write the source table
+    std::map<pair<Int,Int>, Int> sourceFieldIndex; // for the case we need to write the source table
 
     ProgressMeter meter(0.0, nrow * 1.0, "UVFITS Filler", "rows copied",
                 "", "", True, nrow / 100);
@@ -2522,9 +2523,9 @@ void MSFitsInput::fillExtraTables() {
                 // now check if we've seen this field for this spectral window
                 // Use indexed access to the SOURCE sub-table
 		pair<Int, Int> myfldspw = make_pair(lastFieldId, spwId);
-		if(!sourceFieldIndex.isDefined(myfldspw)){
+		if(sourceFieldIndex.find(myfldspw) == sourceFieldIndex.end()){
 
-		    sourceFieldIndex.define(myfldspw, 1); 
+                    sourceFieldIndex.insert(std::make_pair(myfldspw, 1)); 
 
                     _ms.source().addRow();
                     Int j = _ms.source().nrow() - 1;

--- a/msfits/MSFits/SDFeedHandler.cc
+++ b/msfits/MSFits/SDFeedHandler.cc
@@ -41,11 +41,11 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/measures/Measures/Stokes.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/tables/Tables/TableDesc.h>
 
 #include <casacore/casa/sstream.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -390,7 +390,7 @@ void SDFeedHandler::initRow(Vector<Bool> &handledCols, const Record &row)
 
 void SDFeedHandler::stokesToPolType(const Vector<Int> &stokes, Vector<String> &polType)
 {
-    SimpleOrderedMap<String, Int> polTypeMap(-1);
+    std::map<String, Int> polTypeMap;
     for (uInt i=0;i<stokes.nelements();i++) {
 	String type1, type2;
 	switch (Stokes::type(stokes(i))) {
@@ -480,16 +480,17 @@ void SDFeedHandler::stokesToPolType(const Vector<Int> &stokes, Vector<String> &p
 	    break;
 	}
 
-	if (!polTypeMap.isDefined(type1)) {
-	    polTypeMap.define(type1, polTypeMap.ndefined());
+	if (polTypeMap.find(type1) == polTypeMap.end()) {
+	    polTypeMap[type1] = polTypeMap.size();
 	}
-	if (!polTypeMap.isDefined(type2)) {
-	    polTypeMap.define(type2, polTypeMap.ndefined());
+	if (polTypeMap.find(type2) == polTypeMap.end()) {
+	    polTypeMap[type2] = polTypeMap.size();
 	}
     }
-    polType.resize(polTypeMap.ndefined());
-    for (uInt i=0;i<polTypeMap.ndefined();i++) {
-	polType(i) = polTypeMap.getKey(i);
+    polType.resize(polTypeMap.size());
+    int i=0;
+    for (const auto& elem : polTypeMap) {
+      polType[i++] = elem.first;
     }
 }
 

--- a/msfits/MSFits/SDPolarizationHandler.cc
+++ b/msfits/MSFits/SDPolarizationHandler.cc
@@ -40,8 +40,8 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/measures/Measures/Stokes.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -132,23 +132,23 @@ void SDPolarizationHandler::fill(const Record &, const Vector<Int> &stokes)
 	    } else {
 		// construct the corrProduct given the stokes values
 		// first, we need to determine the decomposition of the stokes values
-		SimpleOrderedMap<Int, Int> polTypeMap(-1);
+                std::map<Int, Int> polTypeMap;
 		for (uInt i=0;i<stokes.nelements();i++) {
 		    Int key1, key2;
 		    stokesKeys(stokes(i), key1, key2);
-		    if (!polTypeMap.isDefined(key1)) {
-			polTypeMap.define(key1, polTypeMap.ndefined());
+		    if (polTypeMap.find(key1) == polTypeMap.end()) {
+			polTypeMap[key1] = polTypeMap.size();
 		    }
-		    if (key2 != key1 && !polTypeMap.isDefined(key2)) {
-			polTypeMap.define(key2, polTypeMap.ndefined());
+		    if (polTypeMap.find(key2) == polTypeMap.end()) {
+			polTypeMap[key2] = polTypeMap.size();
 		    }
 		}
 		// now re-assemble these into the corr product
 		for (uInt i=0;i<stokes.nelements();i++) {
 		    Int key1, key2;
 		    stokesKeys(stokes(i), key1, key2);
-		    corrProduct(0,i) = polTypeMap(key1);
-		    corrProduct(1,i) = polTypeMap(key2);
+		    corrProduct(0,i) = polTypeMap[key1];
+		    corrProduct(1,i) = polTypeMap[key2];
 		}
 	    }
 	    // and insert it into the table

--- a/tables/DataMan/DataManInfo.cc
+++ b/tables/DataMan/DataManInfo.cc
@@ -33,7 +33,6 @@
 #include <casacore/tables/Tables/TableDesc.h>
 #include <casacore/tables/DataMan/DataManager.h>
 #include <casacore/casa/Containers/Record.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/BasicSL/String.h>
 
@@ -42,14 +41,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 void DataManInfo::removeHypercolumns (TableDesc& tabDesc)
 {
-  tabDesc.adjustHypercolumns (SimpleOrderedMap<String,String>(String()));
+  tabDesc.adjustHypercolumns (std::map<String,String>());
 }
 
 void DataManInfo::adjustDesc (TableDesc& tdesc, const Record& dminfo)
 {
   // Find out the columns and data manager groups of the fields.
-  SimpleOrderedMap<String,String> dmTypeMap("", tdesc.ncolumn());
-  SimpleOrderedMap<String,String> dmGroupMap("", tdesc.ncolumn());
+  std::map<String,String> dmTypeMap;
+  std::map<String,String> dmGroupMap;
   for (uInt i=0; i<dminfo.nfields(); i++) {
     const Record& sub = dminfo.asRecord (i);
     if (sub.isDefined("COLUMNS")) {
@@ -63,29 +62,31 @@ void DataManInfo::adjustDesc (TableDesc& tdesc, const Record& dminfo)
       }
       Vector<String> cols = sub.asArrayString ("COLUMNS");
       for (uInt j=0; j<cols.nelements(); j++) {
-	dmTypeMap(cols[j]) = dmType;
-	dmGroupMap(cols[j]) = dmGroup;
+	dmTypeMap.insert (std::make_pair(cols[j], dmType));
+        dmGroupMap.insert (std::make_pair(cols[j], dmGroup));
       }
     }
   }
   // Exit if no columns in dminfo.
-  if (dmTypeMap.ndefined() == 0) {
+  if (dmTypeMap.empty()) {
     return;
   }
   // Change data manager type and group as needed.
   for (uInt i=0; i<tdesc.ncolumn(); i++) {
     ColumnDesc& cdesc = tdesc.rwColumnDesc(i);
     const String& name = cdesc.name();
-    String* v = dmTypeMap.isDefined (name);
-    if (v) {
-      if (! v->empty()) {
-	cdesc.dataManagerType() = *v;
+    std::map<String,String>::iterator iter1 = dmTypeMap.find (name);
+    if (iter1 != dmTypeMap.end()) {
+      String v = iter1->second;
+      if (! v.empty()) {
+	cdesc.dataManagerType() = v;
       }
     }
-    v = dmGroupMap.isDefined (name);
-    if (v) {
-      if (! v->empty()) {
-	cdesc.dataManagerGroup() = *v;
+    std::map<String,String>::iterator iter2 = dmGroupMap.find (name);
+    if (iter2 != dmTypeMap.end()) {
+      String v = iter2->second;
+      if (! v.empty()) {
+	cdesc.dataManagerGroup() = v;
       }
     }
   }

--- a/tables/DataMan/DataManager.h
+++ b/tables/DataMan/DataManager.h
@@ -35,11 +35,11 @@
 #include <casacore/tables/DataMan/TSMOption.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/BasicSL/Complex.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/IO/ByteIO.h>
 #include <casacore/casa/OS/Mutex.h>
 #include<iosfwd>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -516,7 +516,7 @@ private:
 
     // Declare the mapping of the data manager type name to a static
     // "makeObject" function.
-    static SimpleOrderedMap<String,DataManagerCtor> theirRegisterMap;
+    static std::map<String,DataManagerCtor> theirRegisterMap;
     static Mutex theirMutex;
 
 public:
@@ -548,7 +548,7 @@ public:
 
 private:
     // Register the main data managers.
-    static SimpleOrderedMap<String,DataManagerCtor> initRegisterMap();
+    static std::map<String,DataManagerCtor> initRegisterMap();
 };
 
 

--- a/tables/DataMan/MSMBase.h
+++ b/tables/DataMan/MSMBase.h
@@ -32,6 +32,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/DataMan/DataManager.h>
+#include <casacore/casa/Containers/Block.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/tables/DataMan/SSMIndex.h
+++ b/tables/DataMan/SSMIndex.h
@@ -30,8 +30,8 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/Block.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -163,7 +163,7 @@ private:
   Block<uInt> itsBucketNumber;
 
   //# Map that contains length/offset pairs for free size (size in bytes).
-  SimpleOrderedMap<Int,Int> itsFreeSpace;
+  std::map<Int,Int> itsFreeSpace;
 
   //# How many rows fit in a bucket?
   uInt itsRowsPerBucket;

--- a/tables/TaQL/TableParse.cc
+++ b/tables/TaQL/TableParse.cc
@@ -237,9 +237,6 @@ TableParseSelect::~TableParseSelect()
   // Note that insSel_p is simply a pointer to another object,
   // so no delete should be done.
   delete resultSet_p;
-  for (uInt i=0; i<update_p.size(); ++i) {
-    delete update_p[i];
-  }
 }
 
 

--- a/tables/TaQL/TableParse.h
+++ b/tables/TaQL/TableParse.h
@@ -499,7 +499,7 @@ public:
   TableRecord& findKeyword (const String& name, String& keyName);
 
   // Add an update object.
-  void addUpdate (TableParseUpdate* upd);
+  void addUpdate (const CountedPtr<TableParseUpdate>& upd);
 
   // Set the insert expressions for all rows.
   void setInsertExprs (const std::vector<TableExprNode> exprs)
@@ -922,7 +922,7 @@ private:
   //# The possible stride in offset:endrow:stride.
   Int64 stride_p;
   //# The update and insert list.
-  std::vector<TableParseUpdate*> update_p;
+  std::vector<CountedPtr<TableParseUpdate>> update_p;
   //# The insert expressions (possibly for multiple rows).
   std::vector<TableExprNode> insertExprs_p;
   //# The table selection to be inserted.
@@ -998,7 +998,7 @@ inline const Block<String>& TableParseSelect::getColumnNames() const
 inline const Table& TableParseSelect::getTable() const
   { return table_p; }
 
-inline void TableParseSelect::addUpdate (TableParseUpdate* upd)
+inline void TableParseSelect::addUpdate (const CountedPtr<TableParseUpdate>& upd)
   { update_p.push_back (upd); }
 
 inline Sort::Order TableParseSelect::getOrder (const TableParseSort& key) const

--- a/tables/Tables.h
+++ b/tables/Tables.h
@@ -929,7 +929,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // #include <casacore/tables/Tables/TableDesc.h>
 // #include <casacore/tables/Tables/ScaColDesc.h>
 // #include <casacore/tables/Tables/ArrColDesc.h>
-// #include <aips/Tables/ScaRecordTabDesc.h>
+// #include <casacore/tables/Tables/ScaRecordTabDesc.h>
 // #include <casacore/tables/Tables/TableRecord.h>
 // #include <casacore/casa/Arrays/IPosition.h>
 // #include <casacore/casa/Arrays/Vector.h>

--- a/tables/Tables/ArrColDesc.h
+++ b/tables/Tables/ArrColDesc.h
@@ -31,7 +31,6 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseColDesc.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Arrays/IPosition.h>
 
 

--- a/tables/Tables/BaseColumn.cc
+++ b/tables/Tables/BaseColumn.cc
@@ -33,10 +33,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 BaseColumn::BaseColumn (const BaseColumnDesc* cdp)
-: colDescPtr_p(cdp),
-    // The following cast is safe, because this class uses colDesc_p
-    // only to give a const ColumnDesc&.
-  colDesc_p   ((BaseColumnDesc*)cdp)
+: colDescPtr_p(cdp)
 {}
 
 BaseColumn::~BaseColumn()
@@ -48,47 +45,47 @@ BaseColumn::~BaseColumn()
 
 void BaseColumn::setShape (uInt, const IPosition&)
 {
-  throw (TableInvOper ("invalid setShape() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid setShape() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
 }
 
 void BaseColumn::setShape (uInt, const IPosition&, const IPosition&)
 {
-  throw (TableInvOper ("invalid setShape() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid setShape() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
 }
 
 uInt BaseColumn::ndimColumn() const
 {
-  throw (TableInvOper ("invalid ndimColumn() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid ndimColumn() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
   return 0;
 }
 
 IPosition BaseColumn::shapeColumn() const
 {
-  throw (TableInvOper ("invalid shapeColumn() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid shapeColumn() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
   return IPosition(0);
 }
 
 uInt BaseColumn::ndim (uInt) const
 {
-  throw (TableInvOper ("invalid ndim() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid ndim() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
   return 0;
 }
 
 IPosition BaseColumn::shape (uInt) const
 {
-  throw (TableInvOper ("invalid shape() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid shape() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
   return IPosition(0);
 }
 
 IPosition BaseColumn::tileShape (uInt) const
 {
-  throw (TableInvOper ("invalid tileShape() for column " + colDesc_p.name() +
+  throw (TableInvOper ("invalid tileShape() for column " + colDescPtr_p->name() +
                        "; only valid for an array"));
 }
 
@@ -133,115 +130,115 @@ Bool BaseColumn::canAccessColumnSlice (Bool& reask) const
 void BaseColumn::getSlice (uInt, const Slicer&, void*) const
 {
   throw (TableInvOper ("getSlice() not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::getScalarColumn (void*) const
 {
   throw (TableInvOper ("getScalarColumn() not implemented for column " +
-                       colDesc_p.name() + "; only valid for a scalar"));
+                       colDescPtr_p->name() + "; only valid for a scalar"));
 }
 
 void BaseColumn::getArrayColumn (void*) const
 {
   throw (TableInvOper ("getArrayColumn() not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::getScalarColumnCells (const RefRows&, void*) const
 {
   throw (TableInvOper ("getScalarColumnCells() not implemented for column " +
-                       colDesc_p.name() + "; only valid for a scalar"));
+                       colDescPtr_p->name() + "; only valid for a scalar"));
 }
 
 void BaseColumn::getArrayColumnCells (const RefRows&, void*) const
 {
   throw (TableInvOper ("getArrayColumnCells() not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::getColumnSliceCells (const RefRows&,
 				      const Slicer&, void*) const
 {
   throw (TableInvOper ("getColumnCells(Slicer&) not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::getColumnSlice (const Slicer&, void*) const
 {
   throw (TableInvOper ("getColumn(Slicer&) not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::putSlice (uInt, const Slicer&, const void*)
 {
   throw (TableInvOper ("putSlice() not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::putScalarColumn (const void*)
 {
   throw (TableInvOper ("putScalarColumn() not implemented for column " +
-                       colDesc_p.name() + "; only valid for a scalar"));
+                       colDescPtr_p->name() + "; only valid for a scalar"));
 }
 
 void BaseColumn::putArrayColumn (const void*)
 {
   throw (TableInvOper ("putArrayColumn() not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::putScalarColumnCells (const RefRows&, const void*)
 {
   throw (TableInvOper ("putScalarColumnCells() not implemented for column " +
-                       colDesc_p.name() + "; only valid for a scalar"));
+                       colDescPtr_p->name() + "; only valid for a scalar"));
 }
 
 void BaseColumn::putArrayColumnCells (const RefRows&, const void*)
 {
   throw (TableInvOper ("putArrayColumnCells() not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::putColumnSlice (const Slicer&, const void*)
 {
   throw (TableInvOper ("putColumn(Slicer&) not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 void BaseColumn::putColumnSliceCells (const RefRows&,
 				      const Slicer&, const void*)
 {
   throw (TableInvOper ("putColumnCells(Slicer&) not implemented for column " +
-                       colDesc_p.name() + "; only valid for an array"));
+                       colDescPtr_p->name() + "; only valid for an array"));
 }
 
 
 void BaseColumn::makeSortKey (Sort&, CountedPtr<BaseCompare>&, Int,
                               const void*&)
 {
-  throw (TableInvOper ("makeSortKey() for column " + colDesc_p.name() +
+  throw (TableInvOper ("makeSortKey() for column " + colDescPtr_p->name() +
                        " is only valid for a scalar"));
 }
 void BaseColumn::makeRefSortKey (Sort&, CountedPtr<BaseCompare>&, Int,
 				 const Vector<uInt>&, const void*&)
 {
-  throw (TableInvOper ("makeSortKey(rownrs) for column " + colDesc_p.name() +
+  throw (TableInvOper ("makeSortKey(rownrs) for column " + colDescPtr_p->name() +
                        " is only valid for a scalar"));
 }
 void BaseColumn::freeSortKey (const void*&)
 {
-  throw (TableInvOper ("freeSortKey() for column " + colDesc_p.name() +
+  throw (TableInvOper ("freeSortKey() for column " + colDescPtr_p->name() +
                        " is only valid for a scalar"));
 }
 void BaseColumn::allocIterBuf (void*&, void*&, CountedPtr<BaseCompare>&)
 {
-  throw (TableInvOper ("allocIterBuf() for column " + colDesc_p.name() +
+  throw (TableInvOper ("allocIterBuf() for column " + colDescPtr_p->name() +
                        " is only valid for a scalar"));
 }
 void BaseColumn::freeIterBuf (void*&, void*&)
 {
-  throw (TableInvOper ("freeIterBuf() for column " + colDesc_p.name() +
+  throw (TableInvOper ("freeIterBuf() for column " + colDescPtr_p->name() +
                        " is only valid for a scalar"));
 }
 
@@ -1044,28 +1041,34 @@ void BaseColumn::putScalar (uInt rownr, const TableRecord& value)
 
 void BaseColumn::throwGetScalar() const
 {
-    throw (TableInvOper ("invalid getScalar() for column " + colDesc_p.name() +
+    throw (TableInvOper ("invalid getScalar() for column " + colDescPtr_p->name() +
                          "; only possible for a scalar"));
 }
 
 void BaseColumn::throwPutScalar() const
 {
-    throw (TableInvOper ("invalid putScalar() for column " + colDesc_p.name() +
+    throw (TableInvOper ("invalid putScalar() for column " + colDescPtr_p->name() +
                          "; only possible for a scalar"));
 }
 
 void BaseColumn::throwGetType (const String& type) const
 {
     throw (TableInvDT ("invalid type promotion in getScalar(" + type +
-                       ") for column " + colDesc_p.name() + " with type "
-                       + ValType::getTypeStr(colDesc_p.dataType())));
+                       ") for column " + colDescPtr_p->name() + " with type "
+                       + ValType::getTypeStr(colDescPtr_p->dataType())));
 }
 
 void BaseColumn::throwPutType (const String& type) const
 {
     throw (TableInvDT ("invalid type promotion in putScalar(" + type +
-                       ") for column " + colDesc_p.name() + " with type "
-                       + ValType::getTypeStr(colDesc_p.dataType())));
+                       ") for column " + colDescPtr_p->name() + " with type "
+                       + ValType::getTypeStr(colDescPtr_p->dataType())));
+}
+
+const ColumnDesc& BaseColumn::columnDesc() const
+{
+  colDesc_p = ColumnDesc(const_cast<BaseColumnDesc*>(colDescPtr_p));
+  return colDesc_p;
 }
 
 } //# NAMESPACE CASACORE - END

--- a/tables/Tables/BaseColumn.h
+++ b/tables/Tables/BaseColumn.h
@@ -117,8 +117,7 @@ public:
     // </group>
 
     // Get const access to the column description.
-    const ColumnDesc& columnDesc() const
-	{ return colDesc_p; }
+    const ColumnDesc& columnDesc() const;
 
     // Get nr of rows in the column.
     virtual uInt nrow() const = 0;
@@ -339,9 +338,11 @@ protected:
 
     //# Data members
     const BaseColumnDesc*  colDescPtr_p;
+
+private:
     //# This ColumnDesc object is created to be able to return 
     //# a const ColumnDesc& by function columnDesc().
-    ColumnDesc             colDesc_p;
+    mutable ColumnDesc     colDesc_p;
 };
 
 

--- a/tables/Tables/ColDescSet.h
+++ b/tables/Tables/ColDescSet.h
@@ -31,9 +31,11 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/ColumnDesc.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/iosfwd.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -106,11 +108,11 @@ public:
 
     // Get nr of columns in this set.
     uInt ncolumn() const
-	{ return cols_p.ndefined(); }
+	{ return cols_p.size(); }
 
     // Test if a column is defined in this set.
     Bool isDefined (const String& name) const
-	{ return  (cols_p.isDefined (name)); }
+        { return (cols_p.find(name) != cols_p.end()); }
 
     // Test if this set equals another one.
     // It is equal if the number of columns is equal and all field names in
@@ -189,7 +191,7 @@ private:
 
 
     // The set of all columns.
-    SimpleOrderedMap<String,ColumnDesc> cols_p;
+    std::map<String,CountedPtr<ColumnDesc>> cols_p;
     // The order of addition of column descriptions.
     //# This is in fact a Block<ColumnDesc*>, but a void* is used
     //# to reduce the number of template instantiations.

--- a/tables/Tables/ColumnDesc.cc
+++ b/tables/Tables/ColumnDesc.cc
@@ -44,6 +44,10 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
+// Initialize the statics.
+Mutex ColumnDesc::theirMutex;
+
+  
 ColumnDesc::ColumnDesc (const BaseColumnDesc& cold)
 : colPtr_p   (cold.clone()),
   allocated_p(True)
@@ -200,15 +204,10 @@ void ColumnDesc::getFile (AipsIO& ios, const TableAttr& parentAttr)
     if (allocated_p) {
 	delete colPtr_p;
     }
-    allocated_p = True;
-
     // If tp is not in the map, (tp, unknownColumnDesc) is added and called (throws).
-    ColumnDesc::ColumnDescCtor cdFunc;
-    {
-        ScopedMutexLock lock(theirMutex);
-        cdFunc = theirRegisterMap(tp);
-    }
+    ColumnDesc::ColumnDescCtor cdFunc = getCtor(tp);
     colPtr_p = (*cdFunc)(tp);
+    allocated_p = True;
     colPtr_p->getFile (ios, parentAttr);
 }
 
@@ -235,95 +234,94 @@ void ColumnDesc::show (ostream& os) const
     }
 }
 
-//# Initialize the static variables for the class registration.
-SimpleOrderedMap<String, ColumnDesc::ColumnDescCtor>
-        ColumnDesc::theirRegisterMap(initRegisterMap());
-Mutex ColumnDesc::theirMutex;
-
-//# The default "ctor" function for unknown types.
-BaseColumnDesc* ColumnDesc::unknownColumnDesc (const String& name)
-{
-    throw (TableUnknownDesc(name));
-    return 0;
-}
 
 //# Register a mapping.
 void ColumnDesc::registerCtor (const String& name,
                                ColumnDesc::ColumnDescCtor func)
 {
     ScopedMutexLock lock(theirMutex);
-    theirRegisterMap.define(name, func);
+    getRegisterMap().insert (std::make_pair(name, func));
 }
 
 //# Get a ColumnDesc constructor.
 //# Return default function if undefined.
 ColumnDesc::ColumnDescCtor ColumnDesc::getCtor (const String& name)
 {
-    ScopedMutexLock lock(theirMutex);
-    return *(theirRegisterMap.isDefined (name));
+  std::map<String, ColumnDesc::ColumnDescCtor>& regMap = getRegisterMap();
+  std::map<String, ColumnDesc::ColumnDescCtor>::iterator iter = regMap.find (name);
+  if (iter == regMap.end()) {
+    throw;
+  }
+  return iter->second;
+}
+
+std::map<String, ColumnDesc::ColumnDescCtor>& ColumnDesc::getRegisterMap()
+{
+  static std::map<String, ColumnDesc::ColumnDescCtor> regMap(initRegisterMap());
+  return regMap;
 }
 
 //# Register the main "static constructors" of all XColumnDesc classes.
 // No locking since private and only called by ctor of static member init.
-SimpleOrderedMap<String, ColumnDesc::ColumnDescCtor> ColumnDesc::initRegisterMap()
+std::map<String, ColumnDesc::ColumnDescCtor> ColumnDesc::initRegisterMap()
 {
-  SimpleOrderedMap<String, ColumnDesc::ColumnDescCtor> regMap(ColumnDesc::unknownColumnDesc);
+  std::map<String, ColumnDesc::ColumnDescCtor> regMap;
 
   ScalarColumnDesc<Bool>     scdb("x");
-  regMap.define(scdb.className(), scdb.makeDesc);
+  regMap.insert (std::make_pair(scdb.className(), scdb.makeDesc));
   ScalarColumnDesc<uChar>    scduc("x");
-  regMap.define(scduc.className(), scduc.makeDesc);
+  regMap.insert (std::make_pair(scduc.className(), scduc.makeDesc));
   ScalarColumnDesc<Short>    scds("x");
-  regMap.define(scds.className(), scds.makeDesc);
+  regMap.insert (std::make_pair(scds.className(), scds.makeDesc));
   ScalarColumnDesc<uShort>   scdus("x");
-  regMap.define(scdus.className(), scdus.makeDesc);
+  regMap.insert (std::make_pair(scdus.className(), scdus.makeDesc));
   ScalarColumnDesc<Int>      scdi("x");
-  regMap.define(scdi.className(), scdi.makeDesc);
+  regMap.insert (std::make_pair(scdi.className(), scdi.makeDesc));
   ScalarColumnDesc<uInt>     scdui("x");
-  regMap.define(scdui.className(), scdui.makeDesc);
+  regMap.insert (std::make_pair(scdui.className(), scdui.makeDesc));
   ScalarColumnDesc<Int64>    scdi64("x");
-  regMap.define(scdi64.className(), scdi64.makeDesc);
+  regMap.insert (std::make_pair(scdi64.className(), scdi64.makeDesc));
   ScalarColumnDesc<float>    scdf("x");
-  regMap.define(scdf.className(), scdf.makeDesc);
+  regMap.insert (std::make_pair(scdf.className(), scdf.makeDesc));
   ScalarColumnDesc<double>   scdd("x");
-  regMap.define(scdd.className(), scdd.makeDesc);
+  regMap.insert (std::make_pair(scdd.className(), scdd.makeDesc));
   ScalarColumnDesc<Complex>  scdcx("x");
-  regMap.define(scdcx.className(), scdcx.makeDesc);
+  regMap.insert (std::make_pair(scdcx.className(), scdcx.makeDesc));
   ScalarColumnDesc<DComplex> scddx("x");
-  regMap.define(scddx.className(), scddx.makeDesc);
+  regMap.insert (std::make_pair(scddx.className(), scddx.makeDesc));
   ScalarColumnDesc<String>   scdst("x");
-  regMap.define(scdst.className(), scdst.makeDesc);
+  regMap.insert (std::make_pair(scdst.className(), scdst.makeDesc));
 
   ScalarRecordColumnDesc     srcd ("x");
-  regMap.define(srcd.className(), srcd.makeDesc);
+  regMap.insert (std::make_pair(srcd.className(), srcd.makeDesc));
 
   ArrayColumnDesc<Bool>     acdb("x");
-  regMap.define(acdb.className(), acdb.makeDesc);
+  regMap.insert (std::make_pair(acdb.className(), acdb.makeDesc));
   ArrayColumnDesc<uChar>    acduc("x");
-  regMap.define(acduc.className(), acduc.makeDesc);
+  regMap.insert (std::make_pair(acduc.className(), acduc.makeDesc));
   ArrayColumnDesc<Short>    acds("x");
-  regMap.define(acds.className(), acds.makeDesc);
+  regMap.insert (std::make_pair(acds.className(), acds.makeDesc));
   ArrayColumnDesc<uShort>   acdus("x");
-  regMap.define(acdus.className(), acdus.makeDesc);
+  regMap.insert (std::make_pair(acdus.className(), acdus.makeDesc));
   ArrayColumnDesc<Int>      acdi("x");
-  regMap.define(acdi.className(), acdi.makeDesc);
+  regMap.insert (std::make_pair(acdi.className(), acdi.makeDesc));
   ArrayColumnDesc<uInt>     acdui("x");
-  regMap.define(acdui.className(), acdui.makeDesc);
+  regMap.insert (std::make_pair(acdui.className(), acdui.makeDesc));
   ArrayColumnDesc<Int64>    acdi64("x");
-  regMap.define(acdi64.className(), acdi64.makeDesc);
+  regMap.insert (std::make_pair(acdi64.className(), acdi64.makeDesc));
   ArrayColumnDesc<float>    acdf("x");
-  regMap.define(acdf.className(), acdf.makeDesc);
+  regMap.insert (std::make_pair(acdf.className(), acdf.makeDesc));
   ArrayColumnDesc<double>   acdd("x");
-  regMap.define(acdd.className(), acdd.makeDesc);
+  regMap.insert (std::make_pair(acdd.className(), acdd.makeDesc));
   ArrayColumnDesc<Complex>  acdcx("x");
-  regMap.define(acdcx.className(), acdcx.makeDesc);
+  regMap.insert (std::make_pair(acdcx.className(), acdcx.makeDesc));
   ArrayColumnDesc<DComplex> acddx("x");
-  regMap.define(acddx.className(), acddx.makeDesc);
+  regMap.insert (std::make_pair(acddx.className(), acddx.makeDesc));
   ArrayColumnDesc<String>   acdst("x");
-  regMap.define(acdst.className(), acdst.makeDesc);
+  regMap.insert (std::make_pair(acdst.className(), acdst.makeDesc));
 
   SubTableDesc std("x", "", TableDesc());
-  regMap.define(std.className(), std.makeDesc);
+  regMap.insert (std::make_pair(std.className(), std.makeDesc));
 
   return regMap;
 }

--- a/tables/Tables/ColumnDesc.cc
+++ b/tables/Tables/ColumnDesc.cc
@@ -205,7 +205,7 @@ void ColumnDesc::getFile (AipsIO& ios, const TableAttr& parentAttr)
 	delete colPtr_p;
     }
     // If tp is not in the map, (tp, unknownColumnDesc) is added and called (throws).
-    ColumnDesc::ColumnDescCtor cdFunc = getCtor(tp);
+    ColumnDesc::ColumnDescCtor* cdFunc = getCtor(tp);
     colPtr_p = (*cdFunc)(tp);
     allocated_p = True;
     colPtr_p->getFile (ios, parentAttr);
@@ -237,7 +237,7 @@ void ColumnDesc::show (ostream& os) const
 
 //# Register a mapping.
 void ColumnDesc::registerCtor (const String& name,
-                               ColumnDesc::ColumnDescCtor func)
+                               ColumnDesc::ColumnDescCtor* func)
 {
     ScopedMutexLock lock(theirMutex);
     getRegisterMap().insert (std::make_pair(name, func));
@@ -245,83 +245,83 @@ void ColumnDesc::registerCtor (const String& name,
 
 //# Get a ColumnDesc constructor.
 //# Return default function if undefined.
-ColumnDesc::ColumnDescCtor ColumnDesc::getCtor (const String& name)
+ColumnDesc::ColumnDescCtor* ColumnDesc::getCtor (const String& name)
 {
-  std::map<String, ColumnDesc::ColumnDescCtor>& regMap = getRegisterMap();
-  std::map<String, ColumnDesc::ColumnDescCtor>::iterator iter = regMap.find (name);
+  std::map<String, ColumnDesc::ColumnDescCtor*>& regMap = getRegisterMap();
+  std::map<String, ColumnDesc::ColumnDescCtor*>::iterator iter = regMap.find (name);
   if (iter == regMap.end()) {
     throw;
   }
   return iter->second;
 }
 
-std::map<String, ColumnDesc::ColumnDescCtor>& ColumnDesc::getRegisterMap()
+std::map<String, ColumnDesc::ColumnDescCtor*>& ColumnDesc::getRegisterMap()
 {
-  static std::map<String, ColumnDesc::ColumnDescCtor> regMap(initRegisterMap());
+  static std::map<String, ColumnDesc::ColumnDescCtor*> regMap(initRegisterMap());
   return regMap;
 }
 
 //# Register the main "static constructors" of all XColumnDesc classes.
 // No locking since private and only called by ctor of static member init.
-std::map<String, ColumnDesc::ColumnDescCtor> ColumnDesc::initRegisterMap()
+std::map<String, ColumnDesc::ColumnDescCtor*> ColumnDesc::initRegisterMap()
 {
-  std::map<String, ColumnDesc::ColumnDescCtor> regMap;
+  std::map<String, ColumnDesc::ColumnDescCtor*> regMap;
 
   ScalarColumnDesc<Bool>     scdb("x");
-  regMap.insert (std::make_pair(scdb.className(), scdb.makeDesc));
+  regMap.insert (std::make_pair(scdb.className(), &scdb.makeDesc));
   ScalarColumnDesc<uChar>    scduc("x");
-  regMap.insert (std::make_pair(scduc.className(), scduc.makeDesc));
+  regMap.insert (std::make_pair(scduc.className(), &scduc.makeDesc));
   ScalarColumnDesc<Short>    scds("x");
-  regMap.insert (std::make_pair(scds.className(), scds.makeDesc));
+  regMap.insert (std::make_pair(scds.className(), &scds.makeDesc));
   ScalarColumnDesc<uShort>   scdus("x");
-  regMap.insert (std::make_pair(scdus.className(), scdus.makeDesc));
+  regMap.insert (std::make_pair(scdus.className(), &scdus.makeDesc));
   ScalarColumnDesc<Int>      scdi("x");
-  regMap.insert (std::make_pair(scdi.className(), scdi.makeDesc));
+  regMap.insert (std::make_pair(scdi.className(), &scdi.makeDesc));
   ScalarColumnDesc<uInt>     scdui("x");
-  regMap.insert (std::make_pair(scdui.className(), scdui.makeDesc));
+  regMap.insert (std::make_pair(scdui.className(), &scdui.makeDesc));
   ScalarColumnDesc<Int64>    scdi64("x");
-  regMap.insert (std::make_pair(scdi64.className(), scdi64.makeDesc));
+  regMap.insert (std::make_pair(scdi64.className(), &scdi64.makeDesc));
   ScalarColumnDesc<float>    scdf("x");
-  regMap.insert (std::make_pair(scdf.className(), scdf.makeDesc));
+  regMap.insert (std::make_pair(scdf.className(), &scdf.makeDesc));
   ScalarColumnDesc<double>   scdd("x");
-  regMap.insert (std::make_pair(scdd.className(), scdd.makeDesc));
+  regMap.insert (std::make_pair(scdd.className(), &scdd.makeDesc));
   ScalarColumnDesc<Complex>  scdcx("x");
-  regMap.insert (std::make_pair(scdcx.className(), scdcx.makeDesc));
+  regMap.insert (std::make_pair(scdcx.className(), &scdcx.makeDesc));
   ScalarColumnDesc<DComplex> scddx("x");
-  regMap.insert (std::make_pair(scddx.className(), scddx.makeDesc));
+  regMap.insert (std::make_pair(scddx.className(), &scddx.makeDesc));
   ScalarColumnDesc<String>   scdst("x");
-  regMap.insert (std::make_pair(scdst.className(), scdst.makeDesc));
+  regMap.insert (std::make_pair(scdst.className(), &scdst.makeDesc));
 
   ScalarRecordColumnDesc     srcd ("x");
-  regMap.insert (std::make_pair(srcd.className(), srcd.makeDesc));
+  regMap.insert (std::make_pair(srcd.className(), &srcd.makeDesc));
 
   ArrayColumnDesc<Bool>     acdb("x");
-  regMap.insert (std::make_pair(acdb.className(), acdb.makeDesc));
+  regMap.insert (std::make_pair(acdb.className(), &acdb.makeDesc));
   ArrayColumnDesc<uChar>    acduc("x");
-  regMap.insert (std::make_pair(acduc.className(), acduc.makeDesc));
+  regMap.insert (std::make_pair(acduc.className(), &acduc.makeDesc));
   ArrayColumnDesc<Short>    acds("x");
-  regMap.insert (std::make_pair(acds.className(), acds.makeDesc));
+  regMap.insert (std::make_pair(acds.className(), &acds.makeDesc));
   ArrayColumnDesc<uShort>   acdus("x");
-  regMap.insert (std::make_pair(acdus.className(), acdus.makeDesc));
+  regMap.insert (std::make_pair(acdus.className(), &acdus.makeDesc));
   ArrayColumnDesc<Int>      acdi("x");
-  regMap.insert (std::make_pair(acdi.className(), acdi.makeDesc));
+  regMap.insert (std::make_pair(acdi.className(), &acdi.makeDesc));
   ArrayColumnDesc<uInt>     acdui("x");
-  regMap.insert (std::make_pair(acdui.className(), acdui.makeDesc));
+  regMap.insert (std::make_pair(acdui.className(), &acdui.makeDesc));
   ArrayColumnDesc<Int64>    acdi64("x");
-  regMap.insert (std::make_pair(acdi64.className(), acdi64.makeDesc));
+  regMap.insert (std::make_pair(acdi64.className(), &acdi64.makeDesc));
   ArrayColumnDesc<float>    acdf("x");
-  regMap.insert (std::make_pair(acdf.className(), acdf.makeDesc));
+  regMap.insert (std::make_pair(acdf.className(), &acdf.makeDesc));
   ArrayColumnDesc<double>   acdd("x");
-  regMap.insert (std::make_pair(acdd.className(), acdd.makeDesc));
+  regMap.insert (std::make_pair(acdd.className(), &acdd.makeDesc));
   ArrayColumnDesc<Complex>  acdcx("x");
-  regMap.insert (std::make_pair(acdcx.className(), acdcx.makeDesc));
+  regMap.insert (std::make_pair(acdcx.className(), &acdcx.makeDesc));
   ArrayColumnDesc<DComplex> acddx("x");
-  regMap.insert (std::make_pair(acddx.className(), acddx.makeDesc));
+  regMap.insert (std::make_pair(acddx.className(), &acddx.makeDesc));
   ArrayColumnDesc<String>   acdst("x");
-  regMap.insert (std::make_pair(acdst.className(), acdst.makeDesc));
+  regMap.insert (std::make_pair(acdst.className(), &acdst.makeDesc));
 
   SubTableDesc std("x", "", TableDesc());
-  regMap.insert (std::make_pair(std.className(), std.makeDesc));
+  regMap.insert (std::make_pair(std.className(), &std.makeDesc));
 
   return regMap;
 }

--- a/tables/Tables/ColumnDesc.h
+++ b/tables/Tables/ColumnDesc.h
@@ -32,10 +32,10 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseColDesc.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/OS/Mutex.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -357,6 +357,9 @@ public:
     static void registerCtor (const String& name, ColumnDescCtor func);
 
 private:
+    // A mutex for additions to the constructor map.
+    static Mutex theirMutex;
+  
     // Define a map which maps the name of the various XXColumnDesc
     // classes to a static function constructing them.
     // This is used when reading a column description back; it in fact
@@ -365,20 +368,11 @@ private:
     // The map is filled with the main XXColumnDesc construction functions
     // by the function registerColumnDesc upon the first call of
     // <src>ColumnDesc::getFile</src>.
-    static SimpleOrderedMap<String, ColumnDescCtor> theirRegisterMap;
-    static Mutex theirMutex;
-
-    // Serve as default function for theirRegisterMap.
-    // which catches all unknown XXColumnDesc class names.
-    // <thrown>
-    //   <li> TableUnknownDesc
-    // </thrown>
-    static BaseColumnDesc* unknownColumnDesc (const String& name);
+    static std::map<String, ColumnDescCtor>& getRegisterMap();
 
     // Register the main data managers.
-    static SimpleOrderedMap<String, ColumnDescCtor> initRegisterMap();
+    static std::map<String, ColumnDescCtor> initRegisterMap();
 
-private:
     // Construct from a pointer (for class BaseColumn).
     ColumnDesc (BaseColumnDesc*);
 

--- a/tables/Tables/ColumnDesc.h
+++ b/tables/Tables/ColumnDesc.h
@@ -348,13 +348,13 @@ public:
 
 
     // Define the type of a XXColumnDesc construction function.
-    typedef BaseColumnDesc* (*ColumnDescCtor) (const String& className);
+    typedef BaseColumnDesc* ColumnDescCtor (const String& className);
 
     // Get a construction function for a XXColumnDesc object (thread-safe).
-    static ColumnDescCtor getCtor (const String& name);
+    static ColumnDescCtor* getCtor (const String& name);
 
     // Register a "XXColumnDesc" constructor (thread-safe).
-    static void registerCtor (const String& name, ColumnDescCtor func);
+    static void registerCtor (const String& name, ColumnDescCtor* func);
 
 private:
     // A mutex for additions to the constructor map.
@@ -368,10 +368,10 @@ private:
     // The map is filled with the main XXColumnDesc construction functions
     // by the function registerColumnDesc upon the first call of
     // <src>ColumnDesc::getFile</src>.
-    static std::map<String, ColumnDescCtor>& getRegisterMap();
+    static std::map<String, ColumnDescCtor*>& getRegisterMap();
 
     // Register the main data managers.
-    static std::map<String, ColumnDescCtor> initRegisterMap();
+    static std::map<String, ColumnDescCtor*> initRegisterMap();
 
     // Construct from a pointer (for class BaseColumn).
     ColumnDesc (BaseColumnDesc*);

--- a/tables/Tables/ColumnSet.h
+++ b/tables/Tables/ColumnSet.h
@@ -34,8 +34,8 @@
 #include <casacore/tables/Tables/TableLockData.h>
 #include <casacore/tables/Tables/BaseTable.h>
 #include <casacore/tables/Tables/StorageOption.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -303,8 +303,7 @@ private:
     // a data manager have to be removed. A count of -1 means that all
     // columns have to be removed. For such columns the flag in the
     // returned Block is False, otherwise True.
-    SimpleOrderedMap<void*,Int> checkRemoveColumn
-					  (const Vector<String>& columnNames);
+    std::map<void*,Int> checkRemoveColumn (const Vector<String>& columnNames);
 
     // Check if the table is locked for read or write.
     // If manual or permanent locking is in effect, it checks if the
@@ -314,17 +313,17 @@ private:
 
 
     //# Declare the variables.
-    TableDesc*                      tdescPtr_p;
-    StorageOption                   storageOpt_p;
-    MultiFileBase*                  multiFile_p;
-    Int64                           nrrow_p;        //# #rows
-    BaseTable*                      baseTablePtr_p;
-    TableLockData*                  lockPtr_p;      //# lock object
-    SimpleOrderedMap<String,void*>  colMap_p;       //# list of PlainColumns
-    uInt                            seqCount_p;     //# sequence number count
-    //#                                                 (used for unique seqnr)
-    Block<void*>                    blockDataMan_p; //# list of data managers
-    Block<Bool>                     dataManChanged_p; //# data has changed
+    TableDesc*              tdescPtr_p;
+    StorageOption           storageOpt_p;
+    MultiFileBase*          multiFile_p;
+    Int64                   nrrow_p;          //# #rows
+    BaseTable*              baseTablePtr_p;
+    TableLockData*          lockPtr_p;        //# lock object
+    std::map<String,void*>  colMap_p;         //# list of PlainColumns
+    uInt                    seqCount_p;       //# sequence number count
+    //#                                           (used for unique seqnr)
+    Block<void*>            blockDataMan_p;   //# list of data managers
+    Block<Bool>             dataManChanged_p; //# data has changed
 };
 
 

--- a/tables/Tables/ConcatTable.cc
+++ b/tables/Tables/ConcatTable.cc
@@ -46,7 +46,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			    int option, const TableLock& lockOptions,
                             const TSMOption& tsmOption)
     : BaseTable (name, option, nrrow),
-      colMap_p  (static_cast<ConcatColumn*>(0)),
       changed_p (False)
   {
     //# Read the file in.
@@ -64,7 +63,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     : BaseTable       ("", Table::Scratch, 0),
       subTableNames_p (subTables),
       subDirName_p    (subDirName),
-      colMap_p        (static_cast<ConcatColumn*>(0)),
       changed_p       (True)
   {
     ///cout<<"cctab1="<<sizeof(*this)<<' '<<this<<' '<<&rows_p<<' '<<&(rows())<<endl;
@@ -96,7 +94,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     : BaseTable       ("", Table::Scratch, 0),
       subTableNames_p (subTables),
       subDirName_p    (subDirName),
-      colMap_p        (static_cast<ConcatColumn*>(0)),
       changed_p       (True)
   {
     ///cout<<"cctab1="<<sizeof(*this)<<' '<<this<<' '<<&rows_p<<' '<<&(rows())<<endl;
@@ -119,8 +116,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     }
     //# Delete all ConcatColumn objects.
-    for (uInt i=0; i<colMap_p.ndefined(); i++) {
-      delete colMap_p.getVal(i);
+    for (const auto& x : colMap_p ) {
+      delete x.second;
     }
     //# Unlink from root.
     for (uInt i=0; i<baseTabPtr_p.nelements(); ++i) {
@@ -419,7 +416,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     for (uInt i=0; i<tdescPtr_p->ncolumn(); i++) {
       const ColumnDesc& cd = tdescPtr_p->columnDesc(i);
-      colMap_p.define (cd.name(), cd.makeConcatColumn (this));
+      colMap_p.insert (std::make_pair(cd.name(), cd.makeConcatColumn (this)));
     }
   }
 
@@ -493,21 +490,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   BaseColumn* ConcatTable::getColumn (const String& columnName) const
   {
     tdescPtr_p->columnDesc(columnName);             // check if column exists
-    return colMap_p(columnName);
+    return colMap_p.at(columnName);
   }
-  //# We cannot simply return colMap_p.getVal(columnIndex), because the order of
-  //# the columns in the description is important. So first get the column
-  //# name and use that as key.
   BaseColumn* ConcatTable::getColumn (uInt columnIndex) const
   { 
     const String& name = tdescPtr_p->columnDesc(columnIndex).name();
-    return colMap_p(name);
+    return colMap_p.at(name);
   }
 
   void ConcatTable::addConcatCol (const ColumnDesc& columnDesc)
   {
     ColumnDesc& cd = tdescPtr_p->addColumn(columnDesc);
-    colMap_p.define(cd.name(), cd.makeConcatColumn(this));
+    colMap_p.insert (std::make_pair(cd.name(), cd.makeConcatColumn(this)));
     changed_p = True;
   }
 

--- a/tables/Tables/ConcatTable.h
+++ b/tables/Tables/ConcatTable.h
@@ -37,7 +37,7 @@
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -362,8 +362,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     //# Data members
     Block<String>     subTableNames_p;
     String            subDirName_p;
-    Block<BaseTable*> baseTabPtr_p;        //# pointers to parent tables
-    SimpleOrderedMap<String,ConcatColumn*> colMap_p; //# map name to column
+    Block<BaseTable*> baseTabPtr_p;           //# pointers to parent tables
+    std::map<String,ConcatColumn*> colMap_p;  //# map name to column
     TableRecord       keywordSet_p;
     Bool              changed_p;           //# True = changed since last write
     ConcatRows        rows_p;

--- a/tables/Tables/PlainColumn.cc
+++ b/tables/Tables/PlainColumn.cc
@@ -46,7 +46,7 @@ PlainColumn::PlainColumn (const BaseColumnDesc* cdp, ColumnSet* csp)
   colSetPtr_p   (csp),
   originalName_p(cdp->name())
 {
-  int trace = TableTrace::traceColumn (colDesc_p);
+  int trace = TableTrace::traceColumn (columnDesc());
   rtraceColumn_p = (trace&TableTrace::READ)  != 0;
   wtraceColumn_p = (trace&TableTrace::WRITE) != 0;
 }
@@ -63,7 +63,7 @@ TableRecord& PlainColumn::rwKeywordSet()
 {
     Bool hasLocked = colSetPtr_p->userLock (FileLocker::Write, True);
     checkWriteLock (True);
-    TableRecord& rec = colDesc_p.rwKeywordSet();
+    TableRecord& rec = const_cast<BaseColumnDesc*>(colDescPtr_p)->rwKeywordSet();
     colSetPtr_p->setTableChanged();
     colSetPtr_p->userUnlock (hasLocked);
     return rec;
@@ -72,7 +72,7 @@ TableRecord& PlainColumn::keywordSet()
 {
     Bool hasLocked = colSetPtr_p->userLock (FileLocker::Read, True);
     checkReadLock (True);
-    TableRecord& rec = colDesc_p.rwKeywordSet();
+    TableRecord& rec = const_cast<BaseColumnDesc*>(colDescPtr_p)->rwKeywordSet();
     colSetPtr_p->userUnlock (hasLocked);
     return rec;
 }
@@ -81,7 +81,7 @@ TableRecord& PlainColumn::keywordSet()
 //# By default defining the array shape is invalid.
 void PlainColumn::setShapeColumn (const IPosition&)
     { throw (TableInvOper ("setShapeColumn not allowed for column " +
-			   columnDesc().name())); }
+			   colDescPtr_p->name())); }
 
 
 Bool PlainColumn::isBound() const
@@ -132,7 +132,7 @@ void PlainColumn::getFile (AipsIO& ios, const ColumnSet& colset,
 
 void PlainColumn::checkValueLength (const String* value) const
 {
-    uInt maxlen = columnDesc().maxLength();
+    uInt maxlen = colDescPtr_p->maxLength();
     if (maxlen > 0  &&  value->length() > maxlen) {
 	throw (TableError ("ScalarColumn::put: string value '" +
 			   *value + "' exceeds maximum length"));
@@ -140,7 +140,7 @@ void PlainColumn::checkValueLength (const String* value) const
 }
 void PlainColumn::checkValueLength (const Array<String>* value) const
 {
-    uInt maxlen = columnDesc().maxLength();
+    uInt maxlen = colDescPtr_p->maxLength();
     if (maxlen == 0) {
 	return;
     }

--- a/tables/Tables/RefTable.h
+++ b/tables/Tables/RefTable.h
@@ -34,7 +34,7 @@
 #include <casacore/tables/Tables/BaseTable.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -329,12 +329,12 @@ public:
     static uInt* getStorage (Vector<uInt>& rownrs);
 
 private:
-    BaseTable*   baseTabPtr_p;                 //# pointer to parent table
-    Bool         rowOrd_p;                     //# True = table is in row order
-    Vector<uInt> rowStorage_p;                 //# row numbers in parent table
-    uInt*        rows_p;                       //# Pointer to rowStorage_p
-    SimpleOrderedMap<String,String> nameMap_p; //# map to column name in parent
-    SimpleOrderedMap<String,RefColumn*> colMap_p; //# map name to column
+    BaseTable*   baseTabPtr_p;              //# pointer to parent table
+    Bool         rowOrd_p;                  //# True = table is in row order
+    Vector<uInt> rowStorage_p;              //# row numbers in parent table
+    uInt*        rows_p;                    //# Pointer to rowStorage_p
+    std::map<String,String> nameMap_p;      //# map to column name in parent
+    std::map<String,RefColumn*> colMap_p;   //# map name to column
     Bool         changed_p;                 //# True = changed since last write
 
     // Copy constructor is forbidden, because copying a table requires
@@ -355,7 +355,7 @@ private:
 
     // Make a table description for the given columns.
     static void makeDesc (TableDesc& desc, const TableDesc& rootDesc,
-			  SimpleOrderedMap<String,String>& nameMap,
+			  std::map<String,String>& nameMap,
 			  Vector<String>& names);
 
     // Setup the main parts of the object.

--- a/tables/Tables/RowCopier.cc
+++ b/tables/Tables/RowCopier.cc
@@ -130,10 +130,10 @@ RowCopier::RowCopier(Table &out, const Table &in)
     columns_p = new ColumnHolder(out,in);
     for (uInt i=0; i < out.tableDesc().ncolumn(); i++) {
 	TableColumn outCol(out, i);
-	if (in.tableDesc().isColumn(outCol.columnDesc().name())) {
-	    TableColumn inCol(in, outCol.columnDesc().name());
-	    columns_p->attach(outCol.columnDesc().name(),
-			      inCol.columnDesc().name());
+        String name (outCol.columnDesc().name());
+	if (in.tableDesc().isColumn(name)) {
+	    TableColumn inCol(in, name);
+	    columns_p->attach(name, inCol.columnDesc().name());
 	}
     }
 }

--- a/tables/Tables/ScaColDesc.h
+++ b/tables/Tables/ScaColDesc.h
@@ -32,7 +32,6 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseColDesc.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/tables/Tables/ScaRecordColDesc.h
+++ b/tables/Tables/ScaRecordColDesc.h
@@ -32,7 +32,6 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseColDesc.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/tables/Tables/SetupNewTab.cc
+++ b/tables/Tables/SetupNewTab.cc
@@ -97,8 +97,7 @@ SetupNewTableRep::SetupNewTableRep (const String& tableName,
   storageOpt_p(storageOpt),
   delete_p    (False),
   tdescPtr_p  (0),
-  colSetPtr_p (0),
-  dataManMap_p(static_cast<void*>(0))
+  colSetPtr_p (0)
 {
     //# Copy the table description.
     tdescPtr_p = new TableDesc(tableDescName);
@@ -116,8 +115,7 @@ SetupNewTableRep::SetupNewTableRep (const String& tableName,
   storageOpt_p(storageOpt),
   delete_p    (False),
   tdescPtr_p  (0),
-  colSetPtr_p (0),
-  dataManMap_p(static_cast<void*>(0))
+  colSetPtr_p (0)
 {
     //# Read the table description.
     tdescPtr_p = new TableDesc(tableDesc, "", "", TableDesc::Scratch);
@@ -178,14 +176,18 @@ DataManager* SetupNewTableRep::getDataManager (const DataManager& dataMan)
     //# However, it is possible that the original was a temporary and
     //# that another original is allocated at the same address.
     //# So also test if the original is indeed cloned.
-    DataManager* dmp = (DataManager*) (dataManMap_p((void*)&dataMan));
+    DataManager* dmp = 0;
+    std::map<void*,void*>::iterator iter = dataManMap_p.find((void*)&dataMan);
+    if (iter != dataManMap_p.end()) {
+        dmp = static_cast<DataManager*>(iter->second);
+    }
     if (dmp == 0  ||  dataMan.getClone() == 0) {
 	//# Not cloned yet, so clone it.
 	//# Add it to the map in the ColumnSet object.
 	//# Tell the original object that it has been cloned.
 	dmp = dataMan.clone();
 	colSetPtr_p->addDataManager (dmp);
-	dataManMap_p((void*)&dataMan) = dmp;
+	dataManMap_p[(void*)&dataMan] = dmp;
 	dataMan.setClone (dmp);
     }
     return dmp;

--- a/tables/Tables/SetupNewTab.h
+++ b/tables/Tables/SetupNewTab.h
@@ -33,8 +33,8 @@
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/tables/Tables/StorageOption.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -206,7 +206,7 @@ private:
     Bool          delete_p;
     TableDesc*    tdescPtr_p;
     ColumnSet*    colSetPtr_p;      //# 0 = object is already used by a Table
-    SimpleOrderedMap<void*,void*> dataManMap_p;
+    std::map<void*,void*> dataManMap_p;
 
     // Copy constructor is forbidden, because copying a table requires
     // some more knowledge (like table name of result).
@@ -388,7 +388,7 @@ public:
 
     // Adjust the hypercolumn definitions.
     // It renames and/or removes columns as necessary.
-    void adjustHypercolumns (const SimpleOrderedMap<String, String>& old2new,
+    void adjustHypercolumns (const std::map<String, String>& old2new,
 			     Bool keepUnknown)
       { newTable_p->tableDescPtr()->adjustHypercolumns(old2new,keepUnknown); }
 

--- a/tables/Tables/SubTabDesc.h
+++ b/tables/Tables/SubTabDesc.h
@@ -31,7 +31,6 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/tables/Tables/BaseColDesc.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/tables/Tables/TableCache.h
+++ b/tables/Tables/TableCache.h
@@ -31,8 +31,8 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/IO/FileLocker.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/OS/Mutex.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -158,7 +158,7 @@ private:
     //# void* iso. PlainTable* is used in the map declaration
     //# to reduce the number of template instantiations.
     //# The .cc file will use (fully safe) casts.
-    SimpleOrderedMap<String,void*> tableMap_p;
+    std::map<String,void*> tableMap_p;
     //# A mutex to synchronize access to the cache.
     mutable Mutex itsMutex;
 };

--- a/tables/Tables/TableCopy.cc
+++ b/tables/Tables/TableCopy.cc
@@ -37,7 +37,6 @@
 #include <casacore/tables/DataMan/DataManager.h>
 #include <casacore/tables/DataMan/DataManInfo.h>
 #include <casacore/casa/Containers/Record.h>
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/Utilities/LinearSearch.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/OS/Path.h>

--- a/tables/Tables/TableDesc.cc
+++ b/tables/Tables/TableDesc.cc
@@ -325,13 +325,13 @@ void TableDesc::renameColumn (const String& newname,
   // First rename the column itself.
   col_p.rename (newname, oldname);
   // Now adjust the hypercolumn descriptions.
-  SimpleOrderedMap<String,String> old2new("", 1);
+  std::map<String,String> old2new;
   // First fill the map with all columns and replace it for the new name.
   for (uInt i=0; i<ncolumn(); i++) {
-    const String& nm = columnDesc(i).name();
-    old2new.define (nm, nm);
+    const String nm = columnDesc(i).name();
+    old2new.insert (std::make_pair(nm, nm));
   }
-  old2new.define (oldname, newname);
+  old2new[oldname] = newname;
   adjustHypercolumns (old2new);
 }
 
@@ -594,7 +594,7 @@ uInt TableDesc::hypercolumnDesc (const String& name,
 }
 
 void TableDesc::adjustHypercolumns
-                        (const SimpleOrderedMap<String, String>& old2new,
+                        (const std::map<String, String>& old2new,
 			 Bool keepUnknownData, Bool keepUnknownCoord,
 			 Bool keepUnknownId)
 {
@@ -607,9 +607,9 @@ void TableDesc::adjustHypercolumns
     // Rename/remove columns in the hypercolumn description.
     uInt nr = 0;
     for (uInt j=0; j<dataNames.nelements(); j++) {
-      const String* newName = old2new.isDefined (dataNames(j));
-      if (newName) {
-	dataNames(nr++) = *newName;
+      std::map<String,String>::const_iterator iter = old2new.find (dataNames(j));
+      if (iter != old2new.end()) {
+	dataNames(nr++) = iter->second;
       } else if (keepUnknownData) {
 	nr++;
       }
@@ -619,9 +619,9 @@ void TableDesc::adjustHypercolumns
       dataNames.resize (nr, True);
       nr = 0;
       for (uInt j=0; j<coordNames.nelements(); j++) {
-	const String* newName = old2new.isDefined (coordNames(j));
-	if (newName) {
-	  coordNames(nr++) = *newName;
+        std::map<String,String>::const_iterator iter = old2new.find (dataNames(j));
+        if (iter != old2new.end()) {
+          coordNames(nr++) = iter->second;
 	} else if (keepUnknownCoord) {
 	  nr++;
 	}
@@ -637,9 +637,9 @@ void TableDesc::adjustHypercolumns
       }
       nr = 0;
       for (uInt j=0; j<idNames.nelements(); j++) {
-	const String* newName = old2new.isDefined (idNames(j));
-	if (newName) {
-	  idNames(nr++) = *newName;
+        std::map<String,String>::const_iterator iter = old2new.find (dataNames(j));
+        if (iter != old2new.end()) {
+          idNames(nr++) = iter->second;
 	} else if (keepUnknownId) {
 	  nr++;
 	}

--- a/tables/Tables/TableDesc.h
+++ b/tables/Tables/TableDesc.h
@@ -34,6 +34,7 @@
 #include <casacore/tables/Tables/ColDescSet.h>
 #include <casacore/casa/IO/AipsIO.h>
 #include <casacore/casa/iosfwd.h>
+#include <map>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -457,7 +458,7 @@ public:
     // <src>keepUnknown==False</src>.
     // If all data columns of a hypercolumn are removed, the entire
     // hypercolumn is removed.
-    void adjustHypercolumns (const SimpleOrderedMap<String,String>& old2new,
+    void adjustHypercolumns (const std::map<String,String>& old2new,
 			     Bool keepUnknownData = False,
 			     Bool keepUnknownCoord = False,
 			     Bool keppUnknownId = False);


### PR DESCRIPTION
Classes Map (and variations), List, Queue and Stack have been replaced by their STL counterparts.
These Casacore classes are not built/installed anymore unless -DBUILD_DEPRECATED is given to cmake.

Close #118