### PR TITLE
returns a default tile shape for contiguous HDF5 data sets

### DIFF
--- a/lattices/Lattices/HDF5Lattice.h
+++ b/lattices/Lattices/HDF5Lattice.h
@@ -266,6 +266,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     CountedPtr<HDF5File>    itsFile;
     CountedPtr<HDF5Group>   itsGroup;
     CountedPtr<HDF5DataSet> itsDataSet;
+    IPosition               itsTileShape;
   };
 
 

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -210,7 +210,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   IPosition HDF5Lattice<T>::tileShape() const
   {
     if (itsDataSet->tileShape().empty()) {
-	  return TiledFileAccess::makeTileShape(itsDataSet->shape());
+      return TiledFileAccess::makeTileShape(itsDataSet->shape());
     }
     return itsDataSet->tileShape();
   }

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -33,6 +33,7 @@
 #include <casacore/lattices/Lattices/LatticeIterator.h>
 #include <casacore/lattices/Lattices/LatticeNavigator.h>
 #include <casacore/tables/DataMan/TSMCube.h>
+#include <casacore/tables/DataMan/TiledFileAccess.h>>
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Arrays/ArrayUtil.h>
@@ -209,8 +210,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   IPosition HDF5Lattice<T>::tileShape() const
   {
     if (itsDataSet->tileShape().empty()) {
-      TiledShape tiledShape(itsDataSet->shape());
-      return tiledShape.tileShape();
+	  return TiledFileAccess::makeTileShape(itsDataSet->shape());
     }
     return itsDataSet->tileShape();
   }

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -33,7 +33,7 @@
 #include <casacore/lattices/Lattices/LatticeIterator.h>
 #include <casacore/lattices/Lattices/LatticeNavigator.h>
 #include <casacore/tables/DataMan/TSMCube.h>
-#include <casacore/tables/DataMan/TiledFileAccess.h>>
+#include <casacore/tables/DataMan/TiledFileAccess.h>
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Arrays/ArrayUtil.h>
@@ -105,9 +105,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<typename T>
   HDF5Lattice<T>::HDF5Lattice (const HDF5Lattice<T>& other)
   : Lattice<T>(),
-    itsFile    (other.itsFile),
-    itsGroup   (other.itsGroup),
-    itsDataSet (other.itsDataSet)
+    itsFile      (other.itsFile),
+    itsGroup     (other.itsGroup),
+    itsDataSet   (other.itsDataSet),
+    itsTileShape (other.itsTileShape)
   {
     DebugAssert (ok(), AipsError);
   }
@@ -122,9 +123,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   HDF5Lattice<T>& HDF5Lattice<T>::operator= (const HDF5Lattice<T>& other)
   {
     if (this != &other) {
-      itsFile    = other.itsFile;
-      itsGroup   = other.itsGroup;
-      itsDataSet = other.itsDataSet;
+      itsFile      = other.itsFile;
+      itsGroup     = other.itsGroup;
+      itsDataSet   = other.itsDataSet;
+      itsTileShape = other.itsTileShape;
     }
     DebugAssert (ok(), AipsError);
     return *this;
@@ -209,10 +211,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<typename T>
   IPosition HDF5Lattice<T>::tileShape() const
   {
-    if (itsDataSet->tileShape().empty()) {
-      return TiledFileAccess::makeTileShape(itsDataSet->shape());
-    }
-    return itsDataSet->tileShape();
+    return itsTileShape;
   }
 
   template<typename T>
@@ -298,6 +297,11 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
     // Open the data set.
     itsDataSet = new HDF5DataSet (*itsGroup, arrayName, (const T*)0);
+    // Calculate tile shape if default tile shape is empty
+    itsTileShape = itsDataSet->tileShape();
+    if (itsTileShape.empty()) {
+      itsTileShape = TiledFileAccess::makeTileShape(itsDataSet->shape());
+    }
   }
 
   template <typename T>
@@ -317,6 +321,11 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Create the data set.
     itsDataSet = new HDF5DataSet (*itsGroup, arrayName, shape.shape(),
 				  shape.tileShape(), (const T*)0);
+    // Calculate tile shape if default tile shape is empty
+    itsTileShape = itsDataSet->tileShape();
+    if (itsTileShape.empty()) {
+      itsTileShape = TiledFileAccess::makeTileShape(itsDataSet->shape());
+    }
   }
 
   template<typename T>

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -208,6 +208,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<typename T>
   IPosition HDF5Lattice<T>::tileShape() const
   {
+    if (itsDataSet->tileShape().empty()) {
+        TiledShape tiledShape(itsDataSet->shape());
+        return tiledShape.tileShape();
+    }
     return itsDataSet->tileShape();
   }
 
@@ -240,7 +244,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
                                              const IPosition& axisPath)
   {
     itsDataSet->setCacheSize (TSMCube::calcCacheSize (itsDataSet->shape(),
-                                                      itsDataSet->tileShape(),
+                                                      tileShape(),
                                                       False,
                                                       sliceShape, windowStart,
                                                       windowLength, axisPath,

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -209,8 +209,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   IPosition HDF5Lattice<T>::tileShape() const
   {
     if (itsDataSet->tileShape().empty()) {
-        TiledShape tiledShape(itsDataSet->shape());
-        return tiledShape.tileShape();
+      TiledShape tiledShape(itsDataSet->shape());
+      return tiledShape.tileShape();
     }
     return itsDataSet->tileShape();
   }


### PR DESCRIPTION
A previous PR allowed contiguous HDF5 data sets to be opened correctly. However, we ran into issues when iterating through the data set, because the `HDF5DataSet` object's `tileShape` was left as an empty `IPosition`. 

This PR modifies `HDF5Lattice` to return a default tile shape for contiguous datasets, rather than the empty tile shape defined by the dataset. The default tile shape is calculated using `TiledShape::tiledShape`, similarly to how FITS files' tile shape is determined. 

I initially placed this functionality in `HDF5DataSet`, but then had linking issues, as `HDF5DataSet` belongs to `casa_casa` library, while `TiledShape` belongs to the `casa_lattices` library, and including it creates circular dependencies. 