### PR TITLE
Allow colon and fix recursive bison parsing

### DIFF
--- a/images/Images/ImageExprGram.cc
+++ b/images/Images/ImageExprGram.cc
@@ -73,21 +73,52 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 static const char*  strpImageExprGram = 0;
 static Int          posImageExprGram = 0;
 
+  
+// Define a class to delete the yy_buffer in case of an exception.
+class ImageExprGramState {
+public:
+  ImageExprGramState (YY_BUFFER_STATE state)
+    : itsState (state)
+  {}
+  ~ImageExprGramState()
+    { clear(); }
+  void clear()
+    { if (itsState) {
+        ImageExprGram_delete_buffer(itsState);
+        itsState=0;
+      }
+    }
+  YY_BUFFER_STATE state() const
+    { return itsState; }
+private:
+  ImageExprGramState (const ImageExprGramState&);
+  ImageExprGramState& operator= (const ImageExprGramState&);
+  YY_BUFFER_STATE itsState;      //# this is a pointer to yy_buffer_state
+};
+
+  
 //# Parse the command.
-//# Do a yyrestart(yyin) first to make the flex scanner reentrant.
 int imageExprGramParseCommand (const String& command)
 {
-    ImageExprGramrestart (ImageExprGramin);
-    yy_start = 1;
-    // Save global state for re-entrancy.
+    // Save current state for re-entrancy.
+    int sav_yy_start = yy_start;
     const char* savStrpImageExprGram = strpImageExprGram;
     Int savPosImageExprGram= posImageExprGram;
+    YY_BUFFER_STATE sav_state = YY_CURRENT_BUFFER;
+    // Create a new state buffer for new expression.
+    ImageExprGramState next (ImageExprGram_create_buffer (ImageExprGramin, YY_BUF_SIZE));
+    ImageExprGram_switch_to_buffer (next.state());
+    yy_start = 1;
     strpImageExprGram = command.chars();     // get pointer to command string
     posImageExprGram  = 0;                   // initialize string position
     int sts = ImageExprGramparse();          // parse command string
-    // Restore global state.
+    // The current state has to be deleted before switching back to previous.
+    next.clear();
+    // Restore previous state.
+    yy_start = sav_yy_start;
     strpImageExprGram = savStrpImageExprGram;
     posImageExprGram= savPosImageExprGram;
+    ImageExprGram_switch_to_buffer (sav_state);
     return sts;
 }
 

--- a/images/Images/ImageExprParse.cc
+++ b/images/Images/ImageExprParse.cc
@@ -596,7 +596,7 @@ LatticeExprNode ImageExprParse::makeIndexinNode (const LatticeExprNode& axis,
 
 LatticeExprNode ImageExprParse::makeLRNode() const
 {
-    // When the name is numeric, we have a temporary lattice number.
+    // If the name is numeric, we have a temporary lattice number.
     // Find it in the block of temporary lattices.
     if (itsType == TpInt) {
         Int latnr = itsIval-1;
@@ -608,13 +608,30 @@ LatticeExprNode ImageExprParse::makeLRNode() const
     }
     // A true name has been given.
     // Split it using : as separator (:: is full separator).
-    // Test if it is a region.
-    Vector<String> names = stringToVector (itsSval, ':');
-    if (names.nelements() != 1) {
-	if ((names.nelements() == 2  &&  names(1).empty())
-	||  (names.nelements() == 3  &&  !names(1).empty()
-         &&  names(2).empty())
-	|| names.nelements() > 3) {
+    // However, ignore if : is escaped with a backslash.
+    std::vector<String> names;
+    int leng = itsSval.length();
+    String part;
+    for (int i=0; i<leng; ++i) {
+	if (itsSval[i] == ':') {
+            // Split at :
+            names.push_back (part);
+            part.clear();
+        } else {
+            if (itsSval[i] == '\\') {
+                i++;
+            }
+            if (i < leng) {
+                part += itsSval[i];
+            }
+        }
+    }
+    // Store last part.
+    names.push_back (part);
+    if (names.size() != 1) {
+	if ((names.size() == 2  &&  names[1].empty())
+	||  (names.size() == 3  &&  !names[1].empty()  &&  names[2].empty())
+	|| names.size() > 3) {
 	    throw (AipsError ("ImageExprParse: '" + itsSval +
 			      "' is an invalid lattice, image, "
 			      "or region name"));
@@ -622,35 +639,35 @@ LatticeExprNode ImageExprParse::makeLRNode() const
     }
     // If 1 element is given, try if it is a lattice or image.
     // If that does not succeed, it'll be tried later as a region.
-    if (names.nelements() == 1) {
+    if (names.size() == 1) {
 	LatticeExprNode node;
-	if (tryLatticeNode (node, addDir(names(0)))) {
-            theirNames.push_back (names(0));
+	if (tryLatticeNode (node, addDir(names[0]))) {
+            theirNames.push_back (names[0]);
 	    return node;
 	}
     }
     // If 2 elements given, it should be an image with a mask name.
-    if (names.nelements() == 2) {
-        theirNames.push_back (names(0));
-        return makeImageNode (addDir(names(0)), names(1));
+    if (names.size() == 2) {
+        theirNames.push_back (names[0]);
+        return makeImageNode (addDir(names[0]), names[1]);
     }
     // One or three elements have been given.
     // If the first one is empty, a table must have been used already.
-    if (names.nelements() == 1) {
+    if (names.size() == 1) {
         if (imageExprParse_hasNoLast()) {
 	    throw (AipsError ("ImageExprParse: '" + itsSval +
 			      "' is an unknown lattice or image "
 			      "or it is an unqualified region"));
 	}
-    } else if (names(0).empty()) {
+    } else if (names[0].empty()) {
         if (imageExprParse_hasNoLast()) {
 	    throw (AipsError ("ImageExprParse: unqualified region '" + itsSval +
 			      "' is used before any table is used"));
 	}
     } else {
 	// The first name is given; see if it is a readable table or HDF5 file.
-        String fileName = addDir(names(0));
-        theirNames.push_back (names(0));
+        String fileName = addDir(names[0]);
+        theirNames.push_back (names[0]);
 	if (Table::isReadable (fileName)) {
 	  Table table (fileName);
 	  theLastTable = table;
@@ -664,14 +681,14 @@ LatticeExprNode ImageExprParse::makeLRNode() const
     }
     // Now try to find the region in the file.
     ImageRegion* regPtr = 0;
-    int index = (names.nelements() == 1  ?  0 : 2);
+    int index = (names.size() == 1  ?  0 : 2);
     if (! theLastTable.isNull()) {
       RegionHandlerTable regHand(getRegionTable, 0);
-      regPtr = regHand.getRegion (names(index), RegionHandler::Any, False);
+      regPtr = regHand.getRegion (names[index], RegionHandler::Any, False);
     }
     if (! theLastHDF5.null()) {
       RegionHandlerHDF5 regHand(getRegionHDF5, 0);
-      regPtr = regHand.getRegion (names(index), RegionHandler::Any, False);
+      regPtr = regHand.getRegion (names[index], RegionHandler::Any, False);
     }
     if (regPtr == 0) {
       if (index == 0) {
@@ -891,12 +908,13 @@ LatticeExprNode ImageExprParse::makeLitLRNode() const
     // instead of      image.file * pi()
     // However, it forbids the use of pi, e, etc. as a lattice name and
     // may make things unclear. Therefore it is not supported (yet?).
+    // This could be solved by enclosing such a name in quotes, e.g., 'pi'.
 ///    if (itsSval == "pi") {
 ///	return LatticeExprNode (C::pi);
 ///    } else if (itsSval == "e") {
 ///	return LatticeExprNode (C::e);
 ///    }
-    // It is a the name of a constant, so it must be a lattice name.
+    // It is not the name of a constant, so it must be a lattice name.
     return makeLRNode();
 }
 

--- a/tables/TaQL/TableGram.cc
+++ b/tables/TaQL/TableGram.cc
@@ -74,21 +74,51 @@ static const char*  strpTableGram = 0;
 static Int          posTableGram = 0;
 
 
+// Define a class to delete the yy_buffer in case of an exception.
+class TableGramState {
+public:
+  TableGramState (YY_BUFFER_STATE state)
+    : itsState (state)
+  {}
+  ~TableGramState()
+    { clear(); }
+  void clear()
+    { if (itsState) {
+        TableGram_delete_buffer(itsState);
+        itsState=0;
+      }
+    }
+  YY_BUFFER_STATE state() const
+    { return itsState; }
+private:
+  TableGramState (const TableGramState&);
+  TableGramState& operator= (const TableGramState&);
+  YY_BUFFER_STATE itsState;      //# this is a pointer to yy_buffer_state
+};
+
+  
 //# Parse the command.
-//# Do a yyrestart(yyin) first to make the flex scanner reentrant.
 int tableGramParseCommand (const String& command)
 {
-    TableGramrestart (TableGramin);
-    yy_start = 1;
-    // Save global state for re-entrancy.
+    // Save current state for re-entrancy.
+    int sav_yy_start = yy_start;
     const char* savStrpTableGram = strpTableGram;
     Int savPosTableGram= posTableGram;
+    YY_BUFFER_STATE sav_state = YY_CURRENT_BUFFER;
+    // Create a new state buffer for new expression.
+    TableGramState next (TableGram_create_buffer (TableGramin, YY_BUF_SIZE));
+    TableGram_switch_to_buffer (next.state());
+    yy_start = 1;
     strpTableGram = command.chars();     // get pointer to command string
     posTableGram  = 0;                   // initialize string position
     int sts = TableGramparse();          // parse command string
-    // Restore global state.
+    // The current state has to be deleted before switching back to previous.
+    next.clear();
+    // Restore previous state.
+    yy_start = sav_yy_start;
     strpTableGram = savStrpTableGram;
     posTableGram= savPosTableGram;
+    TableGram_switch_to_buffer (sav_state);
     return sts;
 }
 


### PR DESCRIPTION
In LEL it was not possible to have a colon as part of the file name, because it was always interpreted as a separator for mask or region. Now it is possible to use it in a quoted file name if the colon is escaped with a backslash.

Testing the code revealed that ImageExprGram did not behave properly when a recursive parse had to be done. This has been fixed. The same fix has been applied to TableGram.
