### PR TITLE
Add a public getter for the mask array to LCRegionFixed

### DIFF
--- a/lattices/LRegions/LCRegionFixed.cc
+++ b/lattices/LRegions/LCRegionFixed.cc
@@ -69,7 +69,7 @@ void LCRegionFixed::setMask (const Array<Bool>& mask)
     setMaskPtr (itsMask);
 }
 
-ArrayLattice<Bool> LCRegionFixed::getMask()
+const ArrayLattice<Bool>& LCRegionFixed::getMask() const
 {
     return itsMask;
 }

--- a/lattices/LRegions/LCRegionFixed.cc
+++ b/lattices/LRegions/LCRegionFixed.cc
@@ -69,7 +69,7 @@ void LCRegionFixed::setMask (const Array<Bool>& mask)
     setMaskPtr (itsMask);
 }
 
-ArrayLattice<Bool> getMask()
+ArrayLattice<Bool> LCRegionFixed::getMask()
 {
     return itsMask;
 }

--- a/lattices/LRegions/LCRegionFixed.cc
+++ b/lattices/LRegions/LCRegionFixed.cc
@@ -69,5 +69,10 @@ void LCRegionFixed::setMask (const Array<Bool>& mask)
     setMaskPtr (itsMask);
 }
 
+ArrayLattice<Bool> getMask()
+{
+    return itsMask;
+}
+
 } //# NAMESPACE CASACORE - END
 

--- a/lattices/LRegions/LCRegionFixed.h
+++ b/lattices/LRegions/LCRegionFixed.h
@@ -98,7 +98,7 @@ public:
     virtual Bool operator== (const LCRegion& other) const;
     
     // Return the mask
-    ArrayLattice<Bool> getMask();
+    const ArrayLattice<Bool>& getMask() const;
 
  protected:
     // Assignment (copy semantics) is only useful for derived classes.

--- a/lattices/LRegions/LCRegionFixed.h
+++ b/lattices/LRegions/LCRegionFixed.h
@@ -96,6 +96,9 @@ public:
     // LCRegionSingle::masksEqual function as well if 
     // you want to check the masks
     virtual Bool operator== (const LCRegion& other) const;
+    
+    // Return the mask
+    ArrayLattice<Bool> getMask();
 
  protected:
     // Assignment (copy semantics) is only useful for derived classes.


### PR DESCRIPTION
I am @veggiesaurus's colleague on the CARTA project. We need to access the mask arrays of regions in order to implement our custom low-level code for reading region statistics in a fast and memory-efficient way from a rotated (XYZW -> ZYXW) image dataset in our HDF5 schema.