### PR TITLE
ObjectID's hash function behavior fix

### DIFF
--- a/casa/System/ObjectID2.cc
+++ b/casa/System/ObjectID2.cc
@@ -38,14 +38,14 @@ uInt hashFunc(const ObjectID &key)
     // We should check to see if this hash is any good
     uInt result = 0;
     char c;
-    c = (char) key.sequence();
-    result = result || c;
-    c = (char) key.pid();
-    result = result || (c<<8);
-    c = (char)key.creationTime();
-    result = result || (c<<16);
-    c = (char)key.hostName()[0];
-    result = result || (c<<24);
+    c = static_cast<char>(key.sequence());
+    result = result | c;
+    c = static_cast<char>(key.pid());
+    result = result | (c << 8);
+    c = static_cast<char>(key.creationTime());
+    result = result | (c << 16);
+    c = key.hostName()[0];
+    result = result | (c << 24);
     return result;
 }
 

--- a/casa/System/test/tObjectID.cc
+++ b/casa/System/test/tObjectID.cc
@@ -34,6 +34,14 @@
 #include <casacore/casa/iostream.h>
 
 #include <casacore/casa/namespace.h>
+
+void assert_hash(const ObjectID &id)
+{
+	if (!id.isNull()) {
+		AlwaysAssertExit(hashFunc(id) == 1);
+	}
+}
+
 int main()
 {
   try{
@@ -41,6 +49,8 @@ int main()
     // default ctor
     ObjectID ID1; 
     ObjectID ID2; 
+    assert_hash(ID1);
+    assert_hash(ID2);
 
     // inequality operator
     AlwaysAssertExit(ID1!=ID2);
@@ -49,10 +59,13 @@ int main()
     ID1 = ID2;
     // equality operator, too!
     AlwaysAssertExit(ID1 == ID2);
+    assert_hash(ID1);
+    assert_hash(ID2);
 
     // copy ctor
     ObjectID ID1copy(ID1);
     AlwaysAssertExit(ID1 == ID1copy);
+    assert_hash(ID1copy);
 
     ObjectID null(True);
     AlwaysAssertExit(null.isNull());
@@ -63,6 +76,7 @@ int main()
     String error;
     AlwaysAssertExit(ID1.fromString(error, copied));
     AlwaysAssertExit(ID1 == ID1copy);
+    assert_hash(ID1);
     ID1.toString(copied);
 
   } catch (AipsError& x) {

--- a/casa/System/test/tObjectID.cc
+++ b/casa/System/test/tObjectID.cc
@@ -38,7 +38,12 @@
 void assert_hash(const ObjectID &id)
 {
 	if (!id.isNull()) {
-		AlwaysAssertExit(hashFunc(id) == 1);
+		// Hash bytes are: seq number, pid, creation time and hostname
+		// All except the first will always have at least one bit set
+		auto hash = hashFunc(id);
+		AlwaysAssertExit(((hash >> 8) & 0xff) != 0);
+		AlwaysAssertExit(((hash >> 16) & 0xff) != 0);
+		AlwaysAssertExit(((hash >> 24) & 0xff) != 0);
 	}
 }
 


### PR DESCRIPTION
The intent of the `hashFunc` function clearly is to fill the individual bytes of an uInt variable with data coming from various fields via shifting and bitwise ORing of the individual bytes. However the current implementation used a *logical* OR operator. This meant that the four individual logical operations don't return an integer value but rather either true or false, which then gets converted into 1 or 0 when written into the uInt value, and then converted to true/false again during the subsequent logical operations. From the four values involved in the logical OR operations, only the sequential number can be zero, while the rest will definitely be different from zero (when the object is "not null"); therefore it is expected that hashFunc always returns 1.

The first commit in this series simply adds a check to the existing tObjectID test that confirms hash values are always 1.

The second commit changes the code to use bitwise ORs, and the test to adjust its expectations regarding the values returning from `hashFunc`.

I'm not sure where in the code this functionality is used, but I would guess this is used to populate hash tables and similar structures, in which case an improved implementation of this hash function will hopefully bring benefits. The test suite seems unbroken by this change.