### PR TITLE
Fix memory leak in TableProxy::getColumnDescription

### DIFF
--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -952,7 +952,7 @@ Record TableProxy::getColumnDescription (const String& columnName,
 					 Bool actual, Bool cOrder)
 {
   // Get the table description.
-  TableDesc* tableDescPtr;
+  const TableDesc* tableDescPtr;
   if (actual) {
     tableDescPtr = new TableDesc(table_p.actualTableDesc());
   } else {
@@ -960,7 +960,10 @@ Record TableProxy::getColumnDescription (const String& columnName,
   }
   // Return the column description as a record.
   const ColumnDesc& columnDescription = (*tableDescPtr) [columnName];
-  return recordColumnDesc (columnDescription, cOrder);
+  Record rec(recordColumnDesc(columnDescription, cOrder));
+
+  delete tableDescPtr;
+  return rec;
 }
 
 String TableProxy::tableName()

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -909,15 +909,14 @@ void TableProxy::setProperties (const String& name, const Record& properties,
 Record TableProxy::getTableDescription (Bool actual, Bool cOrder)
 {
   // Get the table description.
-  const TableDesc* tableDescPtr;
+  std::unique_ptr<const TableDesc> tableDescPtr;
   if (actual) {
-    tableDescPtr = new TableDesc(table_p.actualTableDesc());
+    tableDescPtr.reset(new TableDesc(table_p.actualTableDesc()));
   } else {
-    tableDescPtr = new TableDesc(table_p.tableDesc());
+    tableDescPtr.reset(new TableDesc(table_p.tableDesc()));
   }
   Record rec = getTableDesc(*tableDescPtr, cOrder);
 
-  delete tableDescPtr;
   return rec;
 }
 
@@ -952,18 +951,16 @@ Record TableProxy::getColumnDescription (const String& columnName,
 					 Bool actual, Bool cOrder)
 {
   // Get the table description.
-  const TableDesc* tableDescPtr;
+  std::unique_ptr<const TableDesc> tableDescPtr;
   if (actual) {
-    tableDescPtr = new TableDesc(table_p.actualTableDesc());
+    tableDescPtr.reset(new TableDesc(table_p.actualTableDesc()));
   } else {
-    tableDescPtr = new TableDesc(table_p.tableDesc());
+    tableDescPtr.reset(new TableDesc(table_p.tableDesc()));
   }
   // Return the column description as a record.
   const ColumnDesc& columnDescription = (*tableDescPtr) [columnName];
-  Record rec(recordColumnDesc(columnDescription, cOrder));
 
-  delete tableDescPtr;
-  return rec;
+  return recordColumnDesc (columnDescription, cOrder);
 }
 
 String TableProxy::tableName()


### PR DESCRIPTION
This fix deletes the TableDesc pointer allocated internally with new, similarly as done in TableProxy::getTableDescription().

Maybe using unique_ptr would be a better approach, but I'm not sure if there's any policy on this in casacore.

getColumnDescription() is used in CASA in the table tool, exposed via the getcoldesc() function.
