### PR TITLE
Changed MadfmFunc so that it inherits from ArrayFunctorBase

### DIFF
--- a/casa/Arrays/ArrayPartMath.h
+++ b/casa/Arrays/ArrayPartMath.h
@@ -262,7 +262,7 @@ template<class T> Array<T> partialInterQuartileRanges (const Array<T>& array,
     Bool     itsInPlace;
     mutable Block<T> itsTmp;
   };
-  template<typename T> class MadfmFunc {
+  template<typename T> class MadfmFunc : public ArrayFunctorBase<T> {
   public:
     explicit MadfmFunc(Bool sorted = False, Bool takeEvenMean = True,
                        Bool inPlace = False)


### PR DESCRIPTION
I'm porting ASKAPSoft to casacore3 and some of the components are having issues with minor API changes. One is that the template for the slidingArrayMath. Which now requires an ArrayFunctorBase and MadfmFunc does not inherit from it.

Note my tConvert test fails (all others pass) - but it fails on the current master branch as well. 