### PR TITLE
Changed MadfmFunc so that it inherits from ArrayFunctorBase

### DIFF
--- a/casa/Arrays/ArrayPartMath.h
+++ b/casa/Arrays/ArrayPartMath.h
@@ -262,7 +262,7 @@ template<class T> Array<T> partialInterQuartileRanges (const Array<T>& array,
     Bool     itsInPlace;
     mutable Block<T> itsTmp;
   };
-  template<typename T> class MadfmFunc {
+  template<typename T> class MadfmFunc : public ArrayFunctorBase<T> {
   public:
     explicit MadfmFunc(Bool sorted = False, Bool takeEvenMean = True,
                        Bool inPlace = False)


### PR DESCRIPTION
This is exactly the same as the previous pull request but I've just changed the <from> branch for my own reasons.

Issue is that MadfmFunc should <probably> inherit from ArrayFunctorBase. As it currently does not you cannot use this function as an argument to the slidingArrayMath method