### PR TITLE
Extract Python strings via casacore::String not std::string

### DIFF
--- a/python/Converters/PycArrayComCC.h
+++ b/python/Converters/PycArrayComCC.h
@@ -263,7 +263,7 @@
     for (size_t i=0; i<nr; i++) {
       handle<> py_elem_hdl(src[i]);
       object py_elem_obj(py_elem_hdl);
-      extract<std::string> elem_proxy(py_elem_obj);
+      extract<String> elem_proxy(py_elem_obj);
       to[i] = elem_proxy();
     }
   }

--- a/python/Converters/PycRecord.cc
+++ b/python/Converters/PycRecord.cc
@@ -79,7 +79,7 @@ namespace casacore { namespace python {
       if (PyErr_Occurred()) throw_error_already_set();
       if (!py_elem_hdl.get()) break;             // end of iteration
       object py_elem_key(py_elem_hdl);
-      result.defineFromValueHolder (extract<string>(py_elem_key)(),
+      result.defineFromValueHolder (extract<String>(py_elem_key)(),
            casa_value_from_python::makeValueHolder(d.get(py_elem_key).ptr()));
     }
     return result;

--- a/python/Converters/PycValueHolder.cc
+++ b/python/Converters/PycValueHolder.cc
@@ -168,7 +168,7 @@ namespace casacore { namespace python {
 #else
     } else if (PyString_Check(obj_ptr) || PyUnicode_Check(obj_ptr)) {
 #endif
-      return ValueHolder(String(extract<std::string>(obj_ptr)()));
+      return ValueHolder(String(extract<String>(obj_ptr)()));
     } else if (PyDict_Check(obj_ptr)) {
       dict d = extract<dict>(obj_ptr)();
       if (d.has_key("shape") && d.has_key("array")) {


### PR DESCRIPTION
There is a Unicode converter for casacore strings, but not for
std::string (under Python 2). Rather than define one for std::string
(which would then be foisted on all extensions in the process), change
the few places I could find that use extract<std::string> to use
extract<String> instead (most of them immediately converted the result
to a String anyway).