### PR TITLE
Handle numpy Unicode arrays

### DIFF
--- a/python/Converters/PycArrayComCC.h
+++ b/python/Converters/PycArrayComCC.h
@@ -365,6 +365,12 @@
 	  slen = PyArray_STRIDES(po)[nd-1];
 	}
 	return ValueHolder (ArrayCopyStr_toArray(shp, PyArray_DATA(po), slen));
+      } else if (PyArray_TYPE(po) == NPY_UNICODE) {
+	size_t slen = 0;
+	if (nd > 0) {
+	  slen = PyArray_STRIDES(po)[nd-1];
+	}
+	return ValueHolder (ArrayCopyUnicode_toArray(shp, PyArray_DATA(po), slen));
       }
       break;
     }

--- a/python/Converters/PycArrayComH.h
+++ b/python/Converters/PycArrayComH.h
@@ -81,6 +81,9 @@
   Array<String> ArrayCopyStr_toArray (const IPosition& shape,
 				      void* data, size_t slen);
 
+  Array<String> ArrayCopyUnicode_toArray (const IPosition& shape,
+					  void* data, size_t slen);
+
   // Convert a Casacore array to a Python array object.
   template <typename T>
   boost::python::object makePyArrayObject (casacore::Array<T> const& arr);


### PR DESCRIPTION
This converts numpy Unicode arrays by re-encoding from UTF-32 to UTF-8.
It is intended to supersede #909.