### PR TITLE
Set unit of function arg to rad; fixed little parset bug

### DIFF
--- a/tables/TaQL/ExprFuncNode.cc
+++ b/tables/TaQL/ExprFuncNode.cc
@@ -84,7 +84,6 @@ void TableExprFuncNode::fillUnits()
     case atanFUNC:
     case atan2FUNC:
     case timeFUNC:
-    case argFUNC:
       // These functions return radians (if operand is not complex).
       if (operands_p[0]->dataType() != NTComplex) {
         setUnit ("rad");
@@ -99,6 +98,9 @@ void TableExprFuncNode::fillUnits()
       if (! childUnit.empty()) {
         TableExprNodeUnit::adaptUnit (operands_p[0], "d");
       }
+      break;
+    case argFUNC:
+      setUnit ("rad");
       break;
     case absFUNC:
     case realFUNC:

--- a/tables/TaQL/TableGram.yy
+++ b/tables/TaQL/TableGram.yy
@@ -390,7 +390,10 @@ withpart:  {   /* no WITH part */
 	       TaQLNode::theirNodesCreated.push_back ($$);
            }
          | WITH tables
-           { $$ = $2; }
+           {
+             $$ = $2;
+             theFromQueryDone = False;
+           }
          ;
 
 /* The SELECT command; note that many parts are optional which is handled

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -371,3 +371,6 @@ SHOW
 show a b c d e
 SHOW a b c d e
 
+with [select abs(phase(t1.DATA) - phase(t2.DATA)) as D from a.ms t1, /home/ger/WSRTA190521040_B001_original.MS t2] t select gmax(iif(D>pi(),D-3.14,D)) from t
+WITH [SELECT abs((phase(t1.DATA))-(phase(t2.DATA))) AS D FROM a.ms AS t1,/home/ger/WSRTA190521040_B001_original.MS AS t2] AS t SELECT gmax(iif((D)>(pi()),(D)-(3.14),D)) FROM t AS t
+

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -193,3 +193,5 @@ $casa_checktool ./tTaQLNode 'alter table x.y set keyword x=[] as bool, y=[y1=2,y
 
 $casa_checktool ./tTaQLNode 'show'
 $casa_checktool ./tTaQLNode 'show a b c d e'
+
+$casa_checktool ./tTaQLNode 'with [select abs(phase(t1.DATA) - phase(t2.DATA)) as D from a.ms t1, /home/ger/WSRTA190521040_B001_original.MS t2] t select gmax(iif(D>pi(),D-3.14,D)) from t'

--- a/tables/TaQL/test/tTableGramFunc.cc
+++ b/tables/TaQL/test/tTableGramFunc.cc
@@ -627,6 +627,9 @@ int testScaDComplex()
   nfail += checkScaDComplex ("cube", "1.4+1i", DComplex(1.4,1)*DComplex(1.4,1)*DComplex(1.4,1));
   nfail += checkScaDComplex ("min", "-1.4+1i, -5+8i", DComplex(-1.4,1));
   nfail += checkScaDComplex ("max", "-1.4+1i, -5+8i", DComplex(-5,8));
+  nfail += checkScaDouble ("norm", "-5+8i", norm(DComplex(-5,8)));
+  nfail += checkScaDouble ("abs", "-5+8i", abs(DComplex(-5,8)));
+  nfail += checkScaDouble ("arg", "-5+8i", arg(DComplex(-5,8)), "rad");
   nfail += checkScaDComplex ("complex", "-1.4,1", DComplex(-1.4,1));
   nfail += checkScaDComplex ("complex", "'-1.4+10j'", DComplex(-1.4,10));
   nfail += checkScaDComplex ("complex", "'-1.4'", DComplex(-1.4,0));


### PR DESCRIPTION
1. The result of the arg function on a complex function is an angle, so its unit should be set to rad.
2. A parse error could be given when a WITH clause was used followed by a select function with multiple arguments. This has been fixed.
