### PR TITLE
Fixed remaining leaks and errors in MSSel

### DIFF
--- a/ms/MSSel/MSAntennaGram.yy
+++ b/ms/MSSel/MSAntennaGram.yy
@@ -257,7 +257,6 @@ stationid: identstr // IDENTIFIER
 	      //
 	      //	      MSAntennaIndex myMSAI(MSAntennaParse::thisMSAParser->ms()->antenna());
 	      MSAntennaIndex myMSAI(MSAntennaParse::thisMSAParser->subTable());
-	      if (!($$)) delete $$;
 	      $$=new Vector<Int>(myMSAI.matchStationName($1));
 	      if ((*($$)).nelements() == 0) reportError($1,"Station Expression");
 	      free($1);
@@ -302,7 +301,6 @@ antid: identstr
 	  //
 	  //	  MSAntennaIndex myMSAI(MSAntennaParse::thisMSAParser->ms()->antenna());
 	  MSAntennaIndex myMSAI(MSAntennaParse::thisMSAParser->subTable());
-	  if (!($$)) delete $$;
 	  $$=new Vector<Int>(myMSAI.matchAntennaName($1));
 	  //$$=new Vector<Int>(myMSAI.matchAntennaRegexOrPattern($1));
 	  if ((*($$)).nelements() == 0) reportError($1);
@@ -339,7 +337,6 @@ antid: identstr
 
 antidrange: INT // A single antenna index
              {
-	       if (!($$)) delete $$;
 	       //
 	       // This code is due to VLA specienfic complication
 	       // arising due to the fact that VLA antennam "NAMES"
@@ -368,7 +365,6 @@ antidrange: INT // A single antenna index
 		Vector<Int> antennaids(len);
 		for(Int i = 0; i < len; i++) antennaids[i] = start + i;
 
-		if (!($$)) delete $$;
 		$$ = new Vector<Int>(len);
 
 		//		MSAntennaIndex myMSAI(MSAntennaParse::thisMSAParser->ms()->antenna());
@@ -387,12 +383,12 @@ antidrange: INT // A single antenna index
 
 stationlist: stationid
               {
-	   	if (!($$)) delete $$;
 	   	$$ = new Vector<Int>(*$1);
 	   	delete $1;
 	      }
            | stationlist COMMA stationid 
               {
+                $$ = $1;
 		Int N0=(*($1)).nelements(), N1 = (*($3)).nelements();
 		(*($$)).resize(N0+N1,True);  // Resize the existing list
 		for(Int i=N0;i<N0+N1;i++) (*($$))(i) = (*($3))(i-N0);
@@ -406,12 +402,12 @@ antids: antid        {$$ = $1;}// A singe antenna ID
 
 antlist: antids
           {
-	    if (!($$)) delete $$;
 	    $$ = new Vector<Int>(*$1);
 	    delete $1;
 	  }
-       | antlist COMMA antids  // AntnnaID, AntnnaID,...
+       | antlist COMMA antids  // AnetnnaID, AntennaID,...
           {
+            $$ = $1;
 	    Int N0=(*($1)).nelements(), N1 = (*($3)).nelements();
 	    (*($$)).resize(N0+N1,True);  // Resize the existing list
 	    for(Int i=N0;i<N0+N1;i++) (*($$))(i) = (*($3))(i-N0);
@@ -429,7 +425,6 @@ stationcomp: stationid {$$=$1;}
 
 antatstation: antcomp AT stationcomp
                {
-		 if (!($$)) delete $$;
 		 $$ = new Vector<Int>(set_intersection(*($1),*($3)));
 		 ostringstream token;token << "AntID("<<*($1)<<")@StationID("<<*($3)<<")";
 		 if ((*($$)).nelements() == 0) reportError((char *)token.str().c_str(),"Ant@Station Expression");
@@ -438,7 +433,6 @@ antatstation: antcomp AT stationcomp
 	       }
             | AT stationcomp  //Implicit ANT. 
 	       {
-	    	 if (!($$)) delete $$;
 	    	 $$ = new Vector<Int>(*($2));
 		 ostringstream token;token << "@StationID("<<*($2)<<")";
 		 if ((*($$)).nelements() == 0) reportError((char *)token.str().c_str(),"Station Expression");

--- a/ms/MSSel/MSFeedGram.yy
+++ b/ms/MSSel/MSFeedGram.yy
@@ -136,12 +136,12 @@ feedpairs: feedlist AMPERSAND feedlist  // Two non-identical lists for the '&' o
 
 feedlist: feedids  // single feed or range
           {
-	    if (!($$)) delete $$;
 	    $$ = new Vector<Int>(*$1);
 	    delete $1;
 	  }
        | feedlist COMMA feedids  // feedID, feedID,...
           {
+            $$ = $1;
 	    Int N0=(*($1)).nelements(), N1 = (*($3)).nelements();
 	    (*($$)).resize(N0+N1,True);  // Resize the existing list
 	    for(Int i=N0;i<N0+N1;i++) (*($$))(i) = (*($3))(i-N0);
@@ -150,7 +150,6 @@ feedlist: feedids  // single feed or range
 
 feedids: INT // A single feed index
              {
-	       if (!($$)) delete $$;
 	       $$ = new Vector<Int>(1);
 	       (*($$))(0) = atoi($1);
 	       free($1);
@@ -163,7 +162,6 @@ feedids: INT // A single feed index
 		Vector<Int> feedids(len);
 		for(Int i = 0; i < len; i++) feedids[i] = start + i;
 
-		if (!($$)) delete $$;
 		$$ = new Vector<Int>(len);
 
 		for (Int i=0; i<len; i++) 

--- a/ms/MSSel/MSFieldGram.cc
+++ b/ms/MSSel/MSFieldGram.cc
@@ -123,7 +123,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       {
 	fieldTEN=baseMSFieldGramParseCommand(thisParser, command, selectedIDs);
       }
-    catch(MSSelectionFieldError &x)
+    catch(const MSSelectionFieldError&)
       {
 	delete thisParser;
 	throw;

--- a/ms/MSSel/MSSpwGram.yy
+++ b/ms/MSSel/MSSpwGram.yy
@@ -248,7 +248,6 @@ FListElements: FreqRange
 ;
 FreqList: FListElements
            {
-	     if (!($$)) delete $$;
 	     $$ = new Vector<Float>(0);
 	     Int N0=(*($$)).nelements(),N1=4; 
 	     (*($$)).resize(N0+N1,True);  // Resize the existing list
@@ -276,7 +275,6 @@ Spw: IDENTIFIER
 	//
 	//	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->ms()->spectralWindow());
 	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->subTable());
-	if (!($$)) delete $$;
 	$$=new Vector<Int>(myMSSI.matchName($1));
 	
 	ostringstream m; m << "No match found for ";
@@ -326,7 +324,6 @@ Spw: IDENTIFIER
       {
 	//	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->ms()->spectralWindow());
 	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->subTable());
-	if (!($$)) delete $$;
 	ostringstream m,tok; m << "No spw ID found for > ";
 	if ($2[1] == MSSpwIndex::MSSPW_INDEX)
 	  {
@@ -347,7 +344,6 @@ Spw: IDENTIFIER
       {
 	//	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->ms()->spectralWindow());
 	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->subTable());
-	if (!($$)) delete $$;
 	ostringstream m, tok; m << "No spw ID found for < ";
 	if ($2[1] == MSSpwIndex::MSSPW_INDEX)
 	  {
@@ -368,7 +364,6 @@ Spw: IDENTIFIER
       {
 	//	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->ms()->spectralWindow());
 	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->subTable());
-	if (!($$)) delete $$;
 	ostringstream m,tok; m << "No spw ID found ";
 	if ($1[1] == MSSpwIndex::MSSPW_INDEX)
 	  {
@@ -389,7 +384,6 @@ Spw: IDENTIFIER
       {
 	//	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->ms()->spectralWindow());
 	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->subTable());
-	if (!($$)) delete $$;
 	$$ = new Vector<Int>(myMSSI.matchFrequencyRange($2[0],$2[0],True));
 	
 	ostringstream m,tok; m << "No spw ID found ~= ";
@@ -401,7 +395,6 @@ Spw: IDENTIFIER
 	//	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->ms()->spectralWindow());
 	MSSpwIndex myMSSI(MSSpwParse::thisMSSParser->subTable());
 
-	if (!($$)) delete $$;
 	Int nSpec;
 	// cout << (*($1)) << "  " << endl;
 	// cout << "FreqList ";

--- a/ms/MSSel/MSStateGram.yy
+++ b/ms/MSSel/MSStateGram.yy
@@ -150,7 +150,6 @@ stateid: IDENTIFIER
 	    // Convert name to index
 	    //
 	  MSStateIndex myMSSI(MSStateParse::thisMSSIParser->ms()->state());
-	  if (!($$)) delete $$;
 	  $$=new Vector<Int>(myMSSI.matchStateObsMode($1));
 	  //$$=new Vector<Int>(myMSAI.matchStateRegexOrPattern($1));
 
@@ -196,7 +195,6 @@ stateid: IDENTIFIER
 
 stateidrange: INT // A single state index
             {
-	      if (!($$)) delete $$;
 	      $$ = new Vector<Int>(1);
 	      (*($$))(0) = atoi($1);
 	      free($1);
@@ -210,7 +208,6 @@ stateidrange: INT // A single state index
               for(Int i = 0; i < len; i++) {
                 stateids[i] = start + i;
               }
-	      if (!($$)) delete $$;
               $$ = new Vector<Int>(stateids);	   
 	      free($1); free($3);
             }
@@ -219,7 +216,6 @@ stateidrange: INT // A single state index
 stateidbounds: LT INT // <ID
                 {
 		  MSStateIndex myMSSI(MSStateParse::thisMSSIParser->ms()->state());
-		  if (!($$)) delete $$;
 		  Int n=atoi($2);
 		  $$ = new Vector<Int>(myMSSI.matchStateIDLT(n));
 
@@ -232,7 +228,6 @@ stateidbounds: LT INT // <ID
               | GT INT // >ID
                 {
 		  MSStateIndex myMSSI(MSStateParse::thisMSSIParser->ms()->state());
-		  if (!($$)) delete $$;
 		  Int n=atoi($2);
 		  $$ = new Vector<Int>(myMSSI.matchStateIDGT(n));
 
@@ -244,7 +239,6 @@ stateidbounds: LT INT // <ID
               | GT INT AMPERSAND LT INT // >ID & <ID
                 {
 		  MSStateIndex myMSSI(MSStateParse::thisMSSIParser->ms()->state());
-		  if (!($$)) delete $$;
 		  Int n0=atoi($2), n1=atoi($5);
 		  $$ = new Vector<Int>(myMSSI.matchStateIDGTAndLT(n0,n1));
 
@@ -274,12 +268,12 @@ stateidlist: stateid // A singe state ID
           ;
 indexlist : stateidlist
             {
-	      if (!($$)) delete $$;
 	      $$ = new Vector<Int>(*$1);
 	      delete $1;
 	    }
           | indexlist COMMA stateidlist  
             {
+              $$ = $1;
 	      Int N0=(*($1)).nelements(), 
 		N1 = (*($3)).nelements();
 	      (*($$)).resize(N0+N1,True);  // Resize the existing list


### PR DESCRIPTION
valgrind reported one more leak in MSFieldGram which occurred in case of an exception.
Furthermore, a few obsolete 'delete$$' were removed and '$$=$1' was inserted where needed.
Now all MSSel tests pass without leaks or errors.