### PR TITLE
Added support for Int64 arrays

### DIFF
--- a/images/Images/ImageProxy.cc
+++ b/images/Images/ImageProxy.cc
@@ -122,6 +122,7 @@ namespace casacore { //# name space casa begins
     case TpArrayUShort:
     case TpArrayInt:
     case TpArrayUInt:
+    case TpArrayInt64:
     case TpArrayFloat:
       makeImage (values.asArrayFloat(), mask.asArrayBool(),
                  IPosition(), coordinates,


### PR DESCRIPTION
ImageProxy did not support Int64 arrays. It was desirable to have this since Python3 uses Int64 by default.
