### PR TITLE
Support mix of quoted and unquoted strings

### DIFF
--- a/tables/TaQL/TaQLNodeDer.cc
+++ b/tables/TaQL/TaQLNodeDer.cc
@@ -151,7 +151,7 @@ void TaQLConstNodeRep::show (std::ostream& os) const
   case CTString:
     if (itsIsTableName) {
       /// NOTE: possible special characters in the string should be handled.
-      os << itsSValue;
+      os << addEscape(itsSValue);
     } else {
       /// NOTE: possible quotes in the string should be handled.
       os << "'" << itsSValue << "'";
@@ -1044,7 +1044,7 @@ void TaQLGivingNodeRep::show (std::ostream& os) const
   if (itsExprList.isValid()) {
     itsExprList.show (os);
   } else {
-    os << itsName;
+    os << addEscape(itsName);
     if (itsType.isValid()) {
       os << " AS ";
       itsType.show (os);
@@ -1945,7 +1945,7 @@ void TaQLConcTabNodeRep::showDerived (std::ostream& os) const
     itsSubTables.show (os);
   }
   if (! itsTableName.empty()) {
-    os << " GIVING " << itsTableName;
+    os << " GIVING " << addEscape(itsTableName);
   }
   os << ']';
 }

--- a/tables/TaQL/TaQLNodeRep.cc
+++ b/tables/TaQL/TaQLNodeRep.cc
@@ -28,6 +28,7 @@
 #include <casacore/tables/TaQL/TaQLNodeRep.h>
 #include <casacore/tables/TaQL/TaQLNode.h>
 #include <casacore/tables/Tables/TableError.h>
+#include <casacore/casa/Utilities/Regex.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -79,6 +80,20 @@ String TaQLNodeRep::checkDataType (const String& dtype)
     }
   }
   return dtstr;
+}
+
+String TaQLNodeRep::addEscape (const String& str) const
+{
+  // This Regex contains the NAMETABC characters in TableGram.ll.
+  static Regex re("[A-Za-z0-9_./+\\-~$@:]");
+  String out;
+  for (size_t i=0; i<str.size(); ++i) {
+    if (! String(str[i]).matches (re)) {
+      out += '\\';
+    }
+    out += str[i];
+  }
+  return out;
 }
 
 } //# NAMESPACE CASACORE - END

--- a/tables/TaQL/TaQLNodeRep.h
+++ b/tables/TaQL/TaQLNodeRep.h
@@ -144,6 +144,9 @@ public:
   // Check the data type string and return its standard form.
   static String checkDataType (const String&);
 
+  // Add escape characters to a table name where needed.
+  String addEscape (const String& str) const;
+
 private:
   // Letter objects cannot be copied.
   // <group>

--- a/tables/TaQL/TableGram.cc
+++ b/tables/TaQL/TableGram.cc
@@ -159,6 +159,30 @@ String tableGramRemoveEscapes (const String& in)
     return out;
 }
 
+String tableGramRemoveEscapesQuotes (const String& in)
+{
+    String out;
+    char quote = 0;
+    int leng = in.length();
+    for (int i=0; i<leng; i++) {
+      if (quote) {
+        if (in[i] == quote) {
+          quote = 0;
+        } else {
+          out += in[i];
+        }
+      } else if (in[i] == '"'  ||  in[i] == '\'') {
+        quote = in[i];
+      } else {
+        if (in[i] == '\\') {
+          i++;
+        }
+        out += in[i];
+      }
+    }
+    return out;
+}
+
 String tableGramRemoveQuotes (const String& in)
 {
     //# A string is formed as "..."'...''...' etc.

--- a/tables/TaQL/TableGram.h
+++ b/tables/TaQL/TableGram.h
@@ -84,8 +84,11 @@ Int& tableGramPosition();
 // Declare the input routine for flex/bison.
 int tableGramInput (char* buf, int max_size);
 
-// A function to remove escaped characters.
+// A function to remove escape characters.
 String tableGramRemoveEscapes (const String& in);
+
+// A function to remove escape characters and quotes.
+String tableGramRemoveEscapesQuotes (const String& in);
 
 // A function to remove quotes from a quoted string.
 String tableGramRemoveQuotes (const String& in);

--- a/tables/TaQL/TableGram.ll
+++ b/tables/TaQL/TableGram.ll
@@ -184,7 +184,8 @@ NAMEFLD   ({NAME}".")?{NAME}?("::")?{NAME}("."{NAME})*
 TEMPTAB   [$]{INT}(("."{NAME})?"::"{NAME}("."{NAME})*)?
 /* A table name can contain about every character
    (but is recognized in specific states only).
-   It can be a mix of quoted and unquoted strings (with escaped characters). */
+   It can be a mix of quoted and unquoted strings (with escaped characters).
+   NOTE: when changing NAMETABC, also change TaQLNodeRep::addEscape. */
 NAMETABC  ([A-Za-z0-9_./+\-~$@:]|(\\.))+
 NAMETAB   {NAMETABC}|(({STRING}|{NAMETABC})+)
 /* A UDFlib synonym */

--- a/tables/TaQL/TableGram.ll
+++ b/tables/TaQL/TableGram.ll
@@ -183,8 +183,10 @@ NAMEFLD   ({NAME}".")?{NAME}?("::")?{NAME}("."{NAME})*
 /* A temporary table name can be followed by field names */
 TEMPTAB   [$]{INT}(("."{NAME})?"::"{NAME}("."{NAME})*)?
 /* A table name can contain about every character
-   (but is recognized in specific states only) */
-NAMETAB   ([A-Za-z0-9_./+\-~$@:]|(\\.))+
+   (but is recognized in specific states only).
+   It can be a mix of quoted and unquoted strings (with escaped characters). */
+NAMETABC  ([A-Za-z0-9_./+\-~$@:]|(\\.))+
+NAMETAB   {NAMETABC}|(({STRING}|{NAMETABC})+)
 /* A UDFlib synonym */
 UDFLIBSYN {NAME}{WHITE}"="{WHITE}{NAME}
 /* A regular expression can be delimited by / % or @ optionall=y followed by i
@@ -743,7 +745,7 @@ PATTREX   {OPERREX}{WHITE}({PATTEX}|{DISTEX})
 <FROMstate,CRETABstate,GIVINGstate,SHOWstate>{NAMETAB} {
             tableGramPosition() += yyleng;
             lvalp->val = new TaQLConstNode(
-                new TaQLConstNodeRep (tableGramRemoveEscapes (TableGramtext)));
+                         new TaQLConstNodeRep (tableGramRemoveEscapesQuotes (TableGramtext)));
             TaQLNode::theirNodesCreated.push_back (lvalp->val);
 	    return TABNAME;
 	  }

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -7,7 +7,7 @@ SELECT (1)*(3) GIVING a.b
 select 1*3,5+7 into a.b where a>2 groupby c1,c2 having e1<0 and e2>3 orderby d1,d2 limit 2:5:2
 SELECT (1)*(3),(5)+(7) WHERE (a)>(2) GROUPBY c1,c2 HAVING ((e1)<(0))&&((e2)>(3)) ORDERBY d1,d2 LIMIT 2:5:2 GIVING a.b
 
-with a.tab2 select from a.tab #comment
+with "a."tab2 select from "a.tab" #comment
 WITH a.tab2 SELECT FROM a.tab
 
 select from [a1.tab,a2.tab,[a3a.tab,a3b.tab]]

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -13,8 +13,8 @@ WITH a.tab2 SELECT FROM a.tab
 select from [a1.tab,a2.tab,[a3a.tab,a3b.tab]]
 SELECT FROM [a1.tab,a2.tab,[a3a.tab,a3b.tab]]
 
-select ab,ac,ad,ae,af,ag into tTaQLNode_tmp.data2 from tTaQLNode_tmp.tab sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab
-SELECT ab,ac,ad,ae,af,ag FROM tTaQLNode_tmp.tab AS sh WHERE ((ALL((ab)>(2)))&&(((ae)<(10))||((ae)>(11))))&&((ag)<>((10)+(1i))) ORDERBY ac DESC,ab GIVING tTaQLNode_tmp.data2
+select ab,ac,ad,ae,af,ag into tTaQLNode_tmp\".data2 from "tTaQLNode tmp.tab" sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab
+SELECT ab,ac,ad,ae,af,ag FROM tTaQLNode\ tmp.tab AS sh WHERE ((ALL((ab)>(2)))&&(((ae)<(10))||((ae)>(11))))&&((ag)<>((10)+(1i))) ORDERBY ac DESC,ab GIVING tTaQLNode_tmp\".data2
 
 select ab,ac,ad,ae,af,ag into tTaQLNode_tmp.data2 as PLAIN_LOCAL from tTaQLNode_tmp.tab sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab
 SELECT ab,ac,ad,ae,af,ag FROM tTaQLNode_tmp.tab AS sh WHERE ((ALL((ab)>(2)))&&(((ae)<(10))||((ae)>(11))))&&((ag)<>((10)+(1i))) ORDERBY ac DESC,ab GIVING tTaQLNode_tmp.data2 AS [PLAIN_LOCAL=T]

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -10,7 +10,7 @@ $casa_checktool ./tTaQLNode 'select 1*3'
 $casa_checktool ./tTaQLNode 'select 1*3 giving a.b;'
 $casa_checktool ./tTaQLNode 'select 1*3,5+7 into a.b where a>2 groupby c1,c2 having e1<0 and e2>3 orderby d1,d2 limit 2:5:2'
 
-$casa_checktool ./tTaQLNode 'with a.tab2 select from a.tab #comment'
+$casa_checktool ./tTaQLNode 'with "a."tab2 select from "a.tab" #comment'
 $casa_checktool ./tTaQLNode 'select from [a1.tab,a2.tab,[a3a.tab,a3b.tab]]'
 
 $casa_checktool ./tTaQLNode 'select ab,ac,ad,ae,af,ag into tTaQLNode_tmp.data2 from tTaQLNode_tmp.tab sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab'

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -13,7 +13,7 @@ $casa_checktool ./tTaQLNode 'select 1*3,5+7 into a.b where a>2 groupby c1,c2 hav
 $casa_checktool ./tTaQLNode 'with "a."tab2 select from "a.tab" #comment'
 $casa_checktool ./tTaQLNode 'select from [a1.tab,a2.tab,[a3a.tab,a3b.tab]]'
 
-$casa_checktool ./tTaQLNode 'select ab,ac,ad,ae,af,ag into tTaQLNode_tmp.data2 from tTaQLNode_tmp.tab sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab'
+$casa_checktool ./tTaQLNode 'select ab,ac,ad,ae,af,ag into tTaQLNode_tmp\".data2 from "tTaQLNode tmp.tab" sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab'
 $casa_checktool ./tTaQLNode 'select ab,ac,ad,ae,af,ag into tTaQLNode_tmp.data2 as PLAIN_LOCAL from tTaQLNode_tmp.tab sh where all(ab>2) && (ae<10 || ae>11.0) && ag!= 10 + 1i orderby ac desc,ab'
 $casa_checktool ./tTaQLNode 'select from tTaQLNode_tmp.tab sh giving tTaQLNode_tmp.data2 as [type="PLAIN",endian="local",storage="multifile",blocksize=32768] dminfo [name="ISM1",type="IncrementalStMan"], [name="SSM1",type="StandardStMan", bucketsize=1000]'
 


### PR DESCRIPTION
python-casascore#116 tells that something like $t::subtable results in a parse error because $t is substituted by "name", so the result is "name"::subtable giving a parse error.
This is fixed by this PR which accepts a mix of quoted and unquoted strings.


