### PR TITLE
Small TaQL improvements

### DIFF
--- a/tables/TaQL/TableGram.ll
+++ b/tables/TaQL/TableGram.ll
@@ -49,7 +49,7 @@
 /* Define functions to set the EXPRstate or TABLENAMEstate.
    Unfortunately the symbolic state names above cannot be used because
    Flex defines them just before %% below. So ensure that the values
-   below are indeed the 2nd and 3rd state above (INITIALstate=0).
+   below are indeed the 2nd and 3rd state above (note: INITIALstate=0).
 */
 %{
   void setEXPRstate()      { BEGIN(2); }
@@ -735,7 +735,7 @@ PATTREX   {OPERREX}{WHITE}({PATTEX}|{DISTEX})
 	    return TABNAME;
 	  }
 
- /* A table file name can be given in the UPDATE, FROM, GIVING, CRETAB clause */
+ /* An unquoted table file name can be given at several places */
 <TABLENAMEstate,SHOWstate>{NAMETAB} {
             tableGramPosition() += yyleng;
             lvalp->val = new TaQLConstNode(

--- a/tables/TaQL/TableGram.yy
+++ b/tables/TaQL/TableGram.yy
@@ -268,7 +268,7 @@ topcomm:   topcomm1
          | topcomm1 SEMICOL
          ;
 
-/* A command can be preceeded by the TIME keyword and style arguments */
+/* A command can be preceded by the TIME keyword and style arguments */
 topcomm1:  command
          | sttimcoms command
          ;
@@ -423,7 +423,7 @@ selcomm:   withpart SELECT selcol FROM tables whexpr groupby having order limito
            }
          ;
 
-/* The column list can be preceeded by ALL or DISTINCT */
+/* The column list can be preceded by ALL or DISTINCT */
 selcol:    normcol {
                $$ = $1;
            }
@@ -1346,7 +1346,7 @@ concslist: NAME {
 concgiven: GIVING {
                setTABLENAMEstate();
            }
-         | INTO tabname {
+         | INTO {
                setTABLENAMEstate();
            }
 concinto:  {   /* no GIVING */

--- a/tables/TaQL/TableParse.cc
+++ b/tables/TaQL/TableParse.cc
@@ -3514,7 +3514,7 @@ DataType TableParseSelect::makeDataType (DataType dtype, const String& dtstr,
   }
   if (dtype == TpOther) {
     throw TableInvExpr ("Datatype " + dtstr + " of column " + colName +
-                        " is invalid");
+                        " is invalid (maybe a set with incompatible units)");
   }
   return dtype;
 }

--- a/tables/TaQL/TableParse.cc
+++ b/tables/TaQL/TableParse.cc
@@ -678,7 +678,8 @@ TableExprFuncNode::FunctionType TableParseSelect::findFunc
     }
   } else if (funcName == "norm") {
     ftype = TableExprFuncNode::normFUNC;
-  } else if (funcName == "abs"  ||  funcName == "amplitude") {
+  } else if (funcName == "abs"  ||  funcName == "amplitude"  ||
+             funcName == "ampl") {
     ftype = TableExprFuncNode::absFUNC;
   } else if (funcName == "arg"  ||  funcName == "phase") {
     ftype = TableExprFuncNode::argFUNC;
@@ -1115,9 +1116,14 @@ TableExprNode TableParseSelect::makeUDFNode (TableParseSelect* sel,
                                              const Table& table,
                                              const TaQLStyle& style)
 {
+  Vector<String> parts = stringToVector (name, '.');
+  if (parts.size() == 1) {
+    // No ., thus no UDF but a builtin function.
+    throw TableInvExpr ("TaQL function " + name + " is unknown; "
+                        "use 'show func' to see all functions");
+  }
   TableExprNode udf;
   if (sel) {
-    Vector<String> parts = stringToVector (name, '.');
     if (parts.size() > 2) {
       // At least 3 parts; see if the first part is a table shorthand.
       Table tab = sel->findTable (parts[0], False);

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -374,3 +374,5 @@ SHOW a b c d e
 with [select abs(phase(t1.DATA) - phase(t2.DATA)) as D from a.ms t1, /home/ger/WSRTA190521040_B001_original.MS t2] t select gmax(iif(D>pi(),D-3.14,D)) from t
 WITH [SELECT abs((phase(t1.DATA))-(phase(t2.DATA))) AS D FROM a.ms AS t1,/home/ger/WSRTA190521040_B001_original.MS AS t2] AS t SELECT gmax(iif((D)>(pi()),(D)-(3.14),D)) FROM t AS t
 
+with ~a select 1+2 from [~b,[select 3+4 from [[select 5+6],~c]], ~d giving ~e] where 3+4 giving ~f
+WITH ~a SELECT (1)+(2) FROM [~b,[SELECT (3)+(4) FROM [[SELECT (5)+(6)],~c]],~d GIVING ~e] WHERE (3)+(4) GIVING ~f

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -195,3 +195,5 @@ $casa_checktool ./tTaQLNode 'show'
 $casa_checktool ./tTaQLNode 'show a b c d e'
 
 $casa_checktool ./tTaQLNode 'with [select abs(phase(t1.DATA) - phase(t2.DATA)) as D from a.ms t1, /home/ger/WSRTA190521040_B001_original.MS t2] t select gmax(iif(D>pi(),D-3.14,D)) from t'
+
+$casa_checktool ./tTaQLNode "with ~a select 1+2 from [~b,[select 3+4 from [[select 5+6],~c]], ~d giving ~e] where 3+4 giving ~f"


### PR DESCRIPTION
A few improvements to TaQL:
- Improved error messages
- Better state handling in TableGram.ll/yy, so unquoted table name can be given in concatenation
- function name 'ampl' as synonym for 'amplitude'
