### PR TITLE
Added read prefetch cache in Adios2StMan

### DIFF
--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -77,11 +77,6 @@ IPosition Adios2StManColumn::shape(uInt aRowNr)
         }
         else
         {
-            /*
-            throw(std::runtime_error("Shape not defined for Column "
-                        + static_cast<std::string>(itsColumnName)
-                        + " Row " + std::to_string(aRowNr)));
-                        */
             return IPosition();
         }
     }

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -191,22 +191,19 @@ public:
         arrayVToSelection(rownr);
         if(itsReadCacheMaxRows > 0)
         {
-            if(itsAdiosStart[0] >= itsReadCacheStartRow && itsAdiosStart[0] < itsReadCacheStartRow + itsReadCacheRows)
-            {
-                Bool deleteIt;
-                auto *arrayPtr = asArrayPtr(dataPtr);
-                T *data = arrayPtr->getStorage(deleteIt);
-                size_t index = itsArraySize * (itsAdiosStart[0] - itsReadCacheStartRow);
-                size_t length = sizeof(T) * itsArraySize;
-                std::memcpy(data, itsReadCache.data() + index, length);
-                arrayPtr->putStorage(data, deleteIt);
-            }
-            else
+            if(itsAdiosStart[0] < itsReadCacheStartRow or itsAdiosStart[0] >= itsReadCacheStartRow + itsReadCacheRows)
             {
                 itsAdiosCount[0] = itsReadCacheMaxRows;
                 itsReadCacheRows = itsReadCacheMaxRows;
                 fromAdios(itsReadCache.data());
             }
+            Bool deleteIt;
+            auto *arrayPtr = asArrayPtr(dataPtr);
+            T *data = arrayPtr->getStorage(deleteIt);
+            size_t index = itsArraySize * (itsAdiosStart[0] - itsReadCacheStartRow);
+            size_t length = sizeof(T) * itsArraySize;
+            std::memcpy(data, itsReadCache.data() + index, length);
+            arrayPtr->putStorage(data, deleteIt);
         }
         else
         {

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -29,6 +29,7 @@
 #define ADIOS2STMANCOLUMN_H
 
 #include <unordered_map>
+#include <numeric>
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/tables/DataMan/StManColumn.h>
 #include <casacore/tables/Tables/RefRows.h>
@@ -152,14 +153,31 @@ public:
         itsAdiosEngine = aAdiosEngine;
         itsAdiosOpenMode = aOpenMode;
         itsAdiosVariable = itsAdiosIO->InquireVariable<T>(itsColumnName);
-        if (!itsAdiosVariable && aOpenMode == 'w')
+        if(aOpenMode == 'w')
         {
-            itsAdiosVariable = itsAdiosIO->DefineVariable<T>(
-                itsColumnName,
-                itsAdiosShape,
-                itsAdiosStart,
-                itsAdiosCount);
+            if (!itsAdiosVariable)
+            {
+                itsAdiosVariable = itsAdiosIO->DefineVariable<T>(
+                        itsColumnName,
+                        itsAdiosShape,
+                        itsAdiosStart,
+                        itsAdiosCount);
+            }
         }
+        else if(aOpenMode == 'r')
+        {
+            size_t cacheSize = std::accumulate(
+                    itsAdiosShape.begin() + 1,
+                    itsAdiosShape.end(),
+                    itsReadCacheMaxRows,
+                    std::multiplies<size_t>());
+            itsReadCache.resize(cacheSize);
+        }
+        itsArraySize = std::accumulate(
+                itsAdiosShape.begin() + 1,
+                itsAdiosShape.end(),
+                1,
+                std::multiplies<size_t>());
     }
 
     virtual void putArrayV(uInt rownr, const void *dataPtr)
@@ -171,7 +189,29 @@ public:
     virtual void getArrayV(uInt rownr, void *dataPtr)
     {
         arrayVToSelection(rownr);
-        fromAdios(dataPtr);
+        if(itsReadCacheMaxRows > 0)
+        {
+            if(itsAdiosStart[0] >= itsReadCacheStartRow && itsAdiosStart[0] < itsReadCacheStartRow + itsReadCacheRows)
+            {
+                Bool deleteIt;
+                auto *arrayPtr = asArrayPtr(dataPtr);
+                T *data = arrayPtr->getStorage(deleteIt);
+                size_t index = itsArraySize * (itsAdiosStart[0] - itsReadCacheStartRow);
+                size_t length = sizeof(T) * itsArraySize;
+                std::memcpy(data, itsReadCache.data() + index, length);
+                arrayPtr->putStorage(data, deleteIt);
+            }
+            else
+            {
+                itsAdiosCount[0] = itsReadCacheMaxRows;
+                itsReadCacheRows = itsReadCacheMaxRows;
+                fromAdios(itsReadCache.data());
+            }
+        }
+        else
+        {
+            fromAdios(dataPtr);
+        }
     }
 
     virtual void putScalarV(uInt rownr, const void *dataPtr)
@@ -265,8 +305,13 @@ public:
     }
 
 private:
-    adios2::Variable<T> itsAdiosVariable;
     const String itsStringArrayBarrier = "ADIOS2BARRIER";
+    adios2::Variable<T> itsAdiosVariable;
+    size_t itsReadCacheStartRow = 0;
+    size_t itsReadCacheRows = 0;
+    size_t itsReadCacheMaxRows = 1000;
+    size_t itsArraySize;
+    std::vector<T> itsReadCache;
 
     Array<T> *asArrayPtr(void *dataPtr) const
     {

--- a/tables/DataMan/test/tAdios2StMan.cc
+++ b/tables/DataMan/test/tAdios2StMan.cc
@@ -69,8 +69,9 @@ void VerifyArrayColumn(Table &table, std::string column, uInt rows, IPosition ar
         AlwaysAssertExit (arr_read.nelements() == arr_gen.nelements());
         for(size_t j=0; j<arr_read.nelements(); ++j)
         {
-            std::cout << "read: " << arr_read.data()[j] << std::endl;
-            std::cout << "gen:" << arr_gen.data()[j] << std::endl;
+            std::cout << "Column : " << column << ", Row : " << i << std::endl;
+            std::cout << "Read : " << arr_read.data()[j] << std::endl;
+            std::cout << "Generated : " << arr_gen.data()[j] << std::endl;
             AlwaysAssertExit (arr_read.data()[j] == arr_gen.data()[j]);
         }
     }


### PR DESCRIPTION
The default read mechanism of Adios2StMan could cause big performance issues when the reader application reads only one row at a time and repeat a large number of times. The problem was identified when we were running large-scale SKA simulations on Summit.

This PR added a pre-fetch cache mechanism into Adios2StMan so that it reads a number of rows at a time and put them into a buffer. Thus, when the reader reads a large number of contiguous rows one by one, it will significantly improve the performance. 