### PR TITLE
Recognize Nasmyth mount types

### DIFF
--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -1948,7 +1948,11 @@ void MSFitsInput::fillAntennaTable(BinaryTable& bt) {
             mount = "ORBITING";
             break;
         case 4:
+            mount = "ALT-AZ+NASMYTH-R";
+            break;
         case 5:
+            mount = "ALT-AZ+NASMYTH-L";
+            break;
         case 6:
             mount = "BIZARRE";
             break;


### PR DESCRIPTION
With this fix importuvfits sets the antenna mount type correctly in the MS for UVFITS data with antennas that have Nasmyth mount types such as certain EHT data products and EVN data exported from AIPS.