### PR TITLE
Fit2D::estimate using a Masked array in the minMax call. Needs the right template

### DIFF
--- a/lattices/LatticeMath/Fit2D2.tcc
+++ b/lattices/LatticeMath/Fit2D2.tcc
@@ -32,6 +32,7 @@
 
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <casacore/casa/Arrays/MaskArrMath.h>
 #include <casacore/lattices/Lattices/MaskedLattice.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN


### PR DESCRIPTION
Ok this is a simple one.

One of my tests was failing as Fit2D could not find the correct minMax template for a MaskedArray. I found I had to include the correct header.

Its a one line addition. All the current tests pass. None of them seem to test estimate. Hang on. I'll extend the tFit2D test to do that.....