### PR TITLE
Improve error when executing `cp` fails

### DIFF
--- a/casa/OS/Directory.cc
+++ b/casa/OS/Directory.cc
@@ -301,7 +301,10 @@ void Directory::copy (const Path& target, Bool overwrite,
     String command("cp -r '");
     command += itsFile.path().expandedName() + "' '" +
                targetName.expandedName() + "'";
-    AlwaysAssert (system(command.chars()) == 0, AipsError);
+    int result = system(command.chars());
+    if(result != 0)
+      throw AipsError("Executing cp command returned an error. Command was: "
+		      + command);
     // Give write permission to user if needed.
     if (setUserWritePermission) {
 #if defined(__hpux__) || defined(AIPS_IRIX)

--- a/casa/OS/Directory.cc
+++ b/casa/OS/Directory.cc
@@ -302,9 +302,10 @@ void Directory::copy (const Path& target, Bool overwrite,
     command += itsFile.path().expandedName() + "' '" +
                targetName.expandedName() + "'";
     int result = system(command.chars());
-    if(result != 0)
+    if(result != 0) {
       throw AipsError("Executing cp command returned an error. Command was: "
 		      + command);
+    }
     // Give write permission to user if needed.
     if (setUserWritePermission) {
 #if defined(__hpux__) || defined(AIPS_IRIX)


### PR DESCRIPTION
In lofar-astron/DP3#177 it is reported that casacore sometimes fails with
std exception detected: (/opt/lofar/casacore/src/casa/OS/Directory.cc : 304) Failed AlwaysAssert system(command.chars()) == 0

To avoid having to check the code what this means, I've improved that error msg a bit. The cause is a failing `cp` command (which could still be for various reasons...)