### PR TITLE
Change MSIter sorting algorithm to ParSort

### DIFF
--- a/casa/Utilities/Sort.h
+++ b/casa/Utilities/Sort.h
@@ -340,12 +340,20 @@ public:
     // Note that the records indexed by <src>indexVector(uniqueVector(i))</src>
     // till <src>indexVector(uniqueVector(i+1))</src> are all the same.
     // <br>
+    //
     // It returns the number of unique records. The unique array
     // is resized to that number.
+    // The third version also gives back a vector with the keys that
+    // change in each sorting group. The size of changeKey is the same as
+    // uniqueVector, and for each unique sorting group indicates the index
+    // of the keyword that will change at the end of the group.
     // <group>
     uInt unique (Vector<uInt>& uniqueVector, uInt nrrec) const;
     uInt unique (Vector<uInt>& uniqueVector,
-		 const Vector<uInt>& indexVector) const;
+                 const Vector<uInt>& indexVector) const;
+    uInt unique (Vector<uInt>& uniqueVector,
+                 Vector<uInt>& changeKey,
+                 const Vector<uInt>& indexVector) const;
     // </group>
 
 private:
@@ -388,8 +396,12 @@ private:
     // Siftdown algorithm for heapsort.
     void siftDown (Int low, Int up, uInt* indices) const;
 
-    // Compare the keys of 2 records.
+    // Compare 2 records based on the comparison functions
     int compare (uInt index1, uInt index2) const;
+
+    // As compare() but it also gives back the index of the first comparison
+    // function that didn't match.
+    int compareChangeIdx(uInt i1, uInt i2, uInt& idxComp) const;
 
     // Swap 2 indices.
     inline void swap (Int index1, Int index2, uInt* indices) const;

--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -281,10 +281,12 @@ void MSIter::construct()
       }
     }
     std::shared_ptr<Vector<uInt>> groupBoundaries = std::make_shared<Vector<uInt>>();
+    std::shared_ptr<Vector<uInt>> groupKeyChange  = std::make_shared<Vector<uInt>>();
     if (!useIn && !useSorted) {
       // we have to resort the input
       if (aips_debug) cout << "MSIter::construct - resorting table"<<endl;
-      sorted = bms_p[i].sort(columns, objComp, orders, Sort::ParSort, groupBoundaries);
+      sorted = bms_p[i].sort(columns, objComp, orders, Sort::ParSort,
+                             groupBoundaries, groupKeyChange);
     }
 
     // Only store if globally requested _and_ locally decided
@@ -305,10 +307,12 @@ void MSIter::construct()
     // the sorted table, so the iterator can avoid sorting.
     if (useIn) {
       tabIter_p[i] = new TableIterator(bms_p[i],columns,objComp,orders,
-                                       TableIterator::NoSort, groupBoundaries);
+                                       TableIterator::NoSort,
+                                       groupBoundaries, groupKeyChange);
     } else {
       tabIter_p[i] = new TableIterator(sorted,columns,objComp,orders,
-                                       TableIterator::NoSort, groupBoundaries);
+                                       TableIterator::NoSort,
+                                       groupBoundaries, groupKeyChange);
     }
     tabIterAtStart_p[i]=True;
   }

--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -280,10 +280,11 @@ void MSIter::construct()
         objComp[icol] = timeComp;
       }
     }
+    std::shared_ptr<Vector<uInt>> groupBoundaries = std::make_shared<Vector<uInt>>();
     if (!useIn && !useSorted) {
       // we have to resort the input
       if (aips_debug) cout << "MSIter::construct - resorting table"<<endl;
-      sorted = bms_p[i].sort(columns, objComp, orders, Sort::ParSort);
+      sorted = bms_p[i].sort(columns, objComp, orders, Sort::ParSort, groupBoundaries);
     }
 
     // Only store if globally requested _and_ locally decided
@@ -304,10 +305,10 @@ void MSIter::construct()
     // the sorted table, so the iterator can avoid sorting.
     if (useIn) {
       tabIter_p[i] = new TableIterator(bms_p[i],columns,objComp,orders,
-                                       TableIterator::NoSort);
+                                       TableIterator::NoSort, groupBoundaries);
     } else {
       tabIter_p[i] = new TableIterator(sorted,columns,objComp,orders,
-                                       TableIterator::NoSort);
+                                       TableIterator::NoSort, groupBoundaries);
     }
     tabIterAtStart_p[i]=True;
   }

--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -280,9 +280,11 @@ void MSIter::construct()
         objComp[icol] = timeComp;
       }
     }
-    std::shared_ptr<Vector<uInt>> groupBoundaries = std::make_shared<Vector<uInt>>();
-    std::shared_ptr<Vector<uInt>> groupKeyChange  = std::make_shared<Vector<uInt>>();
+    std::shared_ptr<Vector<uInt>> groupBoundaries;
+    std::shared_ptr<Vector<uInt>> groupKeyChange;
     if (!useIn && !useSorted) {
+      groupBoundaries = std::make_shared<Vector<uInt>>();
+      groupKeyChange  = std::make_shared<Vector<uInt>>();
       // we have to resort the input
       if (aips_debug) cout << "MSIter::construct - resorting table"<<endl;
       sorted = bms_p[i].sort(columns, objComp, orders, Sort::ParSort,

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -369,7 +369,7 @@ public:
 
 protected:
   // handle the construction details
-  void construct(const Block<Int>& sortColumns, Bool addDefaultSortColumns);
+  void construct();
   // advance the iteration
   void advance();
   // set the iteration state
@@ -387,6 +387,9 @@ protected:
   Block<MeasurementSet> bms_p;
   PtrBlock<TableIterator* > tabIter_p;
   Block<Bool> tabIterAtStart_p;
+
+  Block<Int> sortColumns_p;
+  Bool addDefaultSortColumns_p;
 
   Int nMS_p;
   CountedPtr<MSColumns> msc_p;

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -213,10 +213,12 @@ public:
   //# Members
  
   // Set or reset the time interval to use for iteration.
-  // You should call origin() to reset the iteration after 
+  // This will reset the iterator completely, so you should
+  // discard any running iteration and
+  // call origin() to reset the iteration after 
   // calling this.
   void setInterval(Double timeInterval);
- 
+
   // Reset iterator to start of data
   virtual void origin();
  
@@ -442,8 +444,6 @@ protected:
   MFrequency restFrequency_p;
   MPosition telescopePosition_p;
 
-  CountedPtr<MSInterval> timeComp_p; // Points to the time comparator.
-                                     // 0 if not using a time interval.
 };
 
 inline Bool MSIter::more() const { return more_p;}

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -58,15 +58,15 @@ class MSInterval : public BaseCompare
 {
 public:
   explicit MSInterval(Double interval) : interval_p(interval), offset_p(0) {}
-    virtual ~MSInterval() {}
-    virtual int comp(const void * obj1, const void * obj2) const;
-    Double getOffset() const {return offset_p;}
-    virtual void setOffset(Double offset) {offset_p=offset;}
-    Double getInterval() const {return interval_p;}
-    void setInterval(Double interval) {interval_p=interval;}
+  virtual ~MSInterval() {}
+  virtual int comp(const void * obj1, const void * obj2) const;
+  Double getOffset() const {return offset_p;}
+  virtual void setOffset(Double offset) {offset_p=offset;}
+  Double getInterval() const {return interval_p;}
+  void setInterval(Double interval) {interval_p=abs(interval);}
 private:
-    Double interval_p;
-    mutable Double offset_p;
+  Double interval_p;
+  mutable Double offset_p;
 };
 
 // <summary> 
@@ -237,6 +237,8 @@ public:
   const MS& ms() const;
 
   // Return reference to the current MSColumns
+  // Note that this gives access to the columns for the whole MS,
+  // not just the current iteration.
   const MSColumns& msColumns() const;
 
   // Return the current MS Id (according to the order in which 

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -30,6 +30,7 @@
 
 //# Includes
 #include <casacore/casa/aips.h>
+#include <casacore/casa/Arrays/Vector.h>
 #include <casacore/tables/Tables/Table.h>
 #include <casacore/casa/Utilities/Compare.h>
 #include <casacore/casa/Containers/Block.h>

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -93,7 +93,8 @@ public:
                        const Block<CountedPtr<BaseCompare> >&,
                        const Block<Int>& orders,
                        int option,
-                       std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr);
+                       std::shared_ptr<Vector<uInt>> groupBoundaries=nullptr,
+                       std::shared_ptr<Vector<uInt>> groupKeyIdxChange=nullptr);
 
     // Clone this iterator.
     BaseTableIterator* clone() const;
@@ -127,6 +128,10 @@ protected:
     std::shared_ptr<Vector<uInt>>  groupBoundaries_p;
     // Iterator for groupBoundaries_p
     Vector<uInt>::iterator groupBoundariesIt_p;
+    // Vector with Key Id that will change at the end of each sorting group
+    std::shared_ptr<Vector<uInt>>  groupKeyIdxChange_p;
+    // Iterator for groupKeyIdxChange_p
+    Vector<uInt>::iterator groupKeyIdxChangeIt_p;
     // pointer to column objects
     PtrBlock<BaseColumn*>  colPtr_p;
     // comparison object per column

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -89,9 +89,10 @@ public:
     // will be used for the sort and to compare if values are equal.
     // If a comare object is null, the default ObjCompare<T> will be used.
     BaseTableIterator (BaseTable*, const Block<String>& columnNames,
-		       const Block<CountedPtr<BaseCompare> >&,
-		       const Block<Int>& orders,
-		       int option);
+                       const Block<CountedPtr<BaseCompare> >&,
+                       const Block<Int>& orders,
+                       int option,
+                       std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr);
 
     // Clone this iterator.
     BaseTableIterator* clone() const;
@@ -113,12 +114,22 @@ public:
     inline const String& keyChangeAtLastNext() const { return keyChangeAtLastNext_p; };
 
 protected:
-    BaseTable*             sortTab_p;     //# Table sorted in iteration order
-    uInt                   lastRow_p;     //# last row used from reftab
-    uInt                   nrkeys_p;      //# nr of columns in group
-    String                 keyChangeAtLastNext_p;  //# name of column that terminated most recent next()
-    PtrBlock<BaseColumn*>  colPtr_p;      //# pointer to column objects
-    Block<CountedPtr<BaseCompare> > cmpObj_p;  //# comparison object per column
+    // Table sorted in iteration order
+    BaseTable*                     sortTab_p;
+    // last row used from reftab
+    uInt                           lastRow_p;
+    // nr of columns in group
+    uInt                           nrkeys_p;
+    // name of column that terminated most recent next()
+    String                         keyChangeAtLastNext_p;
+    // Vector with row numbers at which a sorting group boundary happens
+    std::shared_ptr<Vector<uInt>>  groupBoundaries_p;
+    // Iterator for groupBoundaries_p
+    Vector<uInt>::iterator groupBoundariesIt_p;
+    // pointer to column objects
+    PtrBlock<BaseColumn*>  colPtr_p;
+    // comparison object per column
+    Block<CountedPtr<BaseCompare> > cmpObj_p;
 
     // Copy constructor (to be used by clone)
     BaseTableIterator (const BaseTableIterator&);
@@ -128,6 +139,8 @@ private:
     // the envelope class TableIterator has reference semantics.
     // Declaring it private, makes it unusable.
     BaseTableIterator& operator= (const BaseTableIterator&);
+
+    BaseTable* noGroupBoundariesNext();
 
     Block<void*>           lastVal_p;     //# last value per column
     Block<void*>           curVal_p;      //# current value per column

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -391,13 +391,15 @@ public:
     BaseTable* sort (const Block<String>& columnNames,
                      const Block<CountedPtr<BaseCompare> >& compareObjects,
                      const Block<Int>& sortOrder, int sortOption,
-                     std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr);
+                     std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr,
+                     std::shared_ptr<Vector<uInt>> groupKeyChange  = nullptr);
 
     // Create an iterator.
     BaseTableIterator* makeIterator (const Block<String>& columnNames,
                                      const Block<CountedPtr<BaseCompare> >&,
                                      const Block<Int>& orders, int option,
-                                     std::shared_ptr<Vector<uInt>> groupBoundaries);
+                                     std::shared_ptr<Vector<uInt>> groupBoundaries,
+                                     std::shared_ptr<Vector<uInt>> groupKeyChange);
 
     // Add one or more columns to the table.
     // The default implementation throws an "invalid operation" exception.
@@ -475,7 +477,8 @@ public:
                                const Block<CountedPtr<BaseCompare> >&,
                                const Block<Int>& sortOrder,
                                int sortOption,
-                               std::shared_ptr<Vector<uInt>> groupBoundaries);
+                               std::shared_ptr<Vector<uInt>> groupBoundaries,
+                               std::shared_ptr<Vector<uInt>> groupKeyChange);
 
     // Create a RefTable object.
     RefTable* makeRefTable (Bool rowOrder, uInt initialNrrow);

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -389,13 +389,15 @@ public:
 
     // Sort a table on one or more columns of scalars.
     BaseTable* sort (const Block<String>& columnNames,
-		     const Block<CountedPtr<BaseCompare> >& compareObjects,
-		     const Block<Int>& sortOrder, int sortOption);
+                     const Block<CountedPtr<BaseCompare> >& compareObjects,
+                     const Block<Int>& sortOrder, int sortOption,
+                     std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr);
 
     // Create an iterator.
     BaseTableIterator* makeIterator (const Block<String>& columnNames,
                                      const Block<CountedPtr<BaseCompare> >&,
-				     const Block<Int>& orders, int option);
+                                     const Block<Int>& orders, int option,
+                                     std::shared_ptr<Vector<uInt>> groupBoundaries);
 
     // Add one or more columns to the table.
     // The default implementation throws an "invalid operation" exception.
@@ -471,8 +473,9 @@ public:
     // Only in RefTable a smarter implementation is provided.
     virtual BaseTable* doSort (PtrBlock<BaseColumn*>&,
                                const Block<CountedPtr<BaseCompare> >&,
-			       const Block<Int>& sortOrder,
-			       int sortOption);
+                               const Block<Int>& sortOrder,
+                               int sortOption,
+                               std::shared_ptr<Vector<uInt>> groupBoundaries);
 
     // Create a RefTable object.
     RefTable* makeRefTable (Bool rowOrder, uInt initialNrrow);

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -871,8 +871,9 @@ Table Table::sort (const Block<String>& names,
 //# Sort on multiple columns and orders with given functions.
 Table Table::sort (const Block<String>& names,
 		   const Block<CountedPtr<BaseCompare> >& cmpObjs,
-		   const Block<Int>& orders, int option) const
-    { return Table(baseTabPtr_p->sort (names, cmpObjs, orders, option)); }
+		   const Block<Int>& orders, int option,
+           std::shared_ptr<Vector<uInt>> groupBoundaries ) const
+    { return Table(baseTabPtr_p->sort (names, cmpObjs, orders, option, groupBoundaries)); }
 
 
 //# Create an expression node to handle a keyword.

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -870,10 +870,14 @@ Table Table::sort (const Block<String>& names,
 
 //# Sort on multiple columns and orders with given functions.
 Table Table::sort (const Block<String>& names,
-		   const Block<CountedPtr<BaseCompare> >& cmpObjs,
-		   const Block<Int>& orders, int option,
-           std::shared_ptr<Vector<uInt>> groupBoundaries ) const
-    { return Table(baseTabPtr_p->sort (names, cmpObjs, orders, option, groupBoundaries)); }
+                   const Block<CountedPtr<BaseCompare> >& cmpObjs,
+                   const Block<Int>& orders, int option,
+                   std::shared_ptr<Vector<uInt>> groupBoundaries,
+                   std::shared_ptr<Vector<uInt>> groupKeyChange) const
+{
+    return Table(baseTabPtr_p->sort (names, cmpObjs, orders, option,
+                                     groupBoundaries, groupKeyChange));
+}
 
 
 //# Create an expression node to handle a keyword.

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -914,7 +914,8 @@ public:
                 const Block<CountedPtr<BaseCompare> >& compareObjects,
                 const Block<Int>& sortOrders,
                 int = Sort::ParSort,
-                std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr) const;
+                std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr,
+                std::shared_ptr<Vector<uInt>> groupKeyChange  = nullptr) const;
     // </group>
 
     // Get a vector of row numbers in the root table of rows in this table.

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -911,9 +911,10 @@ public:
     // A null CountedPtr means using the standard compare object
     // from class <linkto class="ObjCompare:description">ObjCompare</linkto>.
     Table sort (const Block<String>& columnNames,
-		const Block<CountedPtr<BaseCompare> >& compareObjects,
-		const Block<Int>& sortOrders,
-		int = Sort::ParSort) const;
+                const Block<CountedPtr<BaseCompare> >& compareObjects,
+                const Block<Int>& sortOrders,
+                int = Sort::ParSort,
+                std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr) const;
     // </group>
 
     // Get a vector of row numbers in the root table of rows in this table.

--- a/tables/Tables/TableIter.cc
+++ b/tables/Tables/TableIter.cc
@@ -48,7 +48,7 @@ TableIterator::TableIterator (const Table& tab,
     Block<Int> ord(1, order);
     Block<CountedPtr<BaseCompare> > cmpObj(1);
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObj,
-						     ord, option);
+						     ord, option, nullptr);
     next();                            // get first subtable
 }
 
@@ -61,7 +61,7 @@ TableIterator::TableIterator (const Table& tab,
     Block<Int> ord(keys.nelements(), order);
     Block<CountedPtr<BaseCompare> > cmpObj(keys.nelements());
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObj,
-						     ord, option);
+						     ord, option, nullptr);
     next();                            // get first subtable
 }
 
@@ -73,19 +73,20 @@ TableIterator::TableIterator (const Table& tab,
 {
     Block<CountedPtr<BaseCompare> > cmpObj(keys.nelements());
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObj,
-						     orders, option);
+                                                     orders, option, nullptr);
     next();                            // get first subtable
 }
 
 TableIterator::TableIterator (const Table& tab,
-			      const Block<String>& keys,
-			      const Block<CountedPtr<BaseCompare> >& cmpObjs,
-			      const Block<Int>& orders,
-			      Option option)
+                              const Block<String>& keys,
+                              const Block<CountedPtr<BaseCompare> >& cmpObjs,
+                              const Block<Int>& orders,
+                              Option option,
+                              std::shared_ptr<Vector<uInt>> groupBoundaries)
 : tabIterPtr_p (0)
 {
-    tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObjs,
-						     orders, option);
+    tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObjs, orders,
+                                                     option, groupBoundaries);
     next();                            // get first subtable
 }
 

--- a/tables/Tables/TableIter.cc
+++ b/tables/Tables/TableIter.cc
@@ -48,7 +48,8 @@ TableIterator::TableIterator (const Table& tab,
     Block<Int> ord(1, order);
     Block<CountedPtr<BaseCompare> > cmpObj(1);
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObj,
-						     ord, option, nullptr);
+                                                     ord, option,
+                                                     nullptr, nullptr);
     next();                            // get first subtable
 }
 
@@ -61,7 +62,8 @@ TableIterator::TableIterator (const Table& tab,
     Block<Int> ord(keys.nelements(), order);
     Block<CountedPtr<BaseCompare> > cmpObj(keys.nelements());
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObj,
-						     ord, option, nullptr);
+                                                     ord, option,
+                                                     nullptr, nullptr);
     next();                            // get first subtable
 }
 
@@ -73,7 +75,8 @@ TableIterator::TableIterator (const Table& tab,
 {
     Block<CountedPtr<BaseCompare> > cmpObj(keys.nelements());
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObj,
-                                                     orders, option, nullptr);
+                                                     orders, option,
+                                                     nullptr, nullptr);
     next();                            // get first subtable
 }
 
@@ -82,11 +85,13 @@ TableIterator::TableIterator (const Table& tab,
                               const Block<CountedPtr<BaseCompare> >& cmpObjs,
                               const Block<Int>& orders,
                               Option option,
-                              std::shared_ptr<Vector<uInt>> groupBoundaries)
+                              std::shared_ptr<Vector<uInt>> groupBoundaries,
+                              std::shared_ptr<Vector<uInt>> groupKeyIdxChange)
 : tabIterPtr_p (0)
 {
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObjs, orders,
-                                                     option, groupBoundaries);
+                                                     option, groupBoundaries,
+                                                     groupKeyIdxChange);
     next();                            // get first subtable
 }
 

--- a/tables/Tables/TableIter.h
+++ b/tables/Tables/TableIter.h
@@ -173,7 +173,8 @@ public:
     TableIterator (const Table&, const Block<String>& columnNames,
                    const Block<CountedPtr<BaseCompare> >&,
                    const Block<Int>& orders, Option = ParSort,
-                   std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr);
+                   std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr,
+                   std::shared_ptr<Vector<uInt>> groupKeyIdxChange = nullptr);
     // </group>
 
     // Copy constructor (copy semantics).

--- a/tables/Tables/TableIter.h
+++ b/tables/Tables/TableIter.h
@@ -171,8 +171,9 @@ public:
     // Give an optional compare object per column.
     // A zero pointer means that the default compare function will be used.
     TableIterator (const Table&, const Block<String>& columnNames,
-		   const Block<CountedPtr<BaseCompare> >&,
-		   const Block<Int>& orders, Option = ParSort);
+                   const Block<CountedPtr<BaseCompare> >&,
+                   const Block<Int>& orders, Option = ParSort,
+                   std::shared_ptr<Vector<uInt>> groupBoundaries = nullptr);
     // </group>
 
     // Copy constructor (copy semantics).


### PR DESCRIPTION
This PR changes the sorting algorithm of the underlying tables in the MSIter class from the current 
QuickSort to ParSort.

QuickSort algorithm performs significantly slower than the
ParSort algorithm added a few years ago to CASA.
The following benchmarks which simply run a MSIter loop with different
sorting columns show the performance on a relatively small MS
(1M rows) and a larger one (11M rows) and show that ParSort always
performs better by at least a factor of 2x in the case of using
1 thread but it can reach up to a factor of 10x in some cases if
all cores are used.
For comparison, also the STL std::stable_sort algorithm has been
hooked into the CASA Sort class. It improves QuickSort and is close
to the ParSort 1-thread case, but it cannot compete with ParSort
multi-thread case.
The benchmarks have been performed on a 16 core Xeon E5-4620 machine
with 64 GB and HyperThreading enabled running on a CentOS 7 container.

| Large MS. 11M rows, 55GB| - | - | - |
|------------------------------------| - | - | - |
|             |      Sort1  |   Sort2    |   Sort3|
|ParSort |         1100 ms  |   2100 ms  |   450 ms|
|ParSort 1 THR  |  2800 ms  |   8200 ms  |  1000 ms|
|STL stable_sort | 6800 ms  |   7800 ms  |  2100 ms|
|QuickSort     |  14000 ms  |  15000 ms  |  4500 ms}

|Medium MS. 1M rows, 3.4GB| - | - | - |
|------------------------------------| - | - | - |
|        |           Sort1  |   Sort2    |   Sort3|
|ParSort  |         130 ms  |    170 ms  |    70 ms|
|ParSort 1 THR |    400 ms  |    700 ms  |   130 ms|
|STL stable_sort|   600 ms  |    900 ms  |   200 ms|
|QuickSort      |  1100 ms  |   1300 ms  |   370 ms|

Sort1: Default sorting: ARRAY_ID, FIELD_ID, DATA_DESC_ID, MS::TIME
Sort2: ANTENNA1, ANTENNA2, TIME
Sort3: DATA_DESC_ID, ARRAY_ID