### PR TITLE
Prevent setting OpenMP num_threads to zero

### DIFF
--- a/casa/OS/Conversion.cc
+++ b/casa/OS/Conversion.cc
@@ -461,8 +461,9 @@ size_t Conversion::bitToBool (void* to, const void* from,
     const size_t bits_per_loop = 8;
     const size_t nwords = nvalues / bits_per_loop;
 #ifdef _OPENMP
-    size_t nthr = std::min((size_t)omp_get_max_threads(),
-                           nwords / (16 * 1024));
+    size_t nthr =
+        std::max((size_t)1,
+                 std::min((size_t)omp_get_max_threads(), nwords / (16 * 1024)));
 # pragma omp parallel for if (nwords >= 32 * 1024) num_threads(nthr)
 #endif
     for (size_t i = 0; i < nwords; ++i) {

--- a/casa/Utilities/GenSort.tcc
+++ b/casa/Utilities/GenSort.tcc
@@ -259,6 +259,8 @@ uInt GenSort<T>::parSort (T* data, uInt nr, Sort::Order ord, int opt,
     nthr = omp_get_max_threads();
     if (uInt(nthr) > nr) nthr = nr;
   }
+  if (nthr == 0)
+    nthr = 1;
 #else
   nthr = 1;
 #endif
@@ -607,6 +609,8 @@ uInt GenSortIndirect<T>::parSort (uInt* inx, const T* data, uInt nr,
     nthr = omp_get_max_threads();
     if (uInt(nthr) > nr) nthr = nr;
   }
+  if (nthr == 0)
+    nthr = 1;
 #else
   nthr = 1;
 #endif


### PR DESCRIPTION
If a calculation of the number of threads previously yielded a value of zero,
replace it by a value of one.

AFAICT, the OpenMP specification states that a "num_threads" value must be a
positive integer or else the behavior is implementation defined. While the
meaning of "positive integer" appears undefined in the specification, it's usage
in that document suggests a value that is strictly greater than zero, which also
happens to agree with my intuitive sense of a minimum valid value of
"num_threads".

This bug originally appeared (for me) in Conversion.cc when using the OPARI2
tool (https://www.vi-hps.org/projects/score-p/) to instrument the casacore code,
while the bug apparently remains latent when using one of the standard compilers
without the tool.

Note that StatisticsDataset::initThreadVars() also computes a value for a number
of threads, and it does not check for zero. However, I have not changed that
code because I am uncertain that a value of zero would occur in practice, and
there is further initialization done in that method after computing the number
of threads.