### PR TITLE
Fix travis mac2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
     - fftw
     - hdf5
     - ccache
-    - boost-python
     - boost-python3
     - cfitsio
     - wcslib

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -38,6 +38,7 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
         -DBUILD_PYTHON3=ON \
         -DPYTHON3_EXECUTABLE=/usr/local/bin/python3 \
         -DBOOST_PYTHON3_LIBRARY_NAME=python37 \
+        -DBoost_NO_BOOST_CMAKE=True \
         -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
         -DDATA_DIR=$PWD \
         -DSOFA_ROOT_DIR=$PWD \

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -27,7 +27,6 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
 
    ccache -M 80M
 
-   pip2 install numpy
    pip3 install numpy
 
    CXX="ccache $CXX" cmake .. \
@@ -35,9 +34,8 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
         -DBUILD_TESTING=ON \
         -DUSE_OPENMP=OFF \
         -DUSE_HDF5=ON \
-        -DBUILD_PYTHON=ON \
+        -DBUILD_PYTHON=OFF \
         -DBUILD_PYTHON3=ON \
-        -DPYTHON2_EXECUTABLE=/usr/local/bin/python2 \
         -DPYTHON3_EXECUTABLE=/usr/local/bin/python3 \
         -DBOOST_PYTHON3_LIBRARY_NAME=python37 \
         -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \


### PR DESCRIPTION
Homebrew switched to installing CMake config files to find boost components, but apparently this does not work for boost-python. I think the actual fix should be done at the homebrew end ( https://github.com/Homebrew/homebrew-core/issues/44093 )

I disabled the python2 test on Travis Mac to make the test environment a bit easier.