### PR TITLE
Adding more I/O patterns to Adios2StMan

### DIFF
--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -111,8 +111,30 @@ void Adios2StManColumn::arrayVToSelection(uInt rownr)
 
 void Adios2StManColumn::sliceVToSelection(uInt rownr, const Slicer &ns)
 {
-    itsAdiosStart[0] = rownr;
-    itsAdiosCount[0] = 1;
+    columnSliceCellsVToSelection(rownr, 1, ns);
+}
+
+void Adios2StManColumn::columnSliceVToSelection(const Slicer &ns)
+{
+    columnSliceCellsVToSelection(0, itsStManPtr->getNrRows(), ns);
+}
+
+void Adios2StManColumn::columnSliceCellsVToSelection(const RefRows &rows, const Slicer &ns)
+{
+    RefRowsSliceIter iter(rows);
+    auto row_start = iter.sliceStart();
+    auto row_end = iter.sliceEnd();
+    iter.next();
+    if (!iter.pastEnd()) {
+        throw std::runtime_error("Adios2StManColumn::columnSliceCellsVToSelection supports single slices");
+    }
+    columnSliceCellsVToSelection(row_start, row_end - row_start + 1, ns);
+}
+
+void Adios2StManColumn::columnSliceCellsVToSelection(uInt row_start, uInt row_count, const Slicer &ns)
+{
+    itsAdiosStart[0] = row_start;
+    itsAdiosCount[0] = row_count;
     for (size_t i = 1; i < itsAdiosShape.size(); ++i)
     {
         itsAdiosStart[i] = ns.start()(ns.ndim() - i);
@@ -310,5 +332,28 @@ void Adios2StManColumnT<std::string>::putSliceV(uInt /*aRowNr*/, const Slicer &/
     throw std::runtime_error("Not implemented yet");
 }
 
+template<>
+void Adios2StManColumnT<std::string>::getColumnSliceV(const Slicer &/*ns*/, void */*dataPtr*/)
+{
+    throw std::runtime_error("Not implemented yet");
+}
+
+template<>
+void Adios2StManColumnT<std::string>::putColumnSliceV(const Slicer &/*ns*/, const void */*dataPtr*/)
+{
+    throw std::runtime_error("Not implemented yet");
+}
+
+template<>
+void Adios2StManColumnT<std::string>::getColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, void* /*dataPtr*/)
+{
+    throw std::runtime_error("Not implemented yet");
+}
+
+template<>
+void Adios2StManColumnT<std::string>::putColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, const void* /*dataPtr*/)
+{
+    throw std::runtime_error("Not implemented yet");
+}
 
 } // namespace casacore

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -46,6 +46,7 @@ public:
     Adios2StManColumn(Adios2StMan::impl *aParent, int aDataType, String aColName, std::shared_ptr<adios2::IO> aAdiosIO);
 
     virtual Bool canAccessSlice (Bool& reask) const { reask = false; return true; };
+    virtual Bool canAccessColumnSlice (Bool& reask) const { reask = false; return true; };
 
     virtual void create(std::shared_ptr<adios2::Engine> aAdiosEngine,
                         char aOpenMode) = 0;
@@ -116,6 +117,9 @@ protected:
     void scalarVToSelection(uInt rownr);
     void arrayVToSelection(uInt rownr);
     void sliceVToSelection(uInt rownr, const Slicer &ns);
+    void columnSliceVToSelection(const Slicer &ns);
+    void columnSliceCellsVToSelection(const RefRows &rows, const Slicer &ns);
+    void columnSliceCellsVToSelection(uInt row_start, uInt row_end, const Slicer &ns);
 
     Adios2StMan::impl *itsStManPtr;
 
@@ -289,16 +293,30 @@ public:
         fromAdios(dataPtr);
     }
 
+    virtual void putColumnSliceV(const Slicer &ns, const void *dataPtr)
+    {
+        columnSliceVToSelection(ns);
+        toAdios(dataPtr);
+    }
+
     virtual void getColumnSliceV(const Slicer &ns, void *dataPtr)
     {
-        itsAdiosStart[0] = 0;
-        itsAdiosCount[0] = itsAdiosShape[0];
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = ns.start()(i - 1);
-            itsAdiosCount[i] = ns.length()(i - 1);
-        }
+        columnSliceVToSelection(ns);
         fromAdios(dataPtr);
+    }
+
+    virtual void getColumnSliceCellsV(const RefRows& rownrs,
+                                      const Slicer& slicer, void* dataPtr)
+    {
+        columnSliceCellsVToSelection(rownrs, slicer);
+        fromAdios(dataPtr);
+    }
+
+    virtual void putColumnSliceCellsV (const RefRows& rownrs,
+                                       const Slicer& slicer, const void* dataPtr)
+    {
+        columnSliceCellsVToSelection(rownrs, slicer);
+        toAdios(dataPtr);
     }
 
 private:


### PR DESCRIPTION
In Adios2StMan so far we have supported putting scalars and arrays into single cells, or into cell slides, but haven't supported single operations that span across either the whole column, or a slice of a column. Since we haven't advertised such support, the storage manager classes have resorted so
far to perform multiple cell-wise I/O operations, even when at the application level users perform a single write or read. This, in turn, has led us to have poor performance when using ADIOS2 as we have been hit by its bigger metadata-to-data ratio.

This commit adds support for column-wise operations. Whole column slices are fully supported, but partial column slices are supported only when a single slice is requested (requests spanning multiple slices will currently receive an exception).

This is currently enough to improve our use case (writing visibilities from OSKAR), and now single writes are generated at the data manager level.