### PR TITLE
Avoiding UB by not casting through char anymore

### DIFF
--- a/casa/System/ObjectID2.cc
+++ b/casa/System/ObjectID2.cc
@@ -37,15 +37,10 @@ uInt hashFunc(const ObjectID &key)
 {
     // We should check to see if this hash is any good
     uInt result = 0;
-    char c;
-    c = static_cast<char>(key.sequence());
-    result = result | c;
-    c = static_cast<char>(key.pid());
-    result = result | (c << 8);
-    c = static_cast<char>(key.creationTime());
-    result = result | (c << 16);
-    c = key.hostName()[0];
-    result = result | (c << 24);
+    result |= key.sequence() & 0xff;
+    result |= (key.pid() & 0xff) << 8;
+    result |= (key.creationTime() & 0xff) << 16;
+    result |= uInt(key.hostName()[0]) << 24;
     return result;
 }
 


### PR DESCRIPTION
The previous version of this code stored the individual bytes of information into a char variable, which was later shifted to place its value into the final hash. This shifting was illegal though, as it took an 8-bit variable type and shifted it by 8, 16 and 24 places to the left. This might be the underlying reason causing #986, but even if it isn't it still deserves to be fixed.

The fix avoids casting the individual bytes through the char type, and instead it performs the masking and shifting in a single expression, keeping the original value types and avoiding UB. Additionally, the last byte is converted to uInt before bit shifting, as its original type is char.