### PR TITLE
Supports ParSort sorting algorithm in BaseTabIterator class

### DIFF
--- a/tables/Tables/BaseTabIter.cc
+++ b/tables/Tables/BaseTabIter.cc
@@ -43,10 +43,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 
 BaseTableIterator::BaseTableIterator (BaseTable* btp,
-				      const Block<String>& keys,
-				      const Block<CountedPtr<BaseCompare> >& cmp,
-				      const Block<Int>& order,
-				      int option)
+    const Block<String>& keys,
+    const Block<CountedPtr<BaseCompare> >& cmp,
+    const Block<Int>& order,
+    int option)
 : lastRow_p (0),
   nrkeys_p  (keys.nelements()),
   keyChangeAtLastNext_p(""),
@@ -58,28 +58,30 @@ BaseTableIterator::BaseTableIterator (BaseTable* btp,
     // If needed sort the table in order of the iteration keys.
     // The passed in compare functions are for the iteration.
     if (option == TableIterator::NoSort) {
-	sortTab_p = btp;
+        sortTab_p = btp;
     }else{
-	Sort::Option sortopt = Sort::QuickSort;
-	if (option == TableIterator::HeapSort) {
-	    sortopt = Sort::HeapSort;
-	} else if (option == TableIterator::InsSort) {
-	    sortopt = Sort::InsSort;
-	}
-	Block<Int> ord(nrkeys_p, Sort::Ascending);
-	for (uInt i=0; i<nrkeys_p; i++) {
-	    if (order[i] == TableIterator::Descending) {
-		ord[i] = Sort::Descending;
-	    }
-	}
-	sortTab_p = (RefTable*) (btp->sort (keys, cmpObj_p, ord, sortopt));
+        Sort::Option sortopt = Sort::QuickSort;
+        if (option == TableIterator::HeapSort) {
+            sortopt = Sort::HeapSort;
+        } else if (option == TableIterator::ParSort) {
+            sortopt = Sort::ParSort;
+        } else if (option == TableIterator::InsSort) {
+            sortopt = Sort::InsSort;
+        }
+        Block<Int> ord(nrkeys_p, Sort::Ascending);
+        for (uInt i=0; i<nrkeys_p; i++) {
+            if (order[i] == TableIterator::Descending) {
+                ord[i] = Sort::Descending;
+            }
+        }
+        sortTab_p = (RefTable*) (btp->sort (keys, cmpObj_p, ord, sortopt));
     }
     sortTab_p->link();
     // Get the pointers to the BaseColumn object.
     // Get a buffer to hold the current and last value per column.
     for (uInt i=0; i<nrkeys_p; i++) {
-	colPtr_p[i] = sortTab_p->getColumn (keys[i]);
-	colPtr_p[i]->allocIterBuf (lastVal_p[i], curVal_p[i], cmpObj_p[i]);
+        colPtr_p[i] = sortTab_p->getColumn (keys[i]);
+        colPtr_p[i]->allocIterBuf (lastVal_p[i], curVal_p[i], cmpObj_p[i]);
     }
 }
 

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -87,11 +87,11 @@ public:
     // Create the table iterator to iterate through the given
     // columns in the given order. The given compare objects
     // will be used for the sort and to compare if values are equal.
-    // If a comare object is null, the default ObjCompare<T> will be used.
+    // If a compare object is null, the default ObjCompare<T> will be used.
     BaseTableIterator (BaseTable*, const Block<String>& columnNames,
-		       const Block<CountedPtr<BaseCompare> >&,
-		       const Block<Int>& orders,
-		       int option);
+                       const Block<CountedPtr<BaseCompare> >&,
+                       const Block<Int>& orders,
+                       int option);
 
     // Clone this iterator.
     BaseTableIterator* clone() const;
@@ -106,10 +106,10 @@ public:
 
     virtual void copyState(const BaseTableIterator &);
 
-    // Report Name of slowest sort column that changed to 
-    //  terminate the most recent call to next()
-    //  Enables clients to sense iteration boundary properties
-    //  and organize associated iterations
+    // Report Name of slowest sort column that changed (according to the
+    // comparison function) to terminate the most recent call to next()
+    // Enables clients to sense iteration boundary properties
+    // and organize associated iterations
     inline const String& keyChangeAtLastNext() const { return keyChangeAtLastNext_p; };
 
 protected:


### PR DESCRIPTION
Currently, the TableIterator class has a parameter Option in all the constructors which defaults to TableIterator::ParSort. This parameter is propagated trough several classes:    TableIterator::TableIterator() -> BaseTable::makeIterator -> BaseTabIterator::BaseTabIterator()

However the later constructor BaseTabIterator::BaseTabIterator() simply ignores the option ParSort (whereas QuickSort, HeapSort and InsSort are supported.
    
This basically adds the support for ParSort as it is intended by adding the proper "else if".
