### PR TITLE
Allow user control of readline usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ endif()
 
 # By default do not use ADIOS2, HDF5, FFTW3
 option (ENABLE_TABLELOCKING "Make locking for concurrent table access possible" YES)
+option (USE_READLINE "Build readline support" YES)
 option (USE_ADIOS2 "Build ADIOS2 " NO)
 option (USE_HDF5 "Build HDF5 " NO)
 option (USE_FFTW3 "Use FFTW instead of FFTPack" NO)
@@ -323,7 +324,9 @@ include (CTest)
 #    "Maximum ctest time allowed before CTest will kill the test." FORCE)
 
 find_package (DL)
-find_package (Readline)
+if (USE_READLINE)
+    find_package (Readline REQUIRED)
+endif (USE_READLINE)
 find_package (SOFA)
 if (USE_ADIOS2)
     set(USE_MPI ON)


### PR DESCRIPTION
Although readline and sofa are advertised as optional, users have no way to actually control whether or not readline and sofa are used. The unguarded call to `find_package(Readline)` will create casacore libraries that link to readline libraries if they are found (and a similar situation holds with sofa). In some environments, this behavior is not desirable.

This PR allows users to state whether or not to build against and link casacore to the readline and sofa libraries through the use of `USE_READLINE` and `USE_SOFA` CMake options. I have verified that setting `USE_READLINE=OFF` results in casacore libraries that do not link to libreadline.so, even on systems where that library is present.