### PR TITLE
Support explicit comparison functions for iteration grouping

### DIFF
--- a/casa/Utilities/Compare.cc
+++ b/casa/Utilities/Compare.cc
@@ -40,6 +40,16 @@ int CompareNoCase::comp(const void * obj1, const void * obj2) const
   return fcompare (v1, v2);
 }
 
+CompareAlwaysTrue::~CompareAlwaysTrue()
+{}
+
+int CompareAlwaysTrue::comp(const void * obj1, const void * obj2) const
+{
+  (void)obj1; // Avoid compiler warning
+  (void)obj2;
+  return 0;
+}
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/casa/Utilities/Compare.h
+++ b/casa/Utilities/Compare.h
@@ -197,6 +197,21 @@ public:
   virtual int comp(const void * obj1, const void * obj2) const;
 };
 
+// <summary>Comparison class that is always true</summary>
+
+// <synopsis>
+// This class is meant to always give true and can be used to ensure
+// that all the values of a given column are grouped together.
+// </synopsis>
+class CompareAlwaysTrue : public BaseCompare
+{
+public:
+  virtual ~CompareAlwaysTrue();
+
+  // Comparison function that gives always true
+  virtual int comp(const void * obj1, const void * obj2) const;
+};
+
 
 } //# NAMESPACE CASACORE - END
 

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -246,44 +246,65 @@ public:
   // Return true if msId has changed since last iteration
   Bool newMS() const;
 
-  // Return the current ArrayId
+  // Return the current ArrayIds for all rows in this iteration
+  const ScalarColumn<Int>& colArrayIds() const;
+
+  // Return the current FieldIds for all rows in this iteration
+  const ScalarColumn<Int>& colFieldIds() const;
+
+  // Return the current DataDescriptionIds for all rows in this iteration
+  const ScalarColumn<Int>& colDataDescriptionIds() const;
+
+  // Return the ArrayId of the first element in this iteration
   Int arrayId() const;
 
   // Return True if ArrayId has changed since last iteration
+  // Note that if MS_ARRAY is not part of the sorting columns this
+  // will always be true.
   Bool newArray() const;
 
-  // Return the current FieldId
+  // Return the FieldId of the first element in this iteration
   Int fieldId() const;
 
   // Return True if FieldId/Source has changed since last iteration
+  // Note that if MS_FIELD_ID is not part of the sorting columns this
+  // will always be true.
   Bool newField() const;
 
-  // Return current SpectralWindow
+  // Return SpectralWindow of the first element in this iteration
   Int spectralWindowId() const;
 
   // Return True if SpectralWindow has changed since last iteration
+  // Note that if MS_DATA_DESC_ID is not part of the sorting columns this
+  // will always be true.
   Bool newSpectralWindow() const;
 
-  // Return current DataDescriptionId
+  // Return DataDescriptionId of the first element in this iteration
   Int dataDescriptionId() const;
 
   // Return True if DataDescriptionId has changed since last iteration
+  // Note that if MS_DATA_DESC_ID is not part of the sorting columns this
+  // will always be true.
   Bool newDataDescriptionId() const;
 
-  // Return current PolarizationId
+  // Return PolarizationId of the first element in this iteration
   Int polarizationId() const;
 
   // Return True if polarization has changed since last iteration
+  // Note that if MS_DATA_DESC_ID is not part of the sorting columns this
+  // will always be true.
   Bool newPolarizationId() const;
 
 
-  // Return frame for polarization (returns PolFrame enum)
+  // Return frame for polarization of the first element in this iteration
+  // @returns PolFrame enum
   Int polFrame() const;
 
   // Return the frequencies corresponding to the DATA matrix.
   const Vector<Double>& frequency() const;
 
-  // Return frequency of first channel with reference frame as a Measure.
+  // Return frequency of first channel of the first element in iteration
+  // with reference frame as a Measure.
   // The reference frame Epoch is that of the first row, reset it as needed
   // for each row.
   // The reference frame Position is the average of the antenna positions.
@@ -382,15 +403,19 @@ protected:
   PtrBlock<TableIterator* > tabIter_p;
   Block<Bool> tabIterAtStart_p;
 
+  // This booleans determine if given columns are part of the sorting
+  Bool timeInSort_p, arrayInSort_p, ddInSort_p, fieldInSort_p;
+
   size_t nMS_p, curMS_p;
   CountedPtr<MSColumns> msc_p;
   Table curTable_p;
-  Int lastMS_p, curArray_p, lastArray_p, curSource_p;
-  String curFieldName_p, curSourceName_p;
-  Int curField_p, lastField_p, curSpectralWindow_p, lastSpectralWindow_p;
+  Int lastMS_p, curArrayIdFirst_p, lastArrayId_p, curSourceIdFirst_p;
+  String curFieldNameFirst_p, curSourceNameFirst_p;
+  Int curFieldIdFirst_p, lastFieldId_p;
+  Int curSpectralWindowIdFirst_p, lastSpectralWindowId_p;
   Int curPolarizationId_p, lastPolarizationId_p;
-  Int curDataDescId_p, lastDataDescId_p;
-  Bool more_p, newMS_p, newArray_p, newField_p, newSpectralWindow_p,
+  Int curDataDescIdFirst_p, lastDataDescId_p;
+  Bool more_p, newMS_p, newArrayId_p, newFieldId_p, newSpectralWindowId_p,
     newPolarizationId_p, newDataDescId_p,
     timeDepFeed_p, spwDepFeed_p, checkFeed_p;
 
@@ -439,18 +464,24 @@ inline Table MSIter::table() const {return curTable_p;}
 inline const MS& MSIter::ms() const {return bms_p[curMS_p];}
 inline const MSColumns& MSIter::msColumns() const { return *msc_p;}
 inline Bool MSIter::newMS() const { return newMS_p;}
-inline Bool MSIter::newArray() const {return newArray_p;}
-inline Bool MSIter::newField() const { return newField_p;}
+inline Bool MSIter::newArray() const {return newArrayId_p;}
+inline Bool MSIter::newField() const { return newFieldId_p;}
 inline Bool MSIter::newSpectralWindow() const
-{ return newSpectralWindow_p;}
+{ return newSpectralWindowId_p;}
 inline size_t MSIter::msId() const { return curMS_p;}
 inline size_t MSIter::numMS() const { return nMS_p;}
-inline Int MSIter::arrayId() const {return curArray_p;}
-inline Int MSIter::fieldId() const { return curField_p;}
+inline const ScalarColumn<Int>& MSIter::colArrayIds() const
+{ return colArray_p;}
+inline const ScalarColumn<Int>& MSIter::colFieldIds() const
+{ return colField_p;}
+inline const ScalarColumn<Int>& MSIter::colDataDescriptionIds() const
+{ return colDataDesc_p;}
+inline Int MSIter::arrayId() const {return curArrayIdFirst_p;}
+inline Int MSIter::fieldId() const { return curFieldIdFirst_p;}
 inline Int MSIter::spectralWindowId() const
-{ return curSpectralWindow_p;}
+{ return curSpectralWindowIdFirst_p;}
 inline Int MSIter::polarizationId() const {return curPolarizationId_p;}
-inline Int MSIter::dataDescriptionId() const {return curDataDescId_p;}
+inline Int MSIter::dataDescriptionId() const {return curDataDescIdFirst_p;}
 inline Bool MSIter::newPolarizationId() const { return newPolarizationId_p;}
 inline Bool MSIter::newDataDescriptionId() const { return newDataDescId_p;}
 inline Int MSIter::polFrame() const { return polFrame_p;}

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -191,13 +191,24 @@ public:
   // concurrent readers from interfering with each other.
 
   MSIter(const MeasurementSet& ms, const Block<Int>& sortColumns,
-	 Double timeInterval=0, Bool addDefaultSortColumns=True,
-	 Bool storeSorted=True);
+         Double timeInterval=0, Bool addDefaultSortColumns=True,
+         Bool storeSorted=True);
 
   // Same as above with multiple MSs as input.
   MSIter(const Block<MeasurementSet>& mss, const Block<Int>& sortColumns,
-	 Double timeInterval=0, Bool addDefaultSortColumns=True,
-	 Bool storeSorted=True);
+         Double timeInterval=0, Bool addDefaultSortColumns=True,
+         Bool storeSorted=True);
+
+  // This constructor is similar to the previous ones but the comparison
+  // functions used to group the iterations are given explicitly, making
+  // the constructor more generic. Also, the column is specified as a string,
+  // to support sorting by columns not part of the standard MS definition.
+  MSIter(const MeasurementSet& ms,
+         const std::vector<std::pair<String, CountedPtr<BaseCompare>>>& sortColumns);
+
+  // Same as above with multiple MSs as input.
+  MSIter(const Block<MeasurementSet>& mss,
+         const std::vector<std::pair<String, CountedPtr<BaseCompare>>>& sortColumns);
 
   // Copy construct. This calls the assigment operator.
   MSIter(const MSIter & other);
@@ -385,6 +396,8 @@ public:
 protected:
   // handle the construction details
   void construct(const Block<Int>& sortColumns, Bool addDefaultSortColumns);
+  // handle the construction details using explicit comparison functions
+  void construct(const std::vector<std::pair<String, CountedPtr<BaseCompare>>>& sortColumns);
   // advance the iteration
   void advance();
   // set the iteration state
@@ -466,7 +479,7 @@ inline const MSColumns& MSIter::msColumns() const { return *msc_p;}
 inline Bool MSIter::newMS() const { return newMS_p;}
 inline Bool MSIter::newArray() const {return newArrayId_p;}
 inline Bool MSIter::newField() const { return newFieldId_p;}
-inline Bool MSIter::newSpectralWindow() const
+inline Bool MSIter::newSpectralWindow() const 
 { return newSpectralWindowId_p;}
 inline size_t MSIter::msId() const { return curMS_p;}
 inline size_t MSIter::numMS() const { return nMS_p;}

--- a/ms/MeasurementSets/test/tMSIter.cc
+++ b/ms/MeasurementSets/test/tMSIter.cc
@@ -226,6 +226,73 @@ void iter2MSMemory (double binwidth)
   }
 }
 
+// This test exercises the generic sorting function constructor
+// with a trivial comparison which always compares two values equal.
+// The result is that all the rows are grouped together.
+void iterMSGenericSortFuncAlwaysTrue ()
+{
+  MeasurementSet ms("tMSIter_tmp.ms");
+  CountedPtr<BaseCompare> alwaysTrue(new CompareAlwaysTrue());
+  std::vector<std::pair<String, CountedPtr<BaseCompare>>> sortCols;
+  sortCols.push_back(std::make_pair("ANTENNA1", alwaysTrue));
+  MSIter msIter(ms, sortCols);
+  size_t niter = 0;
+  for (msIter.origin(); msIter.more(); msIter++) {
+    cout << "nrow=" << msIter.table().nrow()<<endl;
+    niter++;
+  }
+  AlwaysAssertExit(niter == 1);
+}
+
+class CompareAntennaGrouping : public BaseCompare
+{
+public:
+  virtual ~CompareAntennaGrouping()
+  {
+  }
+
+  // Comparison function that groups together antenna 0 and 1
+  // and antenna 2 on a different group
+  virtual int comp(const void * obj1, const void * obj2) const
+  {
+    const Int& v1 = *static_cast<const Int*>(obj1);
+    const Int& v2 = *static_cast<const Int*>(obj2);
+    double v1_c, v2_c;
+    if( v1 == 0 || v1 == 1)
+      v1_c = 0.5;
+    else
+      v1_c = v1;
+    if( v2 == 0 || v2 == 1)
+      v2_c = 0.5;
+    else
+      v2_c = v2;
+    return (v1_c == v2_c ? 0 : (v1_c < v2_c ? -1 : 1));
+  }
+};
+
+// This test exercises the generic sorting function constructor
+// with a comparison function that groups together antennas 0 and 1
+// and leaves antenna 2 in a different group
+void iterMSGenericSortFuncAntennaGrouping ()
+{
+  MeasurementSet ms("tMSIter_tmp.ms");
+  CountedPtr<BaseCompare> antennaCluster(new CompareAntennaGrouping());
+  std::vector<std::pair<String, CountedPtr<BaseCompare>>> sortCols;
+  sortCols.push_back(std::make_pair("ANTENNA1", antennaCluster));
+  MSIter msIter(ms, sortCols);
+  size_t nAnt01 = 0;
+  size_t nAnt2 = 0;
+  for (msIter.origin(); msIter.more(); msIter++) {
+    cout << "nrow=" << msIter.table().nrow()<<endl;
+    Int antenna =  ScalarColumn<Int>(msIter.table(), "ANTENNA1")(0);
+    if(antenna == 0 || antenna == 1)
+      nAnt01 += msIter.table().nrow();
+    else
+      nAnt2 += msIter.table().nrow();
+  }
+  AlwaysAssertExit(nAnt01 == 25);
+  AlwaysAssertExit(nAnt2 == 5);
+}
 
 int main (int argc, char* argv[])
 {
@@ -258,6 +325,10 @@ int main (int argc, char* argv[])
     iter2MS(binwidth);
     cout << "########" << endl;
     iter2MSMemory(binwidth);
+    cout << "########" << endl;
+    iterMSGenericSortFuncAlwaysTrue();
+    cout << "########" << endl;
+    iterMSGenericSortFuncAntennaGrouping();
   } catch (std::exception& x) {
     cerr << "Unexpected exception: " << x.what() << endl;
     return 1;

--- a/ms/MeasurementSets/test/tMSIter.out
+++ b/ms/MeasurementSets/test/tMSIter.out
@@ -94,3 +94,8 @@ nrow=1 a1=1 a2=2 time=[270]
 nrow=2 a1=2 a2=2 time=[30, 90]
 nrow=2 a1=2 a2=2 time=[150, 210]
 nrow=1 a1=2 a2=2 time=[270]
+########
+nrow=30
+########
+nrow=25
+nrow=5


### PR DESCRIPTION
A new constructor is created to support giving explicit comparison functions to the table sorting algorithms. This makes MSIter more generic. Eventually the other constructors could be removed if   all the code that uses MSIter (like VisibilityIterator* in CASA) moves to the new API.
Note that this new constructor doesn't support cached SORTED_TABLE, which could be considered legacy by now.

This work is in the context of CAS-8352 to allow the combination of SPW within subchunks.