### PR TITLE
Added aipsrc option table.nolocking

### DIFF
--- a/tables/Tables/TableLock.cc
+++ b/tables/Tables/TableLock.cc
@@ -28,6 +28,7 @@
 
 #include <casacore/tables/Tables/TableLock.h>
 #include <casacore/tables/Tables/TableError.h>
+#include <casacore/casa/System/AipsrcValue.h>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -83,15 +84,21 @@ void TableLock::init()
 #ifdef AIPS_TABLE_NOLOCKING
   itsOption = NoLocking;
 #else
-  if (itsOption == DefaultLocking) {
-    itsOption           = AutoLocking;
-    itsIsDefaultLocking = True;
-  } else if (itsOption == AutoNoReadLocking) {
-    itsOption      = AutoLocking;
-    itsReadLocking = False;
-  } else if (itsOption == UserNoReadLocking) {
-    itsOption      = UserLocking;
-    itsReadLocking = False;
+  Bool opt;
+  AipsrcValue<Bool>::find (opt, "table.nolocking", False);
+  if (opt) {
+    itsOption = NoLocking;
+  } else {
+    if (itsOption == DefaultLocking) {
+      itsOption           = AutoLocking;
+      itsIsDefaultLocking = True;
+    } else if (itsOption == AutoNoReadLocking) {
+      itsOption      = AutoLocking;
+      itsReadLocking = False;
+    } else if (itsOption == UserNoReadLocking) {
+      itsOption      = UserLocking;
+      itsReadLocking = False;
+    }
   }
 #endif
   if (itsOption == NoLocking) {
@@ -126,7 +133,9 @@ Bool TableLock::lockingDisabled()
 #ifdef AIPS_TABLE_NOLOCKING
   return True;
 #else
-  return False;
+  Bool opt;
+  AipsrcValue<Bool>::find (opt, "table.nolocking", False);
+  return opt;
 #endif
 }
 

--- a/tables/Tables/TableLock.h
+++ b/tables/Tables/TableLock.h
@@ -56,6 +56,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <p>
 // It also keeps the <src>LockFile</src> object used to do the
 // actual locking/unlocking.
+//
+// It is possible to disable locking by building casacore with -DAIPS_TABLE_NOLOCKING
+// or by setting the aipsrc variable table.nolocking=true.
 
 // <motivation> 
 // Encapsulate Table locking info.
@@ -72,6 +75,9 @@ public:
     // because table data has to be synchronized (thus written to disk)
     // when a lock is released. Otherwise the other processes see data
     // which is not up-to-date.
+    //
+    // Building Casacore with -DTABLE_NOLOCKING or setting aipsrc variable
+    // table.nolocking=1 forces lock option NoLocking.
     enum LockOption {
 	// The table is permanently locked.
 	// A lock is set at the beginning and only released when
@@ -156,7 +162,7 @@ public:
     // Get the maximum wait period in AutoLocking mode.
     uInt maxWait() const;
 
-    // Is table locking disabled (because AIPS_TABLE_NOLOCKING was set)?
+    // Is table locking disabled (because AIPS_TABLE_NOLOCKING or table.nolocking is set)?
     static Bool lockingDisabled();
 
 

--- a/tables/Tables/test/tTableLock.cc
+++ b/tables/Tables/test/tTableLock.cc
@@ -33,23 +33,19 @@
 // Test program for the TableLock class.
 // </summary>
 
-#ifdef AIPS_TABLE_NOLOCKING
-void checkLockOption (const TableLock& lock, TableLock::LockOption,
-                      Bool, Bool)
-{
-    AlwaysAssertExit (lock.option() == TableLock::NoLocking);
-    AlwaysAssertExit (! lock.readLocking());
-    AlwaysAssertExit (! lock.isPermanent());
-}
-#else
 void checkLockOption (const TableLock& lock, TableLock::LockOption opt,
                       Bool readLock, Bool permLock)
 {
+  if (TableLock::lockingDisabled()) {
+    AlwaysAssertExit (lock.option() == TableLock::NoLocking);
+    AlwaysAssertExit (! lock.readLocking());
+    AlwaysAssertExit (! lock.isPermanent());
+  } else {
     AlwaysAssertExit (lock.option() == opt);
     AlwaysAssertExit (lock.readLocking() == readLock);
     AlwaysAssertExit (lock.isPermanent() == permLock);
+  }
 }
-#endif
 
 int main()
 {


### PR DESCRIPTION
Prebuilt packages such as CASA come with table locking enabled, but sometimes file systems fail on locking. In such cases it is useful to disable table locking by means of an aipsrc variable.
