### PR TITLE
Fixing MacOS Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,6 @@ language: cpp
 cache: ccache
 sudo: false
 
-addons:
-  homebrew:
-    packages:
-    - fftw
-    - hdf5
-    - ccache
-    - boost-python3
-    - cfitsio
-    - wcslib
-    update: true
-
 env:
   global:
     - CCACHE_COMPRESS=1

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -27,6 +27,9 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
 
    ccache -M 80M
 
+   # Newer OSX images don't come with python@2 anymore, so this won't be necessary
+   brew unlink python@2
+
    pip3 install numpy
 
    CXX="ccache $CXX" cmake .. \

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -29,6 +29,8 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
 
    # Newer OSX images don't come with python@2 anymore, so this won't be necessary
    brew unlink python@2
+   # boost-python3 requires python@3.8, let's make *that* the default
+   brew unlink python
 
    pip3 install numpy
 
@@ -39,8 +41,7 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
         -DUSE_HDF5=ON \
         -DBUILD_PYTHON=OFF \
         -DBUILD_PYTHON3=ON \
-        -DPYTHON3_EXECUTABLE=/usr/local/bin/python3 \
-        -DBOOST_PYTHON3_LIBRARY_NAME=python37 \
+        -DPYTHON3_EXECUTABLE=/usr/local/bin/python3.8 \
         -DBoost_NO_BOOST_CMAKE=True \
         -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
         -DDATA_DIR=$PWD \

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -6,6 +6,18 @@ set -e
 set -x
 
 if [ "$TRAVIS_OS_NAME" = osx ]; then
+
+    # Setup homebrew packages
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+    brew install fftw hdf5 ccache boost-python3 cfitsio wcslib
+
+    # Newer OSX images don't come with python@2 anymore, so this won't be necessary
+    brew unlink python@2
+
+    pip3 install numpy
+
     SOFA_ARCHIVE=sofa.tgz
     MEASURES_ARCHIVE=WSRT_Measures.ztar
 
@@ -27,13 +39,6 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
 
    ccache -M 80M
 
-   # Newer OSX images don't come with python@2 anymore, so this won't be necessary
-   brew unlink python@2
-   # boost-python3 requires python@3.8, let's make *that* the default
-   brew unlink python
-
-   pip3 install numpy
-
    CXX="ccache $CXX" cmake .. \
         -DUSE_FFTW3=ON \
         -DBUILD_TESTING=ON \
@@ -41,7 +46,6 @@ if [ "$TRAVIS_OS_NAME" = osx ]; then
         -DUSE_HDF5=ON \
         -DBUILD_PYTHON=OFF \
         -DBUILD_PYTHON3=ON \
-        -DPYTHON3_EXECUTABLE=/usr/local/bin/python3.8 \
         -DBoost_NO_BOOST_CMAKE=True \
         -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
         -DDATA_DIR=$PWD \


### PR DESCRIPTION
This might the cause of cmake not being able to build python3 (i.e., the Headers/ directory is still pointing to python@2's). An alternative would be to pass down the include directory explicitly.

I will be force-pushing into this branch until things work -- so expect a couple of failures.