### PR TITLE
Adjusting tests expectations

### DIFF
--- a/casa/OS/test/tHostInfo.cc
+++ b/casa/OS/test/tHostInfo.cc
@@ -79,10 +79,9 @@ int main()
     AlwaysAssertExit(memory == HostInfo::memoryTotal( )); // make sure no chang
 
     Double now = HostInfo::secondsFrom1970();
-    sleep(5);
+    sleep(1);
     Double diff = HostInfo::secondsFrom1970() - now;
-    // Assume granularity could be as bad as 100ms
-    AlwaysAssertExit(diff >= 4.9 && diff <= 5.1);
+    AlwaysAssertExit(diff >= 0);
 
     // No good way to test hostName, other than using the same library call
     // that hostName is built upon!

--- a/casa/System/test/tObjectID.cc
+++ b/casa/System/test/tObjectID.cc
@@ -39,9 +39,9 @@ void assert_hash(const ObjectID &id)
 {
 	if (!id.isNull()) {
 		// Hash bytes are: seq number, pid, creation time and hostname
-		// All except the first will always have at least one bit set
+		// The sequence number starts at zero, and PIDs can be multiples of 256,
+		// but at least the other two fields will always have a bit set
 		auto hash = hashFunc(id);
-		AlwaysAssertExit(((hash >> 8) & 0xff) != 0);
 		AlwaysAssertExit(((hash >> 16) & 0xff) != 0);
 		AlwaysAssertExit(((hash >> 24) & 0xff) != 0);
 	}


### PR DESCRIPTION
This is a follow-up to the problems found during #1007

In tHostInfo an assertion was being made on the amount of time slept on the system as a way to ensure HostInfo::secondsFrom1970 worked as intended. This combination of sleeping plus checking the time difference was very sensible to how computers sleep, their current workload, etc, and the assertion actually broke in a Travis test under MacOS because the sleep(5) call slept either less than 4.9 or more than 5.1 seconds. A less precise but more correct assertion is simply sleeping for less time and assert that the difference is greater or equal than 0, which should always be true.

On the other hand, in tObjectID the byte in the hash coming from the PID can actually be zero 1/256th of the times when the PID of the process running the test is divisible by 256. We are thus again removing the assertion, which was not always correct to make.