### PR TITLE
Replace incorrect implementation of complex asin/acos with std versions

### DIFF
--- a/casa/BasicSL/Complex.cc
+++ b/casa/BasicSL/Complex.cc
@@ -149,36 +149,16 @@ Complex atan(const Complex &in) {
 		 0.25*std::log((1.0+n+2*imag(in))/(1.0+n-2*imag(in))));
 }
 DComplex asin(const DComplex &in) {
-  const Double n = norm(in);
-  Double a = 0.5*std::sqrt(1.0+n+2*real(in));
-  const Double c = 0.5*std::sqrt(1.0+n-2*real(in));
-  const Double b = a-c;
-  a += c;
-  return DComplex(std::asin(b), std::log(a+std::sqrt(a*a-1.0)));
+  return std::asin(in);
 }
 Complex asin(const Complex &in) {
-  const Float n = norm(in);
-  Float a = 0.5*std::sqrt(1.0+n+2*real(in));
-  const Float c = 0.5*sqrt(1.0+n-2*real(in));
-  const Float b = a-c;
-  a += c;
-  return Complex(std::asin(b), std::log(a+std::sqrt(a*a-1.0)));
+  return std::asin(in);
 }
 DComplex acos(const DComplex &in) {
-  const Double n = norm(in);
-  Double a = 0.5*std::sqrt(1.0+n+2*real(in));
-  const Double c = 0.5*std::sqrt(1.0+n-2*real(in));
-  const Double b = a-c;
-  a += c;
-  return DComplex(std::acos(b), -std::log(a+std::sqrt(a*a-1.0)));
+  return std::acos(in);
 }
 Complex acos(const Complex &in) {
-  const Float n = norm(in);
-  Float a = 0.5*std::sqrt(1.0+n+2*real(in));
-  const Float c = 0.5*std::sqrt(1.0+n-2*real(in));
-  const Float b = a-c;
-  a += c;
-  return Complex(std::acos(b), -std::log(a+std::sqrt(a*a-1.0)));
+  return std::acos(in);
 }
 DComplex atan2(const DComplex &in, const DComplex &t2) {
   if (norm(t2) == 0) return DComplex(C::pi_2);

--- a/casa/BasicSL/test/tComplex.cc
+++ b/casa/BasicSL/test/tComplex.cc
@@ -49,10 +49,23 @@ int main() {
   {
     DComplex z(0.7, -0.3);
     bool fail = false;
+    
     TESTOP(fabs, z, fail);
+    
+    TESTOP(tan, z, fail);
+    TESTOP(sin, z, fail);
+    TESTOP(cos, z, fail);
+    
+    TESTOP(atan, z, fail);
     TESTOP(asin, z, fail);
     TESTOP(acos, z, fail);
-    TESTOP(atan, z, fail);
+    
+    TESTOP(tanh, z, fail);
+    TESTOP(sinh, z, fail);
+    TESTOP(cosh, z, fail);
+    
+    TESTOP(sqrt, z, fail);
+    
     AlwaysAssert(!fail, AipsError);
   }
 

--- a/casa/BasicSL/test/tComplex.cc
+++ b/casa/BasicSL/test/tComplex.cc
@@ -27,6 +27,7 @@
 
 //# Includes
 
+#include <casacore/casa/BasicMath/Math.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/BasicSL/IComplex.h>
 
@@ -37,7 +38,23 @@
 #include <unistd.h>
 
 #include <casacore/casa/namespace.h>
+
+#define TESTOP(NAME, Z, FAILVAR) \
+  if(!near(casacore::NAME(Z), std::NAME(Z), 1e-5)) { \
+      cout << "for z=" << Z << ", casacore::" #NAME "(z)=" << casacore::NAME(Z) << ", std::" #NAME "(z)=" << std::NAME(Z) << '\n'; \
+      FAILVAR = true; \
+    }
+
 int main() {
+  {
+    DComplex z(0.7, -0.3);
+    bool fail = false;
+    TESTOP(fabs, z, fail);
+    TESTOP(asin, z, fail);
+    TESTOP(acos, z, fail);
+    TESTOP(atan, z, fail);
+    AlwaysAssert(!fail, AipsError);
+  }
 
   Complex f1(23.9,1.8), f2(9.2,8.2), f3(2.7,1.8), fo(237.561,0.9312), fi;
   IComplex i1(5,2), i3(Int(f1.real()),Int(f1.imag()));

--- a/casa/BasicSL/test/tComplex.cc
+++ b/casa/BasicSL/test/tComplex.cc
@@ -50,8 +50,6 @@ int main() {
     DComplex z(0.7, -0.3);
     bool fail = false;
     
-    TESTOP(fabs, z, fail);
-    
     TESTOP(tan, z, fail);
     TESTOP(sin, z, fail);
     TESTOP(cos, z, fail);


### PR DESCRIPTION
I noticed that the complex versions of asin and acos in casacore return the wrong sign for the imaginary part. In casacore, these two functions are custom implementations and don't use std::asin/std::acos. The std versions do return the right values.

I wrapped my head a bit around the question whether a flipped sign of asin/acos imaginary return value is really incorrect or not, or whether 'both answers are correct' and I believe it is really wrong: for the complex trig functions, for any input phase, the values have a unique output phase, hence an imaginary sign swap is wrong. Even if that were not the case, cos(acos) and sin(asin) do not return the same value in casacore's implementation, while they do for std's version.

I checked and I don't see any usage of complex asin/acos in casacore. I added a small test set to test whether casacore::asin/acos (as well as atan) return the same values as std::asin/acos, which before the fix reports this:

```
for z=(0.7,-0.3), casacore::asin(z)=(0.708903,0.385591), std::asin(z)=(0.708903,-0.385591)
for z=(0.7,-0.3), casacore::acos(z)=(0.861893,-0.385591), std::acos(z)=(0.861893,0.385591)
terminate called after throwing an instance of 'casacore::AipsError'
  what():  (/home/anoko/projects/casacore-fork/casa/BasicSL/test/tComplex.cc : 56) Failed AlwaysAssert !fail
Aborted
```

This fix removes the incorrect custom implementation and returns the value of std::asin/acos. 