### PR TITLE
Port Adios2StMan to use 64bit row numbers

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -74,19 +74,19 @@ String Adios2StMan::dataManagerName() const
 	return pimpl->dataManagerName();
 }
 
-void Adios2StMan::create(uInt aNrRows)
+void Adios2StMan::create64(rownr_t aNrRows)
 {
-	pimpl->create(aNrRows);
+	pimpl->create64(aNrRows);
 }
 
-void Adios2StMan::open(uInt aRowNr, AipsIO &ios)
+rownr_t Adios2StMan::open64(rownr_t aRowNr, AipsIO &ios)
 {
-	pimpl->open(aRowNr, ios);
+	return pimpl->open64(aRowNr, ios);
 }
 
-void Adios2StMan::resync(uInt aRowNr)
+rownr_t Adios2StMan::resync64(rownr_t aRowNr)
 {
-	pimpl->resync(aRowNr);
+	return pimpl->resync64(aRowNr);
 }
 
 Bool Adios2StMan::flush(AipsIO &ios, Bool doFsync)
@@ -117,9 +117,9 @@ void Adios2StMan::deleteManager()
 	pimpl->deleteManager();
 }
 
-void Adios2StMan::addRow(uInt aNrRows)
+void Adios2StMan::addRow64(rownr_t aNrRows)
 {
-	return pimpl->addRow(aNrRows);
+	return pimpl->addRow64(aNrRows);
 }
 
 DataManager *Adios2StMan::makeObject(
@@ -128,7 +128,7 @@ DataManager *Adios2StMan::makeObject(
 	return impl::makeObject(aDataManType, spec);
 }
 
-uInt Adios2StMan::getNrRows()
+rownr_t Adios2StMan::getNrRows()
 {
 	return pimpl->getNrRows();
 }
@@ -217,7 +217,7 @@ Adios2StMan::impl::~impl()
         itsAdiosEngine->EndStep();
         itsAdiosEngine->Close();
     }
-    for (uInt i=0; i<ncolumn(); ++i) {
+    for (uInt i = 0; i < ncolumn(); ++i) {
       delete itsColumnPtrBlk[i];
     }
 }
@@ -237,12 +237,12 @@ DataManager *Adios2StMan::impl::clone() const
 
 String Adios2StMan::impl::dataManagerType() const { return itsDataManName; }
 
-void Adios2StMan::impl::addRow(uInt aNrRows)
+void Adios2StMan::impl::addRow64(rownr_t aNrRows)
 {
     itsRows += aNrRows;
 }
 
-void Adios2StMan::impl::create(uInt aNrRows)
+void Adios2StMan::impl::create64(rownr_t  aNrRows)
 {
     itsRows = aNrRows;
     itsAdiosEngine = std::make_shared<adios2::Engine>(
@@ -254,7 +254,7 @@ void Adios2StMan::impl::create(uInt aNrRows)
     itsAdiosEngine->BeginStep();
 }
 
-void Adios2StMan::impl::open(uInt aNrRows, AipsIO &ios)
+rownr_t Adios2StMan::impl::open64(rownr_t aNrRows, AipsIO &ios)
 {
     itsRows = aNrRows;
     itsAdiosEngine = std::make_shared<adios2::Engine>(
@@ -270,6 +270,7 @@ void Adios2StMan::impl::open(uInt aNrRows, AipsIO &ios)
     ios >> itsStManColumnType;
     ios.getend();
     itsRows = aNrRows;
+    return itsRows;
 }
 
 void Adios2StMan::impl::deleteManager() {}
@@ -356,7 +357,7 @@ DataManagerColumn *Adios2StMan::impl::makeColumnCommon(const String &name,
             break;
         case TpString:
         case TpArrayString:
-            aColumn = new Adios2StManColumnT<std::string>(this, aDataType, name, itsAdiosIO);
+            aColumn = new Adios2StManColumnString(this, aDataType, name, itsAdiosIO);
             break;
         default:
             throw (DataManInvDT (name));
@@ -365,9 +366,9 @@ DataManagerColumn *Adios2StMan::impl::makeColumnCommon(const String &name,
     return aColumn;
 }
 
-uInt Adios2StMan::impl::getNrRows() { return itsRows; }
+rownr_t Adios2StMan::impl::getNrRows() { return itsRows; }
 
-void Adios2StMan::impl::resync(uInt /*aNrRows*/) {}
+rownr_t Adios2StMan::impl::resync64(rownr_t /*aNrRows*/) { return itsRows; }
 
 Bool Adios2StMan::impl::flush(AipsIO &ios, Bool /*doFsync*/)
 {

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -57,9 +57,9 @@ public:
     virtual DataManager *clone() const;
     virtual String dataManagerType() const;
     virtual String dataManagerName() const;
-    virtual void create(uInt aNrRows);
-    virtual void open(uInt aRowNr, AipsIO &ios);
-    virtual void resync(uInt aRowNr);
+    virtual void create64(rownr_t aNrRows);
+    virtual rownr_t open64(rownr_t aRowNr, AipsIO &ios);
+    virtual rownr_t resync64(rownr_t aRowNr);
     virtual Bool flush(AipsIO &, Bool doFsync);
     virtual DataManagerColumn *makeScalarColumn(const String &aName,
                                                 int aDataType,
@@ -71,10 +71,10 @@ public:
                                                 int aDataType,
                                                 const String &aDataTypeID);
     virtual void deleteManager();
-    virtual void addRow(uInt aNrRows);
+    virtual void addRow64(rownr_t aNrRows);
     static DataManager *makeObject(const String &aDataManType,
                                    const Record &spec);
-    uInt getNrRows();
+    rownr_t getNrRows();
 
 private:
 	 class impl;

--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -35,7 +35,7 @@ Adios2StManColumn::Adios2StManColumn(
         int aDataType,
         String aColName,
         std::shared_ptr<adios2::IO> aAdiosIO)
-    :StManColumn(aDataType),
+    :StManColumnBase(aDataType),
     itsStManPtr(aParent),
     itsColumnName(aColName),
     itsAdiosIO(aAdiosIO)
@@ -62,7 +62,7 @@ void Adios2StManColumn::setShapeColumn(const IPosition &aShape)
     }
 }
 
-IPosition Adios2StManColumn::shape(uInt aRowNr)
+IPosition Adios2StManColumn::shape(rownr_t aRowNr)
 {
     if(isShapeFixed)
     {
@@ -92,21 +92,38 @@ Bool Adios2StManColumn::canChangeShape() const
     return !isShapeFixed;
 }
 
-void Adios2StManColumn::setShape (uInt aRowNr, const IPosition& aShape)
+void Adios2StManColumn::setShape (rownr_t aRowNr, const IPosition& aShape)
 {
     itsCasaShapes[aRowNr] = aShape;
 }
 
-void Adios2StManColumn::scalarVToSelection(uInt rownr)
+void Adios2StManColumn::scalarToSelection(rownr_t rownr)
 {
     itsAdiosStart[0] = rownr;
     itsAdiosCount[0] = 1;
 }
 
-void Adios2StManColumn::arrayVToSelection(uInt rownr)
+void Adios2StManColumn::scalarColumnVToSelection()
+{
+    itsAdiosStart[0] = 0;
+    itsAdiosCount[0] = itsStManPtr->getNrRows();
+}
+
+void Adios2StManColumn::arrayVToSelection(rownr_t rownr)
 {
     itsAdiosStart[0] = rownr;
     itsAdiosCount[0] = 1;
+    for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+    {
+        itsAdiosStart[i] = 0;
+        itsAdiosCount[i] = itsAdiosShape[i];
+    }
+}
+
+void Adios2StManColumn::arrayColumnVToSelection()
+{
+    itsAdiosStart[0] = 0;
+    itsAdiosCount[0] = itsStManPtr->getNrRows();
     for (size_t i = 1; i < itsAdiosShape.size(); ++i)
     {
         itsAdiosStart[i] = 0;
@@ -132,7 +149,7 @@ void Adios2StManColumn::scalarColumnCellsVToSelection(const RefRows &rows)
     }
 }
 
-void Adios2StManColumn::sliceVToSelection(uInt rownr, const Slicer &ns)
+void Adios2StManColumn::sliceVToSelection(rownr_t rownr, const Slicer &ns)
 {
     columnSliceCellsVToSelection(rownr, 1, ns);
 }
@@ -154,7 +171,7 @@ void Adios2StManColumn::columnSliceCellsVToSelection(const RefRows &rows, const 
     columnSliceCellsVToSelection(row_start, row_end - row_start + 1, ns);
 }
 
-void Adios2StManColumn::columnSliceCellsVToSelection(uInt row_start, uInt row_count, const Slicer &ns)
+void Adios2StManColumn::columnSliceCellsVToSelection(rownr_t row_start, rownr_t row_count, const Slicer &ns)
 {
     itsAdiosStart[0] = row_start;
     itsAdiosCount[0] = row_count;
@@ -165,43 +182,160 @@ void Adios2StManColumn::columnSliceCellsVToSelection(uInt row_start, uInt row_co
     }
 }
 
-#define DEFINE_GETPUT_TYPE_V(T) \
-void Adios2StManColumn::put ## T ## V(uInt rownr, const T *dataPtr) \
-{ \
-    putScalarV(rownr, dataPtr); \
-} \
-\
-void Adios2StManColumn::get ## T ## V(uInt rownr, T *dataPtr) \
-{ \
-    getScalarV(rownr, dataPtr); \
+void Adios2StManColumn::putArrayV(rownr_t rownr, const ArrayBase& data)
+{
+    arrayVToSelection(rownr);
+    toAdios(&data);
 }
 
-#define DEFINE_GETPUT_SCALAR_COLUMN_CELLS_V(T) \
-void Adios2StManColumn::getScalarColumnCells ## T ## V(const RefRows& rownrs, Vector<T>* dataPtr) \
-{ \
-    getScalarColumnCellsV(rownrs, dataPtr); \
-} \
-\
-void Adios2StManColumn::putScalarColumnCells ## T ## V(const RefRows& rownrs, const Vector<T>* dataPtr) \
-{ \
-    putScalarColumnCellsV(rownrs, dataPtr); \
+void Adios2StManColumn::getArrayV(rownr_t rownr, ArrayBase& data)
+{
+    arrayVToSelection(rownr);
+    fromAdios(&data);
 }
 
-#define DEFINE_GETPUT_SLICE_TYPE_V(T) \
-void Adios2StManColumn::putSlice ## T ## V(uInt rownr, const Slicer& ns, const Array<T>* dataPtr) \
-{ \
-    putSliceV(rownr, ns, dataPtr); \
-}\
-\
-void Adios2StManColumn::getSlice ## T ## V(uInt rownr, const Slicer& ns, Array<T>* dataPtr) \
-{ \
-    getSliceV(rownr, ns, dataPtr); \
+void Adios2StManColumn::putScalar(rownr_t rownr, const void *dataPtr)
+{
+    scalarToSelection(rownr);
+    toAdios(dataPtr);
 }
+
+void Adios2StManColumn::getScalar(rownr_t rownr, void *data)
+{
+    scalarToSelection(rownr);
+    fromAdios(data);
+}
+
+void Adios2StManColumn::putScalarColumnV(const ArrayBase &data)
+{
+    scalarColumnVToSelection();
+    toAdios(&data);
+}
+
+void Adios2StManColumn::getScalarColumnV(ArrayBase &data)
+{
+    scalarColumnVToSelection();
+    fromAdios(&data);
+}
+
+void Adios2StManColumn::getScalarColumnCellsV(const RefRows &rownrs, ArrayBase& data)
+{
+    scalarColumnCellsVToSelection(rownrs);
+    fromAdios(&data);
+}
+
+void Adios2StManColumn::putScalarColumnCellsV(const RefRows &rownrs, const ArrayBase& data)
+{
+    scalarColumnCellsVToSelection(rownrs);
+    toAdios(&data);
+}
+
+void Adios2StManColumn::putArrayColumnCellsV (const RefRows& rownrs, const ArrayBase& data)
+{
+    if(rownrs.isSliced())
+    {
+        rownrs.convert();
+    }
+    Bool deleteIt;
+    const void *dataPtr = data.getVStorage(deleteIt);
+    itsAdiosCount[0] = 1;
+    for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+    {
+        itsAdiosStart[i] = 0;
+        itsAdiosCount[i] = itsAdiosShape[i];
+    }
+    for(uInt i = 0; i < rownrs.rowVector().size(); ++i)
+    {
+        itsAdiosStart[0] = rownrs.rowVector()[i];
+        toAdios(dataPtr, i * itsCasaShape.nelements());
+    }
+    data.freeVStorage(dataPtr, deleteIt);
+}
+
+void Adios2StManColumn::getArrayColumnCellsV (const RefRows& rownrs, ArrayBase &data)
+{
+    if(rownrs.isSliced())
+    {
+        rownrs.convert();
+    }
+    Bool deleteIt;
+    void *dataPtr = data.getVStorage(deleteIt);
+    itsAdiosCount[0] = 1;
+    for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+    {
+        itsAdiosStart[i] = 0;
+        itsAdiosCount[i] = itsAdiosShape[i];
+    }
+    for(uInt i = 0; i < rownrs.rowVector().size(); ++i)
+    {
+        itsAdiosStart[0] = rownrs.rowVector()[i];
+        fromAdios(dataPtr, i * itsCasaShape.nelements());
+    }
+    data.putVStorage(dataPtr, deleteIt);
+}
+
+void Adios2StManColumn::getSliceV(rownr_t aRowNr, const Slicer &ns, ArrayBase& data)
+{
+    sliceVToSelection(aRowNr, ns);
+    fromAdios(&data);
+}
+
+void Adios2StManColumn::putSliceV(rownr_t aRowNr, const Slicer &ns, const ArrayBase& data)
+{
+    sliceVToSelection(aRowNr, ns);
+    toAdios(&data);
+}
+
+void Adios2StManColumn::getArrayColumnV(ArrayBase& data)
+{
+    arrayColumnVToSelection();
+    fromAdios(&data);
+}
+
+void Adios2StManColumn::putArrayColumnV(const ArrayBase& data)
+{
+	arrayColumnVToSelection();
+    toAdios(&data);
+}
+
+void Adios2StManColumn::putColumnSliceV(const Slicer &ns, const ArrayBase& data)
+{
+    columnSliceVToSelection(ns);
+    toAdios(&data);
+}
+
+void Adios2StManColumn::getColumnSliceV(const Slicer &ns, ArrayBase& data)
+{
+    columnSliceVToSelection(ns);
+    fromAdios(&data);
+}
+
+void Adios2StManColumn::getColumnSliceCellsV(const RefRows& rownrs,
+                                  const Slicer& slicer, ArrayBase& data)
+{
+    columnSliceCellsVToSelection(rownrs, slicer);
+    fromAdios(&data);
+}
+
+void Adios2StManColumn::putColumnSliceCellsV(const RefRows& rownrs,
+                                   const Slicer& slicer, const ArrayBase& data)
+{
+    columnSliceCellsVToSelection(rownrs, slicer);
+    toAdios(&data);
+}
+
 
 #define DEFINE_GETPUT(T) \
-DEFINE_GETPUT_TYPE_V(T) \
-DEFINE_GETPUT_SCALAR_COLUMN_CELLS_V(T) \
-DEFINE_GETPUT_SLICE_TYPE_V(T)
+void Adios2StManColumn::put ## T(rownr_t rownr, const T *dataPtr) \
+{ \
+    putScalar(rownr, dataPtr); \
+} \
+\
+void Adios2StManColumn::get ## T(rownr_t rownr, T *dataPtr) \
+{ \
+    getScalar(rownr, dataPtr); \
+}
+
 
 DEFINE_GETPUT(Bool)
 DEFINE_GETPUT(uChar)
@@ -213,13 +347,8 @@ DEFINE_GETPUT(float)
 DEFINE_GETPUT(double)
 DEFINE_GETPUT(Complex)
 DEFINE_GETPUT(DComplex)
-DEFINE_GETPUT_TYPE_V(Int64)
-DEFINE_GETPUT_SLICE_TYPE_V(String)
-DEFINE_GETPUT_SCALAR_COLUMN_CELLS_V(Int64)
+DEFINE_GETPUT(Int64)
 #undef DEFINE_GETPUT
-#undef DEFINE_GETPUT_TYPE_V
-#undef DEFINE_GETPUT_SCALAR_COLUMN_CELLS_V
-#undef DEFINE_GETPUT_SLICE_TYPE_V
 
 
 // string
@@ -230,7 +359,7 @@ void Adios2StManColumnT<std::string>::create(std::shared_ptr<adios2::Engine> aAd
     itsAdiosEngine = aAdiosEngine;
 }
 
-void Adios2StManColumn::putStringV(uInt rownr, const String *dataPtr)
+void Adios2StManColumn::putString(rownr_t rownr, const String *dataPtr)
 {
     std::string variableName = static_cast<std::string>(itsColumnName) + std::to_string(rownr);
     adios2::Variable<std::string> v = itsAdiosIO->InquireVariable<std::string>(variableName);
@@ -241,7 +370,7 @@ void Adios2StManColumn::putStringV(uInt rownr, const String *dataPtr)
     itsAdiosEngine->Put(v, reinterpret_cast<const std::string *>(dataPtr), adios2::Mode::Sync);
 }
 
-void Adios2StManColumn::getStringV(uInt rownr, String *dataPtr)
+void Adios2StManColumn::getString(rownr_t rownr, String *dataPtr)
 {
     std::string variableName = static_cast<std::string>(itsColumnName) + std::to_string(rownr);
     adios2::Variable<std::string> v = itsAdiosIO->InquireVariable<std::string>(variableName);
@@ -251,29 +380,29 @@ void Adios2StManColumn::getStringV(uInt rownr, String *dataPtr)
     }
 }
 
-template<>
-void Adios2StManColumnT<std::string>::putArrayV(uInt rownr, const void *dataPtr)
+void Adios2StManColumnString::putArrayV(rownr_t rownr, const ArrayBase& data)
 {
     String combined;
     Bool deleteIt;
-    const String *data = (reinterpret_cast<const Array<String> *>(dataPtr))->getStorage(deleteIt);
-    for(auto &i : *(reinterpret_cast<const Array<String> *>(dataPtr)))
+    auto *arrayPtr = reinterpret_cast<const Array<String> *>(&data);
+    const String *dataPtr = arrayPtr->getStorage(deleteIt);
+    for(auto &i : *arrayPtr)
     {
         combined = combined + i + itsStringArrayBarrier;
     }
-    (reinterpret_cast<const Array<String> *>(dataPtr))->freeStorage(reinterpret_cast<const String *&>(data), deleteIt);
-    putStringV(rownr, &combined);
+    arrayPtr->freeStorage(dataPtr, deleteIt);
+    putString(rownr, &combined);
 }
 
-template<>
-void Adios2StManColumnT<std::string>::getArrayV(uInt rownr, void *dataPtr)
+void Adios2StManColumnString::getArrayV(rownr_t rownr, ArrayBase& data)
 {
     String combined;
-    getStringV(rownr, &combined);
+    getString(rownr, &combined);
     Bool deleteIt;
-    String *data = (reinterpret_cast<Array<String>*>(dataPtr))->getStorage(deleteIt);
+    auto *arrayPtr = reinterpret_cast<Array<String> *>(&data);
+    String *dataPtr = arrayPtr->getStorage(deleteIt);
     size_t pos = 0;
-    for(auto &i : *(reinterpret_cast<Array<String> *>(dataPtr)))
+    for(auto &i : *arrayPtr)
     {
         size_t found = combined.find(itsStringArrayBarrier, pos);
         if(found != std::string::npos)
@@ -282,41 +411,35 @@ void Adios2StManColumnT<std::string>::getArrayV(uInt rownr, void *dataPtr)
             pos = found + itsStringArrayBarrier.length();
         }
     }
-    reinterpret_cast<Array<String>*>(dataPtr)->putStorage(reinterpret_cast<String *&>(data), deleteIt);
+    arrayPtr->putStorage(dataPtr, deleteIt);
 }
 
-template<>
-void Adios2StManColumnT<std::string>::getSliceV(uInt /*aRowNr*/, const Slicer &/*ns*/, void */*dataPtr*/)
+void Adios2StManColumnString::getSliceV(rownr_t /*aRowNr*/, const Slicer &/*ns*/, ArrayBase &/*data*/)
 {
     throw std::runtime_error("Not implemented yet");
 }
 
-template<>
-void Adios2StManColumnT<std::string>::putSliceV(uInt /*aRowNr*/, const Slicer &/*ns*/, const void */*dataPtr*/)
+void Adios2StManColumnString::putSliceV(rownr_t /*aRowNr*/, const Slicer &/*ns*/, const ArrayBase &/*data*/)
 {
     throw std::runtime_error("Not implemented yet");
 }
 
-template<>
-void Adios2StManColumnT<std::string>::getColumnSliceV(const Slicer &/*ns*/, void */*dataPtr*/)
+void Adios2StManColumnString::getColumnSliceV(const Slicer &/*ns*/, ArrayBase &/*data*/)
 {
     throw std::runtime_error("Not implemented yet");
 }
 
-template<>
-void Adios2StManColumnT<std::string>::putColumnSliceV(const Slicer &/*ns*/, const void */*dataPtr*/)
+void Adios2StManColumnString::putColumnSliceV(const Slicer &/*ns*/, const ArrayBase &/*data*/)
 {
     throw std::runtime_error("Not implemented yet");
 }
 
-template<>
-void Adios2StManColumnT<std::string>::getColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, void* /*dataPtr*/)
+void Adios2StManColumnString::getColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, ArrayBase& /*data*/)
 {
     throw std::runtime_error("Not implemented yet");
 }
 
-template<>
-void Adios2StManColumnT<std::string>::putColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, const void* /*dataPtr*/)
+void Adios2StManColumnString::putColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, const ArrayBase& /*data*/)
 {
     throw std::runtime_error("Not implemented yet");
 }

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -30,7 +30,7 @@
 
 #include <unordered_map>
 #include <casacore/casa/Arrays/Array.h>
-#include <casacore/tables/DataMan/StManColumn.h>
+#include <casacore/tables/DataMan/StManColumnBase.h>
 #include <casacore/tables/Tables/RefRows.h>
 
 #include "Adios2StManImpl.h"
@@ -39,125 +39,109 @@
 namespace casacore
 {
 
-class Adios2StManColumn : public StManColumn
+class Adios2StManColumn : public StManColumnBase
 {
 public:
     Adios2StManColumn(Adios2StMan::impl *aParent, int aDataType, String aColName, std::shared_ptr<adios2::IO> aAdiosIO);
 
-    virtual Bool canAccessSlice (Bool& reask) const { reask = false; return true; };
-    virtual Bool canAccessColumnSlice (Bool& reask) const { reask = false; return true; };
-
     virtual void create(std::shared_ptr<adios2::Engine> aAdiosEngine,
                         char aOpenMode) = 0;
-    virtual void setShapeColumn(const IPosition &aShape);
-    virtual IPosition shape(uInt aRowNr);
-    Bool canChangeShape() const;
-    void setShape (uInt aRowNr, const IPosition& aShape);
+    virtual void setShapeColumn(const IPosition &aShape) override;
+    virtual IPosition shape(rownr_t aRowNr) override;
+    Bool canChangeShape() const override;
+    void setShape (rownr_t aRowNr, const IPosition& aShape) override;
 
     int getDataTypeSize();
     int getDataType();
     String getColumnName();
 
-    virtual void putScalarV(uInt aRowNr, const void *aDataPtr) = 0;
-    virtual void getScalarV(uInt aRowNr, void *aDataPtr) = 0;
-    virtual void getScalarColumnCellsV(const RefRows &rownrs, void *dataPtr) = 0;
-    virtual void putScalarColumnCellsV(const RefRows &rownrs, const void *dataPtr) = 0;
+protected:
 
-    virtual void putBoolV(uInt aRowNr, const Bool *aDataPtr);
-    virtual void putuCharV(uInt aRowNr, const uChar *aDataPtr);
-    virtual void putShortV(uInt aRowNr, const Short *aDataPtr);
-    virtual void putuShortV(uInt aRowNr, const uShort *aDataPtr);
-    virtual void putIntV(uInt aRowNr, const Int *aDataPtr);
-    virtual void putuIntV(uInt aRowNr, const uInt *aDataPtr);
-    virtual void putInt64V(uInt aRowNr, const Int64 *aDataPtr);
-    virtual void putfloatV(uInt aRowNr, const Float *aDataPtr);
-    virtual void putdoubleV(uInt aRowNr, const Double *aDataPtr);
-    virtual void putComplexV(uInt aRowNr, const Complex *aDataPtr);
-    virtual void putDComplexV(uInt aRowNr, const DComplex *aDataPtr);
-    virtual void putStringV(uInt aRowNr, const String *aDataPtr);
+    // scalar get/put
+    virtual void getBool(rownr_t aRowNr, Bool *aDataPtr) override;
+    virtual void getuChar(rownr_t aRowNr, uChar *aDataPtr) override;
+    virtual void getShort(rownr_t aRowNr, Short *aDataPtr) override;
+    virtual void getuShort(rownr_t aRowNr, uShort *aDataPtr) override;
+    virtual void getInt(rownr_t aRowNr, Int *aDataPtr) override;
+    virtual void getuInt(rownr_t aRowNr, uInt *aDataPtr) override;
+    virtual void getInt64(rownr_t aRowNr, Int64 *aDataPtr) override;
+    virtual void getfloat(rownr_t aRowNr, Float *aDataPtr) override;
+    virtual void getdouble(rownr_t aRowNr, Double *aDataPtr) override;
+    virtual void getComplex(rownr_t aRowNr, Complex *aDataPtr) override;
+    virtual void getDComplex(rownr_t aRowNr, DComplex *aDataPtr) override;
+    virtual void getString(rownr_t aRowNr, String *aDataPtr) override;
 
-    virtual void getBoolV(uInt aRowNr, Bool *aDataPtr);
-    virtual void getuCharV(uInt aRowNr, uChar *aDataPtr);
-    virtual void getShortV(uInt aRowNr, Short *aDataPtr);
-    virtual void getuShortV(uInt aRowNr, uShort *aDataPtr);
-    virtual void getIntV(uInt aRowNr, Int *aDataPtr);
-    virtual void getuIntV(uInt aRowNr, uInt *aDataPtr);
-    virtual void getInt64V(uInt aRowNr, Int64 *aDataPtr);
-    virtual void getfloatV(uInt aRowNr, Float *aDataPtr);
-    virtual void getdoubleV(uInt aRowNr, Double *aDataPtr);
-    virtual void getComplexV(uInt aRowNr, Complex *aDataPtr);
-    virtual void getDComplexV(uInt aRowNr, DComplex *aDataPtr);
-    virtual void getStringV(uInt aRowNr, String *aDataPtr);
+    virtual void putBool(rownr_t aRowNr, const Bool *aDataPtr) override;
+    virtual void putuChar(rownr_t aRowNr, const uChar *aDataPtr) override;
+    virtual void putShort(rownr_t aRowNr, const Short *aDataPtr) override;
+    virtual void putuShort(rownr_t aRowNr, const uShort *aDataPtr) override;
+    virtual void putInt(rownr_t aRowNr, const Int *aDataPtr) override;
+    virtual void putuInt(rownr_t aRowNr, const uInt *aDataPtr) override;
+    virtual void putInt64(rownr_t aRowNr, const Int64 *aDataPtr) override;
+    virtual void putfloat(rownr_t aRowNr, const Float *aDataPtr) override;
+    virtual void putdouble(rownr_t aRowNr, const Double *aDataPtr) override;
+    virtual void putComplex(rownr_t aRowNr, const Complex *aDataPtr) override;
+    virtual void putDComplex(rownr_t aRowNr, const DComplex *aDataPtr) override;
+    virtual void putString(rownr_t aRowNr, const String *aDataPtr) override;
 
-    virtual void getScalarColumnCellsBoolV(const RefRows& rownrs, Vector<Bool>* dataPtr);
-    virtual void getScalarColumnCellsuCharV(const RefRows& rownrs, Vector<uChar>* dataPtr);
-    virtual void getScalarColumnCellsShortV(const RefRows& rownrs, Vector<Short>* dataPtr);
-    virtual void getScalarColumnCellsuShortV(const RefRows& rownrs, Vector<uShort>* dataPtr);
-    virtual void getScalarColumnCellsIntV(const RefRows& rownrs, Vector<Int>* dataPtr);
-    virtual void getScalarColumnCellsuIntV(const RefRows& rownrs, Vector<uInt>* dataPtr);
-    virtual void getScalarColumnCellsInt64V(const RefRows& rownrs, Vector<Int64>* dataPtr);
-    virtual void getScalarColumnCellsfloatV(const RefRows& rownrs, Vector<float>* dataPtr);
-    virtual void getScalarColumnCellsdoubleV(const RefRows& rownrs, Vector<double>* dataPtr);
-    virtual void getScalarColumnCellsComplexV(const RefRows& rownrs, Vector<Complex>* dataPtr);
-    virtual void getScalarColumnCellsDComplexV(const RefRows& rownrs, Vector<DComplex>* dataPtr);
+    // The rest of the get and put functions
+    virtual void getScalarColumnV (ArrayBase& dataPtr) override;
+    virtual void putScalarColumnV (const ArrayBase& dataPtr) override;
+    virtual void getScalarColumnCellsV (const RefRows& rownrs,
+                        ArrayBase& dataPtr) override;
+    virtual void putScalarColumnCellsV (const RefRows& rownrs,
+                        const ArrayBase& dataPtr) override;
+    virtual void getArrayV (rownr_t rownr, ArrayBase& dataPtr) override;
+    virtual void putArrayV (rownr_t rownr, const ArrayBase& data) override;
+    virtual void getArrayColumnV (ArrayBase& data) override;
+    virtual void putArrayColumnV (const ArrayBase& data) override;
+    virtual void getArrayColumnCellsV (const RefRows& rownrs,
+                    ArrayBase& data) override;
+    virtual void putArrayColumnCellsV (const RefRows& rownrs,
+                       const ArrayBase& data) override;
+    virtual void getSliceV (rownr_t rownr, const Slicer& slicer, ArrayBase& data) override;
+    virtual void putSliceV (rownr_t rownr, const Slicer& slicer,
+                       const ArrayBase& data) override;
+    virtual void getColumnSliceV (const Slicer& slicer, ArrayBase& data) override;
+    virtual void putColumnSliceV (const Slicer& slicer, const ArrayBase& data) override;
+    virtual void getColumnSliceCellsV (const RefRows& rownrs,
+                       const Slicer& slicer, ArrayBase& data) override;
+    virtual void putColumnSliceCellsV (const RefRows& rownrs,
+                       const Slicer& slicer,
+                       const ArrayBase& data) override;
 
-    virtual void putScalarColumnCellsBoolV(const RefRows& rownrs, const Vector<Bool>* dataPtr);
-    virtual void putScalarColumnCellsuCharV(const RefRows& rownrs, const Vector<uChar>* dataPtr);
-    virtual void putScalarColumnCellsShortV(const RefRows& rownrs, const Vector<Short>* dataPtr);
-    virtual void putScalarColumnCellsuShortV(const RefRows& rownrs, const Vector<uShort>* dataPtr);
-    virtual void putScalarColumnCellsIntV(const RefRows& rownrs, const Vector<Int>* dataPtr);
-    virtual void putScalarColumnCellsuIntV(const RefRows& rownrs, const Vector<uInt>* dataPtr);
-    virtual void putScalarColumnCellsInt64V(const RefRows& rownrs, const Vector<Int64>* dataPtr);
-    virtual void putScalarColumnCellsfloatV(const RefRows& rownrs, const Vector<float>* dataPtr);
-    virtual void putScalarColumnCellsdoubleV(const RefRows& rownrs, const Vector<double>* dataPtr);
-    virtual void putScalarColumnCellsComplexV(const RefRows& rownrs, const Vector<Complex>* dataPtr);
-    virtual void putScalarColumnCellsDComplexV(const RefRows& rownrs, const Vector<DComplex>* dataPtr);
 
-    virtual void putSliceBoolV(uInt rownr, const Slicer& ns, const Array<Bool>* dataPtr);
-    virtual void putSliceuCharV(uInt rownr, const Slicer& ns, const Array<uChar>* dataPtr);
-    virtual void putSliceShortV(uInt rownr, const Slicer& ns, const Array<Short>* dataPtr);
-    virtual void putSliceuShortV(uInt rownr, const Slicer& ns, const Array<uShort>* dataPtr);
-    virtual void putSliceIntV(uInt rownr, const Slicer& ns, const Array<Int>* dataPtr);
-    virtual void putSliceuIntV(uInt rownr, const Slicer& ns, const Array<uInt>* dataPtr);
-    virtual void putSlicefloatV(uInt rownr, const Slicer& ns, const Array<float>* dataPtr);
-    virtual void putSlicedoubleV(uInt rownr, const Slicer& ns, const Array<double>* dataPtr);
-    virtual void putSliceComplexV(uInt rownr, const Slicer& ns, const Array<Complex>* dataPtr);
-    virtual void putSliceDComplexV(uInt rownr, const Slicer& ns, const Array<DComplex>* dataPtr);
-    virtual void putSliceStringV(uInt rownr, const Slicer& ns, const Array<String>* dataPtr);
-
-    virtual void getSliceBoolV(uInt rownr, const Slicer& ns, Array<Bool>* dataPtr);
-    virtual void getSliceuCharV(uInt rownr, const Slicer& ns, Array<uChar>* dataPtr);
-    virtual void getSliceShortV(uInt rownr, const Slicer& ns, Array<Short>* dataPtr);
-    virtual void getSliceuShortV(uInt rownr, const Slicer& ns, Array<uShort>* dataPtr);
-    virtual void getSliceIntV(uInt rownr, const Slicer& ns, Array<Int>* dataPtr);
-    virtual void getSliceuIntV(uInt rownr, const Slicer& ns, Array<uInt>* dataPtr);
-    virtual void getSlicefloatV(uInt rownr, const Slicer& ns, Array<float>* dataPtr);
-    virtual void getSlicedoubleV(uInt rownr, const Slicer& ns, Array<double>* dataPtr);
-    virtual void getSliceComplexV(uInt rownr, const Slicer& ns, Array<Complex>* dataPtr);
-    virtual void getSliceDComplexV(uInt rownr, const Slicer& ns, Array<DComplex>* dataPtr);
-    virtual void getSliceStringV(uInt rownr, const Slicer& ns, Array<String>* dataPtr);
+private:
+    void putScalar(rownr_t rownr, const void *dataPtr);
+    void getScalar(rownr_t rownr, void *dataPtr);
+    virtual void toAdios(const ArrayBase *arrayPtr) = 0;
+    virtual void fromAdios(ArrayBase *arrayPtr) = 0;
+    virtual void toAdios(const void *dataPtr, std::size_t offset=0) = 0;
+    virtual void fromAdios(void *dataPtr, std::size_t offset=0) = 0;
 
 
 protected:
-    void scalarVToSelection(uInt rownr);
-    void arrayVToSelection(uInt rownr);
+    void scalarToSelection(rownr_t rownr);
+    void scalarColumnVToSelection();
     void scalarColumnCellsVToSelection(const RefRows &rownrs);
-    void sliceVToSelection(uInt rownr, const Slicer &ns);
+    void arrayVToSelection(rownr_t rownr);
+    void arrayColumnVToSelection();
+    void sliceVToSelection(rownr_t rownr, const Slicer &ns);
     void columnSliceVToSelection(const Slicer &ns);
     void columnSliceCellsVToSelection(const RefRows &rows, const Slicer &ns);
-    void columnSliceCellsVToSelection(uInt row_start, uInt row_end, const Slicer &ns);
+    void columnSliceCellsVToSelection(rownr_t row_start, rownr_t row_end, const Slicer &ns);
 
     Adios2StMan::impl *itsStManPtr;
 
     String itsColumnName;
     IPosition itsCasaShape;
-    std::unordered_map<uInt, IPosition> itsCasaShapes;
+    std::unordered_map<rownr_t, IPosition> itsCasaShapes;
     Bool isShapeFixed = false;
 
     std::shared_ptr<adios2::IO> itsAdiosIO;
     std::shared_ptr<adios2::Engine> itsAdiosEngine;
     std::string itsAdiosDataType;
-    adios2::Dims itsAdiosShape = {std::numeric_limits<uInt>::max()};
+    adios2::Dims itsAdiosShape = {std::numeric_limits<rownr_t>::max()};
     adios2::Dims itsAdiosStart = {0};
     adios2::Dims itsAdiosCount = {1};
 }; // class Adios2StManColumn
@@ -168,14 +152,7 @@ class Adios2StManColumnT : public Adios2StManColumn
 {
 public:
 
-    Adios2StManColumnT(
-            Adios2StMan::impl *aParent,
-            int aDataType,
-            String aColName,
-            std::shared_ptr<adios2::IO> aAdiosIO)
-    : Adios2StManColumn(aParent, aDataType, aColName, aAdiosIO)
-    {
-    }
+    using Adios2StManColumn::Adios2StManColumn;
 
     void create(std::shared_ptr<adios2::Engine> aAdiosEngine, char aOpenMode)
     {
@@ -191,179 +168,59 @@ public:
         }
     }
 
-    virtual void putArrayV(uInt rownr, const void *dataPtr)
-    {
-        arrayVToSelection(rownr);
-        toAdios(dataPtr);
-    }
-
-    virtual void getArrayV(uInt rownr, void *dataPtr)
-    {
-        arrayVToSelection(rownr);
-        fromAdios(dataPtr);
-    }
-
-    virtual void putScalarV(uInt rownr, const void *dataPtr)
-    {
-        scalarVToSelection(rownr);
-        toAdios(reinterpret_cast<const T *>(dataPtr));
-    }
-
-    virtual void getScalarV(uInt aRowNr, void *data)
-    {
-        scalarVToSelection(aRowNr);
-        fromAdios(reinterpret_cast<T *>(data));
-    }
-
-    virtual void getScalarColumnCellsV(const RefRows &rownrs, void *dataPtr)
-    {
-        scalarColumnCellsVToSelection(rownrs);
-        fromAdios(dataPtr);
-    }
-
-    virtual void putScalarColumnCellsV(const RefRows &rownrs, const void *dataPtr)
-    {
-        scalarColumnCellsVToSelection(rownrs);
-        toAdios(dataPtr);
-    }
-
-    virtual void putArrayColumnCellsV (const RefRows& rownrs, const void* dataPtr)
-    {
-        if(rownrs.isSliced())
-        {
-            rownrs.convert();
-        }
-        Bool deleteIt;
-        auto *arrayPtr = asArrayPtr(dataPtr);
-        const T *data = arrayPtr->getStorage(deleteIt);
-        itsAdiosCount[0] = 1;
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = 0;
-            itsAdiosCount[i] = itsAdiosShape[i];
-        }
-        for(uInt i = 0; i < rownrs.rowVector().size(); ++i)
-        {
-            itsAdiosStart[0] = rownrs.rowVector()[i];
-            toAdios(data + i * itsCasaShape.nelements());
-        }
-        arrayPtr->freeStorage(data, deleteIt);
-    }
-
-    virtual void getArrayColumnCellsV (const RefRows& rownrs, void* dataPtr)
-    {
-        if(rownrs.isSliced())
-        {
-            rownrs.convert();
-        }
-        Bool deleteIt;
-        auto *arrayPtr = asArrayPtr(dataPtr);
-        T *data = arrayPtr->getStorage(deleteIt);
-        itsAdiosCount[0] = 1;
-        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
-        {
-            itsAdiosStart[i] = 0;
-            itsAdiosCount[i] = itsAdiosShape[i];
-        }
-        for(uInt i = 0; i < rownrs.rowVector().size(); ++i)
-        {
-            itsAdiosStart[0] = rownrs.rowVector()[i];
-            fromAdios(data + i * itsCasaShape.nelements());
-        }
-        arrayPtr->putStorage(data, deleteIt);
-    }
-
-    virtual void getSliceV(uInt aRowNr, const Slicer &ns, void *dataPtr)
-    {
-        sliceVToSelection(aRowNr, ns);
-        fromAdios(dataPtr);
-    }
-
-    virtual void putSliceV(uInt aRowNr, const Slicer &ns, const void *dataPtr)
-    {
-        sliceVToSelection(aRowNr, ns);
-        toAdios(dataPtr);
-    }
-
-    virtual void getArrayColumnV(void *dataPtr)
-    {
-        for(auto &i:itsAdiosStart){
-            i=0;
-        }
-        fromAdios(dataPtr);
-    }
-
-    virtual void putColumnSliceV(const Slicer &ns, const void *dataPtr)
-    {
-        columnSliceVToSelection(ns);
-        toAdios(dataPtr);
-    }
-
-    virtual void getColumnSliceV(const Slicer &ns, void *dataPtr)
-    {
-        columnSliceVToSelection(ns);
-        fromAdios(dataPtr);
-    }
-
-    virtual void getColumnSliceCellsV(const RefRows& rownrs,
-                                      const Slicer& slicer, void* dataPtr)
-    {
-        columnSliceCellsVToSelection(rownrs, slicer);
-        fromAdios(dataPtr);
-    }
-
-    virtual void putColumnSliceCellsV (const RefRows& rownrs,
-                                       const Slicer& slicer, const void* dataPtr)
-    {
-        columnSliceCellsVToSelection(rownrs, slicer);
-        toAdios(dataPtr);
-    }
-
 private:
     adios2::Variable<T> itsAdiosVariable;
-    const String itsStringArrayBarrier = "ADIOS2BARRIER";
 
-    Array<T> *asArrayPtr(void *dataPtr) const
+    void toAdios(const void *data, std::size_t offset)
     {
-        return reinterpret_cast<Array<T>*>(dataPtr);
-    }
-
-    const Array<T> *asArrayPtr(const void *dataPtr) const
-    {
-        return reinterpret_cast<const Array<T>*>(dataPtr);
-    }
-
-    void toAdios(const T *data)
-    {
+        const T *tData = static_cast<const T *>(data);
         itsAdiosVariable.SetSelection({itsAdiosStart, itsAdiosCount});
-        itsAdiosEngine->Put<T>(itsAdiosVariable, data, adios2::Mode::Sync);
+        itsAdiosEngine->Put<T>(itsAdiosVariable, tData + offset, adios2::Mode::Sync);
     }
 
-    void fromAdios(T *data)
+    void fromAdios(void *data, std::size_t offset)
     {
+        T *tData = static_cast<T *>(data);
         itsAdiosVariable.SetSelection({itsAdiosStart, itsAdiosCount});
-        itsAdiosEngine->Get<T>(itsAdiosVariable, data, adios2::Mode::Sync);
+        itsAdiosEngine->Get<T>(itsAdiosVariable, tData + offset, adios2::Mode::Sync);
     }
 
-    void toAdios(const void *dataPtr)
+    void toAdios(const ArrayBase *arrayPtr)
     {
         Bool deleteIt;
-        auto *arrayPtr = asArrayPtr(dataPtr);
-        const T *data = arrayPtr->getStorage(deleteIt);
-        toAdios(data);
-        arrayPtr->freeStorage (data, deleteIt);
+        const void *data = arrayPtr->getVStorage(deleteIt);
+        toAdios(data, 0);
+        arrayPtr->freeVStorage (data, deleteIt);
     }
 
-    void fromAdios(void *dataPtr)
+    void fromAdios(ArrayBase *arrayPtr)
     {
         Bool deleteIt;
-        auto *arrayPtr = asArrayPtr(dataPtr);
-        T *data = arrayPtr->getStorage(deleteIt);
-        fromAdios(data);
-        arrayPtr->putStorage(data, deleteIt);
+        void *data = arrayPtr->getVStorage(deleteIt);
+        fromAdios(data, 0);
+        arrayPtr->putVStorage(data, deleteIt);
     }
 
 }; // class Adios2StManColumnT
+
+class Adios2StManColumnString : public Adios2StManColumnT<std::string>
+{
+public:
+	using Adios2StManColumnT::Adios2StManColumnT;
+
+protected:
+	void putArrayV(rownr_t rownr, const ArrayBase& data);
+	void getArrayV(rownr_t rownr, ArrayBase& data);
+	void getSliceV(rownr_t /*aRowNr*/, const Slicer &/*ns*/, ArrayBase &/*data*/);
+	void putSliceV(rownr_t /*aRowNr*/, const Slicer &/*ns*/, const ArrayBase &/*data*/);
+	void getColumnSliceV(const Slicer &/*ns*/, ArrayBase &/*data*/);
+	void putColumnSliceV(const Slicer &/*ns*/, const ArrayBase &/*data*/);
+	void getColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, ArrayBase& /*data*/);
+	void putColumnSliceCellsV(const RefRows& /*rownrs*/, const Slicer& /*slicer*/, const ArrayBase& /*data*/);
+
+private:
+    const String itsStringArrayBarrier = "ADIOS2BARRIER";
+}; // class Adios2StManColumnString
 
 } // namespace casacore
 

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -51,9 +51,9 @@ public:
     DataManager *clone() const;
     String dataManagerType() const;
     String dataManagerName() const;
-    void create(uInt aNrRows);
-    void open(uInt aRowNr, AipsIO &ios);
-    void resync(uInt aRowNr);
+    void create64(rownr_t aNrRows);
+    rownr_t open64(rownr_t aRowNr, AipsIO &ios);
+    rownr_t resync64(rownr_t aRowNr);
     Bool flush(AipsIO &ios, Bool doFsync);
     DataManagerColumn *makeColumnCommon(const String &aName, int aDataType,
                                         const String &aDataTypeID);
@@ -67,15 +67,15 @@ public:
                                         int aDataType,
                                         const String &aDataTypeID);
     void deleteManager();
-    void addRow(uInt aNrRows);
+    void addRow64(rownr_t aNrRows);
     static DataManager *makeObject(const String &aDataManType,
                                    const Record &spec);
-    uInt getNrRows();
+    rownr_t getNrRows();
 
 private:
     Adios2StMan &parent;
     String itsDataManName = "Adios2StMan";
-    uInt itsRows;
+    rownr_t itsRows;
     int itsStManColumnType;
     PtrBlock<Adios2StManColumn *> itsColumnPtrBlk;
 


### PR DESCRIPTION
This patch ports the Adios2StManColumn class hierarchy to inherit
directly from StManBaseColumn (the new, 64bit-only interface) instead of
StManColumn (the old, 32bit-backwards-compatible one) and adjusts the
implementation to comply with the new methods taking rownr_t instead of
uInt. The Adios2StMan class itself (and its pimpl) also needed to be
adjusted, although the changes were minimal.

A major change that happened together with this porting was a small
refactoring of the internal Adios2StManColumn class hierarchy. The
Adios2StManColumn has always been the base class used by the many
AdiosStManColumnT<T> class template specializations, but the latter
contained a fair bit of code that could be moved down to the base class
with minimal changes. In this commit I thus adjusted and moved all the
common code down to Adios2StManColumn, making the derived template class
much leaner. A consequence of this internal refactoring is that now the
std::string specialization of this template class is not used directly
anymore, by instead it is inherited by Adios2StManColumnString, which is
what Adios2StMan instantiates. This was done to ensure that string
columns properly fail to implement certain operations that are not
supported by the storage manager yet.

In doing this porting I also caught some of the I/O patterns not being
fully supported (e.g., we had getArrayColumnV but no putArrayColumnV) or
not properly implemented (e.g., getArrayColumnV did not set the ADIOS2
selection objects correctly). This obviously means that our unit test
coverage is not great, and that our other external use cases are not
touching those remaining parts of the code. This is a limitation that we
should try to improve in future releases.

As per expectations outlined in the DataManagerColumn documentation, the
implementation of Adios2StManColumn is now simpler thanks to it deriving
from StManBaseColumn.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>