### PR TITLE
Use FFTW instead of FFTPack in Fits-IDI to MS table converter

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2216,7 +2216,7 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
 	      }
 	      fftOut[nChan] = 0.0;
 
-	      // Cosine trandorm back to frequency domain
+	      // Cosine transform back to frequency domain
 	      redftPlan.Execute(fftOut.data(), fftIn.data());
 
 	      for (Int chan=0; chan<nChan; chan++)

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -104,7 +104,7 @@
 
 #include <casacore/casa/iomanip.h>
 
-#include <casacore/scimath/Mathematics/FFTPack.h>
+#include <casacore/scimath/Mathematics/FFTW.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -1850,11 +1850,8 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
   Matrix<Float> sigmaSpec(nCorr, nChan);
   Matrix<Float> weightSpec(nCorr, nChan);
 
-  Vector<Float> tmp(nChan + 1);
-  Vector<Float> work(3 * (nChan + 1) + 15);
-  Bool worksave;
-  Float *workptr = work.getStorage(worksave);
-  FFTPack::costi(nChan + 1, workptr);
+  std::vector<float> fftIn(nChan + 1), fftOut(nChan + 1);
+  FFTW::Plan redftPlan = FFTW::plan_redft00( IPosition(1, nChan+1), fftIn.data(), fftOut.data() );
 
   const Int nCat = 3; // three initial categories
   // define the categories
@@ -2198,38 +2195,32 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
 	  // Auto-correlations
 	  for (Int p=0; p<nCorr; p++) {
 	    if (corrProduct_p(0, p) == corrProduct_p(1, p)) {
-	      Bool tmpsave;
-	      Float *tmpptr;
 
 	      for (Int chan=0; chan<nChan; chan++)
-		tmp(chan) = bfacta * vis(p, chan).real();
+		fftIn[chan] = bfacta * vis(p, chan).real();
 
-	      if (abs(tmp(0)) < 1e-20)
+	      if (std::abs(fftIn[0]) < 1e-20)
 		continue;
 
 	      // Extrapolate spectrum as this point has been thrown
 	      // away by the correlator.
-	      tmp(nChan) = 2 * tmp(nChan-1) - tmp(nChan-2);
+	      fftIn[nChan] = 2 * fftIn[nChan-1] - fftIn[nChan-2];
 
 	      // Cosine transform to lag domain
-	      tmpptr = tmp.getStorage(tmpsave);
-	      FFTPack::cost(nChan + 1, tmpptr, workptr);
-	      tmp.putStorage(tmpptr, tmpsave);
+              redftPlan.Execute(fftIn.data(), fftOut.data());
 
 	      // Apply digital correction.
 	      for (Int chan = 1; chan<nChan; chan++) {
-		Float wt = 1.0 - ((Float)chan / nChan);
-		tmp(chan) = (wt * tmp(0)) * rho(tmp(chan) / (wt * tmp(0)));
+                Float wt = 1.0 - ((Float)chan / nChan);
+                fftOut[chan] = (wt * fftOut[0]) * rho(fftOut[chan] / (wt * fftOut[0]));
 	      }
-	      tmp(nChan) = 0.0;
+	      fftOut[nChan] = 0.0;
 
 	      // Cosine trandorm back to frequency domain
-	      tmpptr = tmp.getStorage(tmpsave);
-	      FFTPack::cost(nChan + 1, tmpptr, workptr);
-	      tmp.putStorage(tmpptr, tmpsave);
+	      redftPlan.Execute(fftOut.data(), fftIn.data());
 
 	      for (Int chan=0; chan<nChan; chan++)
-		vis(p, chan) = tmp(chan) / (2*nChan);
+		vis(p, chan) = fftIn[chan] / (2*nChan);
 	    } else {
 	      for (Int chan=0; chan<nChan; chan++)
 		vis(p, chan) *= Complex(bfactc);
@@ -2283,11 +2274,11 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
       msc.observationId().put(putrow,0);
       msc.stateId().put(putrow,-1);
 
-      Vector<Float> tmp(nCorr);
-      tmp=1.0;
-      msc.sigma().put(putrow,tmp);
-      tmp=0.0;
-      msc.weight().put(putrow,tmp);
+      Vector<Float> tmpValue(nCorr);
+      tmpValue=1.0;
+      msc.sigma().put(putrow,tmpValue);
+      tmpValue=0.0;
+      msc.weight().put(putrow,tmpValue);
 
       msc.interval().put(putrow,interval);
       msc.exposure().put(putrow,interval);
@@ -2335,9 +2326,6 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
 
   // fill the receptorAngle with defaults, just in case there is no AN table
   receptorAngle_p=0;
-
-  // Free FFTPack work buffer
-  work.putStorage(workptr, worksave);
 }
 
 // fill Observation table

--- a/scimath/Mathematics/FFTW.cc
+++ b/scimath/Mathematics/FFTW.cc
@@ -237,6 +237,8 @@ std::mutex FFTW::theirMutex;
 
   FFTW::Plan FFTW::plan_redft00(const IPosition &size, float *in, float *out)
   {
+    initialize_fftw();
+    
     std::vector<fftwf_r2r_kind> kinds(size.nelements(), FFTW_REDFT00);
     
     return Plan( new FFTWPlanf(
@@ -246,7 +248,10 @@ std::mutex FFTW::theirMutex;
   
   FFTW::Plan FFTW::plan_redft00(const IPosition &size, double *in, double *out)
   {
+    initialize_fftw();
+    
     std::vector<fftw_r2r_kind> kinds(size.nelements(), FFTW_REDFT00);
+    
     return Plan( new FFTWPlan(
       fftw_plan_r2r(size.nelements(), size.asStdVector().data(),
                     in, out, kinds.data(), FFTW_ESTIMATE)) );

--- a/scimath/Mathematics/FFTW.cc
+++ b/scimath/Mathematics/FFTW.cc
@@ -257,20 +257,6 @@ std::mutex FFTW::theirMutex;
                     in, out, kinds.data(), FFTW_ESTIMATE)) );
   }
   
-  FFTW::Plan::Plan(Plan&&) = default;
-  
-  FFTW::Plan::Plan(FFTWPlan* plan)
-    : _plan(plan)
-  { }
-  
-  FFTW::Plan::Plan(FFTWPlanf* plan)
-    : _planf(plan)
-  { }
-  
-  FFTW::Plan::~Plan() noexcept { }
-  
-  FFTW::Plan& FFTW::Plan::operator=(Plan&&) = default;
-      
   void FFTW::Plan::Execute(float *in, float *out)
   {
     fftwf_execute_r2r(_planf->getPlan(), in, out);
@@ -283,6 +269,9 @@ std::mutex FFTW::theirMutex;
   
 #else
 
+  class FFTWPlan { };
+  class FFTWPlanf { };
+  
   FFTW::FFTW()
   {}
   FFTW::~FFTW()
@@ -316,6 +305,32 @@ std::mutex FFTW::theirMutex;
   void FFTW::c2c(const IPosition&, std::complex<double>*, Bool)
   {}
 
+  FFTW::Plan FFTW::plan_redft00(const IPosition &, float *, float *)
+  { throw std::runtime_error("FFTW not available"); }
+  
+  FFTW::Plan FFTW::plan_redft00(const IPosition &, double *, double *)
+  { throw std::runtime_error("FFTW not available"); }
+  
+  void FFTW::Plan::Execute(float *, float *)
+  { throw std::runtime_error("FFTW not available"); }
+  
+  void FFTW::Plan::Execute(double *, double *)
+  { throw std::runtime_error("FFTW not available"); }
+  
 #endif
+
+FFTW::Plan::Plan(Plan&&) = default;
+
+FFTW::Plan::Plan(FFTWPlan* plan)
+  : _plan(plan)
+{ }
+
+FFTW::Plan::Plan(FFTWPlanf* plan)
+  : _planf(plan)
+{ }
+
+FFTW::Plan::~Plan() noexcept { }
+
+FFTW::Plan& FFTW::Plan::operator=(Plan&&) = default;
 
 } //# NAMESPACE CASACORE - END

--- a/scimath/Mathematics/FFTW.cc
+++ b/scimath/Mathematics/FFTW.cc
@@ -26,12 +26,6 @@
 
 
 #include <casacore/scimath/Mathematics/FFTW.h>
-#include <casacore/casa/Arrays/Array.h>
-#include <casacore/casa/Arrays/ArrayLogical.h>
-#include <casacore/casa/Arrays/VectorIter.h>
-#include <casacore/casa/Arrays/Matrix.h>
-#include <casacore/casa/BasicMath/Math.h>
-#include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/OS/HostInfo.h>
 
 #ifdef HAVE_FFTW3
@@ -46,8 +40,8 @@
 
 namespace casacore {
 
-  volatile Bool FFTW::is_initialized_fftw = False;
-  Mutex FFTW::theirMutex;
+bool FFTW::is_initialized_fftw = false;
+std::mutex FFTW::theirMutex;
 
 
 #ifdef HAVE_FFTW3
@@ -86,58 +80,33 @@ namespace casacore {
 
     
 
-  FFTW::FFTW()
-    : itsPlanR2Cf  (0),
-      itsPlanR2C   (0),
-      itsPlanC2Rf  (0),
-      itsPlanC2R   (0),
-      itsPlanC2CFf (0),
-      itsPlanC2CF  (0),
-      itsPlanC2CBf (0),
-      itsPlanC2CB  (0)
+  FFTW::FFTW() : flags(FFTW_ESTIMATE)
+  { 
+    initialize_fftw();
+  }
+  
+  void FFTW::initialize_fftw()
   {
-    // Always lock. Need C++11 or later to implement double checked locking correctly.
-    // Perceived to be not worth the effort here, because code that uses this class
-    // should be aware that planning only works if activity from other threads is none
-    // (or representative). That means that optimizing for contention here makes no sense.
-    ScopedMutexLock lock(theirMutex);
+    std::lock_guard<std::mutex> lock(theirMutex);
     if (!is_initialized_fftw) {
       int numCPUs = HostInfo::numCPUs();
       int nthreads = 1;
-      // cerr << "Number of threads is " << numCPUs << endl;
       if (numCPUs > 1) {
         nthreads = numCPUs;
       }
       
-      //    std::cout << "init threads " << fftwf_init_threads() << std::endl;
-      //    std::cout << "init threads " << fftw_init_threads() << std::endl;
 #ifdef HAVE_FFTW3_THREADS
       fftwf_init_threads();
       fftw_init_threads();
       fftwf_plan_with_nthreads(nthreads);
       fftw_plan_with_nthreads(nthreads);
 #endif
-      is_initialized_fftw = True;
+      is_initialized_fftw = true;
     }
-    //    std::cerr << "will use " << nthreads << " threads " << std::endl;
-
-    flags = FFTW_ESTIMATE;  
-    
-    //flags = FFTW_MEASURE;  // std::cerr << "Will FFTW_MEASURE..." << std::endl;
-    //flags = FFTW_PATIENT;   std::cerr << "Will FFTW_PATIENT..." << std::endl;
-    //flags = FFTW_EXHAUSTIVE;   std::cerr << "Will FFTW_EXHAUSTIVE..." << std::endl;
   }
 
   FFTW::~FFTW()
   {
-    delete itsPlanR2Cf;
-    delete itsPlanR2C;
-    delete itsPlanC2Rf;
-    delete itsPlanC2R;
-    delete itsPlanC2CFf;
-    delete itsPlanC2CF;
-    delete itsPlanC2CBf;
-    delete itsPlanC2CB;
     // We cannot deinitialize FFTW as in the following because
     // there may be other instances of this class around
     // Could do it when keeping a static counter, but must be made thread-safe.
@@ -150,113 +119,105 @@ namespace casacore {
   }
   
 
-  void FFTW::plan_r2c(const IPosition &size, Float *in, Complex *out) 
+  void FFTW::plan_r2c(const IPosition &size, float *in, std::complex<float> *out) 
   {
-    delete itsPlanR2Cf;
-    itsPlanR2Cf = new FFTWPlanf
+    itsPlanR2Cf.reset( new FFTWPlanf
       (fftwf_plan_dft_r2c(size.nelements(),
-                          size.asVector().data(),
+                          size.asStdVector().data(),
                           in,
                           reinterpret_cast<fftwf_complex *>(out), 
-                          flags));
+                          flags)) );
   }
 
-  void FFTW::plan_r2c(const IPosition &size, Double *in, DComplex *out) 
+  void FFTW::plan_r2c(const IPosition &size, double *in, std::complex<double> *out) 
   {
-    delete itsPlanR2C;
-    itsPlanR2C = new FFTWPlan
+    itsPlanR2C.reset( new FFTWPlan
       (fftw_plan_dft_r2c(size.nelements(),
-                         size.asVector().data(),
+                         size.asStdVector().data(),
                          in,
                          reinterpret_cast<fftw_complex *>(out), 
-                         flags));
+                         flags)) );
   }
 
-  void FFTW::plan_c2r(const IPosition &size, Complex *in, Float *out) {
-    delete itsPlanC2Rf;
-    itsPlanC2Rf = new FFTWPlanf
+  void FFTW::plan_c2r(const IPosition &size, std::complex<float> *in, float *out) {
+    itsPlanC2Rf.reset( new FFTWPlanf
       (fftwf_plan_dft_c2r(size.nelements(),
-                          size.asVector().data(),
+                          size.asStdVector().data(),
                           reinterpret_cast<fftwf_complex *>(in),
                           out, 
-                          flags));
+                          flags)) );
 
   }
 
-  void FFTW::plan_c2r(const IPosition &size, DComplex *in, Double *out) {
-    delete itsPlanC2R;
-    itsPlanC2R = new FFTWPlan
+  void FFTW::plan_c2r(const IPosition &size, std::complex<double> *in, double *out) {
+    itsPlanC2R.reset( new FFTWPlan
       (fftw_plan_dft_c2r(size.nelements(),
-                         size.asVector().data(),
+                         size.asStdVector().data(),
                          reinterpret_cast<fftw_complex *>(in), 
                          out,
-                         flags));
+                         flags)) );
   }
 
-  void FFTW::plan_c2c_forward(const IPosition &size, DComplex *in) {
-    delete itsPlanC2CF;
-    itsPlanC2CF = new FFTWPlan
+  void FFTW::plan_c2c_forward(const IPosition &size, std::complex<double> *in) {
+    itsPlanC2CF.reset( new FFTWPlan
       (fftw_plan_dft(size.nelements(),
-                     size.asVector().data(),
+                     size.asStdVector().data(),
                      reinterpret_cast<fftw_complex *>(in), 
                      reinterpret_cast<fftw_complex *>(in), 
-                     FFTW_FORWARD, flags));
+                     FFTW_FORWARD, flags)) );
 
   }
     
-  void FFTW::plan_c2c_forward(const IPosition &size, Complex *in) {
-    delete itsPlanC2CFf;
-    itsPlanC2CFf = new FFTWPlanf
+  void FFTW::plan_c2c_forward(const IPosition &size, std::complex<float> *in) {
+    itsPlanC2CFf.reset( new FFTWPlanf
       (fftwf_plan_dft(size.nelements(),
-                      size.asVector().data(),
+                      size.asStdVector().data(),
                       reinterpret_cast<fftwf_complex *>(in), 
                       reinterpret_cast<fftwf_complex *>(in), 
-                      FFTW_FORWARD, flags));
+                      FFTW_FORWARD, flags)) );
   }
 
-  void FFTW::plan_c2c_backward(const IPosition &size, DComplex *in) {
-    delete itsPlanC2CB;
-    itsPlanC2CB = new FFTWPlan
+  void FFTW::plan_c2c_backward(const IPosition &size, std::complex<double> *in) {
+    itsPlanC2CB.reset( new FFTWPlan
       (fftw_plan_dft(size.nelements(),
-                     size.asVector().data(),
+                     size.asStdVector().data(),
                      reinterpret_cast<fftw_complex *>(in), 
                      reinterpret_cast<fftw_complex *>(in), 
-                     FFTW_BACKWARD, flags));
+                     FFTW_BACKWARD, flags)) );
       
   }
     
-  void FFTW::plan_c2c_backward(const IPosition &size, Complex *in) {
-    delete itsPlanC2CBf;
-    itsPlanC2CBf = new FFTWPlanf
+  void FFTW::plan_c2c_backward(const IPosition &size, std::complex<float> *in) {
+    itsPlanC2CBf.reset( new FFTWPlanf
       (fftwf_plan_dft(size.nelements(),
-                      size.asVector().data(),
+                      size.asStdVector().data(),
                       reinterpret_cast<fftwf_complex *>(in), 
                       reinterpret_cast<fftwf_complex *>(in), 
-                      FFTW_BACKWARD, flags));
+                      FFTW_BACKWARD, flags)) );
   }
 
   // the parameters are used only in order to overload this function
-  void FFTW::r2c(const IPosition&, Float*, Complex*) 
+  void FFTW::r2c(const IPosition&, float*, std::complex<float>*) 
   {
     fftwf_execute(itsPlanR2Cf->getPlan());
   }
     
-  void FFTW::r2c(const IPosition&, Double*, DComplex*) 
+  void FFTW::r2c(const IPosition&, double*, std::complex<double>*) 
   {
     fftw_execute(itsPlanR2C->getPlan());
   }
 
-  void FFTW::c2r(const IPosition&, Complex*, Float*)
+  void FFTW::c2r(const IPosition&, std::complex<float>*, float*)
   {
     fftwf_execute(itsPlanC2Rf->getPlan());
   }
     
-  void FFTW::c2r(const IPosition&, DComplex*, Double*)
+  void FFTW::c2r(const IPosition&, std::complex<double>*, double*)
   {
     fftw_execute(itsPlanC2R->getPlan());
   }
     
-  void FFTW::c2c(const IPosition&, Complex*, Bool forward)
+  void FFTW::c2c(const IPosition&, std::complex<float>*, bool forward)
   {
     if (forward) {
       fftwf_execute(itsPlanC2CFf->getPlan());
@@ -265,7 +226,7 @@ namespace casacore {
     }
   }
     
-  void FFTW::c2c(const IPosition&, DComplex*, Bool forward)
+  void FFTW::c2c(const IPosition&, std::complex<double>*, bool forward)
   {
     if (forward) {
       fftw_execute(itsPlanC2CF->getPlan());
@@ -274,47 +235,80 @@ namespace casacore {
     }
   }
 
+  FFTW::Plan FFTW::plan_redft00(const IPosition &size, float *in, float *out)
+  {
+    std::vector<fftwf_r2r_kind> kinds(size.nelements(), FFTW_REDFT00);
+    
+    return Plan( new FFTWPlanf(
+      fftwf_plan_r2r(size.nelements(), size.asStdVector().data(),
+                     in, out, kinds.data(), FFTW_ESTIMATE)) );
+  }
+  
+  FFTW::Plan FFTW::plan_redft00(const IPosition &size, double *in, double *out)
+  {
+    std::vector<fftw_r2r_kind> kinds(size.nelements(), FFTW_REDFT00);
+    return Plan( new FFTWPlan(
+      fftw_plan_r2r(size.nelements(), size.asStdVector().data(),
+                    in, out, kinds.data(), FFTW_ESTIMATE)) );
+  }
+  
+  FFTW::Plan::Plan(Plan&&) = default;
+  
+  FFTW::Plan::Plan(FFTWPlan* plan)
+    : _plan(plan)
+  { }
+  
+  FFTW::Plan::Plan(FFTWPlanf* plan)
+    : _planf(plan)
+  { }
+  
+  FFTW::Plan::~Plan() noexcept { }
+  
+  FFTW::Plan& FFTW::Plan::operator=(Plan&&) = default;
+      
+  void FFTW::Plan::Execute(float *in, float *out)
+  {
+    fftwf_execute_r2r(_planf->getPlan(), in, out);
+  }
+  
+  void FFTW::Plan::Execute(double *in, double *out)
+  {
+    fftw_execute_r2r(_plan->getPlan(), in, out);
+  }
+  
 #else
 
   FFTW::FFTW()
-    : itsPlanR2Cf  (0),
-      itsPlanR2C   (0),
-      itsPlanC2Rf  (0),
-      itsPlanC2R   (0),
-      itsPlanC2CFf (0),
-      itsPlanC2CF  (0),
-      itsPlanC2CBf (0),
-      itsPlanC2CB  (0)
   {}
   FFTW::~FFTW()
   {}
-  void FFTW::plan_r2c(const IPosition&, Float*, Complex*) 
+  void FFTW::plan_r2c(const IPosition&, float*, std::complex<float>*) 
   {}
-  void FFTW::plan_r2c(const IPosition&, Double*, DComplex*) 
+  void FFTW::plan_r2c(const IPosition&, double*, std::complex<double>*) 
   {}
-  void FFTW::plan_c2r(const IPosition&, Complex*, Float*)
+  void FFTW::plan_c2r(const IPosition&, std::complex<float>*, float*)
   {}
-  void FFTW::plan_c2r(const IPosition&, DComplex*, Double*)
+  void FFTW::plan_c2r(const IPosition&, std::complex<double>*, double*)
   {}
-  void FFTW::plan_c2c_forward(const IPosition&, DComplex*)
+  void FFTW::plan_c2c_forward(const IPosition&, std::complex<double>*)
   {}
-  void FFTW::plan_c2c_forward(const IPosition&, Complex*)
+  void FFTW::plan_c2c_forward(const IPosition&, std::complex<float>*)
   {}
-  void FFTW::plan_c2c_backward(const IPosition&, DComplex*)
+  void FFTW::plan_c2c_backward(const IPosition&, std::complex<double>*)
   {}
-  void FFTW::plan_c2c_backward(const IPosition&, Complex*)
+  void FFTW::plan_c2c_backward(const IPosition&, std::complex<float>*)
   {}
-  void FFTW::r2c(const IPosition&, Float*, Complex*) 
+  void FFTW::r2c(const IPosition&, float*, std::complex<float>*) 
   {}
-  void FFTW::r2c(const IPosition&, Double*, DComplex*) 
+  void FFTW::r2c(const IPosition&, double*, std::complex<double>*) 
   {}
-  void FFTW::c2r(const IPosition&, Complex*, Float*)
+  void FFTW::c2r(const IPosition&, std::complex<float>*, float*)
   {}
-  void FFTW::c2r(const IPosition&, DComplex*, Double*)
+  void FFTW::c2r(const IPosition&, std::complex<double>*, double*)
   {}
-  void FFTW::c2c(const IPosition&, Complex*, Bool)
+  void FFTW::c2c(const IPosition&, std::complex<float>*, Bool)
   {}
-  void FFTW::c2c(const IPosition&, DComplex*, Bool)
+  void FFTW::c2c(const IPosition&, std::complex<double>*, Bool)
   {}
 
 #endif

--- a/scimath/Mathematics/FFTW.h
+++ b/scimath/Mathematics/FFTW.h
@@ -84,18 +84,22 @@ public:
   class Plan
   {
     public:
-      Plan(FFTWPlan* plan);
-      Plan(FFTWPlanf* plan);
       ~Plan() noexcept;
       Plan(const Plan&) = delete;
       Plan(Plan&&);
       Plan& operator=(const Plan&) = delete;
       Plan& operator=(Plan&&);
     
+      // Perform the FFT associated with this plan with the given
+      // in data, and store it in the given out data.
+      // <group>
       void Execute(float* in, float* out);
       void Execute(double* in, double* out);
+      // </group>
     private:
       friend FFTW;
+      Plan(FFTWPlan* plan);
+      Plan(FFTWPlanf* plan);
       std::unique_ptr<FFTWPlan> _plan;
       std::unique_ptr<FFTWPlanf> _planf;
   };


### PR DESCRIPTION
The FitsIDItoMS class is the only class that was still dependent on the FFTPack
Fortran code. By rewriting it to use FFTW, the FFTPack code can be removed.
This required implementing a wrapper for the real even FFT in the FFTW class,
as that was not available.

The FFTW class should be rewritten to have a more sensible interface. I've added
some TODO comments for that. Despite the use of a mutex, the FFTW wrapper is
also not thread safe.

This is related to the work in #1024 and #1017.