### PR TITLE
Remove modern boost feature

### DIFF
--- a/casa/Arrays/test/tAllocator.cc
+++ b/casa/Arrays/test/tAllocator.cc
@@ -98,9 +98,9 @@ BOOST_AUTO_TEST_CASE(poolallocator)
   int* b = alloc.allocate(5);
   int* c = alloc.allocate(1);
   int* n = alloc.allocate(0);
-  BOOST_CHECK_NE(a, nullptr);
-  BOOST_CHECK_NE(b, nullptr);
-  BOOST_CHECK_NE(c, nullptr);
+  BOOST_CHECK(a != nullptr);
+  BOOST_CHECK(b != nullptr);
+  BOOST_CHECK(c != nullptr);
   BOOST_CHECK_NE(a, b);
   BOOST_CHECK_NE(b, c);
   BOOST_CHECK_NE(a, c);
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(poolallocator)
   
   alloc.deallocate(b, 5);
   int* d = alloc.allocate(3);
-  BOOST_CHECK_NE(d, nullptr);
+  BOOST_CHECK(d != nullptr);
   BOOST_CHECK_NE(a, d);
   BOOST_CHECK_NE(c, d);
   d[0] = 8; d[1] = 9; d[2] = 10;

--- a/casa/Arrays/test/tCpp11Features.cc
+++ b/casa/Arrays/test/tCpp11Features.cc
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE( pointer_vector )
   // Hence now we need this:
   Vector<Array<int>*> ptrArray(3, nullptr);
   for(auto iter=ptrArray.begin(); iter!=ptrArray.end(); ++iter)
-    BOOST_CHECK_EQUAL(*iter, nullptr);
+    BOOST_CHECK(*iter == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE( bool_vector_constructor )


### PR DESCRIPTION
This change makes it possible to compile and test with boost 1.53, as requested by @schiebel.