### PR TITLE
Solve issue when assigning from lower to higher dim array

### DIFF
--- a/casa/Arrays/Cube.h
+++ b/casa/Arrays/Cube.h
@@ -122,17 +122,49 @@ public:
     // Note that the assign function can be used to assign a
     // non-conforming cube.
     // <group>
-     Cube<T, Alloc> &operator=(const Cube<T, Alloc>& source)
+    Cube<T, Alloc> &operator=(const Cube<T, Alloc>& source)
     { Array<T, Alloc>::operator=(source); return *this; }
-     Cube<T, Alloc> &operator=(Cube<T, Alloc>&& source)
+    Cube<T, Alloc> &operator=(Cube<T, Alloc>&& source)
     { Array<T, Alloc>::operator=(std::move(source)); return *this; }
+    
+    Cube<T, Alloc>& operator=(const Array<T, Alloc>& source)
+    {
+      // TODO is it highly confusing that operator= is specialized for Cube, e.g.
+      // this is allowed:
+      //   Cube<int> cube(5,1,1);
+      //   Vector<int> v(5,0);
+      //   cube = v;
+      // But this is not:
+      //   Array arr(IPosition{5,1,1});
+      //   Vector<int> v(5,0);
+      //   arr = v;
+      // If it should be allowed to assign from dim(5,1,1) to dim(5), this should
+      // be supported already by the Array class so that the semantics are the
+      // same!
+      
+      if (source.ndim() == 3) {
+        Array<T, Alloc>::operator=(source);
+      } else {
+        // This might work if a.ndim == 1 or 2
+        (*this) = Cube<T, Alloc>(source);
+      }
+      return *this;
+    }
    
-    //virtual Array<T> &assign_conforming(const Array<T> &other);
+    Cube<T, Alloc>& operator=(Array<T, Alloc>&& source)
+    {
+      if (source.ndim() == 3) {
+        Array<T, Alloc>::operator=(std::move(source));
+      } else {
+        (*this) = Cube<T, Alloc>(std::move(source));
+      }
+      return *this;
+    }
+   
     // </group>
 
     // Copy val into every element of this cube; i.e. behaves as if
     // val were a constant conformant cube.
-    using Array<T, Alloc>::operator=;
     Array<T, Alloc> &operator=(const T &val)
       { return Array<T>::operator=(val); }
 

--- a/casa/Arrays/Matrix.h
+++ b/casa/Arrays/Matrix.h
@@ -134,7 +134,11 @@ public:
     { return assign_conforming(source); }
     Matrix<T, Alloc>& operator=(Matrix<T, Alloc>&& source)
     { return assign_conforming(std::move(source)); }
-    
+    Matrix<T, Alloc>& operator=(const Array<T, Alloc>& source)
+    { return assign_conforming(source); }
+    Matrix<T, Alloc>& operator=(Array<T, Alloc>&& source)
+    { return assign_conforming(std::move(source)); }
+   
     // Copy the values from other to this Matrix. If this matrix has zero
     // elements then it will resize to be the same shape as other; otherwise
     // other must conform to this.
@@ -146,10 +150,29 @@ public:
     Matrix<T, Alloc>& assign_conforming(Matrix<T, Alloc>&& source)
     { Array<T, Alloc>::assign_conforming(std::move(source)); return *this; }
     
-    Array<T, Alloc>& assign_conforming(const Array<T, Alloc>& source)
-    { return Array<T, Alloc>::assign_conforming(source); }
-    Array<T, Alloc>& assign_conforming(Array<T, Alloc>&& source)
-    { return Array<T, Alloc>::assign_conforming(std::move(source)); }
+    Matrix<T, Alloc>& assign_conforming(const Array<T, Alloc>& source)
+    {
+      // TODO Should be supported by the Array class,
+      // see Cube::operator=(const Array&)
+      
+      if (source.ndim() == 2) {
+        Array<T, Alloc>::assign_conforming(source);
+      } else {
+        // This might work if a.ndim == 1 or 2
+        (*this) = Matrix<T, Alloc>(source);
+      }
+      return *this;
+    }
+   
+    Matrix<T, Alloc>& assign_conforming(Array<T, Alloc>&& source)
+    {
+      if (source.ndim() == 2) {
+        Array<T, Alloc>::assign_conforming(std::move(source));
+      } else {
+        (*this) = Matrix<T, Alloc>(std::move(source));
+      }
+      return *this;
+    }
     // </group>
 
     // Copy val into every element of this Matrix; i.e. behaves as if

--- a/casa/Arrays/test/tCube.cc
+++ b/casa/Arrays/test/tCube.cc
@@ -136,4 +136,23 @@ BOOST_AUTO_TEST_CASE( uninitialized_constructor_b )
 	BOOST_CHECK (allEQ(y1, 2));
 }
   
+BOOST_AUTO_TEST_CASE( assign_unmatched )
+{
+  Cube<float> lhs(IPosition{10, 1, 1}, 1.0f);
+  Vector<float> rhs(10, 13.0f);
+  lhs = rhs;
+  std::vector<float> ref(10, 13.0f);
+  BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), ref.begin(), ref.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+BOOST_AUTO_TEST_CASE( move_assign_unmatched )
+{
+  Cube<float> lhs(IPosition{10, 1, 1}, 1.0f);
+  Vector<float> rhs(10, 27.0f);
+  lhs = std::move(rhs);
+  std::vector<float> ref(10, 27.0f);
+  BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), ref.begin(), ref.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/casa/Arrays/test/tMatrix.cc
+++ b/casa/Arrays/test/tMatrix.cc
@@ -261,4 +261,23 @@ BOOST_AUTO_TEST_CASE( uninitialized_constructor_b )
 	BOOST_CHECK (allEQ(y1, 7));
 }
 
+BOOST_AUTO_TEST_CASE( assign_from_vector )
+{
+  Matrix<float> lhs(IPosition{10, 1}, 1.0f);
+  Vector<float> rhs(10, 13.0f);
+  lhs = rhs;
+  std::vector<float> ref(10, 13.0f);
+  BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), ref.begin(), ref.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+BOOST_AUTO_TEST_CASE( move_assign_from_vector )
+{
+  Matrix<float> lhs(IPosition{10, 1}, 1.0f);
+  Vector<float> rhs(10, 27.0f);
+  lhs = std::move(rhs);
+  std::vector<float> ref(10, 27.0f);
+  BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), ref.begin(), ref.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In psuedo code, this didn't work anymore, causing Casa errors:

```
Cube cube(5, 1, 1);
cube = Vector(5);
```

It did "by accident" work for a Matrix, because Matrix didn't implement a specialization of assignment, causing
an implicit call conversion via the Matrix(const Array&) constructor which did allow this.

This "feature" allowing assignment from lower dim arrays isn't yet documented and is also not consistent. For example,
this isn't allowed:

```
Array arr(IPosition{5, 1, 1});
arr = Vector(5);
```

So in the nearby future it would be good if i) this were documented; and ii) this would be made consistent
between Array and Matrix/Cube classes. By doing so, the specialized assignment methods from Matrix and Cube could
be removed, so it would also simplify the code.

This PR also adds unit tests for this.