### PR TITLE
Fix empty dim-changing assignment like matrix = Vector()

### DIFF
--- a/casa/Arrays/Array.tcc
+++ b/casa/Arrays/Array.tcc
@@ -278,8 +278,9 @@ template<class T, typename Alloc> void Array<T, Alloc>::reference(const Array<T,
     IPosition newShape(fixedDimensionality());
     for(size_t i=0; i!=other.ndim(); ++i)
       newShape[i] = other.shape()[i];
+    const int newValue = (other.nelements() == 0) ? 0 : 1;
     for(size_t i=other.ndim(); i!=fixedDimensionality(); ++i)
-      newShape[i] = 1;
+      newShape[i] = newValue;
     Array<T, Alloc> tmp(*other.data_p);
     tmp.reference(other);
     other.baseReform(tmp, newShape);

--- a/casa/Arrays/ArrayBase.cc
+++ b/casa/Arrays/ArrayBase.cc
@@ -167,9 +167,10 @@ void ArrayBase::swap(ArrayBase& source) noexcept
 void ArrayBase::baseReform (ArrayBase& tmp, const IPosition& len, bool strict) const
 {
   // Check if reform can be done.
-  if (strict && len.product() != (long long)(nelements())) {
+  long long prod = len.nelements()==0 ? 0 : len.product();
+  if (strict && prod != (long long)(nelements())) {
     throw(ArrayConformanceError("ArrayBase::reform() - "
-				"total elements differ"));
+          "total elements differ: " + to_string(len) + " vs " + to_string(shape())));
   }
   // Return if the new shape equals the current one.
   if (len.isEqual(length_p)) {
@@ -768,16 +769,19 @@ void ArrayBase::checkMatrixShape()
     length_p.resize(2); 
     inc_p.resize(2);
     originalLength_p.resize(2);
-    int len = 1;
     if (ndim() == 0) {
-      len = 0;
       length_p(0) = 0;
+      length_p(1) = 0;
       inc_p(0) = 1;
+      inc_p(1) = 1;
       originalLength_p(0) = 0;
+      originalLength_p(1) = 0;
     }
-    length_p(1) = len;
-    inc_p(1) = 1;
-    originalLength_p(1) = len;
+    else {
+      length_p(1) = (nelements() == 0) ? 0 : 1;
+      originalLength_p(1) = length_p(1);
+      inc_p(1) = 1;
+    }
     ndimen_p = 2;
     baseMakeSteps();
   }
@@ -794,7 +798,7 @@ void ArrayBase::checkCubeShape()
     length_p.resize(3); 
     inc_p.resize(3);
     originalLength_p.resize(3);
-    int len = 1;
+    int len = (nelements()==0) ? 0 : 1;
     if (ndim() == 0) {
       len = 0;
       length_p(0) = 0;

--- a/casa/Arrays/Vector.h
+++ b/casa/Arrays/Vector.h
@@ -185,8 +185,9 @@ public:
       return assign_conforming_implementation(source, std::is_copy_assignable<T>());
     }
     Vector<T, Alloc>& assign_conforming(Vector<T, Alloc>&& source);
-    // Other must be a 1-dimensional array.
-    Array<T, Alloc>& assign_conforming(const Array<T, Alloc>& source);
+    // source must be a 1-dimensional array.
+    Vector<T, Alloc>& assign_conforming(const Array<T, Alloc>& source);
+    Vector<T, Alloc>& assign_conforming(Array<T, Alloc>&& source);
     // </group>
 
     using Array<T, Alloc>::operator=;
@@ -194,8 +195,10 @@ public:
     { return assign_conforming(source); }
     Vector<T, Alloc>& operator=(Vector<T, Alloc>&& source)
     { return assign_conforming(std::move(source)); }
+    Vector<T, Alloc>& operator=(const Array<T, Alloc>& source)
+    { assign_conforming(source); return *this; }
     Vector<T, Alloc>& operator=(Array<T, Alloc>&& source)
-    { assign_conforming(source); return *this; } // TODO
+    { assign_conforming(std::move(source)); return *this; }
 
     // Convert a Vector to a Block, resizing the block and copying values.
     // This is done this way to avoid having the simpler Block class 

--- a/casa/Arrays/Vector.tcc
+++ b/casa/Arrays/Vector.tcc
@@ -221,12 +221,20 @@ template<typename T, typename Alloc> void Vector<T, Alloc>::resize(const IPositi
   assert(ok());
 }
 
-template<typename T, typename Alloc> Array<T, Alloc>& Vector<T, Alloc>::assign_conforming(const Array<T, Alloc> &a)
+template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming(const Array<T, Alloc>& a)
 {
-    assert(ok());
-    Vector<T, Alloc> tmp(a);
-    assign_conforming(tmp);
-    return *this;
+  assert(ok());
+  Vector<T, Alloc> tmp(a);
+  assign_conforming(tmp);
+  return *this;
+}
+
+template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming(Array<T, Alloc>&& a)
+{
+  assert(ok());
+  Vector<T, Alloc> tmp(std::move(a));
+  assign_conforming(tmp);
+  return *this;
 }
 
 template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming_implementation(const Vector<T, Alloc> &, std::false_type /*movable?*/)

--- a/casa/Arrays/test/tArray.cc
+++ b/casa/Arrays/test/tArray.cc
@@ -1043,4 +1043,12 @@ BOOST_AUTO_TEST_CASE( nondegenerate_on_subsection )
   }
 }
 
+BOOST_AUTO_TEST_CASE( assign_empty )
+{
+  Array<int> zeroArr;
+  zeroArr = Array<int>();
+  BOOST_CHECK_EQUAL( zeroArr.shape().size(), 0);
+  BOOST_CHECK( zeroArr.shape() == IPosition() );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/casa/Arrays/test/tCube.cc
+++ b/casa/Arrays/test/tCube.cc
@@ -155,4 +155,28 @@ BOOST_AUTO_TEST_CASE( move_assign_unmatched )
   BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), ref.begin(), ref.end());
 }
 
+BOOST_AUTO_TEST_CASE( assign_from_empty_array )
+{
+  Cube<int> cube;
+  cube = Array<int>();
+  BOOST_CHECK_EQUAL( cube.shape().size(), 3);
+  BOOST_CHECK_EQUAL( cube.shape(), (IPosition{0,0,0}) );
+}
+
+BOOST_AUTO_TEST_CASE( assign_from_empty_vector )
+{
+  Cube<int> cube;
+  cube = Vector<int>();
+  BOOST_CHECK_EQUAL( cube.shape().size(), 3);
+  BOOST_CHECK_EQUAL( cube.shape(), (IPosition{0,0,0}) );
+}
+
+BOOST_AUTO_TEST_CASE( assign_from_empty_matrix )
+{
+  Cube<int> cube;
+  cube = Matrix<int>();
+  BOOST_CHECK_EQUAL( cube.shape().size(), 3);
+  BOOST_CHECK_EQUAL( cube.shape(), (IPosition{0,0,0}) );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/casa/Arrays/test/tMatrix.cc
+++ b/casa/Arrays/test/tMatrix.cc
@@ -280,4 +280,28 @@ BOOST_AUTO_TEST_CASE( move_assign_from_vector )
   BOOST_CHECK_EQUAL_COLLECTIONS (lhs.begin(), lhs.end(), ref.begin(), ref.end());
 }
 
+BOOST_AUTO_TEST_CASE( assign_from_empty_array )
+{
+  Matrix<int> matrix;
+  matrix = Array<int>();
+  BOOST_CHECK_EQUAL( matrix.shape().size(), 2);
+  BOOST_CHECK_EQUAL( matrix.shape(), (IPosition{0,0}) );
+}
+
+BOOST_AUTO_TEST_CASE( assign_from_empty_vector )
+{
+  Matrix<int> matrix;
+  matrix = Vector<int>();
+  BOOST_CHECK_EQUAL( matrix.shape().size(), 2);
+  BOOST_CHECK_EQUAL( matrix.shape(), (IPosition{0,0}) );
+}
+
+BOOST_AUTO_TEST_CASE( reference_empty_vector )
+{
+  Matrix<int> matrix;
+  matrix.reference(Vector<int>());
+  BOOST_CHECK_EQUAL( matrix.shape().size(), 2);
+  BOOST_CHECK_EQUAL( matrix.shape(), (IPosition{0,0}) );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/casa/Arrays/test/tVector.cc
+++ b/casa/Arrays/test/tVector.cc
@@ -398,4 +398,25 @@ BOOST_AUTO_TEST_CASE( assign_empty_to_zero_len )
   BOOST_CHECK( vec.shape() == IPosition{0} );
 }
 
+BOOST_AUTO_TEST_CASE( assign_dimensional )
+{
+  Vector<int> vec(16, 1);
+  Array<int> arr(IPosition{1, 1, 1, 16}, 2);
+  vec = arr;
+  BOOST_CHECK_EQUAL( vec.shape().size(), 1);
+  BOOST_CHECK( vec.shape() == IPosition{16} );
+  std::vector<int> ref(16, 2);
+  BOOST_CHECK_EQUAL_COLLECTIONS(ref.begin(), ref.end(), vec.begin(), vec.end());
+}
+
+BOOST_AUTO_TEST_CASE( move_assign_dimensional )
+{
+  Vector<int> vec(16, 1);
+  vec = Array<int>(IPosition{1, 1, 1, 16}, 2);
+  BOOST_CHECK_EQUAL( vec.shape().size(), 1);
+  BOOST_CHECK( vec.shape() == IPosition{16} );
+  std::vector<int> ref(16, 2);
+  BOOST_CHECK_EQUAL_COLLECTIONS(ref.begin(), ref.end(), vec.begin(), vec.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/casa/Arrays/test/tVector.cc
+++ b/casa/Arrays/test/tVector.cc
@@ -390,4 +390,12 @@ BOOST_AUTO_TEST_CASE( multi_dimensional_copy )
   BOOST_CHECK (vec.shape() == IPosition(1,0));
 }
 
+BOOST_AUTO_TEST_CASE( assign_empty_to_zero_len )
+{
+  Vector<int> vec;
+  vec = Array<int>();
+  BOOST_CHECK_EQUAL( vec.shape().size(), 1);
+  BOOST_CHECK( vec.shape() == IPosition{0} );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Code like this used to work, but didn't after the array refactor:
  Matrix<int> matrix;
  matrix = Vector<int>();
The same holds for Vector to Cube and Matrix to Cube assignment.

This has been fixed, and test cases have been added for these assignments.