### PR TITLE
Remove boost dependency in DataMan tests

### DIFF
--- a/tables/DataMan/test/CMakeLists.txt
+++ b/tables/DataMan/test/CMakeLists.txt
@@ -54,10 +54,6 @@ foreach (test ${tests})
     add_dependencies(check ${test})
 endforeach (test)
 
-find_package(Boost COMPONENTS filesystem unit_test_framework)
-include_directories(${Boost_INCLUDE_DIR})
-target_link_libraries (tStManAll ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
 if(MPI_FOUND)
     if(ADIOS2_FOUND)
         foreach (test ${tests_mpi})


### PR DESCRIPTION
This commit removes the dependency that DataMan tests have on Boost's
unit testing framework. This was added in cd54d948f, where boost is
effectively used for unit testing some of the new array changes, but
it's definitely not needed by the DataMan tests, as none of them
includes boost or links against it.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>