### PR TITLE
Remove user provided methods

### DIFF
--- a/casa/Quanta/MVAngle.h
+++ b/casa/Quanta/MVAngle.h
@@ -286,8 +286,6 @@ class MVAngle {
     // Construct from type and precision (present due to overlaoding problems)
     Format(uInt intyp, uInt inprec) :
       typ((MVAngle::formatTypes) intyp), prec(inprec) {;};
-    Format(const Format &other) :
-      typ(other.typ), prec(other.prec) {;};
   private:
     MVAngle::formatTypes typ;
     uInt prec;

--- a/casa/Quanta/MVBaseline.cc
+++ b/casa/Quanta/MVBaseline.cc
@@ -46,13 +46,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MVBaseline::MVBaseline() :
   MVPosition() {}
 
-MVBaseline &MVBaseline::operator=(const MVBaseline &other) {
-  if (this != &other) {
-    xyz = other.xyz;
-  }
-  return *this;
-}
-
 MVBaseline::MVBaseline(Double in) :
   MVPosition(in) {}
 
@@ -93,9 +86,6 @@ MVBaseline::MVBaseline(const MVPosition &pos, const MVPosition &base) :
 
 MVBaseline::MVBaseline(const MVPosition &other) :
   MVPosition(other) {}
-
-//# Destructor
-MVBaseline::~MVBaseline() {}
 
 //# Operators
 Bool MVBaseline::

--- a/casa/Quanta/MVBaseline.h
+++ b/casa/Quanta/MVBaseline.h
@@ -58,6 +58,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <ul>
 //   <li> MVBaseline() creates point at origin (0,0,0)
 //   <li> MVBaseline(MVBaseline) creates a copy
+//   <li> MVBaseline(MVPosition) creates (x,y,z) from the given position
 //   <li> MVBaseline(Double, Double, Double) creates (x,y,z) with
 //		specified values (assuming meters)
 //   <li> MVBaseline(Quantity length,Double, Double) creates a MVBaseline assuming
@@ -113,7 +114,7 @@ public:
   //# Constructors
   // Default constructor generates a (0,0,0) Baseline
   MVBaseline();
-  // Copy constructor
+  // Creates from an MVPosition
   MVBaseline(const MVPosition &other);
   // Creates a specified vector
   MVBaseline(Double in0, Double in1, Double in2);
@@ -144,11 +145,6 @@ public:
   // <group>
   MVBaseline(const MVPosition &pos, const MVPosition &base);
   // </group>
-  // Copy assignment
-  MVBaseline &operator=(const MVBaseline &other);
-  
-  // Destructor
-  ~MVBaseline();
   
   //# Operators
   // Multiplication defined as in-product

--- a/casa/Quanta/MVDirection.cc
+++ b/casa/Quanta/MVDirection.cc
@@ -53,13 +53,6 @@ MVDirection::MVDirection() :
 MVDirection::MVDirection(const MVPosition &other) : 
   MVPosition(other) {}
 
-MVDirection &MVDirection::operator=(const MVDirection &other) {
-  if (this != &other) {
-    xyz = other.xyz;
-  }
-  return *this;
-}
-
 MVDirection::MVDirection(Double in0, Double in1, Double in2) : 
   MVPosition(in0,in1,in2) {
     adjust();
@@ -110,9 +103,6 @@ MVDirection::MVDirection(const Vector<Quantity> &angle) :
       throw (AipsError("Illegal quantum vector in MVDirection constructor"));
     }
   }
-
-//# Destructor
-MVDirection::~MVDirection() {}
 
 //# Operators
 MVDirection &MVDirection::operator+=(const MVDirection &right) {

--- a/casa/Quanta/MVDirection.h
+++ b/casa/Quanta/MVDirection.h
@@ -61,6 +61,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <ul>
 //   <li> MVDirection() creates direction cosines for pole: (0,0,1)
 //   <li> MVDirection(MVDirection) creates a copy
+//   <li> MVDirection(MVPosition) creates (x,y,z) from the given position
 //   <li> MVDirection(Double, Double, Double) creates with
 //		specified values and adjust to length of 1.
 //   <li> MVDirection(Double, Double) creates a MVDirection assuming that the two
@@ -112,7 +113,7 @@ public:
   //# Constructors
   // Default constructor generates a direction to the pole (i.e. (0,0,1))
   MVDirection();
-  // Copy constructor
+  // Creates from an MVPosition
   MVDirection(const MVPosition &other);
   // Constructs with elevation = 0.
   // <group>
@@ -146,11 +147,7 @@ public:
   MVDirection(const Vector<Double> &other);
   MVDirection(const Vector<Quantity> &other);
   // </group>
-  // Copy assignment
-  MVDirection &operator=(const MVDirection &other);
   
-  // Destructor
-  ~MVDirection();
   //# Operators
   // Addition and subtraction
   // <group>

--- a/casa/Quanta/MVEarthMagnetic.cc
+++ b/casa/Quanta/MVEarthMagnetic.cc
@@ -49,13 +49,6 @@ MVEarthMagnetic::MVEarthMagnetic() :
 MVEarthMagnetic::MVEarthMagnetic(const MVPosition &other) : 
   MVPosition(other) {}
 
-MVEarthMagnetic &MVEarthMagnetic::operator=(const MVEarthMagnetic &other) {
-  if (this != &other) {
-    xyz = other.xyz;
-  }
-  return *this;
-}
-
 MVEarthMagnetic::MVEarthMagnetic(Double in) :
   MVPosition(in) {}
 
@@ -161,9 +154,6 @@ MVEarthMagnetic::MVEarthMagnetic(const Vector<Quantity> &other) :
       throw (AipsError("Illegal quantity vector in MVEarthMagnetic constructor"));
     }
   }
-
-//# Destructor
-MVEarthMagnetic::~MVEarthMagnetic() {}
 
 //# Operators
 Bool MVEarthMagnetic::

--- a/casa/Quanta/MVEarthMagnetic.h
+++ b/casa/Quanta/MVEarthMagnetic.h
@@ -62,6 +62,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <ul>
 //   <li> MVEarthMagnetic() creates  (0,0,0)
 //   <li> MVEarthMagnetic(MVEarthMagnetic) creates a copy
+//   <li> MVEarthMagnetic(MVPosition) creates (x,y,z) from the given position
 //   <li> MVEarthMagnetic(Double, Double, Double) creates (x,y,z) with
 //		specified values in tesla
 //   <li> MVEarthMagnetic(Quantity length,Double, Double) creates an
@@ -115,7 +116,7 @@ public:
   //# Constructors
   // Default constructor generates a (0,0,0) EarthMagnetic
   MVEarthMagnetic();
-  // Copy constructor
+  // Creates from an MVPosition
   MVEarthMagnetic(const MVPosition &other);
   // Creates a specified vector
   MVEarthMagnetic(Double in0, Double in1, Double in2);
@@ -142,11 +143,6 @@ public:
   MVEarthMagnetic(const Vector<Double> &other);
   MVEarthMagnetic(const Vector<Quantity> &other);
   // </group>
-  // Copy assignment
-  MVEarthMagnetic &operator=(const MVEarthMagnetic &other);
-  
-  // Destructor
-  ~MVEarthMagnetic();
   
   //# Operators
   // Multiplication defined as in-product

--- a/casa/Quanta/MVTime.h
+++ b/casa/Quanta/MVTime.h
@@ -322,8 +322,6 @@ class MVTime {
 // Construct from type and precision (present due to overlaoding problems)
 	Format(uInt intyp, uInt inprec) :
 	typ((MVTime::formatTypes)intyp), prec(inprec) {;};
-	Format(const Format &other) :
-	typ(other.typ), prec(other.prec) {;};
 	private:
 	MVTime::formatTypes typ;
 	uInt prec;

--- a/casa/Quanta/MVuvw.cc
+++ b/casa/Quanta/MVuvw.cc
@@ -50,13 +50,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 MVuvw::MVuvw() :
   MVPosition() {}
 
-MVuvw &MVuvw::operator=(const MVuvw &other) {
-  if (this != &other) {
-    xyz = other.xyz;
-  }
-  return *this;
-}
-
 MVuvw::MVuvw(Double in) :
   MVPosition(in) {}
 
@@ -103,9 +96,6 @@ MVuvw::MVuvw(const MVBaseline &pos, const MVDirection &dr, Bool ew) :
 
 MVuvw::MVuvw(const MVPosition &other) :
   MVPosition(other) {}
-
-//# Destructor
-MVuvw::~MVuvw() {}
 
 //# Operators
 Bool MVuvw::

--- a/casa/Quanta/MVuvw.h
+++ b/casa/Quanta/MVuvw.h
@@ -60,6 +60,7 @@ class MVBaseline;
 // <ul>
 //   <li> MVuvw() creates point at origin (0,0,0)
 //   <li> MVuvw(MVuvw) creates a copy
+//   <li> MVuvw(MVPosition) creates (x,y,z) from the given position
 //   <li> MVuvw(Double, Double, Double) creates (x,y,z) with
 //		specified values (assuming meters)
 //   <li> MVuvw(Quantity length,Double, Double) creates a MVuvw assuming
@@ -116,7 +117,7 @@ public:
   //# Constructors
   // Default constructor generates a (0,0,0) uvw
   MVuvw();
-  // Copy constructor
+  // Creates from an MVPosition
   MVuvw(const MVPosition &other);
   // Creates a specified vector
   MVuvw(Double in0, Double in1, Double in2);
@@ -147,11 +148,6 @@ public:
   // <group>
   MVuvw(const MVBaseline &pos, const MVDirection &dr, Bool ew=False);
   // </group>
-  // Copy assignment
-  MVuvw &operator=(const MVuvw &other);
-  
-  // Destructor
-  ~MVuvw();
   
   //# Operators
   // Multiplication defined as in-product

--- a/casa/Quanta/QBase.cc
+++ b/casa/Quanta/QBase.cc
@@ -35,9 +35,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 QBase::QBase() 
 : qUnit() {}
 
-QBase::QBase(const QBase &other) 
-: qUnit(other.qUnit) {}
-
 QBase::QBase(const Unit &s) 
 : qUnit(s) {}
 

--- a/casa/Quanta/QBase.h
+++ b/casa/Quanta/QBase.h
@@ -84,8 +84,6 @@ public:
   //# Constructors
   // Default constructor, generates ""
   QBase();
-  // Copy constructor
-  QBase(const QBase &other);
   // Construct dimensioned QBase (e.g. 'km/Mpc')
   // <thrown>
   //   <li> AipsError if non-matching unit dimensions
@@ -96,10 +94,6 @@ public:
   
   // Destructor
   virtual ~QBase();
-  
-  //# Operators
-  // Assignment (copy)
-  QBase &operator=(const QBase &other);
   
   //# Member functions
   // Get units of QBase

--- a/casa/Quanta/QVector.h
+++ b/casa/Quanta/QVector.h
@@ -73,10 +73,6 @@ template <class T> class QVector : public Quantum<Vector<T> > {
 	// to the same unit.
 	QVector(const Vector<Quantum<T> >& q);
 
-	// Copy constructor (deep copy)
-	QVector(const QVector& other);
-
-	~QVector();
 	// access single element
 	Quantum<T> operator[](uInt index) const;
 

--- a/casa/Quanta/QVector.tcc
+++ b/casa/Quanta/QVector.tcc
@@ -57,10 +57,6 @@ template <class T> QVector<T>::QVector(const Vector<Quantum<T> >& q)
     this->setValue(copy);
 }
 
-template <class T> QVector<T>::QVector(const QVector<T>& other) : Quantum<Vector<T> >(other) {}
-
-template <class T> QVector<T>::~QVector() {}
-
 template <class T> Quantum<T> QVector<T>::operator[](uInt index) const {
 	return Quantum<T>(this->getValue()[index], this->getUnit());
 }

--- a/casa/Quanta/Quantum.h
+++ b/casa/Quanta/Quantum.h
@@ -276,8 +276,6 @@ template <class Qtype> class Quantum : public QBase{
   //# Constructors
   // Default constructor, generates '0'
   Quantum();
-  // Copy constructor (deep copy)
-  Quantum(const Quantum<Qtype> &other);
   // Construct undimensioned quantum (i.e. unit="")
   Quantum(const Qtype &factor);
   // Construct dimensioned quantum (e.g. '1.23 km/Mpc')
@@ -289,14 +287,6 @@ template <class Qtype> class Quantum : public QBase{
   // </group>
   // Construct quantum with unit copied from existing quantum
   Quantum(const Qtype &factor, const QBase &other);
-  
-  // Destructor
-  ~Quantum();
-
-  //# Operators
-  // Assignment (deep copy)
-  Quantum<Qtype> &operator=(const Quantum<Qtype> &other);
-  
   
   // Unary operations
   // <group>

--- a/casa/Quanta/Quantum.tcc
+++ b/casa/Quanta/Quantum.tcc
@@ -50,12 +50,6 @@ Quantum<Qtype>::Quantum() :
     QBase() { qVal = Qtype();}
 
 template <class Qtype>
-Quantum<Qtype>::Quantum(const Quantum<Qtype> &other) :
-    QBase(other) {
-  qVal = other.qVal;
-}
-
-template <class Qtype>
 Quantum<Qtype>::Quantum(const Qtype &factor) : 
   QBase() {
   qVal = factor;
@@ -73,19 +67,7 @@ Quantum<Qtype>::Quantum(const Qtype &factor, const QBase &other) :
   qVal = factor;
 }
 
-template <class Qtype>
-Quantum<Qtype>::~Quantum() {}
-
 //# Quantum operators
-
-template <class Qtype>
-Quantum<Qtype> &Quantum<Qtype>::operator=(const Quantum<Qtype> &other) {
-    if (this != &other) {
-      qVal=other.qVal;
-      qUnit=other.qUnit;
-    }
-    return *this;
-}
 
 template <class Qtype>
 const Quantum<Qtype> &Quantum<Qtype>::operator+() const{

--- a/tables/DataMan/test/dRetypedArrayEngine.h
+++ b/tables/DataMan/test/dRetypedArrayEngine.h
@@ -69,7 +69,6 @@ class RetypedArrayEx1
 public:
     RetypedArrayEx1(): x_p(0), y_p(0) {}
     RetypedArrayEx1(float x, float y) : x_p(x), y_p(y) {}
-    RetypedArrayEx1(const RetypedArrayEx1& that): x_p(that.x_p), y_p(that.y_p) {}
     static String dataTypeId()
         { return "RetypedArrayEx1"; }
     static IPosition shape()

--- a/tables/DataMan/test/dVSCEngine.h
+++ b/tables/DataMan/test/dVSCEngine.h
@@ -40,7 +40,6 @@ class VSCExample
 public:
     VSCExample(): x_p(0), y_p(0) {}
     VSCExample(Int x, float y, const String& z) : x_p(x), y_p(y), z_p(z) {}
-    VSCExample(const VSCExample& that): x_p(that.x_p), y_p(that.y_p), z_p(that.z_p) {}
     static String dataTypeId()
 	{ return "VSCExample"; }
     Int x() const

--- a/tables/Tables/test/tTableDesc.h
+++ b/tables/Tables/test/tTableDesc.h
@@ -56,7 +56,6 @@ class ExampleDesc
 public:
     ExampleDesc(): x_p(0), y_p(0) {}
     ExampleDesc(Int x, float y) : x_p(x), y_p(y) {}
-    ExampleDesc(const ExampleDesc& that): x_p(that.x_p), y_p(that.y_p) {}
     static String dataTypeId()
 	{ return "ExampleDesc"; }
     Int x() const


### PR DESCRIPTION
In C++11 generation of implicitly-declared copy assignment operator is deprecated if a user-provided copy constructor is given, and vice-versa. In new-ish versions of gcc (9+) a very visible set of warnings is issued because of this, and therefore the situation needed to be tackled.

These two commits remove a few user-provided methods that prevent the generation of other implicitly-defined ones. In all cases removing these user-defined methods leads to no loss, as the compiler will still implicitly define them, and with the expected behavior.

There was also a misleading comment in one of the constructors of the classes *deriving* from `MVPosition`: the comment above the constructor read "Copy constructor", but in reality the constructor took always an `const MVPosition &` argument. I updated the comment and the class documentation to indicate that these classes can be created from an `MVPosition`, while the actual copy constructor is now implicitly defined.