### PR TITLE
Use H5free_memory instead of free

### DIFF
--- a/casa/HDF5/HDF5DataType.cc
+++ b/casa/HDF5/HDF5DataType.cc
@@ -37,6 +37,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 #ifdef HAVE_HDF5
 
+// H5free_memory was introduced in 1.8.13
+// If the versions of hdf5 we depend on was formalized this could be simpler
+#if H5_VERS_MAJOR == 1 && (H5_VERS_MINOR < 8 || (H5_VERS_MINOR == 8 && H5_VERS_RELEASE < 13))
+auto &H5free_memory = free;
+#endif
+
   HDF5DataType::HDF5DataType (const Bool*)
     : itsSize (sizeof(Bool))
   {
@@ -328,8 +334,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       char* f0 = H5Tget_member_name(dtid, 0);
       char* f1 = H5Tget_member_name(dtid, 1);
       res = (strcmp(f0, "re") == 0  &&  strcmp (f1, "im") == 0);
-      free(f0);
-      free(f1);
+      H5free_memory(f0);
+      H5free_memory(f1);
     }
     return res;
   }
@@ -343,9 +349,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       char* f2 = H5Tget_member_name(dtid, 2);
       res = (strcmp(f0, "emptyarray") == 0  &&  strcmp (f1, "rank") == 0  &&
              strcmp(f2, "casatype") == 0);
-      free(f0);
-      free(f1);
-      free(f2);
+      H5free_memory(f0);
+      H5free_memory(f1);
+      H5free_memory(f2);
     }
     return res;
   }


### PR DESCRIPTION
H5free_memory was introduced in 1.8.13 and is the way one should free memory allocated via the HDF5 library. Using free has worked until now, but local tests against HDF5 1.12 are broken due to this (they segfault).

When building against HDF5 versions older than 1.8.13 we simply define H5free_memory = free. There is no clear statement in casacore about which HDF5 versions are supported, so I played it conservatively and avoided using the H5_VERSION_LE macro introduced in 1.8.7, and used a boolean logic combination to check the major/minor/release components of the HDF5 version at compile time.