### PR TITLE
Improve error message when chmod fails

### DIFF
--- a/casa/OS/Directory.cc
+++ b/casa/OS/Directory.cc
@@ -315,7 +315,10 @@ void Directory::copy (const Path& target, Bool overwrite,
 	command = "chmod -Rf u+w '";
 #endif
 	command += targetName.expandedName() + "'";
-	AlwaysAssert (system(command.chars()) == 0, AipsError);
+	int result = system(command.chars());
+	if(result != 0)
+	  throw AipsError("Executing chmod command returned an error. Command was: "
+			  + command);	  
     }
 #endif
 }


### PR DESCRIPTION
Copying a dir causes a call to chmod. When this fails
(e.g. because a second process has deleted the dir in the mean time), Casacore
causes a very cryptic message. This PR improves the error message
somewhat.