### PR TITLE
allow for direct specification of IERS data with AppState

### DIFF
--- a/casa/System/AppState.h
+++ b/casa/System/AppState.h
@@ -65,6 +65,14 @@ public:
         return result;
     }
 
+    // get directory containing IERS measures data
+    // an exception is thrown if it does not exist or
+    // does not contain the IERS tables
+    virtual std::string measuresDir( ) const {
+        static std::string result;
+        return result;
+    }
+
     virtual bool initialized( ) const { return false; }
 
     virtual ~AppState( ) { }

--- a/casa/System/AppState.h
+++ b/casa/System/AppState.h
@@ -65,9 +65,11 @@ public:
         return result;
     }
 
-    // get directory containing IERS measures data
-    // an exception is thrown if it does not exist or
-    // does not contain the IERS tables
+    // Get AppState specified directory for (IERS) measures data.
+    //
+    // If data is not found in the specified directory and the
+    // specified directiory name is nonempty (size > 0), an
+    // exception will be thrown in findTab.
     virtual std::string measuresDir( ) const {
         static std::string result;
         return result;

--- a/measures/Measures/MeasIERS.cc
+++ b/measures/Measures/MeasIERS.cc
@@ -399,44 +399,31 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
         "/geodetic/"
       };
 
-      
       Bool found = False;
-      const std::list<std::string> &state_path = AppStateSource::fetch( ).dataPath( );
-      if ( state_path.size( ) > 0 ) {
-        String mdir;
-        for ( std::list<std::string>::const_iterator it=state_path.begin(); ! found && it != state_path.end(); ++it ) {
-          for (Int i=0; i<2; i++) {
-            Path mpath = Path(*it + "/" + (std::string) path[i]);
-            ldir = mpath.absoluteName()+"/";
-            searched.resize(searched.nelements()+1, True);
-            searched[searched.nelements()-1] = ldir;
-            if  (Table::isReadable(ldir+name)) {
-              found = True;
-              break;
-            }
+      const std::string &measures_data = AppStateSource::fetch( ).measuresDir( );
+      if ( measures_data.size( ) > 0 ) {
+        for (Int i=0; i<2; i++) {
+          Path mpath = Path(measures_data + "/" + (std::string) path[i]);
+          ldir = mpath.absoluteName()+"/";
+          searched.resize(searched.nelements()+1, True);
+          searched[searched.nelements()-1] = ldir;
+          if  (Table::isReadable(ldir+name)) {
+            found = True;
+            break;
           }
         }
-      } else if ( ! found ) {
-
-        if (Aipsrc::find(ldir, rc)){
-          ldir += '/';
-          searched.resize(searched.nelements() + 1, True);
-          searched[searched.nelements() - 1] = ldir;
-        }
-        else {
-          String udir;
-
-          if(!dir.empty()) {
-            udir = dir + '/';
+          if ( found == False ) {
+            throw(AipsError("Measures directory specified which does not contain the IERS data."));
           }
+      }
 
+      if ( found == False ) {
+        const std::list<std::string> &state_path = AppStateSource::fetch( ).dataPath( );
+        if ( state_path.size( ) > 0 ) {
           String mdir;
-          if (Aipsrc::find(mdir, "measures.directory")) {
-            mdir.trim();
-            Path mpath = Path(mdir);
-            mpath.append(udir);
+          for ( std::list<std::string>::const_iterator it=state_path.begin(); ! found && it != state_path.end(); ++it ) {
             for (Int i=0; i<2; i++) {
-              Path mpath = Path(mdir +"/" + path[i]);
+              Path mpath = Path(*it + "/" + (std::string) path[i]);
               ldir = mpath.absoluteName()+"/";
               searched.resize(searched.nelements()+1, True);
               searched[searched.nelements()-1] = ldir;
@@ -446,18 +433,49 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
               }
             }
           }
-          if (!found) {
-            String casadata=String(CASADATA);
-            casadata.gsub("%CASAROOT%", Aipsrc::aipsRoot());
-            casadata.gsub("%CASAHOME%", Aipsrc::aipsHome());
-            Path cdatapath(casadata);
-            for (Int i=0; i<2; i++) {
-              ldir = cdatapath.absoluteName() + path[i];
-              searched.resize(searched.nelements() + 1, True);
-              searched[searched.nelements() - 1] = ldir;
-              if (Table::isReadable(ldir + name)) {
-                found = True;
-                break;
+        } else if ( ! found ) {
+
+          if (Aipsrc::find(ldir, rc)){
+            ldir += '/';
+            searched.resize(searched.nelements() + 1, True);
+            searched[searched.nelements() - 1] = ldir;
+          }
+          else {
+            String udir;
+
+            if(!dir.empty()) {
+              udir = dir + '/';
+            }
+
+            String mdir;
+            if (Aipsrc::find(mdir, "measures.directory")) {
+              mdir.trim();
+              Path mpath = Path(mdir);
+              mpath.append(udir);
+              for (Int i=0; i<2; i++) {
+                Path mpath = Path(mdir +"/" + path[i]);
+                ldir = mpath.absoluteName()+"/";
+                searched.resize(searched.nelements()+1, True);
+                searched[searched.nelements()-1] = ldir;
+                if  (Table::isReadable(ldir+name)) {
+                  found = True;
+                  break;
+                }
+              }
+            }
+            if (!found) {
+              String casadata=String(CASADATA);
+              casadata.gsub("%CASAROOT%", Aipsrc::aipsRoot());
+              casadata.gsub("%CASAHOME%", Aipsrc::aipsHome());
+              Path cdatapath(casadata);
+              for (Int i=0; i<2; i++) {
+                ldir = cdatapath.absoluteName() + path[i];
+                searched.resize(searched.nelements() + 1, True);
+                searched[searched.nelements() - 1] = ldir;
+                if (Table::isReadable(ldir + name)) {
+                  found = True;
+                  break;
+                }
               }
             }
           }

--- a/measures/Measures/MeasIERS.cc
+++ b/measures/Measures/MeasIERS.cc
@@ -413,7 +413,7 @@ Bool MeasIERS::findTab(Table& tab, const Table *tabin, const String &rc,
           }
         }
           if ( found == False ) {
-            throw(AipsError("Measures directory specified which does not contain the IERS data."));
+            throw(AipsError(std::string("Measures directory specified which does not contain the IERS data: ") + measures_data));
           }
       }
 


### PR DESCRIPTION
CASA is moving toward supporting user configuration via a Python config file that is evaluated. These configuration settings are made available in C++ via the AppState class. There is already a dataPath( ) option which provides a list of directories which MeasIERS searches for IERS data. In general this has worked well, but some CASA stakeholders want to explicitly set the specific path that is used instead of leaving it up to a path search. This modification adds a measuresDir( ) option to AppState which take precedence over the dataPath( ) in MeasIERS.

This change should have no effect outside of CASA. The default value returned by measuresDir( ) is an empty string which MeasIERS ignores. To change this, a casacore user (like CASA) derives from AppState and provides a non empty string to direct MeasIERS to a specific path to look for the IERS tables. Since measuresDir( ) is specific to the measures module, an exception is thrown if the returned directory does not exist.
