### PR TITLE
Fix compilation warnings with g++ 10.2

### DIFF
--- a/casa/OS/HostInfoDarwin.h
+++ b/casa/OS/HostInfoDarwin.h
@@ -110,8 +110,8 @@ HostMachineInfo::HostMachineInfo( ) : valid(1) {
     struct host_basic_info basic_info;
     unsigned int count = HOST_BASIC_INFO_COUNT;
 
-    /* get the page size with "getpagesize" and calculate pageshift from it */
-    pagesize_ = pagesize = getpagesize();
+    /* get the page size with portable sysconf and calculate pageshift from it */
+    pagesize_ = pagesize = sysconf(_SC_PAGESIZE);
     pageshift = 0;
     while (pagesize > 1)
     {

--- a/measures/Measures/test/tMeasMath.cc
+++ b/measures/Measures/test/tMeasMath.cc
@@ -247,10 +247,10 @@ int main()
 	cout << " equation of equinoxes 45882.5: " <<
 	    nt1.getEqoxAngle(45882,"''") << endl;
 	cout << " equation at 45882.5 from derivative at 45882.7: " <<
-	    nt1.getEqoxAngle(45882.2,"''") - (const Double) 0.2 *
+	    nt1.getEqoxAngle(45882.2,"''") -  0.2 *
 		Quantity(nt1.derivativeEqox(45882.2)/C::arcsec,"''") << endl;
 	cout << " equation at 45882.5 from derivative at 45882.54: " <<
-	    nt1.getEqoxAngle(45882.04,"''") - (const Double) 0.04 *
+	    nt1.getEqoxAngle(45882.04,"''") -  0.04 *
 		Quantity(nt1.derivativeEqox(45882.04)/C::arcsec,"''") << endl;
 	cout << "J2000 nutation: " << endl;
 	Double eq;

--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -1468,7 +1468,6 @@ Bool JPLDE(tableProperties &tprop, inputValues &inVal) {
   uInt ksize(0);
   uInt ncoeff(0);
   Double stepo(0);
-  Double endepo(0);
   uInt incepo(0);
   vector<String> kwnames;
   vector<Double> kwval;
@@ -1500,7 +1499,6 @@ Bool JPLDE(tableProperties &tprop, inputValues &inVal) {
     for (++bc; bc<bl; ++bc) {
       if (hfields[bc].size()<3) continue;
       stepo = double_data(hfields[bc][0]) -2400000.5;
-      endepo = double_data(hfields[bc][1]) -2400000.5;
       incepo = int_data(hfields[bc][2]);
       break;
     };
@@ -1568,24 +1566,25 @@ Bool JPLDE(tableProperties &tprop, inputValues &inVal) {
   while (read_line(line, infile)) {
     if (line.size() < 2 || int_data(line[1]) != Int(ncoeff)) continue;
     Double st0;
-    Double st1;
     vector<Double> res;
     while (read_line(line, infile)) {
       for (uInt i=0; i<line.size(); ++i) {
-	if (res.size() == 0 && i<2) {
-	  if (i==0) st0 = double_data(line[i])-2400000.5;
-	  else st1 = double_data(line[i])-2400000.5;
-	  continue;
-	};
-	if (st0 <= inVal.lastmjd) break;
-	res.push_back(double_data(line[i]));
-      };
-      if (st0 <= inVal.lastmjd) break;
+        if (res.size() == 0 && i<2) {
+          if (i==0) 
+            st0 = double_data(line[i])-2400000.5;
+          continue;
+        }
+        if (st0 <= inVal.lastmjd) 
+          break;
+        res.push_back(double_data(line[i]));
+      }
+      if (st0 <= inVal.lastmjd) 
+        break;
       if (res.size() >= ncoeff) {
-	res.resize(ncoeff);
-	allcol.push_back(res);
-	allmjd.push_back(st0);
-	break;
+        res.resize(ncoeff);
+        allcol.push_back(res);
+        allmjd.push_back(st0);
+        break;
       };
     };
   };

--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -88,15 +88,16 @@ int MSInterval::comp(const void * obj1, const void * obj2) const
 
 MSIter::MSIter(const MeasurementSet& ms,
                const std::vector<std::pair<String, CountedPtr<BaseCompare>>>& sortColumns) :
-  curMS_p(0),lastMS_p(-1),
-  storeSorted_p(false),
-  interval_p(0), prevFirstTimeStamp_p(-1.0),
-  allBeamOffsetsZero_p(True),
-  timeComp_p(0),
   timeInSort_p(false),
   arrayInSort_p(false),
   ddInSort_p(false),
-  fieldInSort_p(false)
+  fieldInSort_p(false),
+  curMS_p(0),lastMS_p(-1),
+  storeSorted_p(false),
+  interval_p(0),
+  prevFirstTimeStamp_p(-1.0),
+  allBeamOffsetsZero_p(True),
+  timeComp_p(0)
 {
     This = (MSIter*)this;
     bms_p.resize(1);
@@ -106,15 +107,16 @@ MSIter::MSIter(const MeasurementSet& ms,
 
 MSIter::MSIter(const Block<MeasurementSet>& mss,
   const std::vector<std::pair<String, CountedPtr<BaseCompare>>>& sortColumns) :
-  bms_p(mss), curMS_p(0),lastMS_p(-1),
-  storeSorted_p(false),
-  interval_p(0), prevFirstTimeStamp_p(-1.0),
-  allBeamOffsetsZero_p(True),
-  timeComp_p(0),
+  bms_p(mss),
   timeInSort_p(false),
   arrayInSort_p(false),
   ddInSort_p(false),
-  fieldInSort_p(false)
+  fieldInSort_p(false),
+  curMS_p(0),lastMS_p(-1),
+  storeSorted_p(false),
+  interval_p(0), prevFirstTimeStamp_p(-1.0),
+  allBeamOffsetsZero_p(True),
+  timeComp_p(0)
 {
     This = (MSIter*)this;
     construct(sortColumns);
@@ -125,7 +127,7 @@ void MSIter::construct(
 {
     nMS_p=bms_p.nelements();
     if (nMS_p==0) throw(AipsError("MSIter::construct -  No input MeasurementSets"));
-    for (Int i=0; i<nMS_p; i++) {
+    for (size_t i=0; i<nMS_p; i++) {
         if (bms_p[i].nrow()==0) {
             throw(AipsError("MSIter::construct - Input MeasurementSet.has zero selected rows"));
         }
@@ -149,8 +151,7 @@ void MSIter::construct(
     }
 
     // Create the table iterators
-    for (Int i=0; i<nMS_p; i++) {
-        Bool useIn=False, store=False, useSorted=False;
+    for (size_t i=0; i<nMS_p; i++) {
         // create the iterator for each MS
         tabIter_p[i] = new TableIterator(bms_p[i],sortColumnNames,
                                          sortCompareFunctions,sortOrders);
@@ -609,7 +610,7 @@ const MFrequency& MSIter::restFrequency(Int line) const
 
 void MSIter::setMSInfo()
 {
-  newMS_p = (lastMS_p != curMS_p);
+  newMS_p = (lastMS_p != (ssize_t)curMS_p);
   if (newMS_p) {
     lastMS_p = curMS_p;
     if (!tabIterAtStart_p[curMS_p]) tabIter_p[curMS_p]->reset();

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -420,9 +420,10 @@ protected:
   Bool timeInSort_p, arrayInSort_p, ddInSort_p, fieldInSort_p;
 
   size_t nMS_p, curMS_p;
+  ssize_t lastMS_p;
   CountedPtr<MSColumns> msc_p;
   Table curTable_p;
-  Int lastMS_p, curArrayIdFirst_p, lastArrayId_p, curSourceIdFirst_p;
+  Int curArrayIdFirst_p, lastArrayId_p, curSourceIdFirst_p;
   String curFieldNameFirst_p, curSourceNameFirst_p;
   Int curFieldIdFirst_p, lastFieldId_p;
   Int curSpectralWindowIdFirst_p, lastSpectralWindowId_p;

--- a/msfits/MSFits/MSFitsInput.cc
+++ b/msfits/MSFits/MSFitsInput.cc
@@ -1737,7 +1737,6 @@ void MSFitsInput::_fillSysPowerTable(BinaryTable& bt) {
     ThrowIf(nIF > 1, "Currently SYSPOWER tables with only a single IF may be imported");
     ThrowIf(nIF == 0, "Number of IFs in SY table cannot be 0");
     const auto nPol = btKeywords.asInt("NO_POL");
-    Int nrows = bt.nrows();
     Table syTab = bt.fullTable();
     //syTab.tableDesc().show();
     const static String name = "SYSPOWER";

--- a/tables/DataMan/test/tIncrementalStMan.cc
+++ b/tables/DataMan/test/tIncrementalStMan.cc
@@ -560,7 +560,7 @@ void testWithLocking()
                                                    IPosition(1,n)));
       // Check the contents.
       for (uInt i=0; i<n; ++i) {
-        AlwaysAssertExit (vec[i] == row/10000*10000);
+        AlwaysAssertExit (vec[i] == (Int)row/10000*10000);
         row++;
       }
       tab.unlock();

--- a/tables/TaQL/test/tTableExprData.cc
+++ b/tables/TaQL/test/tTableExprData.cc
@@ -141,7 +141,7 @@ int main()
     Vector<uInt> m = findMatches (fld1, fld2);
     AlwaysAssertExit (m.nelements() == 1);
     AlwaysAssertExit (m(0) == 3);
-  } catch (std::exception x) {
+  } catch (std::exception& x) {
     cout << "Unexpected exception: " << x.what() << endl;
     return 1;
   } catch (...) {


### PR DESCRIPTION
This PR fixes some warnings that I have seen while compiling with g++ 10.2.

The warnings that are now fixed are:
```
casacore_github/casacore/casa/OS/HostInfo.cc: In static member function ‘static casacore::Double casacore::HostInfo::secondsFrom1970()’:
/home/cgarcia/PPS/src/casacore_github/casacore/casa/OS/HostInfo.cc:114:28: warning: ‘int ftime(timeb*)’ is deprecated [-Wdeprecated-declarations]
  114 |     AlwaysAssert(ftime(&ftm) >= 0, AipsError);

casacore/msfits/MSFits/MSFitsInput.cc:1740:9: warning: unused variable ‘nrows’ [-Wunused-variable]
 1740 |     Int nrows = bt.nrows();

casacore/tables/DataMan/test/tIncrementalStMan.cc:563:34: warning: comparison of integer expressions of different signedness: ‘int’ and ‘casacore::uInt’ {aka ‘unsigned int’} [-Wsign-compare]
  563 |         AlwaysAssertExit (vec[i] == row/10000*10000);

casacore/tables/TaQL/test/tTableExprData.cc:144:27: warning: catching polymorphic type ‘class std::exception’ by value [-Wcatch-value=]
  144 |   } catch (std::exception x) {

casacore/measures/Measures/test/tMeasMath.cc:250:39: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  250 |      nt1.getEqoxAngle(45882.2,"''") - (const Double) 0.2 *
      |                                       ^~~~~~~~~~~~~~~~~~

casacore/measures/Measures/test/tMeasMath.cc:253:40: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  253 |      nt1.getEqoxAngle(45882.04,"''") - (const Double) 0.04 *

casacore/casacore/ms/MeasurementSets/MSIter.h: In constructor ‘casacore::MSIter::MSIter(const casacore::MeasurementSet&, const std::vector<std::pair<casacore::String, casacore::CountedPtr<casacore::BaseCompare> > >&)’:
/home/cgarcia/PPS/src/casacore_github/casacore/casacore/ms/MeasurementSets/MSIter.h:471:26: warning: ‘casacore::MSIter::timeComp_p’ will be initialized after [-Wreorder]
  471 |   CountedPtr<MSInterval> timeComp_p; // Points to the time comparator.
      |                          ^~~~~~~~~~

casacore/casacore/ms/MeasurementSets/MSIter.h:420:8: warning:   ‘casacore::Bool casacore::MSIter::timeInSort_p’ [-Wreorder]
  420 |   Bool timeInSort_p, arrayInSort_p, ddInSort_p, fieldInSort_p;
      |        ^~~~~~~~~~~~

casacore/ms/MeasurementSets/MSIter.cc:89:1: warning:   when initialized here [-Wreorder]
   89 | MSIter::MSIter(const MeasurementSet& ms,
      | ^~~~~~

casacore/casacore/ms/MeasurementSets/MSIter.h: In constructor ‘casacore::MSIter::MSIter(const casacore::Block<casacore::MeasurementSet>&, const std::vector<std::pair<casacore::String, casacore::CountedPtr<casacore::BaseCompare> > >&)’:
casacore/casacore/ms/MeasurementSets/MSIter.h:471:26: warning: ‘casacore::MSIter::timeComp_p’ will be initialized after [-Wreorder]
  471 |   CountedPtr<MSInterval> timeComp_p; // Points to the time comparator.
      |                          ^~~~~~~~~~

casacore/ms/MeasurementSets/MSIter.cc:128:20: warning: comparison of integer expressions of different signedness: ‘casacore::Int’ {aka ‘int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  128 |     for (Int i=0; i<nMS_p; i++) {
      |                   ~^~~~~~

casacore/ms/MeasurementSets/MSIter.cc:152:20: warning: comparison of integer expressions of different signedness: ‘casacore::Int’ {aka ‘int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  152 |     for (Int i=0; i<nMS_p; i++) {
      |                   ~^~~~~~

casacore/ms/MeasurementSets/MSIter.cc:153:14: warning: unused variable ‘useIn’ [-Wunused-variable]
  153 |         Bool useIn=False, store=False, useSorted=False;
      |              ^~~~~

casacore/ms/MeasurementSets/MSIter.cc:153:27: warning: unused variable ‘store’ [-Wunused-variable]
  153 |         Bool useIn=False, store=False, useSorted=False;
      |                           ^~~~~

casacore/ms/MeasurementSets/MSIter.cc:153:40: warning: unused variable ‘useSorted’ [-Wunused-variable]
  153 |         Bool useIn=False, store=False, useSorted=False;
      |                                        ^~~~~~~~~

casacore/ms/MeasurementSets/MSIter.cc: In member function ‘void casacore::MSIter::setMSInfo()’:
casacore/ms/MeasurementSets/MSIter.cc:612:23: warning: comparison of integer expressions of different signedness: ‘casacore::Int’ {aka ‘int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  612 |   newMS_p = (lastMS_p != curMS_p);
      |              ~~~~~~~~~^~~~~~~~~~

casacore/msfits/MSFits/MSFitsInput.cc:1740:9: warning: unused variable ‘nrows’ [-Wunused-variable]
 1740 |     Int nrows = bt.nrows();
      |         ^~~~~

```

Note that for the HostInfo::secondsFrom1970() function now it relies exclusively on POSIX standard clock_gettime() rather than all the platform-specific solutions as before