### PR TITLE
Minor changes to the test reference output files 

### DIFF
--- a/casa/IO/test/tAipsIO.out
+++ b/casa/IO/test/tAipsIO.out
@@ -233,10 +233,10 @@ str1 str1 strin2 strin2
 strin2 strin2 stri3 stri3
 stri3 stri3 string45 string45
 string45 string45 s s
-MemoryIO::read - incorrect number of bytes read:
+MemoryIO::read - incorrect number of bytes read:  
   size=4, used=3000555, pos=3000555, left=0
 3000288
-MemoryIO::read - incorrect number of bytes read:
+MemoryIO::read - incorrect number of bytes read:  
   size=4, used=3000555, pos=3000555, left=0
 Length=3000555
 AipsIO::getNextType: no magic value found

--- a/casa/IO/test/tByteIO.out
+++ b/casa/IO/test/tByteIO.out
@@ -1,4 +1,4 @@
-MemoryIO::read - incorrect number of bytes read:
+MemoryIO::read - incorrect number of bytes read:  
   size=1, used=61, pos=61, left=0
 MemoryIO::seek - cannot seek before start of object
 MemoryIO::write - buffer cannot be expanded

--- a/measures/TableMeasures/test/tTableMeasures.out
+++ b/measures/TableMeasures/test/tTableMeasures.out
@@ -284,7 +284,7 @@ TableMeasDescBase::reconstruct; MEASINFO record not found for column TimeRef
 The following line should be a null column exception.
 Invalid Table operation: MeasTableColumn object is null
 The following line should be an illegal offset column type exception.
-Invalid Table data type when accessing column in ScalarColumn ctor for column SpareCol1
+Invalid Table data type when accessing column  in ScalarColumn ctor for column SpareCol1
 Reopening the table read-only and reading contents...
 Filling the MDirection column MDirColumn
 put: Direction: [0.565521, 0.205833, 0.798636]

--- a/ms/MSSel/test/tMSSelection.out
+++ b/ms/MSSel/test/tMSSelection.out
@@ -809,7 +809,7 @@ DDIDs(SPW)   = [1]
 StateList    = []
 Number of selected rows: 529
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-###MSSelectionError: No Spw ID(s) matched specifications
+###MSSelectionError: No Spw ID(s) matched specifications 
 (near char. 0 in string ""ALMA_RB_03#BB_1#SW-01#FULL_RE"")
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 BE: Baseline Expr=(DV*,DA*)@(A1*,P*,S*)&(DV*)@(P*);!5;!11

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -376,3 +376,4 @@ WITH [SELECT abs((phase(t1.DATA))-(phase(t2.DATA))) AS D FROM a.ms AS t1,/home/g
 
 with ~a select 1+2 from [~b,[select 3+4 from [[select 5+6],~c]], ~d giving ~e] where 3+4 giving ~f
 WITH ~a SELECT (1)+(2) FROM [~b,[SELECT (3)+(4) FROM [[SELECT (5)+(6)],~c]],~d GIVING ~e] WHERE (3)+(4) GIVING ~f
+


### PR DESCRIPTION
Some of the test output reference files (.out) have diverged slightly (mainly spaces and return carriages) from what the tests are delivering. These differences are masked by the fact that casacore_floatcheck tool tries to see numerical differences, so they are not really a problem, but I thought it is good to have them aligned with the real output.
By the way, I come across this issue when running the tests in a machine without the python command installed (only python3 was installed). See also https://github.com/casacore/casacore/issues/983.