### PR TITLE
Restore Quantum user-defined copy constructor

### DIFF
--- a/casa/Quanta/Quantum.h
+++ b/casa/Quanta/Quantum.h
@@ -276,6 +276,8 @@ template <class Qtype> class Quantum : public QBase{
   //# Constructors
   // Default constructor, generates '0'
   Quantum();
+  // Copy constructor (deep copy)
+  Quantum(const Quantum<Qtype> &other);
   // Construct undimensioned quantum (i.e. unit="")
   Quantum(const Qtype &factor);
   // Construct dimensioned quantum (e.g. '1.23 km/Mpc')
@@ -288,6 +290,10 @@ template <class Qtype> class Quantum : public QBase{
   // Construct quantum with unit copied from existing quantum
   Quantum(const Qtype &factor, const QBase &other);
   
+  //# Operators
+  // Assignment (deep copy)
+  Quantum<Qtype> &operator=(const Quantum<Qtype> &other);
+
   // Unary operations
   // <group>
   const Quantum<Qtype> &operator+() const;

--- a/casa/Quanta/Quantum.tcc
+++ b/casa/Quanta/Quantum.tcc
@@ -50,6 +50,19 @@ Quantum<Qtype>::Quantum() :
     QBase() { qVal = Qtype();}
 
 template <class Qtype>
+Quantum<Qtype>::Quantum(const Quantum<Qtype> &other) :
+    QBase(other) {
+  // Here qVal is copy-assigned in the constructor body
+  // instead of direct-initialized in the member initializer list (which invokes
+  // its copy constructor) to cope with Array/Vector/Matrix values: they copy by
+  // reference on the copy construction, but by value on copy assignment (and
+  // this class wants to do the latter).
+  // See https://github.com/casacore/casacore/commit/e5d8484b5108f0a890ddd9d494c2efcab738ce7c#r42799565
+  // for reference
+  qVal = other.qVal;
+}
+
+template <class Qtype>
 Quantum<Qtype>::Quantum(const Qtype &factor) : 
   QBase() {
   qVal = factor;
@@ -68,6 +81,9 @@ Quantum<Qtype>::Quantum(const Qtype &factor, const QBase &other) :
 }
 
 //# Quantum operators
+
+template <class Qtype>
+Quantum<Qtype> &Quantum<Qtype>::operator=(const Quantum<Qtype> &/*other*/) = default;
 
 template <class Qtype>
 const Quantum<Qtype> &Quantum<Qtype>::operator+() const{

--- a/casa/Quanta/test/tQuantum.cc
+++ b/casa/Quanta/test/tQuantum.cc
@@ -308,6 +308,21 @@ try {
     	AlwaysAssert(near(q.getValue("MHz"), 99930.8, 1e-5), AipsError);
 
     }
+
+    // Test copy construction and copy assignment with Vector does deep copying
+    {
+        // Copy constructor
+        Quantum<Vector<Int>> original({1, 2, 3}, "m");
+        Quantum<Vector<Int>> copy_constructed(original);
+        copy_constructed.getValue()[0] = 100;
+        AlwaysAssert(original.getValue()[0] == 1, AipsError);
+
+        // Copy assignment
+        Quantum<Vector<Int>> copy_assigned;
+        copy_assigned = original;
+        copy_assigned.getValue()[0] = 100;
+        AlwaysAssert(original.getValue()[0] == 1, AipsError);
+    }
     cout << endl << "--------------------------" << endl;
     return 0;
 }


### PR DESCRIPTION
The removal of the copy-constructor in the `Quantum` class brought unintended consequences, breaking one of the CASA tests  (original report [here](https://github.com/casacore/casacore/commit/e5d8484b5108f0a890ddd9d494c2efcab738ce7c#r42799565) by @dmehring). This test is present in the casacore codebase, but is skipped by default as it requires some extra data hosted by NRAO, making the problem invisible to the Travis CI environment.

After some investigation, it turned out this was due to the different semantics of the copy constructor and copy assignment of the casacore Array classes (see [this explanation](https://github.com/casacore/casacore/commit/e5d8484b5108f0a890ddd9d494c2efcab738ce7c#r42992327)).

This PR brings back the user-defined copy-constructor, which needs to *assign* `other.qVal` rather than direct initializing it via copy construction if one wants `Quantum` to perform deep-copying of Vectors at copy-construction time. The copy-assignment operator is also brought back (if one is defined, the other should also be -- that was the whole point of #1057), but defaulted since the default behavior is already what we need.

The existing `tQuantum` test is also being augmented to include deep-copying checks for the Vector class, thus preventing this bug is introduced again.