### PR TITLE
Only skip over a subtable if there still is data to skip

### DIFF
--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -341,7 +341,7 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 	  }
 	}
 	else{ // ignore this subtable
-	  if (infits.datasize() > 0)
+	  if (infits.currsize() > 0)
 	    infits.skip_all(FITS::BinaryTableHDU);
 	}
       }


### PR DESCRIPTION
This improves upon commit 8f1127361ea745c9eecc78adc4c4c45e9f677f8b
by handling the case where the subtable contains a small amount
of data that has already been read when parsing the table header.

This fixes skipping the GATEMODL subtable found in VLBA pulsar
bin data.