### PR TITLE
Fix IPosition constructor from Array<long long> and add test

### DIFF
--- a/casa/Arrays/IPosition.cc
+++ b/casa/Arrays/IPosition.cc
@@ -76,11 +76,11 @@ IPosition::IPosition (const Array<int> &other)
 
 IPosition::IPosition (const Array<long long> &other)
   : size_p (0),
-    data_p (0)
+    data_p (buffer_p)
 {
     if (other.size() > 0) {
         if (other.ndim() != 1) {
-            throw(ArrayError("IPosition::IPosition(const Array<Int64> &other) - "
+            throw(ArrayError("IPosition::IPosition(const Array<long long> &other) - "
                             "other is not one-dimensional"));
         }
         fill (other.size(), other.begin());
@@ -208,7 +208,7 @@ IPosition::IPosition (const std::vector<int> &other)
 
 IPosition::IPosition (const std::vector<long long> &other)
   : size_p (0),
-    data_p (0)
+    data_p (nullptr)
 {
     fill (other.size(), other.begin());
     assert(ok());

--- a/casa/Arrays/test/tIPosition.cc
+++ b/casa/Arrays/test/tIPosition.cc
@@ -119,6 +119,44 @@ BOOST_AUTO_TEST_CASE( common_operations )
   }
 }
 
+BOOST_AUTO_TEST_CASE( construct_from_int_array )
+{
+  Vector<int> emptyVec;
+  IPosition emptyPos(emptyVec);
+  BOOST_CHECK(emptyPos.nelements() == 0);
+
+  Vector<int> filledVec{ 19, 82 };
+  IPosition filledPos(filledVec);
+  BOOST_CHECK(filledPos.nelements() == 2);
+  BOOST_CHECK(filledPos[0] == 19);
+  BOOST_CHECK(filledPos[1] == 82);
+
+  Vector<int> bigVec{ 9, 8, 7, 6, 5, 4, 3 };
+  IPosition bigPos(bigVec);
+  BOOST_CHECK(bigPos.nelements() == 7);
+  for(int i=0; i!=7; ++i)
+    BOOST_CHECK(bigPos[i] == (9-i));
+}
+
+BOOST_AUTO_TEST_CASE( construct_from_ll_array )
+{
+  Vector<long long> emptyVec;
+  IPosition emptyPos(emptyVec);
+  BOOST_CHECK(emptyPos.nelements() == 0);
+
+  Vector<long long> filledVec{ 19, 82 };
+  IPosition filledPos(filledVec);
+  BOOST_CHECK(filledPos.nelements() == 2);
+  BOOST_CHECK(filledPos[0] == 19);
+  BOOST_CHECK(filledPos[1] == 82);
+
+  Vector<long long> bigVec{ 9, 8, 7, 6, 5, 4, 3 };
+  IPosition bigPos(bigVec);
+  BOOST_CHECK(bigPos.nelements() == 7);
+  for(int i=0; i!=7; ++i)
+    BOOST_CHECK(bigPos[i] == (9-i));
+}
+
 BOOST_AUTO_TEST_CASE( move_exhaustively )
 {
   int i;


### PR DESCRIPTION
Benjamin Bean found a bug in the IPosition(const Array<long long>&) constructor. I've added
a test for this constructor, which indeed failed before the fix and now passes.