### PR TITLE
Fix further compiler warnings

### DIFF
--- a/casa/IO/RegularFileIO.cc
+++ b/casa/IO/RegularFileIO.cc
@@ -76,6 +76,7 @@ int RegularFileIO::openCreate (const RegularFile& file,
 	    throw (AipsError ("RegularFileIO: new file " + name +
 			      " already exists"));
 	}
+	CASACORE_FALLTHROUGH;
     case ByteIO::New:
     case ByteIO::Scratch:
         create = True;

--- a/casa/Utilities/Regex.cc
+++ b/casa/Utilities/Regex.cc
@@ -382,6 +382,7 @@ String Regex::fromSQLPattern(const String& pattern)
 	case ')':
 	case '\\':
             result.push_back ('\\');
+            CASACORE_FALLTHROUGH;
 	default:
             result.push_back (c);
 	}

--- a/casa/Utilities/ValType.cc
+++ b/casa/Utilities/ValType.cc
@@ -284,6 +284,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpComplex:
     case TpArrayComplex:
       nrElementsPerValue = 2;
+      CASACORE_FALLTHROUGH;
     case TpFloat:
     case TpArrayFloat:
       readFunc  = CanonicalConversion::getToLocal (static_cast<float*>(0));
@@ -292,6 +293,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpDComplex:
     case TpArrayDComplex:
       nrElementsPerValue = 2;
+      CASACORE_FALLTHROUGH;
     case TpDouble:
     case TpArrayDouble:
       readFunc  = CanonicalConversion::getToLocal (static_cast<double*>(0));
@@ -346,6 +348,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpComplex:
     case TpArrayComplex:
       nrElementsPerValue = 2;
+      CASACORE_FALLTHROUGH;
     case TpFloat:
     case TpArrayFloat:
       readFunc  = LECanonicalConversion::getToLocal (static_cast<float*>(0));
@@ -354,6 +357,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpDComplex:
     case TpArrayDComplex:
       nrElementsPerValue = 2;
+      CASACORE_FALLTHROUGH;
     case TpDouble:
     case TpArrayDouble:
       readFunc  = LECanonicalConversion::getToLocal (static_cast<double*>(0));
@@ -378,17 +382,21 @@ Bool ValType::isPromotable (DataType from, DataType to)
     case TpChar:
 	if (to == TpShort)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpShort:
 	if (to == TpInt)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpInt:
 	if (to == TpInt64)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpInt64:
     case TpFloat:
     case TpDouble:
 	if (to == TpFloat  ||  to == TpDouble)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpComplex:
     case TpDComplex:
 	if (to == TpComplex  ||  to == TpDComplex)
@@ -397,9 +405,11 @@ Bool ValType::isPromotable (DataType from, DataType to)
     case TpUChar:
 	if (to == TpUShort)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpUShort:
 	if (to == TpUInt)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpUInt:
         if (to == TpInt64)
             return True;

--- a/casa/aipsdef.h
+++ b/casa/aipsdef.h
@@ -78,4 +78,16 @@ extern Bool aips_debug_on;
 #define CASACORE_STRINGIFY(x) CASACORE_STRINGIFY_HELPER(x)
 #define CASACORE_STRINGIFY_HELPER(x) #x
 
+// A fallthrough attribute to avoid compiler warnings,
+// available only from C++17 onwards
+#if __cplusplus >= 201703L
+#define CASACORE_FALLTHROUGH [[fallthrough]]
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#define CASACORE_FALLTHROUGH [[gnu::fallthrough]]
+#elif defined(__clang__)
+#define CASACORE_FALLTHROUGH [[clang::fallthrough]]
+#else
+#define CASACORE_FALLTHROUGH
+#endif
+
 #endif

--- a/coordinates/Coordinates/Projection.cc
+++ b/coordinates/Coordinates/Projection.cc
@@ -341,10 +341,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		switch (actualSize) { // absence of breaks statements intended
 		case 0:
 		    parameters_p(0) = 0.; // mu
+		    CASACORE_FALLTHROUGH;
 		case 1:
 		    parameters_p(1) = 0.; // phi_c
+		    CASACORE_FALLTHROUGH;
 		case 2:
 		    parameters_p(2) = 90.; // theta_c
+		    CASACORE_FALLTHROUGH;
 		default:
 		    break;
 		}

--- a/fits/FITS/BinTable.cc
+++ b/fits/FITS/BinTable.cc
@@ -119,6 +119,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
 			    maxsize = nbytes;
 			}
 			// fall throught to BYTE for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr_p[i] = (void *)(new uChar[maxsize]);
 			AlwaysAssert(vaptr_p[i], AipsError);

--- a/fits/FITS/FITSReader.cc
+++ b/fits/FITS/FITSReader.cc
@@ -310,6 +310,7 @@ void showBinaryTable(BinaryTableExtension &x) {
                 if (maxsize % 8) nbytes++;
                 maxsize = nbytes;
             }
+            CASACORE_FALLTHROUGH;
             case FITS::BYTE: 
                vaptr[i] = (void *)(new unsigned char[maxsize]);
                break;

--- a/fits/FITS/FITSTable.cc
+++ b/fits/FITS/FITSTable.cc
@@ -853,6 +853,7 @@ Bool FITSTable::reopen(const String &fileName)
 			maxsize = nbytes;
 		    }
 		    // fall through to BYTE for actual allocation
+		    CASACORE_FALLTHROUGH;
 		case FITS::BYTE: 
 		    vaptr_p[i] = (void *)(new uChar[maxsize]);
 		    AlwaysAssert(vaptr_p[i], AipsError);

--- a/fits/FITS/FITSTable2.cc
+++ b/fits/FITS/FITSTable2.cc
@@ -99,6 +99,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpBool:
 	  sizeInBytes += size*1;
 	  code = "L";
@@ -115,6 +116,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpUChar:
 	  sizeInBytes += size*1;
 	  code = "B";
@@ -131,6 +133,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpShort:
 	  sizeInBytes += size*2;
 	  code = "I";
@@ -147,6 +150,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpInt:
 	  sizeInBytes += size*4;
 	  code = "J";
@@ -163,6 +167,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpFloat:
 	  sizeInBytes += size*4;
 	  code = "E";
@@ -179,6 +184,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpDouble:
 	  sizeInBytes += size*8;
 	  code = "D";
@@ -195,6 +201,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpComplex:
 	  sizeInBytes += size*8;
 	  code = "C";
@@ -211,6 +218,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+	  CASACORE_FALLTHROUGH;
       case TpDComplex:
 	  sizeInBytes += size*16;
 	  code = "M";

--- a/fits/FITS/test/tfits1.cc
+++ b/fits/FITS/test/tfits1.cc
@@ -183,6 +183,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    maxsize = nbytes;
 			}
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsread_data.cc
+++ b/fits/FITS/test/tfitsread_data.cc
@@ -186,6 +186,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    maxsize = nbytes;
 			}
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsskip.cc
+++ b/fits/FITS/test/tfitsskip.cc
@@ -187,6 +187,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    maxsize = nbytes;
 			}
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsskip_all.cc
+++ b/fits/FITS/test/tfitsskip_all.cc
@@ -186,6 +186,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    maxsize = nbytes;
 			}
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsskip_hdu.cc
+++ b/fits/FITS/test/tfitsskip_hdu.cc
@@ -176,6 +176,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    maxsize = nbytes;
 			}
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/images/Regions/WCEllipsoid.cc
+++ b/images/Regions/WCEllipsoid.cc
@@ -378,6 +378,7 @@ WCEllipsoid* WCEllipsoid::fromRecord (
 			}
 			theta = qh.asQuantity();
 			// do not break, allow fall thru to default to get radii too.
+			CASACORE_FALLTHROUGH;
 		case NOT_SPECIAL:
 		default:
 			{

--- a/measures/Measures/MCDirection.cc
+++ b/measures/Measures/MCDirection.cc
@@ -445,6 +445,7 @@ void MCDirection::doConvert(MVDirection &in,
     
     case R_COMET:
       if (comID == MDirection::APP) break;
+      CASACORE_FALLTHROUGH;
     case TOPO_APP: 
       measMath.deapplyAPPtoTOPO(in, lengthP);
       break;

--- a/measures/Measures/Nutation.cc
+++ b/measures/Measures/Nutation.cc
@@ -320,6 +320,7 @@ void Nutation::calcNut(Double time, Bool calcDer) {
       for (uInt i=0; i<14; i++) {
 	pfa(i) = MeasTable::planetaryArg2000(i)(t);
       }
+      CASACORE_FALLTHROUGH;
     case IAU2000A:
       neval_p = 0;
       for (Int i=32; i>=0; --i) {
@@ -480,6 +481,7 @@ void Nutation::calcNut(Double time, Bool calcDer) {
 	pfa(i) = MeasTable::planetaryArg2000(i)(t);
 	pdfa(i) = (MeasTable::planetaryArg2000(i).derivative())(t);
       }
+      CASACORE_FALLTHROUGH;
     case IAU2000A:
       neval_p = deval_p = 0;
       for (Int i=32; i>=0; --i) {

--- a/msfits/MSFits/SDPolarizationHandler.cc
+++ b/msfits/MSFits/SDPolarizationHandler.cc
@@ -296,6 +296,7 @@ void SDPolarizationHandler::stokesKeys(Int stokesValue, Int &key1, Int &key2)
     case Stokes::QP:
 	key1 = Stokes::QQ;
 	key2 = Stokes::PP;
+	break;
     default:
 	// the two keys are identical to each other and to the stokes type
 	key1 = key2 = stokesValue;

--- a/scimath/Fitting/test/dConstraints.cc
+++ b/scimath/Fitting/test/dConstraints.cc
@@ -132,14 +132,17 @@ int main (int argc, const char* argv[])
       constrArg = 0.0;
       constrArg[2] = 1.0;
       fitter.addConstraint(constrArg, v[2]);
+      CASACORE_FALLTHROUGH;
     case '2':					// W1==W2
       constrArg = 0.0;
       constrArg[2] = 1.0; constrArg[5] = -1.0;
       fitter.addConstraint(constrArg);
+      CASACORE_FALLTHROUGH;
     case '1':					// A1/A2=2
       constrArg = 0.0;
       constrArg[0] = 1.0; constrArg[3] = -2.0;
       fitter.addConstraint(constrArg);
+      CASACORE_FALLTHROUGH;
     default:
       break;
     }

--- a/scimath/Functionals/CompiledFunction.tcc
+++ b/scimath/Functionals/CompiledFunction.tcc
@@ -154,6 +154,7 @@ T CompiledFunction<T>::eval(typename Function<T>::FunctionArg x) const {
 	exec_p.back() = atan(exec_p.back());
 	break;
       }
+      CASACORE_FALLTHROUGH;
     case FuncExprData::ATAN2:
       exec_p.back() = atan2(exec_p.back(), t);
       break;

--- a/scimath/Functionals/FuncExpression.cc
+++ b/scimath/Functionals/FuncExpression.cc
@@ -522,6 +522,7 @@ Bool FuncExpression::exec(Double &res) const {
 	  exec_p.back() = atan(exec_p.back());
 	  break;
 	}
+	CASACORE_FALLTHROUGH;
       case FuncExprData::ATAN2: {
 	Double t(exec_p.back());
 	exec_p.pop_back();

--- a/scimath/Mathematics/SquareMatrix.tcc
+++ b/scimath/Mathematics/SquareMatrix.tcc
@@ -168,6 +168,7 @@ SquareMatrix<T,n>& SquareMatrix<T,n>::operator*=(const SquareMatrix<T,n>& other)
 		return *this;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case Diagonal: 
 	switch (other.type_p) {
 	    case ScalarId: {
@@ -191,6 +192,7 @@ SquareMatrix<T,n>& SquareMatrix<T,n>::operator*=(const SquareMatrix<T,n>& other)
 		return *this;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case General: 
 	switch (other.type_p) {
 	    case ScalarId: {

--- a/scimath/Mathematics/SquareMatrix2.cc
+++ b/scimath/Mathematics/SquareMatrix2.cc
@@ -63,6 +63,7 @@ directProduct(SquareMatrix<Complex,4>& result,
 		return result;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case SquareMatrix<Complex,2>::Diagonal: 
 	switch (right.type_p) {
 	    case SquareMatrix<Complex,2>::ScalarId: {
@@ -90,6 +91,7 @@ directProduct(SquareMatrix<Complex,4>& result,
 		return result;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case SquareMatrix<Complex,2>::General: 
 	switch (right.type_p) {
 	    case SquareMatrix<Complex,2>::ScalarId: {

--- a/tables/TaQL/ExprAggrNode.cc
+++ b/tables/TaQL/ExprAggrNode.cc
@@ -100,6 +100,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gminsFUNC:
     case gmaxsFUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case gminFUNC:
     case gmaxFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -108,6 +109,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gproductsFUNC:
     case gsumsqrsFUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case gsumFUNC:
     case gproductFUNC:
     case gsumsqrFUNC:
@@ -115,6 +117,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       return checkDT (dtypeOper, NTNumeric, NTNumeric, nodes);
     case gmeansFUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case gmeanFUNC:
       checkNumOfArg (1, 1, nodes);
       return checkDT (dtypeOper, NTNumeric, NTDouCom, nodes);
@@ -123,6 +126,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gstddevs0FUNC:
     case gstddevs1FUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case gvariance0FUNC:
     case gvariance1FUNC:
     case gstddev0FUNC:
@@ -131,6 +135,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       return checkDT (dtypeOper, NTNumeric, NTDouble, nodes);
     case grmssFUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case grmsFUNC:
     case gmedianFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -146,6 +151,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case ganysFUNC:
     case gallsFUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case ganyFUNC:
     case gallFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -153,6 +159,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gntruesFUNC:
     case gnfalsesFUNC:
       resVT = VTArray;
+      CASACORE_FALLTHROUGH;
     case gntrueFUNC:
     case gnfalseFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -238,6 +245,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
           break;
         }
         // Fall through, so e.g. mean of ints can be done
+        CASACORE_FALLTHROUGH;
       case NTDouble:
         switch (funcType()) {
         case gminFUNC:
@@ -342,6 +350,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         break;
       }
       // Fall through, so e.g. mean of ints can be done
+      CASACORE_FALLTHROUGH;
     case NTDouble:
       switch (funcType()) {
       case gminFUNC:

--- a/tables/TaQL/ExprAggrNodeArray.cc
+++ b/tables/TaQL/ExprAggrNodeArray.cc
@@ -136,6 +136,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         break;
       }
       // Fall through, so e.g. mean of ints can be done
+      CASACORE_FALLTHROUGH;
     case NTDouble:
       switch (funcType()) {
       case TableExprFuncNode::gminsFUNC:

--- a/tables/TaQL/ExprFuncNode.cc
+++ b/tables/TaQL/ExprFuncNode.cc
@@ -1595,6 +1595,7 @@ TableExprNodeRep::NodeDataType TableExprFuncNode::checkOperands
             break;
         case resizeFUNC:
             optarg = 1;
+            CASACORE_FALLTHROUGH;
         case arrayFUNC:
         case transposeFUNC:
         case areverseFUNC:
@@ -1747,6 +1748,7 @@ TableExprNodeRep::NodeDataType TableExprFuncNode::checkOperands
     case weekdayFUNC:
     case weekFUNC:
         dtout = NTInt;
+        CASACORE_FALLTHROUGH;
     case mjdFUNC:
     case timeFUNC:
         if (checkNumOfArg (0, 1, nodes) == 1) {

--- a/tables/TaQL/ExprFuncNodeArray.cc
+++ b/tables/TaQL/ExprFuncNodeArray.cc
@@ -346,6 +346,7 @@ void TableExprFuncNodeArray::tryToConst()
         break;
     case TableExprFuncNode::arrfractilesFUNC:
         axarg = 2;
+        CASACORE_FALLTHROUGH;
     case TableExprFuncNode::arrsumsFUNC:
     case TableExprFuncNode::arrproductsFUNC:
     case TableExprFuncNode::arrsumsqrsFUNC:

--- a/tables/Tables/ColumnCache.h
+++ b/tables/Tables/ColumnCache.h
@@ -30,6 +30,9 @@
 
 
 //# Includes
+#include <cassert>
+#include <limits>
+
 #include <casacore/casa/aips.h>
 
 
@@ -136,8 +139,12 @@ inline void ColumnCache::invalidate()
 
 inline Int64 ColumnCache::offset (rownr_t rownr) const
 {
-    return rownr<itsStart || rownr>itsEnd  ?  -1 :
-	                                      (rownr-itsStart)*itsIncr;
+    if (rownr < itsStart || rownr > itsEnd) {
+        return -1;
+    }
+    auto offset = (rownr - itsStart) * itsIncr;
+    assert(offset <= std::numeric_limits<Int64>::max());
+    return Int64(offset);
 }
 
 inline const void* ColumnCache::dataPtr() const

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -491,6 +491,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpFloat:
     defPrec = 9;
+    CASACORE_FALLTHROUGH;
   case TpDouble:
     {
       // set precision; set it back at the end.
@@ -502,6 +503,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpComplex:
     defPrec = 9;
+    CASACORE_FALLTHROUGH;
   case TpDComplex:
     {
       // set precision; set it back at the end.
@@ -555,6 +557,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpArrayFloat:
     defPrec = 9;
+    CASACORE_FALLTHROUGH;
   case TpArrayDouble:
     {
       // set precision; set it back at the end.
@@ -578,6 +581,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpArrayComplex:
     defPrec = 9;
+    CASACORE_FALLTHROUGH;
   case TpArrayDComplex:
     {
       // set precision; set it back at the end.


### PR DESCRIPTION
These are in addition to those fixed in #1069 and #1062, yielding a cleaner compilation of casacore in newer compilers.

Most of the changes are making switch case fallthrough explicit. Most of them looked legit; one looked like it needed a break though, so I'd appreciate if someone double-checked this is correct.