### PR TITLE
FITS import: prevent 2^32 pixels overflow in loop counter, CAS-12837

### DIFF
--- a/images/Images/ImageFITSConverter.tcc
+++ b/images/Images/ImageFITSConverter.tcc
@@ -248,7 +248,7 @@ void ImageFITSConverterImpl<HDUType>::FITSToImage(
 				Bool deleteMaskPtr;
 				Bool* mPtr = maskCursor.getStorage(deleteMaskPtr);
 				if (zeroBlanks) {
-					for (uInt i=0; i<maskCursor.nelements(); i++) {
+					for (size_t i=0; i<maskCursor.nelements(); i++) {
 						if (isNaN(ptr[i])) {
 							mPtr[i] = False;
 							hasBlanks = True;
@@ -260,7 +260,7 @@ void ImageFITSConverterImpl<HDUType>::FITSToImage(
 					}
 				}
 				else {
-					for (uInt i=0; i<maskCursor.nelements(); i++) {
+					for (size_t i=0; i<maskCursor.nelements(); i++) {
 						if (isNaN(ptr[i])) {
 							mPtr[i] = False;
 							hasBlanks = True;
@@ -275,7 +275,7 @@ void ImageFITSConverterImpl<HDUType>::FITSToImage(
 			}
 			else {
 				if (zeroBlanks) {
-					for (uInt i=0; i<cursor.nelements(); i++) {
+					for (size_t i=0; i<cursor.nelements(); i++) {
 						if (isNaN(ptr[i])) {
 							hasBlanks = True;
 							ptr[i] = 0.0;


### PR DESCRIPTION
Fixes #1075 - see issue for details.