### PR TITLE
Fix two erros reported by valgrind in IPosition

### DIFF
--- a/casa/Arrays/IPosition.cc
+++ b/casa/Arrays/IPosition.cc
@@ -41,6 +41,7 @@ IPosition::IPosition (size_t length)
     if (length > BufferLength) {
 	allocateBuffer();
     }
+    memset(data_p, 0, size_p * sizeof(ssize_t));
 }
 
 IPosition::IPosition(std::initializer_list<ssize_t> list)
@@ -324,6 +325,8 @@ IPosition& IPosition::operator= (const IPosition& other)
 IPosition& IPosition::operator=(IPosition&& source)
 {
   size_p = source.size_p;
+  if (data_p != &buffer_p[0])
+    delete [] data_p;
   data_p = size_p > BufferLength ? source.data_p : buffer_p;
   for(size_t i=0; i!=size_p; ++i)
     data_p[i] = source.data_p[i];


### PR DESCRIPTION
This PR fixes two small errors reported by valgrind in IPosition:
- uninitialized values in IPosition constructor. This has been triggered by the use of the IPosition constructor with just the length without specifying the values of the vector. I guess this constructor is not used much, but the unit test tCpp11Features uses it in lines 350 and 394.
- memory leak in IPosition move constructor.