### PR TITLE
Fix several warnings

### DIFF
--- a/casa/Containers/RecordDescRep.cc
+++ b/casa/Containers/RecordDescRep.cc
@@ -365,7 +365,7 @@ Int RecordDescRep::fieldNumber (const String& fieldName) const
 
 String RecordDescRep::makeName (Int whichField) const
 {
-    char strc[12];
+    char strc[13];
     sprintf(strc, "*%i", whichField+1);
     return uniqueName (strc);
 }

--- a/casa/Containers/RecordDescRep.cc
+++ b/casa/Containers/RecordDescRep.cc
@@ -365,7 +365,7 @@ Int RecordDescRep::fieldNumber (const String& fieldName) const
 
 String RecordDescRep::makeName (Int whichField) const
 {
-    char strc[8];
+    char strc[12];
     sprintf(strc, "*%i", whichField+1);
     return uniqueName (strc);
 }

--- a/casa/IO/RegularFileIO.cc
+++ b/casa/IO/RegularFileIO.cc
@@ -76,6 +76,7 @@ int RegularFileIO::openCreate (const RegularFile& file,
 	    throw (AipsError ("RegularFileIO: new file " + name +
 			      " already exists"));
 	}
+	[[fallthrough]];
     case ByteIO::New:
     case ByteIO::Scratch:
         create = True;

--- a/casa/IO/RegularFileIO.cc
+++ b/casa/IO/RegularFileIO.cc
@@ -76,7 +76,7 @@ int RegularFileIO::openCreate (const RegularFile& file,
 	    throw (AipsError ("RegularFileIO: new file " + name +
 			      " already exists"));
 	}
-	[[fallthrough]];
+	CASACORE_FALLTHROUGH;
     case ByteIO::New:
     case ByteIO::Scratch:
         create = True;

--- a/casa/Utilities/Regex.cc
+++ b/casa/Utilities/Regex.cc
@@ -403,7 +403,7 @@ String Regex::fromSQLPattern(const String& pattern)
 	case ')':
 	case '\\':
             result.push_back ('\\');
-	    // fall through
+            CASACORE_FALLTHROUGH;
 	default:
             result.push_back (c);
 	}

--- a/casa/Utilities/ValType.cc
+++ b/casa/Utilities/ValType.cc
@@ -284,6 +284,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpComplex:
     case TpArrayComplex:
       nrElementsPerValue = 2;
+      [[fallthrough]];
     case TpFloat:
     case TpArrayFloat:
       readFunc  = CanonicalConversion::getToLocal (static_cast<float*>(0));
@@ -292,6 +293,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpDComplex:
     case TpArrayDComplex:
       nrElementsPerValue = 2;
+      [[fallthrough]];
     case TpDouble:
     case TpArrayDouble:
       readFunc  = CanonicalConversion::getToLocal (static_cast<double*>(0));
@@ -346,6 +348,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpComplex:
     case TpArrayComplex:
       nrElementsPerValue = 2;
+      [[fallthrough]];
     case TpFloat:
     case TpArrayFloat:
       readFunc  = LECanonicalConversion::getToLocal (static_cast<float*>(0));
@@ -354,6 +357,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpDComplex:
     case TpArrayDComplex:
       nrElementsPerValue = 2;
+      [[fallthrough]];
     case TpDouble:
     case TpArrayDouble:
       readFunc  = LECanonicalConversion::getToLocal (static_cast<double*>(0));

--- a/casa/Utilities/ValType.cc
+++ b/casa/Utilities/ValType.cc
@@ -284,7 +284,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpComplex:
     case TpArrayComplex:
       nrElementsPerValue = 2;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case TpFloat:
     case TpArrayFloat:
       readFunc  = CanonicalConversion::getToLocal (static_cast<float*>(0));
@@ -293,7 +293,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpDComplex:
     case TpArrayDComplex:
       nrElementsPerValue = 2;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case TpDouble:
     case TpArrayDouble:
       readFunc  = CanonicalConversion::getToLocal (static_cast<double*>(0));
@@ -348,7 +348,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpComplex:
     case TpArrayComplex:
       nrElementsPerValue = 2;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case TpFloat:
     case TpArrayFloat:
       readFunc  = LECanonicalConversion::getToLocal (static_cast<float*>(0));
@@ -357,7 +357,7 @@ void ValType::getCanonicalFunc (DataType dt,
     case TpDComplex:
     case TpArrayDComplex:
       nrElementsPerValue = 2;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case TpDouble:
     case TpArrayDouble:
       readFunc  = LECanonicalConversion::getToLocal (static_cast<double*>(0));
@@ -382,17 +382,21 @@ Bool ValType::isPromotable (DataType from, DataType to)
     case TpChar:
 	if (to == TpShort)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpShort:
 	if (to == TpInt)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpInt:
 	if (to == TpInt64)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpInt64:
     case TpFloat:
     case TpDouble:
 	if (to == TpFloat  ||  to == TpDouble)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpComplex:
     case TpDComplex:
 	if (to == TpComplex  ||  to == TpDComplex)
@@ -401,9 +405,11 @@ Bool ValType::isPromotable (DataType from, DataType to)
     case TpUChar:
 	if (to == TpUShort)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpUShort:
 	if (to == TpUInt)
 	    return True;
+	CASACORE_FALLTHROUGH;
     case TpUInt:
         if (to == TpInt64)
             return True;

--- a/casa/aipsdef.h
+++ b/casa/aipsdef.h
@@ -78,4 +78,16 @@ extern Bool aips_debug_on;
 #define CASACORE_STRINGIFY(x) CASACORE_STRINGIFY_HELPER(x)
 #define CASACORE_STRINGIFY_HELPER(x) #x
 
+// A fallthrough attribute to avoid compiler warnings,
+// available only from C++17 onwards
+#if __cplusplus >= 201703L
+#define CASACORE_FALLTHROUGH [[fallthrough]]
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#define CASACORE_FALLTHROUGH [[gnu::fallthrough]]
+#elif defined(__clang__)
+#define CASACORE_FALLTHROUGH [[clang::fallthrough]]
+#else
+#define CASACORE_FALLTHROUGH
+#endif
+
 #endif

--- a/coordinates/Coordinates/Projection.cc
+++ b/coordinates/Coordinates/Projection.cc
@@ -341,13 +341,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		switch (actualSize) { // absence of breaks statements intended
 		case 0:
 		    parameters_p(0) = 0.; // mu
-		    [[fallthrough]];
+		    CASACORE_FALLTHROUGH;
 		case 1:
 		    parameters_p(1) = 0.; // phi_c
-		    [[fallthrough]];
+		    CASACORE_FALLTHROUGH;
 		case 2:
 		    parameters_p(2) = 90.; // theta_c
-		    [[fallthrough]];
+		    CASACORE_FALLTHROUGH;
 		default:
 		    break;
 		}

--- a/coordinates/Coordinates/Projection.cc
+++ b/coordinates/Coordinates/Projection.cc
@@ -341,10 +341,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		switch (actualSize) { // absence of breaks statements intended
 		case 0:
 		    parameters_p(0) = 0.; // mu
+		    [[fallthrough]];
 		case 1:
 		    parameters_p(1) = 0.; // phi_c
+		    [[fallthrough]];
 		case 2:
 		    parameters_p(2) = 90.; // theta_c
+		    [[fallthrough]];
 		default:
 		    break;
 		}

--- a/fits/FITS/BinTable.cc
+++ b/fits/FITS/BinTable.cc
@@ -119,6 +119,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
 			    maxsize = nbytes;
 			}
 			// fall throught to BYTE for the actual allocation
+			[[fallthrough]];
 		    case FITS::BYTE: 
 			vaptr_p[i] = (void *)(new uChar[maxsize]);
 			AlwaysAssert(vaptr_p[i], AipsError);
@@ -174,7 +175,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
    String kwname;
    // will hold the index portion for indexed keywords, this should be
    // more than enough space
-   char index[8];
+   char index[11];
    while ((kw = kwl.next())) {
        if (!kw->isreserved() || (sdfits && isSDFitsColumn(kw->kw().name()))) {
 	   // Get the kw name and remove the trailing spaces

--- a/fits/FITS/BinTable.cc
+++ b/fits/FITS/BinTable.cc
@@ -119,7 +119,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
 			    maxsize = nbytes;
 			}
 			// fall throught to BYTE for the actual allocation
-			[[fallthrough]];
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr_p[i] = (void *)(new uChar[maxsize]);
 			AlwaysAssert(vaptr_p[i], AipsError);

--- a/fits/FITS/FITSReader.cc
+++ b/fits/FITS/FITSReader.cc
@@ -310,6 +310,7 @@ void showBinaryTable(BinaryTableExtension &x) {
                 if (maxsize % 8) nbytes++;
                 maxsize = nbytes;
             }
+            [[fallthrough]];
             case FITS::BYTE: 
                vaptr[i] = (void *)(new unsigned char[maxsize]);
                break;

--- a/fits/FITS/FITSReader.cc
+++ b/fits/FITS/FITSReader.cc
@@ -310,7 +310,7 @@ void showBinaryTable(BinaryTableExtension &x) {
                 if (maxsize % 8) nbytes++;
                 maxsize = nbytes;
             }
-            [[fallthrough]];
+            CASACORE_FALLTHROUGH;
             case FITS::BYTE: 
                vaptr[i] = (void *)(new unsigned char[maxsize]);
                break;

--- a/fits/FITS/FITSTable.cc
+++ b/fits/FITS/FITSTable.cc
@@ -853,7 +853,7 @@ Bool FITSTable::reopen(const String &fileName)
 			maxsize = nbytes;
 		    }
 		    // fall through to BYTE for actual allocation
-        [[fallthrough]];
+		    CASACORE_FALLTHROUGH;
 		case FITS::BYTE: 
 		    vaptr_p[i] = (void *)(new uChar[maxsize]);
 		    AlwaysAssert(vaptr_p[i], AipsError);

--- a/fits/FITS/FITSTable.cc
+++ b/fits/FITS/FITSTable.cc
@@ -853,6 +853,7 @@ Bool FITSTable::reopen(const String &fileName)
 			maxsize = nbytes;
 		    }
 		    // fall through to BYTE for actual allocation
+        [[fallthrough]];
 		case FITS::BYTE: 
 		    vaptr_p[i] = (void *)(new uChar[maxsize]);
 		    AlwaysAssert(vaptr_p[i], AipsError);

--- a/fits/FITS/FITSTable2.cc
+++ b/fits/FITS/FITSTable2.cc
@@ -99,6 +99,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpBool:
 	  sizeInBytes += size*1;
 	  code = "L";
@@ -115,6 +116,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpUChar:
 	  sizeInBytes += size*1;
 	  code = "B";
@@ -131,6 +133,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpShort:
 	  sizeInBytes += size*2;
 	  code = "I";
@@ -147,6 +150,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpInt:
 	  sizeInBytes += size*4;
 	  code = "J";
@@ -163,6 +167,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpFloat:
 	  sizeInBytes += size*4;
 	  code = "E";
@@ -179,6 +184,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpDouble:
 	  sizeInBytes += size*8;
 	  code = "D";
@@ -195,6 +201,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpComplex:
 	  sizeInBytes += size*8;
 	  code = "C";
@@ -211,6 +218,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
+      [[fallthrough]];
       case TpDComplex:
 	  sizeInBytes += size*16;
 	  code = "M";

--- a/fits/FITS/FITSTable2.cc
+++ b/fits/FITS/FITSTable2.cc
@@ -99,7 +99,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpBool:
 	  sizeInBytes += size*1;
 	  code = "L";
@@ -116,7 +116,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpUChar:
 	  sizeInBytes += size*1;
 	  code = "B";
@@ -133,7 +133,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpShort:
 	  sizeInBytes += size*2;
 	  code = "I";
@@ -150,7 +150,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpInt:
 	  sizeInBytes += size*4;
 	  code = "J";
@@ -167,7 +167,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpFloat:
 	  sizeInBytes += size*4;
 	  code = "E";
@@ -184,7 +184,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpDouble:
 	  sizeInBytes += size*8;
 	  code = "D";
@@ -201,7 +201,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpComplex:
 	  sizeInBytes += size*8;
 	  code = "C";
@@ -218,7 +218,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	      buffer << size;
 	      repeat = String(buffer);
 	  }
-      [[fallthrough]];
+	  CASACORE_FALLTHROUGH;
       case TpDComplex:
 	  sizeInBytes += size*16;
 	  code = "M";

--- a/fits/FITS/fits.h
+++ b/fits/FITS/fits.h
@@ -91,15 +91,14 @@ class FitsLogical {
 	friend ostream & operator << (ostream &o, const FitsLogical &);
     public:
 	FitsLogical() : v('\0') { }
-	FitsLogical(Bool x) { v = (x == True ? 'T' : 'F'); }
-	FitsLogical(const FitsLogical &x) : v(x.v) { }
-	FitsLogical & operator = (const FitsLogical &x) { 
-		v = x.v; return *this; }
+	FitsLogical(Bool x) : v(x == True ? 'T' : 'F') { }
 	FitsLogical & operator = (Bool x) { 
 		v = (x == True ? 'T' : 'F'); return *this; }
-	Bool isdefined() const { return v == '\0' ? True : False; }
+  ///ARO 2021-02-20:
+  ///Removed the following function, because it seems incorrectly implemented and isn't used
+	///Bool isdefined() const { return v == '\0' ? True : False; }
 	void undefine() { v = '\0'; }
-	operator Bool() { return (v == 'T' ? True : False); }
+	operator Bool() const { return v == 'T'; }
     protected:
 	char v;
 };
@@ -118,11 +117,8 @@ class FitsBit {
     public:
 	FitsBit() : bit_array(0) { }
 	FitsBit(unsigned char x) : bit_array(x) { }
-	FitsBit(const FitsBit &x) : bit_array(x.bit_array) { }
-	FitsBit & operator = (const FitsBit &x) { 
-		bit_array = x.bit_array; return *this; }
 	FitsBit & operator = (unsigned char x) { bit_array = x; return *this; }
-	operator unsigned char() { return bit_array; }
+	operator unsigned char() const { return bit_array; }
     protected:
 	unsigned char bit_array;
 };

--- a/fits/FITS/fitsio.cc
+++ b/fits/FITS/fitsio.cc
@@ -594,11 +594,11 @@ int FitsInput::skip_hdu() { //Skip an entire header-data unit
     }
 
     // check if the header of the current HDU is properly ended
-    char l_message[FLEN_ERRMSG];
+    char l_message[137 /*FLEN_ERRMSG*/];
     char l_keyname[FLEN_KEYWORD];
     char l_keyval[FLEN_VALUE];
     char l_card[FLEN_CARD];
-    char* l_comm = NULL;
+    char* l_comm = nullptr;
 
     int l_status = 0;
 

--- a/fits/FITS/hdu.h
+++ b/fits/FITS/hdu.h
@@ -858,7 +858,7 @@ class FitsBase {
 	static FitsBase *make(const FITS::ValueType &, int, int *);
 	static FitsBase *make(FitsBase &);
 
-	FitsBase & operator = (FitsBase &);
+	FitsBase & operator = (FitsBase &) = delete;
 	virtual void show(std::ostream &) = 0;
 
     protected:

--- a/fits/FITS/hdu2.cc
+++ b/fits/FITS/hdu2.cc
@@ -862,13 +862,6 @@ int *FitsBase::vdim() {
 	return &no_elements; 
 }
 //====================================================================================
-/*FitsBase & FitsBase::operator = (FitsBase &x) {
-	if (fieldtype() == x.fieldtype() &&
-	    nelements() == x.nelements())
-	    memcpy(data(),x.data(),localfieldsize());
-	return *this;
-}*/
-//====================================================================================
 FitsBase * FitsBase::make(const FITS::ValueType &type,int n) {
 	switch (type) {
 	    case FITS::LOGICAL: return (new FitsField<FitsLogical> (n));

--- a/fits/FITS/hdu2.cc
+++ b/fits/FITS/hdu2.cc
@@ -862,12 +862,12 @@ int *FitsBase::vdim() {
 	return &no_elements; 
 }
 //====================================================================================
-FitsBase & FitsBase::operator = (FitsBase &x) {
+/*FitsBase & FitsBase::operator = (FitsBase &x) {
 	if (fieldtype() == x.fieldtype() &&
 	    nelements() == x.nelements())
 	    memcpy(data(),x.data(),localfieldsize());
 	return *this;
-}
+}*/
 //====================================================================================
 FitsBase * FitsBase::make(const FITS::ValueType &type,int n) {
 	switch (type) {

--- a/fits/FITS/test/tfits1.cc
+++ b/fits/FITS/test/tfits1.cc
@@ -182,6 +182,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
+      [[fallthrough]];
 			// fall through to byte for the actual allocation
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);

--- a/fits/FITS/test/tfits1.cc
+++ b/fits/FITS/test/tfits1.cc
@@ -182,8 +182,8 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
-      [[fallthrough]];
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsread_data.cc
+++ b/fits/FITS/test/tfitsread_data.cc
@@ -185,8 +185,8 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
-      [[fallthrough]];
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsread_data.cc
+++ b/fits/FITS/test/tfitsread_data.cc
@@ -185,6 +185,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
+      [[fallthrough]];
 			// fall through to byte for the actual allocation
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);

--- a/fits/FITS/test/tfitsskip.cc
+++ b/fits/FITS/test/tfitsskip.cc
@@ -186,8 +186,8 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
-      [[fallthrough]];
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsskip.cc
+++ b/fits/FITS/test/tfitsskip.cc
@@ -186,6 +186,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
+      [[fallthrough]];
 			// fall through to byte for the actual allocation
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);

--- a/fits/FITS/test/tfitsskip_all.cc
+++ b/fits/FITS/test/tfitsskip_all.cc
@@ -185,8 +185,8 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
-      [[fallthrough]];
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsskip_all.cc
+++ b/fits/FITS/test/tfitsskip_all.cc
@@ -185,6 +185,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
+      [[fallthrough]];
 			// fall through to byte for the actual allocation
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);

--- a/fits/FITS/test/tfitsskip_hdu.cc
+++ b/fits/FITS/test/tfitsskip_hdu.cc
@@ -175,8 +175,8 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
-      [[fallthrough]];
 			// fall through to byte for the actual allocation
+			CASACORE_FALLTHROUGH;
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);
 			break;

--- a/fits/FITS/test/tfitsskip_hdu.cc
+++ b/fits/FITS/test/tfitsskip_hdu.cc
@@ -175,6 +175,7 @@ void do_binary_table(BinaryTableExtension &x) {
 			    if (maxsize % 8) nbytes++;
 			    maxsize = nbytes;
 			}
+      [[fallthrough]];
 			// fall through to byte for the actual allocation
 		    case FITS::BYTE: 
 			vaptr[i] = (void *)(new unsigned char[maxsize]);

--- a/images/Regions/WCEllipsoid.cc
+++ b/images/Regions/WCEllipsoid.cc
@@ -378,7 +378,7 @@ WCEllipsoid* WCEllipsoid::fromRecord (
 			}
 			theta = qh.asQuantity();
 			// do not break, allow fall thru to default to get radii too.
-      [[fallthrough]];
+			CASACORE_FALLTHROUGH;
 		case NOT_SPECIAL:
 		default:
 			{

--- a/images/Regions/WCEllipsoid.cc
+++ b/images/Regions/WCEllipsoid.cc
@@ -378,6 +378,7 @@ WCEllipsoid* WCEllipsoid::fromRecord (
 			}
 			theta = qh.asQuantity();
 			// do not break, allow fall thru to default to get radii too.
+      [[fallthrough]];
 		case NOT_SPECIAL:
 		default:
 			{

--- a/measures/Measures/MCDirection.cc
+++ b/measures/Measures/MCDirection.cc
@@ -445,6 +445,7 @@ void MCDirection::doConvert(MVDirection &in,
     
     case R_COMET:
       if (comID == MDirection::APP) break;
+      [[fallthrough]];
     case TOPO_APP: 
       measMath.deapplyAPPtoTOPO(in, lengthP);
       break;

--- a/measures/Measures/MCDirection.cc
+++ b/measures/Measures/MCDirection.cc
@@ -445,7 +445,7 @@ void MCDirection::doConvert(MVDirection &in,
     
     case R_COMET:
       if (comID == MDirection::APP) break;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case TOPO_APP: 
       measMath.deapplyAPPtoTOPO(in, lengthP);
       break;

--- a/measures/Measures/Nutation.cc
+++ b/measures/Measures/Nutation.cc
@@ -320,7 +320,7 @@ void Nutation::calcNut(Double time, Bool calcDer) {
       for (uInt i=0; i<14; i++) {
 	pfa(i) = MeasTable::planetaryArg2000(i)(t);
       }
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case IAU2000A:
       neval_p = 0;
       for (Int i=32; i>=0; --i) {
@@ -481,7 +481,7 @@ void Nutation::calcNut(Double time, Bool calcDer) {
 	pfa(i) = MeasTable::planetaryArg2000(i)(t);
 	pdfa(i) = (MeasTable::planetaryArg2000(i).derivative())(t);
       }
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case IAU2000A:
       neval_p = deval_p = 0;
       for (Int i=32; i>=0; --i) {

--- a/measures/Measures/Nutation.cc
+++ b/measures/Measures/Nutation.cc
@@ -320,6 +320,7 @@ void Nutation::calcNut(Double time, Bool calcDer) {
       for (uInt i=0; i<14; i++) {
 	pfa(i) = MeasTable::planetaryArg2000(i)(t);
       }
+      [[fallthrough]];
     case IAU2000A:
       neval_p = 0;
       for (Int i=32; i>=0; --i) {
@@ -480,6 +481,7 @@ void Nutation::calcNut(Double time, Bool calcDer) {
 	pfa(i) = MeasTable::planetaryArg2000(i)(t);
 	pdfa(i) = (MeasTable::planetaryArg2000(i).derivative())(t);
       }
+      [[fallthrough]];
     case IAU2000A:
       neval_p = deval_p = 0;
       for (Int i=32; i>=0; --i) {

--- a/mirlib/uvio.c
+++ b/mirlib/uvio.c
@@ -745,15 +745,15 @@ void uvopen_c(int *tno,Const char *name,Const char *status)
     CHECK(iostat,(message,"Error accessing visdata for %s, in UVOPEN(old)",name));
 #ifdef MIR4
     /* figure out if to read old MIR3 or new MIR4 */
-    if (1) {
+#if true
       rdhdl_c(*tno,"vislen",&(uv->max_offset),hsize_c(uv->item));
-    } else {
+#else
       int old_vislen;
       rdhdi_c(*tno,"vislen",&old_vislen,hsize_c(uv->item));
       if (old_vislen < 0) 
 	ERROR('f',(message,"Bad conversion MIR3<->MIR4 in UVOPEN: vislen=%d",old_vislen));
       uv->max_offset = old_vislen;
-    }
+#endif
 #else
     /* MIR3 and before format: */
     rdhdi_c(*tno,"vislen",&(uv->max_offset),hsize_c(uv->item));

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -3559,7 +3559,7 @@ Bool FITSIDItoMS1::handleGainCurve()
   ScalarColumn<Int> ytyp_2S;
   ScalarColumn<Float> gain_2S;
   ScalarColumn<Float> sens_2S;
-  Int ytyp, nterm;
+  Int ytyp = 0, nterm = 0;
   try {
     type_1.attach(gcTab, "TYPE_1");
     nterm_1.attach(gcTab, "NTERM_1");

--- a/msfits/MSFits/SDPolarizationHandler.cc
+++ b/msfits/MSFits/SDPolarizationHandler.cc
@@ -296,6 +296,7 @@ void SDPolarizationHandler::stokesKeys(Int stokesValue, Int &key1, Int &key2)
     case Stokes::QP:
 	key1 = Stokes::QQ;
 	key2 = Stokes::PP;
+  break;
     default:
 	// the two keys are identical to each other and to the stokes type
 	key1 = key2 = stokesValue;

--- a/msfits/MSFits/SDPolarizationHandler.cc
+++ b/msfits/MSFits/SDPolarizationHandler.cc
@@ -296,7 +296,7 @@ void SDPolarizationHandler::stokesKeys(Int stokesValue, Int &key1, Int &key2)
     case Stokes::QP:
 	key1 = Stokes::QQ;
 	key2 = Stokes::PP;
-  break;
+	break;
     default:
 	// the two keys are identical to each other and to the stokes type
 	key1 = key2 = stokesValue;

--- a/scimath/Fitting/FitGaussian.tcc
+++ b/scimath/Fitting/FitGaussian.tcc
@@ -134,7 +134,7 @@ void FitGaussian<T>::setNumGaussians(uInt numgaussians)
   itsRetryFctr.resize();
   itsFirstEstimate.resize();
   itsMask.resize();
-  if (itsDimension*3!=0 && itsNGaussians) {
+  if (itsDimension*3 != 0 && itsNGaussians) {
     itsMask.resize(itsNGaussians, itsDimension*3); itsMask = 1;
   }
 }

--- a/scimath/Fitting/FitGaussian.tcc
+++ b/scimath/Fitting/FitGaussian.tcc
@@ -134,7 +134,7 @@ void FitGaussian<T>::setNumGaussians(uInt numgaussians)
   itsRetryFctr.resize();
   itsFirstEstimate.resize();
   itsMask.resize();
-  if (itsDimension*3 && itsNGaussians) {
+  if (itsDimension*3!=0 && itsNGaussians) {
     itsMask.resize(itsNGaussians, itsDimension*3); itsMask = 1;
   }
 }

--- a/scimath/Fitting/test/dConstraints.cc
+++ b/scimath/Fitting/test/dConstraints.cc
@@ -132,14 +132,17 @@ int main (int argc, const char* argv[])
       constrArg = 0.0;
       constrArg[2] = 1.0;
       fitter.addConstraint(constrArg, v[2]);
+      [[fallthrough]];
     case '2':					// W1==W2
       constrArg = 0.0;
       constrArg[2] = 1.0; constrArg[5] = -1.0;
       fitter.addConstraint(constrArg);
+      [[fallthrough]];
     case '1':					// A1/A2=2
       constrArg = 0.0;
       constrArg[0] = 1.0; constrArg[3] = -2.0;
       fitter.addConstraint(constrArg);
+      [[fallthrough]];
     default:
       break;
     }

--- a/scimath/Fitting/test/dConstraints.cc
+++ b/scimath/Fitting/test/dConstraints.cc
@@ -132,17 +132,17 @@ int main (int argc, const char* argv[])
       constrArg = 0.0;
       constrArg[2] = 1.0;
       fitter.addConstraint(constrArg, v[2]);
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case '2':					// W1==W2
       constrArg = 0.0;
       constrArg[2] = 1.0; constrArg[5] = -1.0;
       fitter.addConstraint(constrArg);
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case '1':					// A1/A2=2
       constrArg = 0.0;
       constrArg[0] = 1.0; constrArg[3] = -2.0;
       fitter.addConstraint(constrArg);
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     default:
       break;
     }

--- a/scimath/Functionals/CompiledFunction.tcc
+++ b/scimath/Functionals/CompiledFunction.tcc
@@ -154,6 +154,7 @@ T CompiledFunction<T>::eval(typename Function<T>::FunctionArg x) const {
 	exec_p.back() = atan(exec_p.back());
 	break;
       }
+      [[fallthrough]];
     case FuncExprData::ATAN2:
       exec_p.back() = atan2(exec_p.back(), t);
       break;

--- a/scimath/Functionals/CompiledFunction.tcc
+++ b/scimath/Functionals/CompiledFunction.tcc
@@ -154,7 +154,7 @@ T CompiledFunction<T>::eval(typename Function<T>::FunctionArg x) const {
 	exec_p.back() = atan(exec_p.back());
 	break;
       }
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case FuncExprData::ATAN2:
       exec_p.back() = atan2(exec_p.back(), t);
       break;

--- a/scimath/Functionals/FuncExpression.cc
+++ b/scimath/Functionals/FuncExpression.cc
@@ -522,7 +522,7 @@ Bool FuncExpression::exec(Double &res) const {
 	  exec_p.back() = atan(exec_p.back());
 	  break;
 	}
-	[[fallthrough]];
+	CASACORE_FALLTHROUGH;
       case FuncExprData::ATAN2: {
 	Double t(exec_p.back());
 	exec_p.pop_back();

--- a/scimath/Functionals/FuncExpression.cc
+++ b/scimath/Functionals/FuncExpression.cc
@@ -522,6 +522,7 @@ Bool FuncExpression::exec(Double &res) const {
 	  exec_p.back() = atan(exec_p.back());
 	  break;
 	}
+	[[fallthrough]];
       case FuncExprData::ATAN2: {
 	Double t(exec_p.back());
 	exec_p.pop_back();

--- a/scimath/Functionals/Function.h
+++ b/scimath/Functionals/Function.h
@@ -219,14 +219,6 @@ class RecordInterface;
      template <class W, class X>
      Function(const Function<W,X> &other) : param_p(other.parameters()),
      arg_p(0), parset_p(other.parsetp()), locked_p(False) {}
-     Function(const Function<T,U> &other) :
-       Functional<typename FunctionTraits<T>::ArgType, U>        (other),
-       Functional<Vector<typename FunctionTraits<T>::ArgType>, U>(other),
-       param_p(other.param_p),
-       arg_p(other.arg_p),
-       parset_p(other.parset_p),
-       locked_p(False)
-     {}
      // </group>
      
      // Destructor

--- a/scimath/Functionals/Function1D.h
+++ b/scimath/Functionals/Function1D.h
@@ -84,7 +84,6 @@ template<class T, class U=T> class Function1D : public Function<T,U> {
   explicit Function1D(const uInt n) : Function<T,U>(n) {}
   explicit Function1D(const Vector<T> &in) : Function<T,U>(in) {}
   Function1D(const FunctionParam<T> &other) : Function<T,U>(other) {}
-  Function1D(const Function1D<T,U> &other) : Function<T,U>(other) {}
   template <class W, class X>
   Function1D(const Function1D<W,X> &other) : Function<T,U>(other) {}
   // </group>

--- a/scimath/Mathematics/SquareMatrix.tcc
+++ b/scimath/Mathematics/SquareMatrix.tcc
@@ -168,6 +168,7 @@ SquareMatrix<T,n>& SquareMatrix<T,n>::operator*=(const SquareMatrix<T,n>& other)
 		return *this;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case Diagonal: 
 	switch (other.type_p) {
 	    case ScalarId: {
@@ -191,6 +192,7 @@ SquareMatrix<T,n>& SquareMatrix<T,n>::operator*=(const SquareMatrix<T,n>& other)
 		return *this;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case General: 
 	switch (other.type_p) {
 	    case ScalarId: {

--- a/scimath/Mathematics/SquareMatrix2.cc
+++ b/scimath/Mathematics/SquareMatrix2.cc
@@ -63,6 +63,7 @@ directProduct(SquareMatrix<Complex,4>& result,
 		return result;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case SquareMatrix<Complex,2>::Diagonal: 
 	switch (right.type_p) {
 	    case SquareMatrix<Complex,2>::ScalarId: {
@@ -90,6 +91,7 @@ directProduct(SquareMatrix<Complex,4>& result,
 		return result;
 	    }
 	}
+	CASACORE_FALLTHROUGH;
     case SquareMatrix<Complex,2>::General: 
 	switch (right.type_p) {
 	    case SquareMatrix<Complex,2>::ScalarId: {

--- a/scimath_f/atmroutines.f
+++ b/scimath_f/atmroutines.f
@@ -732,7 +732,8 @@ C
          IF(L.EQ.1)B=DV1
          IF(IL.EQ.0.)A3=A3*FMEN(L)*FLIN(V,FMEN(L),B)
          IF(IL.EQ.1.)A3=A3*FMEN(L)*FVVW(V,FMEN(L),B)
-1     SUM=SUM+(A1+A2+A3)*EXP(-E)
+1     CONTINUE
+      SUM=SUM+(A1+A2+A3)*EXP(-E)
       KO2=SUM*KO2
 C
 C	RAYAS CON DN=2
@@ -803,7 +804,8 @@ C----------------------------------------------------------------------
          TOX=TOX+TEM*EXP(-OXI)*(1.-EXP(-OX))
          OXI=OXI+OX
          TEMI=TEMI+TEM*EXP(-KV)*(1.-EXP(-AG-OX))
-1     KV=AGU+OXI
+1     CONTINUE
+      KV=AGU+OXI
       KVAT=KV
       IF ( KV.LE.1.E-10 ) THEN
          IER = 1

--- a/tables/DataMan/test/dVACEngine.h
+++ b/tables/DataMan/test/dVACEngine.h
@@ -40,7 +40,6 @@ class VACExample
 public:
     VACExample(): x_p(0), y_p(0) {}
     VACExample(Int x, float y, const String& z) : x_p(x), y_p(y), z_p(z) {}
-    VACExample(const VACExample& that): x_p(that.x_p), y_p(that.y_p), z_p(that.z_p) {}
     static String dataTypeId()
 	{ return "VACExample"; }
     Int x() const

--- a/tables/DataMan/test/tExternalStMan.cc
+++ b/tables/DataMan/test/tExternalStMan.cc
@@ -59,7 +59,7 @@ namespace casacore {
   class LofarColumn;
 
 
-  class LofarStMan final : public DataManager
+  class LofarStMan : public DataManager
   {
   public:
     // Create a Lofar storage manager with the given name.
@@ -215,7 +215,7 @@ namespace casacore {
 
   // <summary>ANTENNA1 column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class Ant1Column final : public LofarColumn
+  class Ant1Column : public LofarColumn
   {
   public:
     explicit Ant1Column (LofarStMan* parent, int dtype)
@@ -226,7 +226,7 @@ namespace casacore {
 
   // <summary>ANTENNA2 column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class Ant2Column final : public LofarColumn
+  class Ant2Column : public LofarColumn
   {
   public:
     explicit Ant2Column (LofarStMan* parent, int dtype)
@@ -237,7 +237,7 @@ namespace casacore {
 
   // <summary>TIME and TIME_CENTROID column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class TimeColumn final : public LofarColumn
+  class TimeColumn : public LofarColumn
   {
   public:
     explicit TimeColumn (LofarStMan* parent, int dtype)
@@ -248,7 +248,7 @@ namespace casacore {
 
   // <summary>INTERVAL and EXPOSURE column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class IntervalColumn final : public LofarColumn
+  class IntervalColumn : public LofarColumn
   {
   public:
     explicit IntervalColumn (LofarStMan* parent, int dtype)
@@ -259,7 +259,7 @@ namespace casacore {
 
   // <summary>All columns in the LOFAR Storage Manager with value 0.</summary>
   // <use visibility=local>
-  class ZeroColumn final : public LofarColumn
+  class ZeroColumn : public LofarColumn
   {
   public:
     explicit ZeroColumn (LofarStMan* parent, int dtype)
@@ -272,7 +272,7 @@ namespace casacore {
 
   // <summary>All columns in the LOFAR Storage Manager with value False.</summary>
   // <use visibility=local>
-  class FalseColumn final : public LofarColumn
+  class FalseColumn : public LofarColumn
   {
   public:
     explicit FalseColumn (LofarStMan* parent, int dtype)
@@ -285,7 +285,7 @@ namespace casacore {
 
   // <summary>UVW column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class UvwColumn final : public LofarColumn
+  class UvwColumn : public LofarColumn
   {
   public:
     explicit UvwColumn (LofarStMan* parent, int dtype)
@@ -298,7 +298,7 @@ namespace casacore {
 
   // <summary>DATA column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class DataColumn final : public LofarColumn
+  class DataColumn : public LofarColumn
   {
   public:
     explicit DataColumn (LofarStMan* parent, int dtype)
@@ -314,7 +314,7 @@ namespace casacore {
 
   // <summary>FLAG column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class FlagColumn final : public LofarColumn
+  class FlagColumn : public LofarColumn
   {
   public:
     explicit FlagColumn (LofarStMan* parent, int dtype)
@@ -327,7 +327,7 @@ namespace casacore {
 
   // <summary>WEIGHT column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class WeightColumn final : public LofarColumn
+  class WeightColumn : public LofarColumn
   {
   public:
     explicit WeightColumn (LofarStMan* parent, int dtype)
@@ -340,7 +340,7 @@ namespace casacore {
 
   // <summary>SIGMA column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class SigmaColumn final : public LofarColumn
+  class SigmaColumn : public LofarColumn
   {
   public:
     explicit SigmaColumn (LofarStMan* parent, int dtype)
@@ -353,7 +353,7 @@ namespace casacore {
 
   // <summary>WEIGHT_SPECTRUM column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class WSpectrumColumn final : public LofarColumn
+  class WSpectrumColumn : public LofarColumn
   {
   public:
     explicit WSpectrumColumn (LofarStMan* parent, int dtype)
@@ -366,7 +366,7 @@ namespace casacore {
 
   // <summary>FLAG_CATEGORY column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class FlagCatColumn final : public LofarColumn
+  class FlagCatColumn : public LofarColumn
   {
   public:
     explicit FlagCatColumn (LofarStMan* parent, int dtype)

--- a/tables/DataMan/test/tExternalStMan.cc
+++ b/tables/DataMan/test/tExternalStMan.cc
@@ -59,7 +59,7 @@ namespace casacore {
   class LofarColumn;
 
 
-  class LofarStMan : public DataManager
+  class LofarStMan final : public DataManager
   {
   public:
     // Create a Lofar storage manager with the given name.
@@ -73,31 +73,31 @@ namespace casacore {
     ~LofarStMan();
 
     // Clone this object.
-    virtual DataManager* clone() const;
+    virtual DataManager* clone() const override;
   
     // Get the type name of the data manager (i.e. LofarStMan).
-    virtual String dataManagerType() const;
+    virtual String dataManagerType() const override;
   
     // Get the name given to the storage manager (in the constructor).
-    virtual String dataManagerName() const;
+    virtual String dataManagerName() const override;
   
     // Record a record containing data manager specifications.
-    virtual Record dataManagerSpec() const;
+    virtual Record dataManagerSpec() const override;
 
     // The storage manager is not a regular one.
-    virtual Bool isRegular() const;
+    virtual Bool isRegular() const override;
   
     // The storage manager cannot add rows.
-    virtual Bool canAddRow() const;
+    virtual Bool canAddRow() const override;
   
     // The storage manager cannot delete rows.
-    virtual Bool canRemoveRow() const;
+    virtual Bool canRemoveRow() const override;
   
     // The storage manager can add columns, which does not really do something.
-    virtual Bool canAddColumn() const;
+    virtual Bool canAddColumn() const override;
   
     // Columns can be removed, but it does not do anything at all.
-    virtual Bool canRemoveColumn() const;
+    virtual Bool canRemoveColumn() const override;
   
     // Make the object from the type name string.
     // This function gets registered in the DataManager "constructor" map.
@@ -122,53 +122,53 @@ namespace casacore {
   
     // Flush and optionally fsync the data.
     // It does nothing, and returns False.
-    virtual Bool flush (AipsIO&, Bool doFsync);
+    virtual Bool flush (AipsIO&, Bool doFsync) override;
   
     // Let the storage manager create files as needed for a new table.
     // This allows a column with an indirect array to create its file.
-    virtual void create (uInt nrrow);
+    virtual void create (uInt nrrow) override;
   
     // Open the storage manager file for an existing table.
     // Return the number of rows in the data file.
     // <group>
-    virtual void open (uInt nrrow, AipsIO&); //# should never be called
-    virtual uInt open1 (uInt nrrow, AipsIO&);
+    virtual void open (uInt nrrow, AipsIO&) override; //# should never be called
+    virtual uInt open1 (uInt nrrow, AipsIO&) override;
     // </group>
 
     // Prepare the columns.
-    virtual void prepare();
+    virtual void prepare() override;
 
     // Resync the storage manager with the new file contents.
     // It does nothing.
     // <group>
-    virtual void resync (uInt nrrow);   //# should never be called
-    virtual uInt resync1 (uInt nrrow);
+    virtual void resync (uInt nrrow) override;   //# should never be called
+    virtual uInt resync1 (uInt nrrow) override;
     // </group>
   
     // Reopen the storage manager files for read/write.
     // It does nothing.
-    virtual void reopenRW();
+    virtual void reopenRW() override;
   
     // The data manager will be deleted (because all its columns are
     // requested to be deleted).
     // So clean up the things needed (e.g. delete files).
-    virtual void deleteManager();
+    virtual void deleteManager() override;
 
     // Add rows to the storage manager.
     // It cannot do it, so throws an exception.
-    virtual void addRow (uInt nrrow);
+    virtual void addRow (uInt nrrow) override;
   
     // Delete a row from all columns.
     // It cannot do it, so throws an exception.
-    virtual void removeRow (uInt rowNr);
+    virtual void removeRow (uInt rowNr) override;
   
     // Do the final addition of a column.
     // It won't do anything.
-    virtual void addColumn (DataManagerColumn*);
+    virtual void addColumn (DataManagerColumn*) override;
   
     // Remove a column from the data file.
     // It won't do anything.
-    virtual void removeColumn (DataManagerColumn*);
+    virtual void removeColumn (DataManagerColumn*) override;
   
     // Create a column in the storage manager on behalf of a table column.
     // The caller has to delete the newly created object.
@@ -176,15 +176,15 @@ namespace casacore {
     // Create a scalar column.
     virtual DataManagerColumn* makeScalarColumn (const String& aName,
                                                  int aDataType,
-                                                 const String& aDataTypeID);
+                                                 const String& aDataTypeID) override;
     // Create a direct array column.
     virtual DataManagerColumn* makeDirArrColumn (const String& aName,
                                                  int aDataType,
-                                                 const String& aDataTypeID);
+                                                 const String& aDataTypeID) override;
     // Create an indirect array column.
     virtual DataManagerColumn* makeIndArrColumn (const String& aName,
                                                  int aDataType,
-                                                 const String& aDataTypeID);
+                                                 const String& aDataTypeID) override;
     // </group>
 
     //# Declare member variables.
@@ -204,9 +204,9 @@ namespace casacore {
     {}
     virtual ~LofarColumn();
     // Most columns are not writable (only DATA is writable).
-    virtual Bool isWritable() const;
+    virtual Bool isWritable() const override;
     // Set column shape of fixed shape columns; it does nothing.
-    virtual void setShapeColumn (const IPosition& shape);
+    virtual void setShapeColumn (const IPosition& shape) override;
     // Prepare the column. By default it does nothing.
     virtual void prepareCol();
   protected:
@@ -215,165 +215,165 @@ namespace casacore {
 
   // <summary>ANTENNA1 column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class Ant1Column : public LofarColumn
+  class Ant1Column final : public LofarColumn
   {
   public:
     explicit Ant1Column (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~Ant1Column();
-    virtual void getIntV (uInt rowNr, Int* dataPtr);
+    virtual void getIntV (uInt rowNr, Int* dataPtr) override;
   };
 
   // <summary>ANTENNA2 column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class Ant2Column : public LofarColumn
+  class Ant2Column final : public LofarColumn
   {
   public:
     explicit Ant2Column (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~Ant2Column();
-    virtual void getIntV (uInt rowNr, Int* dataPtr);
+    virtual void getIntV (uInt rowNr, Int* dataPtr) override;
   };
 
   // <summary>TIME and TIME_CENTROID column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class TimeColumn : public LofarColumn
+  class TimeColumn final : public LofarColumn
   {
   public:
     explicit TimeColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~TimeColumn();
-    virtual void getdoubleV (uInt rowNr, Double* dataPtr);
+    virtual void getdoubleV (uInt rowNr, Double* dataPtr) override;
   };
 
   // <summary>INTERVAL and EXPOSURE column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class IntervalColumn : public LofarColumn
+  class IntervalColumn final : public LofarColumn
   {
   public:
     explicit IntervalColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~IntervalColumn();
-    virtual void getdoubleV (uInt rowNr, Double* dataPtr);
+    virtual void getdoubleV (uInt rowNr, Double* dataPtr) override;
   };
 
   // <summary>All columns in the LOFAR Storage Manager with value 0.</summary>
   // <use visibility=local>
-  class ZeroColumn : public LofarColumn
+  class ZeroColumn final : public LofarColumn
   {
   public:
     explicit ZeroColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~ZeroColumn();
-    virtual void getIntV (uInt rowNr, Int* dataPtr);
+    virtual void getIntV (uInt rowNr, Int* dataPtr) override;
   private:
     Int itsValue;
   };
 
   // <summary>All columns in the LOFAR Storage Manager with value False.</summary>
   // <use visibility=local>
-  class FalseColumn : public LofarColumn
+  class FalseColumn final : public LofarColumn
   {
   public:
     explicit FalseColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~FalseColumn();
-    virtual void getBoolV (uInt rowNr, Bool* dataPtr);
+    virtual void getBoolV (uInt rowNr, Bool* dataPtr) override;
   private:
     Bool itsValue;
   };
 
   // <summary>UVW column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class UvwColumn : public LofarColumn
+  class UvwColumn final : public LofarColumn
   {
   public:
     explicit UvwColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~UvwColumn();
-    virtual IPosition shape (uInt rownr);
+    virtual IPosition shape (uInt rownr) override;
     virtual void getArraydoubleV (uInt rowNr,
-                                  Array<Double>* dataPtr);
+                                  Array<Double>* dataPtr) override;
   };
 
   // <summary>DATA column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class DataColumn : public LofarColumn
+  class DataColumn final : public LofarColumn
   {
   public:
     explicit DataColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~DataColumn();
-    virtual Bool isWritable() const;
-    virtual IPosition shape (uInt rownr);
+    virtual Bool isWritable() const override;
+    virtual IPosition shape (uInt rownr) override;
     virtual void getArrayComplexV (uInt rowNr,
-                                   Array<Complex>* dataPtr);
+                                   Array<Complex>* dataPtr) override;
     virtual void putArrayComplexV (uInt rowNr,
-                                   const Array<Complex>* dataPtr);
+                                   const Array<Complex>* dataPtr) override;
   };
 
   // <summary>FLAG column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class FlagColumn : public LofarColumn
+  class FlagColumn final : public LofarColumn
   {
   public:
     explicit FlagColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~FlagColumn();
-    virtual IPosition shape (uInt rownr);
+    virtual IPosition shape (uInt rownr) override;
     virtual void getArrayBoolV (uInt rowNr,
-                                Array<Bool>* dataPtr);
+                                Array<Bool>* dataPtr) override;
   };
 
   // <summary>WEIGHT column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class WeightColumn : public LofarColumn
+  class WeightColumn final : public LofarColumn
   {
   public:
     explicit WeightColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~WeightColumn();
-    virtual IPosition shape (uInt rownr);
+    virtual IPosition shape (uInt rownr) override;
     virtual void getArrayfloatV (uInt rowNr,
-                                 Array<Float>* dataPtr);
+                                 Array<Float>* dataPtr) override;
   };
 
   // <summary>SIGMA column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class SigmaColumn : public LofarColumn
+  class SigmaColumn final : public LofarColumn
   {
   public:
     explicit SigmaColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~SigmaColumn();
-    virtual IPosition shape (uInt rownr);
+    virtual IPosition shape (uInt rownr) override;
     virtual void getArrayfloatV (uInt rowNr,
-                                 Array<Float>* dataPtr);
+                                 Array<Float>* dataPtr) override;
   };
 
   // <summary>WEIGHT_SPECTRUM column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class WSpectrumColumn : public LofarColumn
+  class WSpectrumColumn final : public LofarColumn
   {
   public:
     explicit WSpectrumColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~WSpectrumColumn();
-    virtual IPosition shape (uInt rownr);
+    virtual IPosition shape (uInt rownr) override;
     virtual void getArrayfloatV (uInt rowNr,
-                                 Array<Float>* dataPtr);
+                                 Array<Float>* dataPtr) override;
   };
 
   // <summary>FLAG_CATEGORY column in the LOFAR Storage Manager.</summary>
   // <use visibility=local>
-  class FlagCatColumn : public LofarColumn
+  class FlagCatColumn final : public LofarColumn
   {
   public:
     explicit FlagCatColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~FlagCatColumn();
-    virtual Bool isShapeDefined (uInt rownr);
-    virtual IPosition shape (uInt rownr);
+    virtual Bool isShapeDefined (uInt rownr) override;
+    virtual IPosition shape (uInt rownr) override;
   };
 
 

--- a/tables/DataMan/test/tExternalStMan.cc
+++ b/tables/DataMan/test/tExternalStMan.cc
@@ -291,6 +291,7 @@ namespace casacore {
     explicit UvwColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~UvwColumn();
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
     virtual void getArraydoubleV (uInt rowNr,
                                   Array<Double>* dataPtr) override;
@@ -305,6 +306,7 @@ namespace casacore {
       : LofarColumn(parent, dtype) {}
     virtual ~DataColumn();
     virtual Bool isWritable() const override;
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
     virtual void getArrayComplexV (uInt rowNr,
                                    Array<Complex>* dataPtr) override;
@@ -320,6 +322,7 @@ namespace casacore {
     explicit FlagColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~FlagColumn();
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
     virtual void getArrayBoolV (uInt rowNr,
                                 Array<Bool>* dataPtr) override;
@@ -333,6 +336,7 @@ namespace casacore {
     explicit WeightColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~WeightColumn();
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
     virtual void getArrayfloatV (uInt rowNr,
                                  Array<Float>* dataPtr) override;
@@ -346,6 +350,7 @@ namespace casacore {
     explicit SigmaColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~SigmaColumn();
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
     virtual void getArrayfloatV (uInt rowNr,
                                  Array<Float>* dataPtr) override;
@@ -359,6 +364,7 @@ namespace casacore {
     explicit WSpectrumColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~WSpectrumColumn();
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
     virtual void getArrayfloatV (uInt rowNr,
                                  Array<Float>* dataPtr) override;
@@ -372,7 +378,9 @@ namespace casacore {
     explicit FlagCatColumn (LofarStMan* parent, int dtype)
       : LofarColumn(parent, dtype) {}
     virtual ~FlagCatColumn();
+    using LofarColumn::isShapeDefined;
     virtual Bool isShapeDefined (uInt rownr) override;
+    using LofarColumn::shape;
     virtual IPosition shape (uInt rownr) override;
   };
 

--- a/tables/TaQL/ExprAggrNode.cc
+++ b/tables/TaQL/ExprAggrNode.cc
@@ -100,7 +100,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gminsFUNC:
     case gmaxsFUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case gminFUNC:
     case gmaxFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -109,7 +109,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gproductsFUNC:
     case gsumsqrsFUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case gsumFUNC:
     case gproductFUNC:
     case gsumsqrFUNC:
@@ -117,7 +117,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       return checkDT (dtypeOper, NTNumeric, NTNumeric, nodes);
     case gmeansFUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case gmeanFUNC:
       checkNumOfArg (1, 1, nodes);
       return checkDT (dtypeOper, NTNumeric, NTDouCom, nodes);
@@ -126,7 +126,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gstddevs0FUNC:
     case gstddevs1FUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case gvariance0FUNC:
     case gvariance1FUNC:
     case gstddev0FUNC:
@@ -135,7 +135,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       return checkDT (dtypeOper, NTNumeric, NTDouble, nodes);
     case grmssFUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case grmsFUNC:
     case gmedianFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -151,7 +151,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case ganysFUNC:
     case gallsFUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case ganyFUNC:
     case gallFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -159,7 +159,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gntruesFUNC:
     case gnfalsesFUNC:
       resVT = VTArray;
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case gntrueFUNC:
     case gnfalseFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -245,7 +245,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
           break;
         }
         // Fall through, so e.g. mean of ints can be done
-      [[fallthrough]];
+        CASACORE_FALLTHROUGH;
       case NTDouble:
         switch (funcType()) {
         case gminFUNC:
@@ -350,7 +350,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         break;
       }
       // Fall through, so e.g. mean of ints can be done
-      [[fallthrough]];
+      CASACORE_FALLTHROUGH;
     case NTDouble:
       switch (funcType()) {
       case gminFUNC:

--- a/tables/TaQL/ExprAggrNode.cc
+++ b/tables/TaQL/ExprAggrNode.cc
@@ -100,6 +100,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gminsFUNC:
     case gmaxsFUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case gminFUNC:
     case gmaxFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -108,6 +109,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gproductsFUNC:
     case gsumsqrsFUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case gsumFUNC:
     case gproductFUNC:
     case gsumsqrFUNC:
@@ -115,6 +117,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       return checkDT (dtypeOper, NTNumeric, NTNumeric, nodes);
     case gmeansFUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case gmeanFUNC:
       checkNumOfArg (1, 1, nodes);
       return checkDT (dtypeOper, NTNumeric, NTDouCom, nodes);
@@ -123,6 +126,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gstddevs0FUNC:
     case gstddevs1FUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case gvariance0FUNC:
     case gvariance1FUNC:
     case gstddev0FUNC:
@@ -131,6 +135,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       return checkDT (dtypeOper, NTNumeric, NTDouble, nodes);
     case grmssFUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case grmsFUNC:
     case gmedianFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -146,6 +151,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case ganysFUNC:
     case gallsFUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case ganyFUNC:
     case gallFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -153,6 +159,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     case gntruesFUNC:
     case gnfalsesFUNC:
       resVT = VTArray;
+      [[fallthrough]];
     case gntrueFUNC:
     case gnfalseFUNC:
       checkNumOfArg (1, 1, nodes);
@@ -238,6 +245,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
           break;
         }
         // Fall through, so e.g. mean of ints can be done
+      [[fallthrough]];
       case NTDouble:
         switch (funcType()) {
         case gminFUNC:
@@ -342,6 +350,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         break;
       }
       // Fall through, so e.g. mean of ints can be done
+      [[fallthrough]];
     case NTDouble:
       switch (funcType()) {
       case gminFUNC:

--- a/tables/TaQL/ExprAggrNodeArray.cc
+++ b/tables/TaQL/ExprAggrNodeArray.cc
@@ -136,6 +136,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         break;
       }
       // Fall through, so e.g. mean of ints can be done
+      CASACORE_FALLTHROUGH;
     case NTDouble:
       switch (funcType()) {
       case TableExprFuncNode::gminsFUNC:

--- a/tables/TaQL/ExprFuncNode.cc
+++ b/tables/TaQL/ExprFuncNode.cc
@@ -1595,7 +1595,7 @@ TableExprNodeRep::NodeDataType TableExprFuncNode::checkOperands
             break;
         case resizeFUNC:
             optarg = 1;
-            [[fallthrough]];
+            CASACORE_FALLTHROUGH;
         case arrayFUNC:
         case transposeFUNC:
         case areverseFUNC:
@@ -1748,7 +1748,7 @@ TableExprNodeRep::NodeDataType TableExprFuncNode::checkOperands
     case weekdayFUNC:
     case weekFUNC:
         dtout = NTInt;
-        [[fallthrough]];
+        CASACORE_FALLTHROUGH;
     case mjdFUNC:
     case timeFUNC:
         if (checkNumOfArg (0, 1, nodes) == 1) {

--- a/tables/TaQL/ExprFuncNode.cc
+++ b/tables/TaQL/ExprFuncNode.cc
@@ -1595,6 +1595,7 @@ TableExprNodeRep::NodeDataType TableExprFuncNode::checkOperands
             break;
         case resizeFUNC:
             optarg = 1;
+            [[fallthrough]];
         case arrayFUNC:
         case transposeFUNC:
         case areverseFUNC:
@@ -1747,6 +1748,7 @@ TableExprNodeRep::NodeDataType TableExprFuncNode::checkOperands
     case weekdayFUNC:
     case weekFUNC:
         dtout = NTInt;
+        [[fallthrough]];
     case mjdFUNC:
     case timeFUNC:
         if (checkNumOfArg (0, 1, nodes) == 1) {

--- a/tables/TaQL/ExprFuncNodeArray.cc
+++ b/tables/TaQL/ExprFuncNodeArray.cc
@@ -346,6 +346,7 @@ void TableExprFuncNodeArray::tryToConst()
         break;
     case TableExprFuncNode::arrfractilesFUNC:
         axarg = 2;
+        [[fallthrough]];
     case TableExprFuncNode::arrsumsFUNC:
     case TableExprFuncNode::arrproductsFUNC:
     case TableExprFuncNode::arrsumsqrsFUNC:

--- a/tables/TaQL/ExprFuncNodeArray.cc
+++ b/tables/TaQL/ExprFuncNodeArray.cc
@@ -346,7 +346,7 @@ void TableExprFuncNodeArray::tryToConst()
         break;
     case TableExprFuncNode::arrfractilesFUNC:
         axarg = 2;
-        [[fallthrough]];
+        CASACORE_FALLTHROUGH;
     case TableExprFuncNode::arrsumsFUNC:
     case TableExprFuncNode::arrproductsFUNC:
     case TableExprFuncNode::arrsumsqrsFUNC:

--- a/tables/TaQL/ExprGroup.h
+++ b/tables/TaQL/ExprGroup.h
@@ -81,9 +81,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   private:
     TableExprNodeRep::NodeDataType itsDT;
-    Bool   itsBool;
-    Int64  itsInt64;
-    Double itsDouble;
+    Bool   itsBool = false;
+    Int64  itsInt64 = 0;
+    Double itsDouble = 0.0;
     String itsString;
   };
 

--- a/tables/Tables/ColumnCache.h
+++ b/tables/Tables/ColumnCache.h
@@ -30,6 +30,9 @@
 
 
 //# Includes
+#include <cassert>
+#include <limits>
+
 #include <casacore/casa/aips.h>
 
 
@@ -136,8 +139,12 @@ inline void ColumnCache::invalidate()
 
 inline Int64 ColumnCache::offset (rownr_t rownr) const
 {
-    return rownr<itsStart || rownr>itsEnd  ?  -1 :
-	                                      (rownr-itsStart)*itsIncr;
+    if (rownr < itsStart || rownr > itsEnd) {
+        return -1;
+    }
+    auto offset = (rownr - itsStart) * itsIncr;
+    assert(offset <= std::numeric_limits<Int64>::max());
+    return Int64(offset);
 }
 
 inline const void* ColumnCache::dataPtr() const

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -491,6 +491,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpFloat:
     defPrec = 9;
+    [[fallthrough]];
   case TpDouble:
     {
       // set precision; set it back at the end.
@@ -502,6 +503,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpComplex:
     defPrec = 9;
+    [[fallthrough]];
   case TpDComplex:
     {
       // set precision; set it back at the end.
@@ -555,6 +557,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpArrayFloat:
     defPrec = 9;
+    [[fallthrough]];
   case TpArrayDouble:
     {
       // set precision; set it back at the end.
@@ -578,6 +581,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpArrayComplex:
     defPrec = 9;
+    [[fallthrough]];
   case TpArrayDComplex:
     {
       // set precision; set it back at the end.
@@ -1168,7 +1172,7 @@ Record TableProxy::getVarColumn (const String& columnName,
   Int64 nrows = getRowsCheck (columnName, row, nrow, incr, "getVarColumn");
   TableColumn tabcol (table_p, columnName);
   Record rec;
-  char namebuf[16];
+  char namebuf[22];
   for (Int64 i=0; i<nrows; i++) {
     // Add the result to the record with field name formed from 1-based rownr.
     sprintf (namebuf, "r%lli", row+1);

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -491,7 +491,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpFloat:
     defPrec = 9;
-    [[fallthrough]];
+    CASACORE_FALLTHROUGH;
   case TpDouble:
     {
       // set precision; set it back at the end.
@@ -503,7 +503,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpComplex:
     defPrec = 9;
-    [[fallthrough]];
+    CASACORE_FALLTHROUGH;
   case TpDComplex:
     {
       // set precision; set it back at the end.
@@ -557,7 +557,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpArrayFloat:
     defPrec = 9;
-    [[fallthrough]];
+    CASACORE_FALLTHROUGH;
   case TpArrayDouble:
     {
       // set precision; set it back at the end.
@@ -581,7 +581,7 @@ void TableProxy::printValueHolder (const ValueHolder& vh, ostream& os,
     break;
   case TpArrayComplex:
     defPrec = 9;
-    [[fallthrough]];
+    CASACORE_FALLTHROUGH;
   case TpArrayDComplex:
     {
       // set precision; set it back at the end.


### PR DESCRIPTION
This fixes in particular a lot of 'fallthrough' warnings inside switch statements. To suppress the warning, I use the (C++14) attribute '[[fallthrough]]' to annotate / suppress fallthrough. Although this is a C++14 attribute, C++11 compilers ignore unknown attributes, which I think is therefore fine. A few warnings remain of which I'm not 100% sure they are intended to fallthrough. Also one fallthrough seemed clearly unintended (in SDPolarizationHandler), so this fixes a bug.

Some classes also declared either an explicit default copy constructor or copy assignment operator, causing a warning if the non-declared counter part is used. In FitsBase some of these warnings remain, but since it's not a trivial copy in those cases, it looks wrong to explicitly declare a default constructor.

BTW the test tFITSImage fails locally on my computer on master (already before the fix)