### PR TITLE
Revert zeroing IPosition and some clean-up

### DIFF
--- a/casa/Arrays/IPosition.h
+++ b/casa/Arrays/IPosition.h
@@ -124,7 +124,7 @@ public:
     // A zero-length IPosition.
     IPosition() noexcept;
 
-    // An IPosition of size "length." The values in the object are undefined.
+    // An IPosition of size "length." The values in the object are uninitialized.
     explicit IPosition(size_t length);
 
     // An IPosition initialized from the given list
@@ -137,6 +137,7 @@ public:
     // An IPosition of size "length" with defined values. You need to supply
     // a value for each element of the IPosition (up to 10). [Unfortunately
     // varargs might not be sufficiently portable.]
+    //TODO: [[deprecated("Use the initialize list constructor")]]
     IPosition (size_t length, ssize_t val0, ssize_t val1, ssize_t val2=MIN_INT, 
 	       ssize_t val3=MIN_INT, ssize_t val4=MIN_INT, ssize_t val5=MIN_INT,
 	       ssize_t val6=MIN_INT, ssize_t val7=MIN_INT, ssize_t val8=MIN_INT,

--- a/casa/Arrays/MaskArrMath.tcc
+++ b/casa/Arrays/MaskArrMath.tcc
@@ -1531,8 +1531,8 @@ template<class T> T median(const MaskedArray<T> &left, bool sorted,
   const T *leftarrS = leftarrStorage;
   
   bool leftmaskDelete;
-  const LogicalArrayElem *leftmaskStorage
-  = left.getMaskStorage(leftmaskDelete);
+  const LogicalArrayElem *leftmaskStorage =
+    left.getMaskStorage(leftmaskDelete);
   const LogicalArrayElem *leftmaskS = leftmaskStorage;
   
   size_t n2 = (nelem - 1)/2;

--- a/casa/Arrays/test/tCpp11Features.cc
+++ b/casa/Arrays/test/tCpp11Features.cc
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE( cube_move_constructor )
   Cube<int> empty;
   BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), empty.begin(), empty.end());
   
-  BOOST_CHECK_THROW(Cube<int>(Array<int>(IPosition(5))), std::exception);
+  BOOST_CHECK_THROW(Cube<int>(Array<int>(IPosition(5, 0))), std::exception);
   
   Cube<int> d(Vector<int>(3, 17));
   BOOST_CHECK_EQUAL(d.shape(), IPosition(3, 3, 1, 1));


### PR DESCRIPTION
This reverts one part of #1079 (by @cquike). An IPosition does not need to be zeroed; it's part of its interface to leave it uninitialized by default. The valgrind error that cquike reported was actually an invalid use of IPosition, which I've corrected in the test.

It's open to discussion whether the IPosition *should* be like that or whether we better chose for the safe option, but currently it's often declared and then filled.

On top of that I also went through IPosition and used std::copy, std::fill and std::move where appropriate to replace for loops, and this simplifies/removes a lot of for statements.