### PR TITLE
Fix valgrind report of uninitialised memory

### DIFF
--- a/casa/IO/FilebufIO.cc
+++ b/casa/IO/FilebufIO.cc
@@ -94,7 +94,7 @@ void FilebufIO::setBuffer (Int64 bufSize)
     itsBufOffset = -1;
   }
   if (bufSize > 0) {
-    itsBuffer  = new char[bufSize];
+    itsBuffer  = new char[bufSize]();
     itsBufSize = bufSize;
     itsBufOffset = -Int(itsBufSize+1);
   }

--- a/casa/IO/MemoryIO.cc
+++ b/casa/IO/MemoryIO.cc
@@ -46,7 +46,7 @@ MemoryIO::MemoryIO (uInt64 initialSize, uInt64 expandSize)
   itsCanDelete  (True)
 {
   if (itsAlloc > 0) {
-    itsBuffer = new uChar[itsAlloc];
+    itsBuffer = new uChar[itsAlloc]();
     AlwaysAssert (itsBuffer != 0, AipsError);
   }
 }


### PR DESCRIPTION
valgrind reports a problem with uninitialised memory in two IO classes.
The buffer used by Filebuf and MemoryIO is now default initialised when allocating it.