### PR TITLE
Use setenv() rather than putenv() to set environmental variables.

### DIFF
--- a/casa/OS/EnvVar.cc
+++ b/casa/OS/EnvVar.cc
@@ -48,14 +48,7 @@ String EnvironmentVariable::get (const String& name)
 
 void EnvironmentVariable::set (const String& name, const String& value)
 {
-  uInt nl = name.length();
-  uInt vl = value.length();
-  Char* str = new Char [nl + vl + 2];
-  strcpy (str, name.chars());
-  str[nl] = '=';
-  strcpy (str+nl+1, value.chars());
-  // Note that putenv takes over the pointer, so we should not delete str.
-  AlwaysAssert (putenv(str) == 0, AipsError);
+  AlwaysAssert (setenv(name.chars(), value.chars(), 1) == 0, AipsError);
 }
 
 } //# NAMESPACE CASACORE - END


### PR DESCRIPTION
setenv() is prefered over putenv() as descirbed in the POSIX standard:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/putenv.html#

Addtionally this fix a small memory leak, since with putenv one
cannot modify the input buffer and therefore the buffer must remain allocated. With setenv() that's not the case and is therefore cleaner. 