### PR TITLE
Rewrite the IPosition(size, args...) constructor to use a parameter pack

### DIFF
--- a/casa/Arrays/IPosition.cc
+++ b/casa/Arrays/IPosition.cc
@@ -115,47 +115,6 @@ IPosition::IPosition (size_t length, ssize_t val)
     std::fill_n(data_p, size_p, val);
 }
 
-// <thrown>
-//    <item> std::runtime_error
-// </thrown>
-IPosition::IPosition (size_t length, ssize_t val0, ssize_t val1, ssize_t val2,
-                      ssize_t val3, ssize_t val4, ssize_t val5, ssize_t val6,
-                      ssize_t val7, ssize_t val8, ssize_t val9)
-: size_p (length),
-  data_p (buffer_p)
-{
-    if (size_p > BufferLength) {
-	allocateBuffer();
-    }
-    if (size_p > 10  ||  length < 1) {
-	throw(std::runtime_error("IPosition::IPosition(size_t length, val0, ...) - "
-			 "Can only initialize from 1 to 10 elements"));
-    }
-    switch (length) {
-         case 10: data_p[9] = val9;    // Fall through
-	 case 9:  data_p[8] = val8;    // Fall through
-	 case 8:  data_p[7] = val7;    // Fall through
-	 case 7:  data_p[6] = val6;    // Fall through
-	 case 6:  data_p[5] = val5;    // Fall through
-	 case 5:  data_p[4] = val4;    // Fall through
-	 case 4:  data_p[3] = val3;    // Fall through
-	 case 3:  data_p[2] = val2;    // Fall through
-	 case 2:  data_p[1] = val1;    // Fall through
-	 case 1:  data_p[0] = val0; break;
-	 default:
-             throw(std::runtime_error("IPosition::IPosition(size_t length, val0, ...) - "
-			     "Can only initialize from 1 to 10 elements"));
-    }
-    for (size_t i=0; i<size_p; i++) {
-	if (data_p[i] == MIN_INT) {
-	    throw(std::runtime_error("IPosition::IPosition(size_t length, val0, ...) - "
-		    "One or more valn == INT_MIN. Probably haven't defined "
-		    "enough values. Otherwise specify after construction."));
-	}
-    }
-    assert(ok());
-}
-
 IPosition::IPosition (const IPosition& other)
 : size_p (other.size_p),
   data_p (buffer_p)

--- a/casa/Arrays/IPosition.h
+++ b/casa/Arrays/IPosition.h
@@ -129,7 +129,7 @@ public:
     // An IPosition initialized from the given list
     IPosition(std::initializer_list<ssize_t> list);
     
-    // An IPosition of size "length." The values in the object get
+    // An IPosition of size "length." All values in the object are
     // initialized to val.
     IPosition(size_t length, ssize_t val);
 
@@ -148,8 +148,8 @@ public:
     // method. Both of those methods do not have the above issues.
     template<typename... Vals>
     //[[ deprecated("Use the initializer list constructor or Make() method") ]]
-    IPosition (size_t /*dummy*/, Vals... vals) :
-    IPosition{static_cast<ssize_t>(vals)...} { }
+    IPosition (size_t /*dummy*/, ssize_t val1, ssize_t val2, Vals... vals) :
+    IPosition{val1, val2, static_cast<ssize_t>(vals)...} { }
 
     // Makes a copy (copy, NOT reference, semantics) of source.
     IPosition(const IPosition& source);

--- a/casa/Arrays/IPosition.h
+++ b/casa/Arrays/IPosition.h
@@ -135,13 +135,13 @@ public:
 
     // An IPosition initialized from a variable number of parameters.
     // The first parameter should specify the size, but the actual
-    // size of he resulting IPosition is determined from the number
-    // of parameters (the first arugment is ignored).
+    // size of the resulting IPosition is determined from the number
+    // of parameters (the first argument is ignored).
     //
     // This constructor should be disfavoured, because i) of the
     // dummy parameter and ii) because it may narrow the
     // specified parameter without a warning. 
-    
+    //
     // Instead, use an initializer list constructor whenever possible.
     // If an IPosition is created inside a macro, an initializer list
     // is not possible. In those cases, use the Make(Vals...) factory

--- a/casa/Arrays/IPosition.h
+++ b/casa/Arrays/IPosition.h
@@ -120,7 +120,6 @@ class IPosition
     friend class IPositionComparator;
     
 public:
-    enum {MIN_INT = -2147483647};
     // A zero-length IPosition.
     IPosition() noexcept;
 
@@ -134,14 +133,23 @@ public:
     // initialized to val.
     IPosition(size_t length, ssize_t val);
 
-    // An IPosition of size "length" with defined values. You need to supply
-    // a value for each element of the IPosition (up to 10). [Unfortunately
-    // varargs might not be sufficiently portable.]
-    //TODO: [[deprecated("Use the initialize list constructor")]]
-    IPosition (size_t length, ssize_t val0, ssize_t val1, ssize_t val2=MIN_INT, 
-	       ssize_t val3=MIN_INT, ssize_t val4=MIN_INT, ssize_t val5=MIN_INT,
-	       ssize_t val6=MIN_INT, ssize_t val7=MIN_INT, ssize_t val8=MIN_INT,
-	       ssize_t val9=MIN_INT);
+    // An IPosition initialized from a variable number of parameters.
+    // The first parameter should specify the size, but the actual
+    // size of he resulting IPosition is determined from the number
+    // of parameters (the first arugment is ignored).
+    //
+    // This constructor should be disfavoured, because i) of the
+    // dummy parameter and ii) because it may narrow the
+    // specified parameter without a warning. 
+    
+    // Instead, use an initializer list constructor whenever possible.
+    // If an IPosition is created inside a macro, an initializer list
+    // is not possible. In those cases, use the Make(Vals...) factory
+    // method. Both of those methods do not have the above issues.
+    template<typename... Vals>
+    //[[ deprecated("Use the initializer list constructor or Make() method") ]]
+    IPosition (size_t /*dummy*/, Vals... vals) :
+    IPosition{static_cast<ssize_t>(vals)...} { }
 
     // Makes a copy (copy, NOT reference, semantics) of source.
     IPosition(const IPosition& source);
@@ -150,6 +158,11 @@ public:
     
     ~IPosition();
 
+    template<typename... Vals>
+    static IPosition Make (Vals... vals) {
+      return IPosition{vals...};
+    }
+    
     // Makes this a copy of other. When the dest is not of the same
     // size, it will resize itself to be the same length as the source.
     IPosition& operator=(const IPosition& source);

--- a/casa/Arrays/IPosition.h
+++ b/casa/Arrays/IPosition.h
@@ -158,6 +158,16 @@ public:
     
     ~IPosition();
 
+    // Construct an IPosition that is initialized from a variable number of parameter.
+    // The resulting size of the IPosition will equal the number of parameters specified.
+    //
+    // In general, using the initializer list constructor should be preferred. Defining
+    // an initializer list inside macros is however not possible. In those cases, this
+    // method can be used to construct the IPosition.
+    //
+    // Example: IPosition::Make(3, 5) creates an IPosition of size 2, with values 3 and 5.
+    // It is identical to IPosition{3, 5}. A program is ill-formed when narrowing of
+    // a parameter is required, causing a compiler warning or error.
     template<typename... Vals>
     static IPosition Make (Vals... vals) {
       return IPosition{vals...};

--- a/casa/Arrays/test/tIPosition.cc
+++ b/casa/Arrays/test/tIPosition.cc
@@ -157,6 +157,21 @@ BOOST_AUTO_TEST_CASE( construct_from_ll_array )
     BOOST_CHECK(bigPos[i] == (9-i));
 }
 
+BOOST_AUTO_TEST_CASE(make)
+{
+  IPosition d = IPosition::Make(8, 5, 19, 82);
+  BOOST_CHECK_EQUAL(d.nelements(), 4);
+  BOOST_CHECK_EQUAL(d[0], 8);
+  BOOST_CHECK_EQUAL(d[1], 5);
+  BOOST_CHECK_EQUAL(d[2], 19);
+  BOOST_CHECK_EQUAL(d[3], 82);
+  
+  IPosition l = IPosition::Make(9, 8, 7, 6, 5, 4, 3);
+  BOOST_CHECK_EQUAL(l.nelements(), 7);
+  for(int i=0; i!=7; ++i)
+    BOOST_CHECK_EQUAL(l[i], 9-i);
+}
+
 BOOST_AUTO_TEST_CASE( move_exhaustively )
 {
   int i;

--- a/tables/DataMan/test/tTiledShapeStMan.cc
+++ b/tables/DataMan/test/tTiledShapeStMan.cc
@@ -337,7 +337,7 @@ void writeFixVar(const TSMOption& tsmOpt)
     SetupNewTable newtab("tTiledShapeStMan_tmp.data", td, Table::New);
     // Create a storage manager for it.
     // Let the tile shape match the cube shape.
-    TiledShapeStMan sm1 ("TSMExample", IPosition(2,16,25,1));
+    TiledShapeStMan sm1 ("TSMExample", IPosition(2,16,25));
     newtab.bindAll (sm1);
     Table table(newtab, 0, False, Table::LocalEndian, tsmOpt);
 


### PR DESCRIPTION
The old constructor was inefficient. To prepare for deprecation of this constructor,
I've added a Make() factory function which is to replace this constructor for
cases where a initializer list isn't possible (i.e. inside a macro).