### PR TITLE
[casacore#1092] 👷 Fix OSX build on github actions

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,14 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: install homebrew deps
-        run: |
-          brew install fftw hdf5 boost-python3 cfitsio wcslib wget gfortran
-
-      - name: debug gfortran
-        continue-on-error: true
-        run: |
-          set -ex
-          which gfortran-10
+        run: brew install fftw hdf5 boost-python3 cfitsio wcslib wget gfortran
 
       - name: pip install numpy
         run: pip3 install numpy

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,4 +1,4 @@
-name: OS X
+name: macOS
 
 on:
   push:
@@ -10,14 +10,20 @@ on:
 jobs:
   osx:
     runs-on: macos-10.15
-    continue-on-error: true
 
     steps:
       - name: checkout
         uses: actions/checkout@v2
 
       - name: install homebrew deps
-        run: brew install fftw hdf5 boost-python3 cfitsio wcslib wget gfortran
+        run: |
+          brew install fftw hdf5 boost-python3 cfitsio wcslib wget gfortran
+
+      - name: debug gfortran
+        continue-on-error: true
+        run: |
+          set -ex
+          which gfortran-10
 
       - name: pip install numpy
         run: pip3 install numpy
@@ -25,7 +31,7 @@ jobs:
       - name:  get WSRT measures
         run: wget ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar -O WSRT_Measures.ztar
 
-      - name: make build folder 
+      - name: make build folder
         run: |
           mkdir -p build
           cd build
@@ -34,13 +40,28 @@ jobs:
       - name: configure
         run: |
           cd build
-          cmake -DBUILD_TESTING=ON -DCMAKE_PREFIX_PATH=/usr/local/ -DUSE_OPENMP=OFF -DUSE_HDF5=ON -DBUILD_PYTHON=OFF -DBUILD_PYTHON3=ON -DBoost_NO_BOOST_CMAKE=True -DDATA_DIR=. ..
+          cmake \
+            -DBUILD_TESTING=ON \
+            -DCMAKE_PREFIX_PATH=/usr/local/ \
+            -DUSE_OPENMP=OFF \
+            -DUSE_HDF5=ON \
+            -DBUILD_PYTHON=OFF \
+            -DBUILD_PYTHON3=ON \
+            -DBoost_NO_BOOST_CMAKE=True \
+            -DCMAKE_Fortran_COMPILER=gfortran-10 \
+            -DDATA_DIR=. ..
 
       - name: build
-        run: make -j3
+        run: |
+          cd build
+          make -j3
 
-      - name: run tests  
-        run: CTEST_OUTPUT_ON_FAILURE=1 ctest -E tConvert
-    
+      - name: run tests
+        run: |
+          cd build
+          CTEST_OUTPUT_ON_FAILURE=1 ctest -E tConvert
+
       - name: install
-        run: make install
+        run: |
+          cd build
+          make install

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -54,7 +54,7 @@ jobs:
       - name: build
         run: |
           cd build
-          make -j3
+          make -j
 
       - name: run tests
         run: |


### PR DESCRIPTION
What I did:

- fix https://github.com/casacore/casacore/issues/1092
- re-enabled the build script in `.github/workflows/osx.yml` (removed `continue-on-error`)
- set Fortran compiler with `-DCMAKE_Fortran_COMPILER=gfortran-10` (GitHub Actions quirk)
- made minimal syntax changes to the build script so that it would work with GitHub Actions (e.g. `cd build` in each job)
- removed job count limit with `make -j` (reduces build time by 3 minutes!)