### PR TITLE
MSIter: Fix call to table sort.

### DIFF
--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -343,7 +343,7 @@ void MSIter::construct(const Block<Int>& sortColumns,
     if (!useIn && !useSorted) {
       // we have to resort the input
       if (aips_debug) cout << "MSIter::construct - resorting table"<<endl;
-      sorted = bms_p[i].sort(columns, Sort::Ascending, Sort::QuickSort);
+      sorted = bms_p[i].sort(columns, objComp, orders, Sort::QuickSort);
     }
 
     // Only store if globally requested _and_ locally decided


### PR DESCRIPTION
The MSIter class calls the table sort() method and later on calls TableIterator without sorting because the sort already took place. However the sorting criteria for both calls is different, which might lead to inconsistencies. In the call to table sort() no sorting functions are specified, which would mean that the default sorting functions are used. This is fixed by this PR.

Since until now almost no code sets sorting functions different from the default ones there has been no impact from this bug. However in CASA there will be more use of non-default sorting functions in the future (mainly to support the SPW combination in VI/VB2).