### PR TITLE
MSIter: Compute DDId information on demand.

### DIFF
--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -413,7 +413,7 @@ MSIter::operator=(const MSIter& other)
   lastFieldId_p = other.lastFieldId_p;
   curSpectralWindowIdFirst_p = other.curSpectralWindowIdFirst_p;
   lastSpectralWindowId_p = other.lastSpectralWindowId_p;
-  curPolarizationId_p = other.curPolarizationId_p;
+  curPolarizationIdFirst_p = other.curPolarizationIdFirst_p;
   lastPolarizationId_p = other.lastPolarizationId_p;
   curDataDescIdFirst_p = other.curDataDescIdFirst_p;
   lastDataDescId_p = other.lastDataDescId_p;
@@ -523,12 +523,51 @@ void MSIter::setState()
     checkFeed_p=True;
   curTable_p=tabIter_p[curMS_p]->table();
   colArray_p.attach(curTable_p,MS::columnName(MS::ARRAY_ID));
-  colDataDesc_p.attach(curTable_p,MS::columnName(MS::DATA_DESC_ID));
   colField_p.attach(curTable_p,MS::columnName(MS::FIELD_ID));
   // msc_p is already defined here (it is set in setMSInfo)
   if(newMS_p)
     msc_p->antenna().mount().getColumn(antennaMounts_p,True);
-  setDataDescInfo();
+
+  if(!ddInSort_p)
+  {
+    // If Data Description is not in the sorting columns, then the DD, SPW, pol
+    // can change between elements of the same iteration, so the safest
+    // is to signal that it changes.
+    newDataDescId_p = true;
+    newSpectralWindowId_p = true;
+    newPolarizationId_p = true;
+    freqCacheOK_p= false;
+
+    // This indicates that the current DD, SPW, Pol Ids are not computed.
+    // Note that the last* variables are not set, since the new* variables
+    // are unconditionally set to true.
+    // These cur* vars wiil be computed lazily if it is needed, together
+    // with some more vars set in cacheExtraDDInfo().
+    curDataDescIdFirst_p = -1;
+    curSpectralWindowIdFirst_p = -1;
+    curPolarizationIdFirst_p = -1;
+  }
+  else
+  {
+    // First we cache the current DD, SPW, Pol since we know it changed
+    cacheCurrentDDInfo();
+    
+    // In this case we know that the last* variables were computed and
+    // we can know whether there was a changed in these keywords by
+    // comparing the two.
+    newDataDescId_p=(lastDataDescId_p!=curDataDescIdFirst_p);
+    newSpectralWindowId_p=(lastSpectralWindowId_p!=curSpectralWindowIdFirst_p);
+    newPolarizationId_p=(lastPolarizationId_p!=curPolarizationIdFirst_p);
+
+    lastDataDescId_p=curDataDescIdFirst_p;
+    lastSpectralWindowId_p = curSpectralWindowIdFirst_p;
+    lastPolarizationId_p = curPolarizationIdFirst_p;
+
+    // Some extra information depends on the new* keywords, so compute
+    // it now that new* have been set.
+    cacheExtraDDInfo();
+  }
+
   setArrayInfo();
   setFeedInfo();
   setFieldInfo();
@@ -575,18 +614,29 @@ void MSIter::setState()
 const Vector<Double>& MSIter::frequency() const
 {
   if (!freqCacheOK_p) {
-    This->freqCacheOK_p=True;
+    if(curSpectralWindowIdFirst_p==-1)
+    {
+      cacheCurrentDDInfo();
+      cacheExtraDDInfo();
+    }
+    cacheCurrentDDInfo();
+    freqCacheOK_p = true;
     Int spw = curSpectralWindowIdFirst_p;
     msc_p->spectralWindow().chanFreq().
-      get(spw,This->frequency_p,True);
+      get(spw, frequency_p, true);
   }
   return frequency_p;
 }
 
 const MFrequency& MSIter::frequency0() const
 {
+  if(curSpectralWindowIdFirst_p==-1)
+  {
+    cacheCurrentDDInfo();
+    cacheExtraDDInfo();
+  }
   // set the channel0 frequency measure
-    This->frequency0_p=
+  This->frequency0_p=
       Vector<MFrequency>(msc_p->spectralWindow().
 			 chanFreqMeas()(curSpectralWindowIdFirst_p))(0);
     // get the reference frame out off the freq measure and set epoch measure.
@@ -726,6 +776,11 @@ void MSIter::setFeedInfo()
   // assume there's no time dependence, if there is we'll end up using the
   // last entry.
   if ((spwDepFeed_p && newSpectralWindowId_p) || first) {
+    if(curSpectralWindowIdFirst_p==-1)
+    {
+      cacheCurrentDDInfo();
+      cacheExtraDDInfo();
+    }
     Vector<Int> antennaId=msc_p->feed().antennaId().getColumn();
     Vector<Int> feedId=msc_p->feed().feedId().getColumn();
     Int maxAntId=max(antennaId);
@@ -785,39 +840,27 @@ void MSIter::setFeedInfo()
   }
 }
 
-void MSIter::setDataDescInfo()
+void MSIter::cacheCurrentDDInfo() const
 {
+  colDataDesc_p.attach(curTable_p,MS::columnName(MS::DATA_DESC_ID));
+
   curDataDescIdFirst_p = colDataDesc_p(0);
   curSpectralWindowIdFirst_p = msc_p->dataDescription().spectralWindowId()
     (curDataDescIdFirst_p);
-  curPolarizationId_p = msc_p->dataDescription().polarizationId()
+  curPolarizationIdFirst_p = msc_p->dataDescription().polarizationId()
     (curDataDescIdFirst_p);
-  if(ddInSort_p)
-  {
-    newDataDescId_p=(lastDataDescId_p!=curDataDescIdFirst_p);
-    newSpectralWindowId_p=(lastSpectralWindowId_p!=curSpectralWindowIdFirst_p);
-    newPolarizationId_p=(lastPolarizationId_p!=curPolarizationId_p);
-  }
-  //If array is not in the sorting columns, then the DD, SPW, pol
-  //can change between elements of the same iteration, so the safest
-  //is to signal that it changes.
-  else
-  {
-    newDataDescId_p = true;
-    newSpectralWindowId_p = true;
-    newPolarizationId_p = true;
-  }
-  lastDataDescId_p=curDataDescIdFirst_p;
-  lastSpectralWindowId_p = curSpectralWindowIdFirst_p;
-  lastPolarizationId_p = curPolarizationId_p;
 
+}
+
+void MSIter::cacheExtraDDInfo() const
+{
   if (newSpectralWindowId_p)
     freqCacheOK_p=False;
 
   if (newPolarizationId_p) {
     polFrame_p=Circular;
     Int polType = Vector<Int>(msc_p->polarization().
-			      corrType()(curPolarizationId_p))(0);
+			      corrType()(curPolarizationIdFirst_p))(0);
     if (polType>=Stokes::XX && polType<=Stokes::YY) polFrame_p=Linear;
   }
 }

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -405,7 +405,14 @@ protected:
   void setMSInfo();
   void setArrayInfo();
   void setFeedInfo();
-  void setDataDescInfo();
+  // Store the current DD, SPW, Pol ID.
+  // It can be called in logically const objects although it modifies
+  // caching (mutable) variables for performance reasons.
+  void cacheCurrentDDInfo() const;
+  // Store extra info related to the DD.
+  // It can be called in logically const objects although it modifies
+  // caching (mutable) variables for performance reasons.
+  void cacheExtraDDInfo() const;
   void setFieldInfo();
 
 // Determine if the numbers in r1 are a sorted subset of those in r2
@@ -425,9 +432,16 @@ protected:
   Int lastMS_p, curArrayIdFirst_p, lastArrayId_p, curSourceIdFirst_p;
   String curFieldNameFirst_p, curSourceNameFirst_p;
   Int curFieldIdFirst_p, lastFieldId_p;
-  Int curSpectralWindowIdFirst_p, lastSpectralWindowId_p;
-  Int curPolarizationId_p, lastPolarizationId_p;
-  Int curDataDescIdFirst_p, lastDataDescId_p;
+  // These variables point to the current (as in this iteration)
+  // DD, SPW and polarization IDs. They are mutable since they are
+  // evaluated in a lazy way, i.e., only when needed. If the DDId is
+  // part of the sorting columns then it is always computed when calling
+  // next(), otherwise it is only computed when some accesor of
+  // metadata that depends on them is called by the application.
+  mutable Int curDataDescIdFirst_p, curSpectralWindowIdFirst_p,
+    curPolarizationIdFirst_p;
+  // These variables point to the IDs of the previous iteration.
+  Int lastDataDescId_p, lastSpectralWindowId_p, lastPolarizationId_p;
   Bool more_p, newMS_p, newArrayId_p, newFieldId_p, newSpectralWindowId_p,
     newPolarizationId_p, newDataDescId_p,
     timeDepFeed_p, spwDepFeed_p, checkFeed_p;
@@ -438,8 +452,11 @@ protected:
   // time selection
   Double interval_p;
 
-  // columns
-  ScalarColumn<Int> colArray_p, colDataDesc_p, colField_p;
+  // This column is mutable since it is only attached when it is
+  // neccesary to read the DD Ids. That might happen when calling
+  // a const accesor like dataDescriptionId().
+  mutable ScalarColumn<Int> colDataDesc_p;
+  ScalarColumn<Int> colArray_p, colField_p;
 
   MDirection phaseCenter_p;
   Double prevFirstTimeStamp_p;
@@ -461,9 +478,10 @@ protected:
   Bool allBeamOffsetsZero_p;       // True if all elements of beamOffsets_p
                                    // are zero (to speed things up in a
 				   // single beam case)
-  PolFrame polFrame_p;
-  Bool freqCacheOK_p;
-  Vector<Double> frequency_p;
+  mutable PolFrame polFrame_p;     // polarization Frame. It is lazily cached,
+                                   // hence mutable. See cacheExtraDDInfo()
+  mutable Bool freqCacheOK_p;      // signal that the frequency cache is fine
+  mutable Vector<Double> frequency_p;
   MFrequency frequency0_p;
   MFrequency restFrequency_p;
   MPosition telescopePosition_p;
@@ -488,16 +506,24 @@ inline const ScalarColumn<Int>& MSIter::colArrayIds() const
 inline const ScalarColumn<Int>& MSIter::colFieldIds() const
 { return colField_p;}
 inline const ScalarColumn<Int>& MSIter::colDataDescriptionIds() const
-{ return colDataDesc_p;}
+{if(curDataDescIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
+  return colDataDesc_p;}
 inline Int MSIter::arrayId() const {return curArrayIdFirst_p;}
 inline Int MSIter::fieldId() const { return curFieldIdFirst_p;}
 inline Int MSIter::spectralWindowId() const
-{ return curSpectralWindowIdFirst_p;}
-inline Int MSIter::polarizationId() const {return curPolarizationId_p;}
-inline Int MSIter::dataDescriptionId() const {return curDataDescIdFirst_p;}
+{if(curSpectralWindowIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
+  return curSpectralWindowIdFirst_p;}
+inline Int MSIter::polarizationId() const
+{if(curPolarizationIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
+  return curPolarizationIdFirst_p;}
+inline Int MSIter::dataDescriptionId() const
+{if(curDataDescIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
+  return curDataDescIdFirst_p;}
 inline Bool MSIter::newPolarizationId() const { return newPolarizationId_p;}
 inline Bool MSIter::newDataDescriptionId() const { return newDataDescId_p;}
-inline Int MSIter::polFrame() const { return polFrame_p;}
+inline Int MSIter::polFrame() const
+{if(curPolarizationIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
+  return polFrame_p;}
 inline const MPosition& MSIter::telescopePosition() const
 { return telescopePosition_p;}
 inline const Vector<SquareMatrix<Complex,2> >& MSIter::CJones() const

--- a/ms/MeasurementSets/test/tMSIter.out
+++ b/ms/MeasurementSets/test/tMSIter.out
@@ -99,3 +99,134 @@ nrow=30
 ########
 nrow=25
 nrow=5
+########
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=75
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=75
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=75
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=75
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=75
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=75
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+ Skipping row
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=75
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09


### PR DESCRIPTION
Some metadata related to Data Description that has been computed at every iteration (i.e, when calling next()) is now computed less often to improve performance. This is driven by a change in CASA that now uses the MSIter class in the subchunk iteration loop of the VI/VB2. Usually each subchunk has single timestamp and there is no need to query metadata such as the DDID, SpwID or PolID, since this is done in the chunk iteration. With this PR only if the application asks for such information will MSIter compute (and cache) it, rather than computing it unconditionally in each next() call. In a test MS that saves 50 ms per subchunk iteration on a total budget of 400 ms.

Specifically:

1) If DDId is in the sorting columns then the information is always computed, since it likely that the application will request DD related metadata. This is typically the case in the CASA VI/VB2 chunk iteration.

2) If not, then the DDId related information is computed only if any of the accesors to retrieve it is called. This is typically the case in the subchunk iteration of the CASA VI/VB2. In this case  the information is cached internally for the next time. The relevant accessors are frequency(), frequency0(), colDataDescriptionIds(), spectralWindowId(), polarizationId(), dataDescriptionId(), polFrame().

 As a reference, it has been verified that after this change the following CASA tests pass: test_agentflagger, test_bandpass, test_calanalysis, test_concat, test_coordsys,  test_cvel, test_fixvis, test_flagcmd, test_flagdata, test_flagmanager, test_hanningsmooth, test_listpartition, test_mstransform, test_mstransform_mms, test_partition, test_plotcal, test_plotms, test_req_task_listobs, test_req_task_statwt, test_sdbaseline, test_sdfit, test_sdfixscan, test_sdgaincal, test_sdsmooth, test_sdtimeaverage, test_split, test_tclean, test_uvcontsub, test_uvcontsub3.

