### PR TITLE
 MSIter: Compute Feed information on demand.

### DIFF
--- a/ms/MeasurementSets/test/tMSIter.out
+++ b/ms/MeasurementSets/test/tMSIter.out
@@ -100,6 +100,8 @@ nrow=30
 nrow=25
 nrow=5
 ########
+Iteration with DDID sorting
+===========================
 nrow=75
 ddid = 0 spwid = 0 polid = 0
 freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
@@ -130,6 +132,160 @@ freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e
 nrow=75
 ddid = 4 spwid = 4 polid = 0
 freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+Iteration with ANTENNA1 and DDID sorting
+========================================
+nrow=25
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=20
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=15
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=10
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=5
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=25
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=20
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=15
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=10
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=5
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=25
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=20
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=15
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=10
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=5
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=25
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=20
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=15
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=10
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=5
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=25
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=20
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=15
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=10
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=5
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=25
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=20
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=15
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=10
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=5
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=25
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=20
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=15
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=10
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=5
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=25
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=20
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=15
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=10
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=5
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=25
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=20
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=15
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=10
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=5
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=25
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=20
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=15
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=10
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=5
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+Iteration with TIME sorting
+===========================
  Skipping row
  Skipping row
  Skipping row


### PR DESCRIPTION
Some metadata related to the feed that has been computed at every iteration (i.e, when calling next()) is now computed only when some feed related metadata is requested.

Similar to #1103 this is driven by a change in CASA that now uses the MSIter class in the subchunk iteration loop of the VI/VB2. Usually each subchunk has single timestamp and there is no need to query metadata related to the feed.
With this change, the MSIter next() method reduces its execution time from ~400 microseconds to  ~100 microseconds, which is a big improvement since the next() is called very often in each subchunk.

In particular, the feed related metadata is computed (and cached) when the following methods are called: CJones(), CJonesAll(),
receptorAngle(), receptorAngles(), getBeamOffsets(), allBeamOffsetsZero().

As a reference, it has been verified that after this change the following CASA tests pass: test_agentflagger, test_bandpass, test_calanalysis, test_concat, test_coordsys, test_cvel, test_fixvis, test_flagcmd, test_flagdata, test_flagmanager, test_hanningsmooth, test_listpartition, test_mstransform, test_mstransform_mms, test_partition, test_plotcal, test_plotms, test_req_task_listobs, test_req_task_statwt, test_sdbaseline, test_sdfit, test_sdfixscan, test_sdgaincal, test_sdsmooth, test_sdtimeaverage, test_split, test_tclean, test_uvcontsub, test_uvcontsub3.

Note that this PR depends on #1103, so it probably should be merged only after that one.