### PR TITLE
TableIter: Add support for caching the iteration boundaries that have been created while sorting the tables

### DIFF
--- a/casa/Utilities/Sort.cc
+++ b/casa/Utilities/Sort.cc
@@ -181,7 +181,7 @@ Sort::Sort (const Sort& that)
 
 Sort::~Sort()
 {
-    for (uInt i=0; i<nrkey_p; i++) {
+    for (size_t i=0; i<nrkey_p; i++) {
 	delete keys_p[i];
     }
 }
@@ -196,12 +196,12 @@ Sort& Sort::operator= (const Sort& that)
 
 void Sort::copy (const Sort& that)
 {
-    for (uInt i=0; i<nrkey_p; i++) {
+    for (size_t i=0; i<nrkey_p; i++) {
 	delete keys_p[i];
     }
     nrkey_p = that.nrkey_p;
     keys_p.resize (nrkey_p);
-    for (uInt i=0; i<nrkey_p; i++) {
+    for (size_t i=0; i<nrkey_p; i++) {
 	keys_p = new SortKey (*(that.keys_p[i]));
     }
     data_p  = that.data_p;
@@ -276,12 +276,22 @@ uInt Sort::unique (Vector<uInt>& uniqueVector,
                    const Vector<uInt>& indexVector) const
   { return doUnique (uniqueVector, indexVector); }
 
+uInt Sort::unique (Vector<uInt>& uniqueVector,
+                   Vector<size_t>& changeKey,
+                   const Vector<uInt>& indexVector) const
+  { return doUnique (uniqueVector, changeKey, indexVector); }
+
 uInt64 Sort::unique (Vector<uInt64>& uniqueVector, uInt64 nrrec) const
   { return doUnique (uniqueVector, nrrec); }
 
 uInt64 Sort::unique (Vector<uInt64>& uniqueVector,
                      const Vector<uInt64>& indexVector) const
   { return doUnique (uniqueVector, indexVector); }
+
+uInt64 Sort::unique (Vector<uInt64>& uniqueVector,
+                     Vector<size_t>& changeKey,
+                     const Vector<uInt64>& indexVector) const
+  { return doUnique (uniqueVector, changeKey, indexVector); }
     // </group>
 
 } //# NAMESPACE CASACORE - END

--- a/casa/Utilities/Sort.h
+++ b/casa/Utilities/Sort.h
@@ -343,12 +343,22 @@ public:
     // <br>
     // It returns the number of unique records. The unique array
     // is resized to that number.
+    // The third version also gives back a vector with the keys that
+    // change in each sorting group. The size of changeKey is the same as
+    // uniqueVector, and for each unique sorting group indicates the index
+    // of the keyword that will change at the end of the group.
     // <group>
     uInt unique (Vector<uInt>& uniqueVector, uInt nrrec) const;
     uInt unique (Vector<uInt>& uniqueVector,
                  const Vector<uInt>& indexVector) const;
+    uInt unique (Vector<uInt>& uniqueVector,
+                 Vector<size_t>& changeKey,
+                 const Vector<uInt>& indexVector) const;
     uInt64 unique (Vector<uInt64>& uniqueVector, uInt64 nrrec) const;
     uInt64 unique (Vector<uInt64>& uniqueVector,
+                   const Vector<uInt64>& indexVector) const;
+    uInt64 unique (Vector<uInt64>& uniqueVector,
+                   Vector<size_t>& changeKey,
                    const Vector<uInt64>& indexVector) const;
     // </group>
 
@@ -361,6 +371,9 @@ private:
     T doUnique (Vector<T>& uniqueVector, T nrrec) const;
     template <typename T>
     T doUnique (Vector<T>& uniqueVector, const Vector<T>& indexVector) const;
+    template <typename T>
+    T doUnique (Vector<T>& uniqueVector, Vector<size_t>& changeKey,
+                const Vector<T>& indexVector) const;
 
     // Copy that Sort object to this.
     void copy (const Sort& that);
@@ -411,9 +424,14 @@ private:
     template<typename T>
     void siftDown (T low, T up, T* indices) const;
 
-    // Compare the keys of 2 records.
+    // Compare 2 records based on the comparison functions
     template<typename T>
     int compare (T index1, T index2) const;
+
+    // As compare() but it also gives back the index of the first comparison
+    // function that didn't match.
+    template<typename T>
+    int compareChangeIdx(T i1, T i2, size_t& idxComp) const;
 
     // Swap 2 indices.
     template<typename T>
@@ -426,7 +444,7 @@ private:
 
     //# Data memebers
     PtrBlock<SortKey*> keys_p;                    //# keys to sort on
-    uInt               nrkey_p;                   //# #sort-keys
+    size_t             nrkey_p;                   //# #sort-keys
     const void*        data_p;                    //# pointer to data records
     uInt               size_p;                    //# size of data record
     int                order_p;                   //# -1=asc 0=mixed 1=desc

--- a/casa/Utilities/test/tSort.out
+++ b/casa/Utilities/test/tSort.out
@@ -30,3 +30,4 @@
  0,2 0,1 0,0 1,5 1,4 1,3 2,8 2,7 2,6 3,9
  0,abc 0,abc 0,ABC 1,xyzabc 1,abc 1,abc 2,abc 2,abc 2,abc 3,abc
  0,abc 0,ABC 1,xyzabc 1,abc 2,abc 3,abc
+0 (change 1) 2 (change 1) 4 (change 1) 6 (change 0) 8 (change 1) 10 (change 1) 12 (change 1) 14 (change 0) 16 (change 1) 18 (change 1) 20 (change 1) 22 (change 0) 24 (change 1) 26 (change 1) 28 (change 1) 30 (change 0) 

--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -154,7 +154,8 @@ void MSIter::construct(
     for (size_t i=0; i<nMS_p; i++) {
         // create the iterator for each MS
         tabIter_p[i] = new TableIterator(bms_p[i],sortColumnNames,
-                                         sortCompareFunctions,sortOrders);
+                                         sortCompareFunctions,sortOrders,
+                                         TableIterator::ParSort, true);
         tabIterAtStart_p[i]=True;
     }
     setMSInfo();

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -87,11 +87,20 @@ public:
     // Create the table iterator to iterate through the given
     // columns in the given order. The given compare objects
     // will be used for the sort and to compare if values are equal.
-    // If a compare object is null, the default ObjCompare<T> will be used.
+    // If a compare object in cmpObjs is null, the default ObjCompare<T> 
+    // will be used.
+    // If cacheIterationBoundaries is set to true then the iteration
+    // boundaries computed at construction time while sorting the table
+    // are used when advancing with next(). Otherwise, for each next()
+    // call the comparison functions are reevaluated again to get the
+    // iteration boundary. This improves performance in general but will
+    // break existing applications that change the comparison objects
+    // (cmpObjs) between iterations.
     BaseTableIterator (BaseTable*, const Block<String>& columnNames,
-                       const Block<CountedPtr<BaseCompare> >&,
+                       const Block<CountedPtr<BaseCompare> >& cmpObjs,
                        const Block<Int>& orders,
-                       int option);
+                       int option,
+                       bool cacheIterationBoundaries = false);
 
     // Clone this iterator.
     BaseTableIterator* clone() const;
@@ -123,6 +132,8 @@ protected:
     // Copy constructor (to be used by clone)
     BaseTableIterator (const BaseTableIterator&);
 
+    BaseTable* noCachedIterBoundariesNext();
+
 private:
     // Assignment is not needed, because the assignment operator in
     // the envelope class TableIterator has reference semantics.
@@ -131,6 +142,11 @@ private:
 
     Block<void*>           lastVal_p;     //# last value per column
     Block<void*>           curVal_p;      //# current value per column
+
+    std::shared_ptr<Vector<rownr_t>> sortIterBoundaries_p;
+    std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange_p;
+    Vector<rownr_t>::iterator sortIterBoundariesIt_p;
+    Vector<size_t>::iterator  sortIterKeyIdxChangeIt_p;
 };
 
 

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -390,13 +390,16 @@ public:
 
     // Sort a table on one or more columns of scalars.
     BaseTable* sort (const Block<String>& columnNames,
-		     const Block<CountedPtr<BaseCompare> >& compareObjects,
-		     const Block<Int>& sortOrder, int sortOption);
+                     const Block<CountedPtr<BaseCompare> >& compareObjects,
+                     const Block<Int>& sortOrder, int sortOption,
+                     std::shared_ptr<Vector<rownr_t>> sortIterBoundaries = nullptr,
+                     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange = nullptr);
 
     // Create an iterator.
     BaseTableIterator* makeIterator (const Block<String>& columnNames,
                                      const Block<CountedPtr<BaseCompare> >&,
-				     const Block<Int>& orders, int option);
+                                     const Block<Int>& orders, int option,
+                                     bool cacheIterationBoundaries = false);
 
     // Add one or more columns to the table.
     // The default implementation throws an "invalid operation" exception.
@@ -472,8 +475,10 @@ public:
     // Only in RefTable a smarter implementation is provided.
     virtual BaseTable* doSort (PtrBlock<BaseColumn*>&,
                                const Block<CountedPtr<BaseCompare> >&,
-			       const Block<Int>& sortOrder,
-			       int sortOption);
+                               const Block<Int>& sortOrder,
+                               int sortOption,
+                               std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
+                               std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange);
 
     // Create a RefTable object.
     RefTable* makeRefTable (Bool rowOrder, rownr_t initialNrrow);

--- a/tables/Tables/TableIter.cc
+++ b/tables/Tables/TableIter.cc
@@ -78,14 +78,16 @@ TableIterator::TableIterator (const Table& tab,
 }
 
 TableIterator::TableIterator (const Table& tab,
-			      const Block<String>& keys,
-			      const Block<CountedPtr<BaseCompare> >& cmpObjs,
-			      const Block<Int>& orders,
-			      Option option)
+                              const Block<String>& keys,
+                              const Block<CountedPtr<BaseCompare> >& cmpObjs,
+                              const Block<Int>& orders,
+                              Option option,
+                              bool cacheIterationBoundaries)
 : tabIterPtr_p (0)
 {
     tabIterPtr_p = tab.baseTablePtr()->makeIterator (keys, cmpObjs,
-						     orders, option);
+                                                     orders, option,
+                                                     cacheIterationBoundaries);
     next();                            // get first subtable
 }
 

--- a/tables/Tables/TableIter.h
+++ b/tables/Tables/TableIter.h
@@ -170,9 +170,17 @@ public:
     // Give the iteration order per column.
     // Give an optional compare object per column.
     // A zero pointer means that the default compare function will be used.
+    // If cacheIterationBoundaries is set to true then the iteration
+    // boundaries computed at construction time while sorting the table
+    // are used when advancing with next(). Otherwise, for each next()
+    // call the comparison functions are reevaluated again to get the
+    // iteration boundary. This improves performance in general but will
+    // break existing applications that change the comparison objects
+    // (cmpObjs) between iterations.
     TableIterator (const Table&, const Block<String>& columnNames,
-		   const Block<CountedPtr<BaseCompare> >&,
-		   const Block<Int>& orders, Option = ParSort);
+                   const Block<CountedPtr<BaseCompare> >& cmpObjs,
+                   const Block<Int>& orders, Option = ParSort,
+                   bool cacheIterationBoundaries = false);
     // </group>
 
     // Copy constructor (copy semantics).


### PR DESCRIPTION
This PR allows the caching of the iteration boundaries by the table iterators. Those boundaries are cheap to obtain while sorting the table in the first place.  

This avoids calling the sorting functions again when doing a next() iteration call as it has been done until now, since a vector with the iteration boundaries is cached and hence the information of which rows are part of the next iteration is readily available.

The mechanism is disable by default and controlled by a boolean switch in the  TableIterator constructor. For the time being only MSIter makes (partial) use of it.

As a reference, it has been verified that after this change the following CASA tests pass: test_agentflagger, test_bandpass, test_calanalysis, test_concat, test_coordsys, test_cvel, test_fixvis, test_flagcmd, test_flagdata, test_flagmanager, test_hanningsmooth, test_listpartition, test_mstransform, test_mstransform_mms, test_partition, test_plotcal, test_plotms, test_req_task_listobs, test_req_task_statwt, test_sdbaseline, test_sdfit, test_sdfixscan, test_sdgaincal, test_sdsmooth, test_sdtimeaverage, test_split, test_tclean, test_uvcontsub, test_uvcontsub3.