### PR TITLE
Table iterator: Reuse a RefTable for each iteration

### DIFF
--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -147,6 +147,7 @@ private:
     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange_p;
     Vector<rownr_t>::iterator sortIterBoundariesIt_p;
     Vector<size_t>::iterator  sortIterKeyIdxChangeIt_p;
+    RefTable* aRefTable_p;
 };
 
 

--- a/tables/Tables/RefTable.cc
+++ b/tables/Tables/RefTable.cc
@@ -548,6 +548,22 @@ void RefTable::addRownr (rownr_t rnr)
     changed_p = True;
 }
 
+//# Add a row number range of the root table.
+void RefTable::addRownrRange (rownr_t startRownr, rownr_t endRownr)
+{
+    rownr_t nrow = rowStorage_p.nelements();
+    rownr_t new_nrrow_p = nrrow_p + endRownr - startRownr + 1;
+    if (new_nrrow_p > nrow) {
+        rowStorage_p.resize (nrow + endRownr - startRownr + 1, True);
+        rows_p = getStorage (rowStorage_p);
+    }
+    std::iota(rows_p + nrrow_p, rows_p + new_nrrow_p, startRownr);
+    //for(rownr_t irow = startRownr; irow <= endRownr; ++irow)
+    //    rows_p[nrrow_p++] = irow;
+    nrrow_p = new_nrrow_p;
+    changed_p = True;
+}
+
 //# Set exact number of rows.
 void RefTable::setNrrow (rownr_t nrrow)
 {
@@ -821,6 +837,11 @@ void RefTable::removeRow (rownr_t rownr)
     changed_p = True;
 }
 
+void RefTable::removeAllRow ()
+{
+    nrrow_p=0;
+    changed_p = True;
+}
 
 void RefTable::removeColumn (const Vector<String>& columnNames)
 {

--- a/tables/Tables/RefTable.h
+++ b/tables/Tables/RefTable.h
@@ -247,6 +247,9 @@ public:
     // Remove the given row.
     virtual void removeRow (rownr_t rownr);
 
+    // Remove the given row.
+    virtual void removeAllRow ();
+
     // Add one or more columns to the table.
     // The column is added to the parent table if told so and if not existing.
     // <group>
@@ -306,6 +309,8 @@ public:
 
     // Add a rownr to reference table.
     void addRownr (rownr_t rownr);
+
+void addRownrRange (rownr_t startRownr, rownr_t endRownr);
 
     // Set the exact number of rows in the table.
     // An exception is thrown if more than current nrrow.


### PR DESCRIPTION
 This PR will use an existing RefTable created at construction time in the BaseTableIterator class  to avoid paying the cost of a RefTable creation every time the next() method is called to advance iteration.

 When next() is called then the RefTable is reset with a call to RefTable::removeAllRow() and then the rows for this iteration are added. For that, also a convenient function addRownrRange() has been added to RefTable, to avoid calling addRownr() in a tight loop.

In a dataset with 10 rows per iteration the cost goes down from ~80 usecs per next() call to ~13 usecs.

Note that this PR depends on PR #1106 and should merged after that one.
