### PR TITLE
MSIter: Compute field attributes on demand.

### DIFF
--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -391,7 +391,7 @@ public:
   //phasecenters, i.e time varying for a given field_id..
   //If the iterator is set so as one iteration has more that 1 time stamp
   //then this version is correct only for fixed phasecenters
-  const MDirection& phaseCenter() const ;
+  const MDirection& phaseCenter() const;
 
   //If the iterator is set so as one iteration has more that 1 value of time stamp
   // or fieldid
@@ -422,7 +422,7 @@ protected:
   // It can be called in logically const objects although it modifies
   // caching (mutable) variables for performance reasons.
   void cacheExtraDDInfo() const;
-  void setFieldInfo();
+  void setFieldInfo() const;
 
 // Determine if the numbers in r1 are a sorted subset of those in r2
   Bool isSubSet(const Vector<rownr_t>& r1, const Vector<rownr_t>& r2);
@@ -440,8 +440,10 @@ protected:
   CountedPtr<MSColumns> msc_p;
   Table curTable_p;
   Int curArrayIdFirst_p, lastArrayId_p, curSourceIdFirst_p;
-  String curFieldNameFirst_p, curSourceNameFirst_p;
-  Int curFieldIdFirst_p, lastFieldId_p;
+  mutable String curFieldNameFirst_p;
+  String curSourceNameFirst_p;
+  mutable Int curFieldIdFirst_p;
+  Int lastFieldId_p;
   // These variables point to the current (as in this iteration)
   // DD, SPW and polarization IDs. They are mutable since they are
   // evaluated in a lazy way, i.e., only when needed. If the DDId is
@@ -469,11 +471,11 @@ protected:
   // This column is mutable since it is only attached when it is
   // neccesary to read the DD Ids. That might happen when calling
   // a const accesor like dataDescriptionId().
-  mutable ScalarColumn<Int> colDataDesc_p;
-  ScalarColumn<Int> colArray_p, colField_p;
+  mutable ScalarColumn<Int> colDataDesc_p, colField_p;
+  ScalarColumn<Int> colArray_p;
 
-  MDirection phaseCenter_p;
-  Double prevFirstTimeStamp_p;
+  mutable MDirection phaseCenter_p;
+  mutable Double prevFirstTimeStamp_p;
   //cache for access functions
   mutable Matrix<Double> receptorAnglesFeed0_p; // former receptorAngle_p,
                                    // temporary retained for compatibility
@@ -523,7 +525,7 @@ inline const ScalarColumn<Int>& MSIter::colDataDescriptionIds() const
 {if(curDataDescIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
   return colDataDesc_p;}
 inline Int MSIter::arrayId() const {return curArrayIdFirst_p;}
-inline Int MSIter::fieldId() const { return curFieldIdFirst_p;}
+inline Int MSIter::fieldId() const {if(curFieldIdFirst_p==-1) setFieldInfo(); return curFieldIdFirst_p;}
 inline Int MSIter::spectralWindowId() const
 {if(curSpectralWindowIdFirst_p==-1) {cacheCurrentDDInfo(); cacheExtraDDInfo();}
   return curSpectralWindowIdFirst_p;}

--- a/ms/MeasurementSets/test/tMSIter.out
+++ b/ms/MeasurementSets/test/tMSIter.out
@@ -100,6 +100,8 @@ nrow=30
 nrow=25
 nrow=5
 ########
+Iteration with DDID sorting
+===========================
 nrow=75
 ddid = 0 spwid = 0 polid = 0
 freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
@@ -130,6 +132,160 @@ freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e
 nrow=75
 ddid = 4 spwid = 4 polid = 0
 freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+Iteration with ANTENNA1 and DDID sorting
+========================================
+nrow=25
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=20
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=15
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=10
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=5
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=25
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=20
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=15
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=10
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=5
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=25
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=20
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=15
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=10
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=5
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=25
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=20
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=15
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=10
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=5
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=25
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=20
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=15
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=10
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=5
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=25
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=20
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=15
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=10
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=5
+ddid = 0 spwid = 0 polid = 0
+freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+nrow=25
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=20
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=15
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=10
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=5
+ddid = 1 spwid = 1 polid = 1
+freqs = [1.01e+09, 1.011e+09, 1.012e+09, 1.013e+09, 1.014e+09, 1.015e+09, 1.016e+09, 1.017e+09] freq0 Frequency: 1.01e+09
+nrow=25
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=20
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=15
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=10
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=5
+ddid = 2 spwid = 2 polid = 0
+freqs = [1.02e+09, 1.021e+09, 1.022e+09, 1.023e+09, 1.024e+09, 1.025e+09, 1.026e+09, 1.027e+09] freq0 Frequency: 1.02e+09
+nrow=25
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=20
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=15
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=10
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=5
+ddid = 3 spwid = 3 polid = 1
+freqs = [1.03e+09, 1.031e+09, 1.032e+09, 1.033e+09, 1.034e+09, 1.035e+09, 1.036e+09, 1.037e+09] freq0 Frequency: 1.03e+09
+nrow=25
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=20
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=15
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=10
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+nrow=5
+ddid = 4 spwid = 4 polid = 0
+freqs = [1.04e+09, 1.041e+09, 1.042e+09, 1.043e+09, 1.044e+09, 1.045e+09, 1.046e+09, 1.047e+09] freq0 Frequency: 1.04e+09
+Iteration with TIME sorting
+===========================
  Skipping row
  Skipping row
  Skipping row

--- a/ms/MeasurementSets/test/tMSIter.out
+++ b/ms/MeasurementSets/test/tMSIter.out
@@ -386,3 +386,220 @@ freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09
 nrow=75
 ddid = 0 spwid = 0 polid = 0
 freqs = [1e+09, 1.001e+09, 1.002e+09, 1.003e+09, 1.004e+09, 1.005e+09, 1.006e+09, 1.007e+09] freq0 Frequency: 1e+09
+########
+Iteration with FIELD sorting
+===========================
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 1
+nrow=75
+fieldid = 2
+nrow=75
+fieldid = 3
+nrow=75
+fieldid = 4
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 1
+nrow=75
+fieldid = 2
+nrow=75
+fieldid = 3
+nrow=75
+fieldid = 4
+Iteration with ANTENNA1 and FIELD sorting
+========================================
+nrow=25
+fieldid = 0
+nrow=20
+fieldid = 0
+nrow=15
+fieldid = 0
+nrow=10
+fieldid = 0
+nrow=5
+fieldid = 0
+nrow=25
+fieldid = 1
+nrow=20
+fieldid = 1
+nrow=15
+fieldid = 1
+nrow=10
+fieldid = 1
+nrow=5
+fieldid = 1
+nrow=25
+fieldid = 2
+nrow=20
+fieldid = 2
+nrow=15
+fieldid = 2
+nrow=10
+fieldid = 2
+nrow=5
+fieldid = 2
+nrow=25
+fieldid = 3
+nrow=20
+fieldid = 3
+nrow=15
+fieldid = 3
+nrow=10
+fieldid = 3
+nrow=5
+fieldid = 3
+nrow=25
+fieldid = 4
+nrow=20
+fieldid = 4
+nrow=15
+fieldid = 4
+nrow=10
+fieldid = 4
+nrow=5
+fieldid = 4
+nrow=25
+fieldid = 0
+nrow=20
+fieldid = 0
+nrow=15
+fieldid = 0
+nrow=10
+fieldid = 0
+nrow=5
+fieldid = 0
+nrow=25
+fieldid = 1
+nrow=20
+fieldid = 1
+nrow=15
+fieldid = 1
+nrow=10
+fieldid = 1
+nrow=5
+fieldid = 1
+nrow=25
+fieldid = 2
+nrow=20
+fieldid = 2
+nrow=15
+fieldid = 2
+nrow=10
+fieldid = 2
+nrow=5
+fieldid = 2
+nrow=25
+fieldid = 3
+nrow=20
+fieldid = 3
+nrow=15
+fieldid = 3
+nrow=10
+fieldid = 3
+nrow=5
+fieldid = 3
+nrow=25
+fieldid = 4
+nrow=20
+fieldid = 4
+nrow=15
+fieldid = 4
+nrow=10
+fieldid = 4
+nrow=5
+fieldid = 4
+Iteration with TIME sorting
+===========================
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+fieldid = 0
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+ Skipping row
+ Skipping row
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+ Skipping row
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+fieldid = 0
+ Skipping row
+ Skipping row
+ Skipping row
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+ Skipping row
+ Skipping row
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+ Skipping row
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0
+nrow=75
+fieldid = 0


### PR DESCRIPTION
Similar to PR #1103  and #1104  some metadata like field attributes (fieldID, field name) and related attributes (restFrequency and phaseCenter) are now computed on demand only if it is asked for. For clients that don't require retrieving of field information for each iteration there is no need to compute that metadata.
Note that the relevant metadata accessors are phaseCenter(), fieldId(), fieldName(), restFrequency().