### PR TITLE
fixed a bug in Adios2StMan::setShape()

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -61,76 +61,76 @@ Adios2StMan::~Adios2StMan() = default;
 
 DataManager *Adios2StMan::clone() const
 {
-	return pimpl->clone();
+    return pimpl->clone();
 }
 
 String Adios2StMan::dataManagerType() const
 {
-	return pimpl->dataManagerType();
+    return pimpl->dataManagerType();
 }
 
 String Adios2StMan::dataManagerName() const
 {
-	return pimpl->dataManagerName();
+    return pimpl->dataManagerName();
 }
 
 void Adios2StMan::create64(rownr_t aNrRows)
 {
-	pimpl->create64(aNrRows);
+    pimpl->create64(aNrRows);
 }
 
 rownr_t Adios2StMan::open64(rownr_t aRowNr, AipsIO &ios)
 {
-	return pimpl->open64(aRowNr, ios);
+    return pimpl->open64(aRowNr, ios);
 }
 
 rownr_t Adios2StMan::resync64(rownr_t aRowNr)
 {
-	return pimpl->resync64(aRowNr);
+    return pimpl->resync64(aRowNr);
 }
 
 Bool Adios2StMan::flush(AipsIO &ios, Bool doFsync)
 {
-	return pimpl->flush(ios, doFsync);
+    return pimpl->flush(ios, doFsync);
 }
 
 DataManagerColumn *Adios2StMan::makeScalarColumn(
-    const String &aName, int aDataType, const String &aDataTypeID)
+        const String &aName, int aDataType, const String &aDataTypeID)
 {
-	return pimpl->makeScalarColumn(aName, aDataType, aDataTypeID);
+    return pimpl->makeScalarColumn(aName, aDataType, aDataTypeID);
 }
 
 DataManagerColumn *Adios2StMan::makeDirArrColumn(
-    const String &aName, int aDataType, const String &aDataTypeID)
+        const String &aName, int aDataType, const String &aDataTypeID)
 {
-	return pimpl->makeDirArrColumn(aName, aDataType, aDataTypeID);
+    return pimpl->makeDirArrColumn(aName, aDataType, aDataTypeID);
 }
 
 DataManagerColumn *Adios2StMan::makeIndArrColumn(
-    const String &aName, int aDataType, const String &aDataTypeID)
+        const String &aName, int aDataType, const String &aDataTypeID)
 {
-	return pimpl->makeIndArrColumn(aName, aDataType, aDataTypeID);
+    return pimpl->makeIndArrColumn(aName, aDataType, aDataTypeID);
 }
 
 void Adios2StMan::deleteManager()
 {
-	pimpl->deleteManager();
+    pimpl->deleteManager();
 }
 
 void Adios2StMan::addRow64(rownr_t aNrRows)
 {
-	return pimpl->addRow64(aNrRows);
+    return pimpl->addRow64(aNrRows);
 }
 
 DataManager *Adios2StMan::makeObject(
-    const String &aDataManType, const Record &spec)
+        const String &aDataManType, const Record &spec)
 {
-	return impl::makeObject(aDataManType, spec);
+    return impl::makeObject(aDataManType, spec);
 }
 
 rownr_t Adios2StMan::getNrRows()
 {
-	return pimpl->getNrRows();
+    return pimpl->getNrRows();
 }
 
 
@@ -217,9 +217,13 @@ Adios2StMan::impl::~impl()
         itsAdiosEngine->EndStep();
         itsAdiosEngine->Close();
     }
-    for (uInt i = 0; i < ncolumn(); ++i) {
-      delete itsColumnPtrBlk[i];
+    for (uInt i = 0; i < ncolumn(); ++i)
+    {
+        delete itsColumnPtrBlk[i];
     }
+    Adios2StMan::impl::itsAdiosEngineType.clear();
+    Adios2StMan::impl::itsAdiosEngineParams.clear();
+    Adios2StMan::impl::itsAdiosTransportParamsVec.clear();
 }
 
 DataManager *Adios2StMan::impl::makeObject(const String &/*aDataManType*/,

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -77,8 +77,8 @@ public:
     rownr_t getNrRows();
 
 private:
-	 class impl;
-	 std::unique_ptr<impl> pimpl;
+    class impl;
+    std::unique_ptr<impl> pimpl;
 }; // end of class Adios2StMan
 
 extern "C" void register_adios2stman();

--- a/tables/DataMan/Adios2StManColumn.cc
+++ b/tables/DataMan/Adios2StManColumn.cc
@@ -77,11 +77,6 @@ IPosition Adios2StManColumn::shape(rownr_t aRowNr)
         }
         else
         {
-            /*
-            throw(std::runtime_error("Shape not defined for Column "
-                        + static_cast<std::string>(itsColumnName)
-                        + " Row " + std::to_string(aRowNr)));
-                        */
             return IPosition();
         }
     }
@@ -111,12 +106,37 @@ void Adios2StManColumn::scalarColumnVToSelection()
 
 void Adios2StManColumn::arrayVToSelection(rownr_t rownr)
 {
-    itsAdiosStart[0] = rownr;
-    itsAdiosCount[0] = 1;
-    for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+    if(isShapeFixed)
     {
-        itsAdiosStart[i] = 0;
-        itsAdiosCount[i] = itsAdiosShape[i];
+        itsAdiosStart[0] = rownr;
+        itsAdiosCount[0] = 1;
+        for (size_t i = 1; i < itsAdiosShape.size(); ++i)
+        {
+            itsAdiosStart[i] = 0;
+            itsAdiosCount[i] = itsAdiosShape[i];
+        }
+    }
+    else
+    {
+        auto casaShape = itsCasaShapes.find(rownr);
+        if(casaShape != itsCasaShapes.end())
+        {
+            itsAdiosShape.resize(casaShape->second.size() + 1);
+            itsAdiosStart.resize(casaShape->second.size() + 1);
+            itsAdiosCount.resize(casaShape->second.size() + 1);
+            itsAdiosStart[0] = rownr;
+            itsAdiosCount[0] = 1;
+            for (size_t i = 0; i < casaShape->second.size(); ++i)
+            {
+                itsAdiosShape[i + 1] = casaShape->second[casaShape->second.size() - i - 1];
+                itsAdiosCount[i + 1] = casaShape->second[casaShape->second.size() - i - 1];
+                itsAdiosStart[i + 1] = 0;
+            }
+        }
+        else
+        {
+            cerr << "Shape of Row " << rownr << " has not been set" << endl;
+        }
     }
 }
 

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -174,6 +174,8 @@ private:
     void toAdios(const void *data, std::size_t offset)
     {
         const T *tData = static_cast<const T *>(data);
+        if(!isShapeFixed)
+            itsAdiosVariable.SetShape(itsAdiosShape);
         itsAdiosVariable.SetSelection({itsAdiosStart, itsAdiosCount});
         itsAdiosEngine->Put<T>(itsAdiosVariable, tData + offset, adios2::Mode::Sync);
     }

--- a/tables/DataMan/test/tAdios2StMan.cc
+++ b/tables/DataMan/test/tAdios2StMan.cc
@@ -26,12 +26,13 @@
 //# $Id$
 
 #include <casacore/tables/DataMan/Adios2StMan.h>
-#include <casacore/tables/Tables/TableDesc.h>
-#include <casacore/tables/Tables/SetupNewTab.h>
+#include <casacore/tables/Tables/ArrayColumn.h>
+#include <casacore/tables/Tables/ArrColDesc.h>
 #include <casacore/tables/Tables/ScaColDesc.h>
 #include <casacore/tables/Tables/ScalarColumn.h>
-#include <casacore/tables/Tables/ArrColDesc.h>
-#include <casacore/tables/Tables/ArrayColumn.h>
+#include <casacore/tables/Tables/SetupNewTab.h>
+#include <casacore/tables/Tables/TableCopy.h>
+#include <casacore/tables/Tables/TableDesc.h>
 #include <casacore/casa/namespace.h>
 
 
@@ -257,6 +258,24 @@ void doReadArray(std::string filename, uInt rows, IPosition array_pos){
     VerifyArrayColumn<String>(casa_table, "array_String", rows, array_pos);
 }
 
+void doCopyTable(std::string inTable, std::string outTable, std::string column)
+{
+    Table tab(inTable);
+    TableDesc td("", "1", TableDesc::Scratch);
+    SetupNewTable newtab(outTable, td, Table::New);
+    Table duptab(newtab);
+    duptab.addRow(tab.nrow());
+    Adios2StMan a2stman;
+    duptab.addColumn(tab.tableDesc().columnDesc(column), a2stman);
+    TableCopy::copyColumnData(tab, column, duptab, column, false);
+}
+
+void doReadCopiedTable(std::string filename, std::string column, uInt rows, IPosition array_pos)
+{
+    Table tab(filename);
+    VerifyArrayColumn<Complex>(tab, "array_Complex", rows, array_pos);
+}
+
 int main(int argc, char **argv){
 
     MPI_Init(&argc,&argv);
@@ -267,6 +286,9 @@ int main(int argc, char **argv){
     doWriteDefault("default.table", rows, array_pos);
     doReadScalar("default.table", rows);
     doReadArray("default.table", rows, array_pos);
+
+    doCopyTable("default.table", "duplicated.table", "array_Complex");
+    doReadCopiedTable("duplicated.table", "array_Complex", rows, array_pos);
 
     MPI_Finalize();
 }


### PR DESCRIPTION
There was a bug in Adios2StMan::setShape() which messed up some functionalities in TableCopy. The bug was identified when we recently tried to copy tables with huge sparse data produced by the ASKAP DINGO survey. This PR fixes the bug, and also includes a testing section in the tAdios2StMan test. 