### PR TITLE
Revert "Simplify MeasFrame"

### DIFF
--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -490,6 +490,7 @@ void MCFrame::makeEpoch() {
   epConvTDB = new MEpoch::Convert(*(myf.epoch()), REFTDB);
   epConvUT1 = new MEpoch::Convert(*(myf.epoch()), REFUT1);
   epConvTT  = new MEpoch::Convert(*(myf.epoch()), REFTT);
+  uInt locker = 0;			// locking assurance
   if (epTDBp) {
     delete epTDBp; epTDBp = 0;
   }
@@ -499,12 +500,14 @@ void MCFrame::makeEpoch() {
   if (epTTp) {
     delete epTTp; epTTp = 0;
   }
+  myf.lock(locker);
   if (epConvLAST) {
     delete static_cast<MEpoch::Convert *>(epConvLAST);
     epConvLAST = 0;
   }
   epConvLAST = new MEpoch::Convert(*(myf.epoch()),
 				   MEpoch::Ref(MEpoch::LAST, this->myf));
+  myf.unlock(locker);
   if (epLASTp) {
     delete epLASTp; epLASTp = 0;
   }
@@ -547,6 +550,7 @@ void MCFrame::makePosition() {
 void MCFrame::makeDirection() {
   static const MDirection::Ref REFJ2000 = MDirection::Ref(MDirection::J2000);
   uInt locker =0;
+  myf.lock(locker);
   if (dirConvJ2000) {
     delete static_cast<MDirection::Convert *>(dirConvJ2000);
     dirConvJ2000 = 0;
@@ -554,8 +558,10 @@ void MCFrame::makeDirection() {
   dirConvJ2000 = new MDirection::Convert(*(myf.direction()),
 					 MDirection::Ref(MDirection::J2000,
 							 this->myf));
+  myf.unlock(locker);
 
   static const MDirection::Ref REFB1950 = MDirection::Ref(MDirection::B1950);
+  myf.lock(locker);
   if (dirConvB1950) {
     delete static_cast<MDirection::Convert *>(dirConvB1950);
     dirConvB1950 = 0;
@@ -563,6 +569,8 @@ void MCFrame::makeDirection() {
   dirConvB1950 = new MDirection::Convert(*(myf.direction()),
 					 MDirection::Ref(MDirection::B1950,
 							 this->myf));
+  myf.unlock(locker);
+  myf.lock(locker);
   if (dirConvApp) {
     delete static_cast<MDirection::Convert *>(dirConvApp);
     dirConvApp = 0;
@@ -570,6 +578,7 @@ void MCFrame::makeDirection() {
   dirConvApp = new MDirection::Convert(*(myf.direction()),
 				       MDirection::Ref(MDirection::APP,
 						       this->myf));
+  myf.unlock(locker);
   if (j2000Longp) {
     delete j2000Longp; j2000Longp = 0;
     delete dirJ2000p; dirJ2000p = 0;

--- a/measures/Measures/MeasFrame.h
+++ b/measures/Measures/MeasFrame.h
@@ -175,6 +175,11 @@ class MeasFrame {
   MeasFrame(const Measure &meas1, const Measure &meas2,
 	    const Measure &meas3);
   // </group>
+  // Copy constructor (reference semantics)
+  MeasFrame(const MeasFrame &other);
+  // Copy assignment (reference semantics)
+  MeasFrame &operator=(const MeasFrame &other);
+  // Destructor
   ~MeasFrame();
   
   //# Operators
@@ -289,7 +294,7 @@ private:
   
   //# Data
   // Representation of MeasFrame
-  std::shared_ptr<FrameRep> rep;
+  FrameRep *rep;
   
   //# Member functions
   // Create an instance of the MeasFrame class
@@ -311,6 +316,10 @@ private:
   void makeComet();
   // Throw reset error
   void errorReset(const String &txt);
+  // Lock the frame to make sure deletion occurs when needed
+  void lock(uInt &locker);
+  // Unlock the frame
+  void unlock(const uInt locker);
 };
 
 //# Global functions


### PR DESCRIPTION
As discussed in #1111 the commit #1084 is causing problems to some CASA tests that are not trivial to fix as seen both in the issue comments and in the PR #1112 that tried to fix it.
This PR will then revert #1084 as a temporary measure.

This reverts commit 5e130cfa47b974b0783b5ab12c11d7247fdf019f.