### PR TITLE
Add support for X-Y mounts

### DIFF
--- a/ms/MSOper/MSDerivedValues.cc
+++ b/ms/MSOper/MSDerivedValues.cc
@@ -269,7 +269,7 @@ Double MSDerivedValues::parAngle()
   Double pa=0;
 
   if (mount_p(antenna_p)==0 || mount_p(antenna_p)==4 ||
-      mount_p(antenna_p)== 5) {
+      mount_p(antenna_p)==5) {
     // Now we can do the conversions using the machines
     mRADecInAzEl_p     = cRADecToAzEl_p();
     mHADecPoleInAzEl_p = cHADecToAzEl_p();
@@ -291,6 +291,10 @@ Double MSDerivedValues::parAngle()
     //#  cout<<"Antenna "<<iant<<" at time: "<<MVTime(mEpoch.getValue())<<
     //#  " has PA = "<<pa_p(iant)*57.28<<endl;
     
+  } else if (mount_p(antenna_p)==2) {
+    Double ha = cRADecToHADec_p().getValue().get()(0);
+    Double dec = cRADecToHADec_p().getValue().get()(1);
+    pa = atan2(-cos(ha), -sin(ha) * sin(dec));
   } else if (mount_p(antenna_p)==1) {
     // nothing to do for equatorial mounts, pa is always 0
   } else {

--- a/ms/MSOper/MSDerivedValues.cc
+++ b/ms/MSOper/MSDerivedValues.cc
@@ -190,9 +190,9 @@ MSDerivedValues& MSDerivedValues::setAntennaMount(const Vector<String>& mount)
 	mount_p(i)=0;
       } else if (mount(i)=="equatorial" || mount(i)=="EQUATORIAL") {
         mount_p(i)=1;
-      } else if (mount(i)=="X-Y" || mount(i)=="x-y") {
-        mount_p(i)=2;
       } else if (mount(i)=="orbiting" || mount(i)=="ORBITING") {
+        mount_p(i)=2;
+      } else if (mount(i)=="x-y" || mount(i)=="X-Y") {
         mount_p(i)=3;
       } else if (mount(i)=="alt-az+nasmyth-r" || mount(i)=="ALT-AZ+NASMYTH-R") {
 	mount_p(i)=4;
@@ -291,7 +291,7 @@ Double MSDerivedValues::parAngle()
     //#  cout<<"Antenna "<<iant<<" at time: "<<MVTime(mEpoch.getValue())<<
     //#  " has PA = "<<pa_p(iant)*57.28<<endl;
     
-  } else if (mount_p(antenna_p)==2) {
+  } else if (mount_p(antenna_p)==3) {
     Double ha = cRADecToHADec_p().getValue().get()(0);
     Double dec = cRADecToHADec_p().getValue().get()(1);
     pa = atan2(-cos(ha), -sin(ha) * sin(dec));

--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2586,8 +2586,8 @@ void FITSIDItoMS1::fillAntennaTable()
      switch (mntid(i)) {
      case 0: mount="ALT-AZ"; break;
      case 1: mount="EQUATORIAL"; break;
-     case 2: mount="X-Y"; break;
-     case 3: mount="ORBITING"; break;
+     case 2: mount="ORBITING"; break;
+     case 3: mount="X-Y"; break;
      case 4: mount="ALT-AZ+NASMYTH-R"; break;
      case 5: mount="ALT-AZ+NASMYTH-L"; break;
      default: mount="UNKNOWN"; break;


### PR DESCRIPTION
This makes it possibly to apply the (co)-parallactic angle correction needed for VLBI data processing of data that includes antennas with an X-Y mount. An example of such an antenna is the 26m antenna at Hobart that is part of the Australian Long Baseline Array (LBA).
This code has been tested by applying the parallacting angle correction to data for LBA observation VT23 in both AIPS and CASA and comparing the phases on baselines that include the Hobart antenna.