### PR TITLE
Adios2stman improvements

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -271,7 +271,11 @@ rownr_t Adios2StMan::impl::open64(rownr_t aNrRows, AipsIO &ios)
 
     ios.getstart(itsDataManName);
     ios >> itsDataManName;
-    ios >> itsStManColumnType;
+    {
+      // see comment on flush()
+      int dummy;
+      ios >> dummy;
+    }
     ios.getend();
     itsRows = aNrRows;
     return itsRows;
@@ -378,7 +382,10 @@ Bool Adios2StMan::impl::flush(AipsIO &ios, Bool /*doFsync*/)
 {
     ios.putstart(itsDataManName, 2);
     ios << itsDataManName;
-    ios << itsStManColumnType;
+    // Here we used to write itsStManColumnType (int), but that was an otherwise
+    // unused member, so we are writing a dummy 0 instead to preserve backwards
+    // compatibility
+    ios << 0;
     ios.putend();
     return true;
 }

--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -302,7 +302,10 @@ DataManager *Adios2StMan::impl::clone() const
     return new Adios2StMan(itsMpiComm, itsAdiosEngineType, itsAdiosEngineParams, itsAdiosTransportParamsVec);
 }
 
-String Adios2StMan::impl::dataManagerType() const { return itsDataManName; }
+String Adios2StMan::impl::dataManagerType() const
+{
+    return DATA_MANAGER_TYPE;
+}
 
 void Adios2StMan::impl::addRow64(rownr_t aNrRows)
 {
@@ -332,7 +335,7 @@ rownr_t Adios2StMan::impl::open64(rownr_t aNrRows, AipsIO &ios)
     }
     itsAdiosEngine->BeginStep();
 
-    ios.getstart(itsDataManName);
+    ios.getstart(DATA_MANAGER_TYPE);
     ios >> itsDataManName;
     {
       // see comment on flush()
@@ -443,7 +446,7 @@ rownr_t Adios2StMan::impl::resync64(rownr_t /*aNrRows*/) { return itsRows; }
 
 Bool Adios2StMan::impl::flush(AipsIO &ios, Bool /*doFsync*/)
 {
-    ios.putstart(itsDataManName, 2);
+    ios.putstart(DATA_MANAGER_TYPE, 2);
     ios << itsDataManName;
     // Here we used to write itsStManColumnType (int), but that was an otherwise
     // unused member, so we are writing a dummy 0 instead to preserve backwards

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -74,6 +74,7 @@ public:
     virtual void addRow64(rownr_t aNrRows);
     static DataManager *makeObject(const String &aDataManType,
                                    const Record &spec);
+    Record dataManagerSpec() const;
     rownr_t getNrRows();
 
 private:

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -76,7 +76,6 @@ private:
     Adios2StMan &parent;
     String itsDataManName = "Adios2StMan";
     rownr_t itsRows;
-    int itsStManColumnType;
     PtrBlock<Adios2StManColumn *> itsColumnPtrBlk;
 
     std::shared_ptr<adios2::ADIOS> itsAdios;

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -75,7 +75,7 @@ public:
 private:
     Adios2StMan &parent;
     String itsDataManName = "Adios2StMan";
-    rownr_t itsRows;
+    rownr_t itsRows {0};
     PtrBlock<Adios2StManColumn *> itsColumnPtrBlk;
 
     std::shared_ptr<adios2::ADIOS> itsAdios;

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -93,6 +93,8 @@ private:
     // MPI communicator to be used by all instances of this storage manager
     static MPI_Comm itsMpiComm;
 
+    // The type of this storage manager
+    static constexpr const char *DATA_MANAGER_TYPE = "Adios2StMan";
     // The name of the specification field for the I/O engine type
     static constexpr const char *SPEC_FIELD_ENGINE_TYPE = "ENGINETYPE";
     // The name of the specification field for the I/O engine parameters

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -70,6 +70,7 @@ public:
     void addRow64(rownr_t aNrRows);
     static DataManager *makeObject(const String &aDataManType,
                                    const Record &spec);
+    Record dataManagerSpec() const;
     rownr_t getNrRows();
 
 private:
@@ -82,11 +83,22 @@ private:
     std::shared_ptr<adios2::IO> itsAdiosIO;
     std::shared_ptr<adios2::Engine> itsAdiosEngine;
 
-    static std::string itsAdiosEngineType;
-    static adios2::Params itsAdiosEngineParams;
-    static std::vector<adios2::Params> itsAdiosTransportParamsVec;
+    // The ADIOS2 I/O Engine type
+    std::string itsAdiosEngineType;
+    // Parameters for the ADIOS2 I/O engine
+    adios2::Params itsAdiosEngineParams;
+    // Parameters for the ADIOS2 I/O Transports
+    std::vector<adios2::Params> itsAdiosTransportParamsVec;
 
+    // MPI communicator to be used by all instances of this storage manager
     static MPI_Comm itsMpiComm;
+
+    // The name of the specification field for the I/O engine type
+    static constexpr const char *SPEC_FIELD_ENGINE_TYPE = "ENGINETYPE";
+    // The name of the specification field for the I/O engine parameters
+    static constexpr const char *SPEC_FIELD_ENGINE_PARAMS = "ENGINEPARAMS";
+    // The name of the specification field for the transport parameters
+    static constexpr const char *SPEC_FIELD_TRANSPORT_PARAMS = "TRANSPORTPARAMS";
 
     uInt ncolumn() const { return parent.ncolumn(); }
     String fileName() const { return parent.fileName(); }


### PR DESCRIPTION
This set of commits improves on the flexibility of the `Adios2StMan` by allow it to be configured via properties, and exposing its specification to external users. This allows us to remove a number of static members that were previously used to transmit state between different storage manager copies, and to flexibly configure instances of the storage manager from non-C++ environments like python or taql.

The storage manager also confused its "name" with its "type name", so that distinction has been clarified. This was changed in such a way that serialization from/to the `AipsIO` object remains backwards compatible.

cc: @JasonRuonanWang 