### PR TITLE
Make Dysco part of casacore tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option (BUILD_PYTHON3 "Build the python3 bindings" NO)
 
 option (BUILD_DEPRECATED "build and install deprecated classes (such as Map)" NO)
 option (BUILD_FFTPACK_DEPRECATED "build FFTPack" NO)
+option (BUILD_DYSCO "Build the Dysco compression storage manager" YES)
 
 # By default build shared libraries
 option (ENABLE_SHARED "Build shared libraries" YES)
@@ -579,6 +580,7 @@ message (STATUS "FFTW3 library? ........ = ${FFTW3_LIBRARIES}")
 
 message (STATUS "BUILD_FFTPACK_DEPRECATED= ${BUILD_FFTPACK_DEPRECATED}")
 message (STATUS "BUILD_DEPRECATED ...... = ${BUILD_DEPRECATED}")
+message (STATUS "BUILD_DYSCO ........... = ${BUILD_DYSCO}")
 message (STATUS "BUILD_PYTHON .......... = ${BUILD_PYTHON}")
 message (STATUS "BUILD_PYTHON3 ......... = ${BUILD_PYTHON3}")
 

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -209,6 +209,10 @@ if(MPI_FOUND)
     endif(ADIOS2_FOUND)
 endif(MPI_FOUND)
 
+if(BUILD_DYSCO)
+  add_subdirectory(Dysco)
+endif(BUILD_DYSCO)
+
 add_subdirectory (apps)
 
 install (TARGETS casa_tables

--- a/tables/Dysco/CMakeLists.txt
+++ b/tables/Dysco/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.6)
+
+project(dysco)
+
+find_package(GSL REQUIRED)
+
+find_package(Threads REQUIRED)
+
+include_directories(${GSL_INCLUDE_DIRS})
+
+add_compile_options(-O3 -Wall -DNDEBUG)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(PORTABLE "Generate portable code" OFF)
+option(BUILD_PACKAGES "Build Debian packages" OFF)
+
+if(NOT PORTABLE)
+  if(USE_AVX512F)
+    add_compile_options(-mavx512f)
+  elseif(USE_AVX2)
+    add_compile_options(-mavx2)
+  elseif(USE_AVX)
+    add_compile_options(-mavx)
+  else()
+    add_compile_options(-march=native)
+  endif()
+else()
+  if(USE_AVX512F OR USE_AVX2 OR USE_AVX)
+    message(FATAL_ERROR "Cannot enable AVX features when building portable code.")
+  endif()
+endif()
+
+add_library(dyscostman-object OBJECT
+	aftimeblockencoder.cpp
+	dyscostman.cpp
+	dyscodatacolumn.cpp
+	dyscoweightcolumn.cpp
+	stochasticencoder.cpp
+	threadeddyscocolumn.cpp
+	rftimeblockencoder.cpp
+	rowtimeblockencoder.cpp)
+set_property(TARGET dyscostman-object PROPERTY POSITION_INDEPENDENT_CODE 1) 
+
+add_library(dyscostman SHARED $<TARGET_OBJECTS:dyscostman-object>)
+set_target_properties(dyscostman PROPERTIES SOVERSION 0)
+target_link_libraries(dyscostman ${GSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+find_package(Boost COMPONENTS system filesystem unit_test_framework)
+if(Boost_FOUND)
+	include_directories(${Boost_INCLUDE_DIR})
+  add_executable(tDysco
+    $<TARGET_OBJECTS:dyscostman-object>
+    tests/runtests.cpp 
+    tests/testbytepacking.cpp
+    tests/testdithering.cpp
+    tests/testdyscostman.cpp
+    tests/testtimeblockencoder.cpp
+    )
+  target_link_libraries(tDysco ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} casa_tables casa_casa)
+  add_test(tDysco tDysco)
+else()
+  message("Boost testing framework not found.")
+endif()
+
+install (TARGETS dyscostman DESTINATION lib) 

--- a/tables/Dysco/LICENSE
+++ b/tables/Dysco/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/tables/Dysco/README.md
+++ b/tables/Dysco/README.md
@@ -1,0 +1,19 @@
+The Dysco compression technique is explained in the article "Compression of interferometric radio-astronomical data",
+A. R. Offringa (2016; http://arxiv.org/abs/1609.02019). If you use this software, please cite the paper.
+
+# dysco
+A compressing storage manager for Casacore mearement sets
+
+To install:
+
+    mkdir build
+    cd build
+    cmake ../
+    make -j 4
+    make install
+
+To be able to open compressed measurement sets, the dysco library ("libdyscostman.so") must be in your path.
+
+The Dysco compression technique is explained in [the article](http://arxiv.org/abs/1609.02019). Further documentation for the storage manager, including documentation of the `dscompress` tool:
+
+https://github.com/aroffringa/dysco/wiki

--- a/tables/Dysco/aftimeblockencoder.cpp
+++ b/tables/Dysco/aftimeblockencoder.cpp
@@ -1,0 +1,437 @@
+#include "aftimeblockencoder.h"
+
+#include <random>
+
+AFTimeBlockEncoder::AFTimeBlockEncoder(size_t nPol, size_t nChannels,
+                                       bool fitToMaximum)
+    : _nPol(nPol), _nChannels(nChannels), _fitToMaximum(fitToMaximum),
+      _rmsPerChannel(_nChannels * nPol),
+      _ditherDist(
+          dyscostman::StochasticEncoder<double>::GetDitherDistribution()) {}
+
+AFTimeBlockEncoder::~AFTimeBlockEncoder() {}
+
+void AFTimeBlockEncoder::Normalize(
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    TimeBlockBuffer<std::complex<float>> &buffer, size_t antennaCount) {
+  if (_rmsPerAntenna.size() < antennaCount)
+    _rmsPerAntenna.resize(antennaCount);
+  std::vector<DBufferRow> data;
+  buffer.ConvertVector<std::complex<double>>(data);
+  const size_t visPerRow = _nPol * _nChannels;
+
+  // Normalize the channels
+  std::vector<RMSMeasurement> channelRMSes(_nChannels * _nPol);
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      channelRMSes[i].Include(row.visibilities[i]);
+    }
+  }
+  for (DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      double rms = channelRMSes[i].RMS();
+      row.visibilities[i] /= rms;
+    }
+  }
+
+  for (size_t p = 0; p != _nPol; ++p) {
+    // Normalize the antennae
+    calculateAntennaeRMS(data, p, antennaCount);
+    for (DBufferRow &row : data) {
+      double mul =
+          (_rmsPerAntenna[row.antenna1] * _rmsPerAntenna[row.antenna2]);
+      double fac = (mul == 0.0) ? 0.0 : 1.0 / mul;
+      for (size_t ch = 0; ch != _nChannels; ++ch) {
+        row.visibilities[ch * _nPol + p] *= fac;
+      }
+    }
+  }
+
+  if (_fitToMaximum) {
+    for (size_t visIndex = 0; visIndex != visPerRow; ++visIndex) {
+      double factor = 1.0;
+      for (const DBufferRow &row : data) {
+        if (row.antenna1 != row.antenna2) {
+          const std::complex<double> *ptr = &row.visibilities[visIndex];
+          double complMax = std::max(ptr->real(), ptr->imag());
+          double complMin = std::min(ptr->real(), ptr->imag());
+
+          if (complMax * factor > gausEncoder.MaxQuantity()) {
+            factor = complMax / gausEncoder.MaxQuantity();
+          } else if (complMin * factor < gausEncoder.MinQuantity()) {
+            factor = complMin / gausEncoder.MinQuantity();
+          }
+        }
+      }
+      for (DBufferRow &row : data)
+        row.visibilities[visIndex] *= factor;
+    }
+  }
+}
+
+void AFTimeBlockEncoder::changeAntennaFactor(std::vector<DBufferRow> &data,
+                                             float *metaBuffer,
+                                             size_t antennaIndex,
+                                             size_t antennaCount,
+                                             size_t polIndex, double factor) {
+  const size_t visPerRow = _nPol * _nChannels;
+  size_t metaIndex = visPerRow + antennaCount * polIndex;
+  metaBuffer[metaIndex + antennaIndex] /= factor;
+  for (DBufferRow &row : data) {
+    unsigned count = 0;
+    if (row.antenna1 == antennaIndex)
+      ++count;
+    if (row.antenna2 == antennaIndex)
+      ++count;
+    for (unsigned repeat = 0; repeat != count; ++repeat) {
+      for (size_t i = 0; i != _nChannels; ++i)
+        row.visibilities[i * _nPol + polIndex] *= factor;
+    }
+  }
+}
+
+void AFTimeBlockEncoder::changeChannelFactor(std::vector<DBufferRow> &data,
+                                             float *metaBuffer, size_t visIndex,
+                                             double factor) {
+  metaBuffer[visIndex] /= factor;
+  for (DBufferRow &row : data)
+    row.visibilities[visIndex] *= factor;
+}
+
+//
+// There are 3 axes to maximize over; antenna1, antenna2, channel
+// We want to maximize all values (average abs value as large as possible)
+// Example: (10=max)
+//  ch1     ch2
+//  a1a2a3   a1a2a3
+//  ------   ------
+//   1 1 1    1 1 1
+//  10 1 1    1 1 1
+//   1 1 1    1 1 1
+// ant3 * 10 -> sum = (3 * 1 + 10 + 5 * 10) + (4 * 1 + 5 * 10) = 117
+//  ch2 * 10 -> sum = 18 + 90 = 108
+// both * s10 -> sum = (13 + 5*s10) + (s10*4 + 10*5) = 91.5
+//  ch1     ch2
+//   1 1 1    1 1 1
+//   1 1 1    1 1 1
+//   1 2 1    1 1.5 1
+// ant3 * 10 -> sum = (3 * 1 + 10 + 5 * 10) + (4 * 1 + 5 * 10) = 117
+//  ch2 * 10 -> sum = 18 + 90 = 108
+// both * s10 -> sum = (13 + 5*s10) + (s10*4 + 10*5) = 91.5
+//
+// Approach: iterate over all antenna and channels, and find the antenna/channel
+// that can increase the sum the most.
+void AFTimeBlockEncoder::fitToMaximum(
+    std::vector<DBufferRow> &data, float *metaBuffer,
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    size_t antennaCount) {
+  // First, the channels and polarizations are scaled such that the maximum
+  // value
+  // equals the maximum encodable value
+  const size_t visPerRow = _nPol * _nChannels;
+  for (size_t visIndex = 0; visIndex != visPerRow; ++visIndex) {
+    double largestComp = 0.0;
+    for (const DBufferRow &row : data) {
+      if (row.antenna1 != row.antenna2) {
+        const std::complex<double> *ptr = &row.visibilities[visIndex];
+        double complMax = std::max(std::max(ptr->real(), ptr->imag()),
+                                   -std::min(ptr->real(), ptr->imag()));
+        if (std::isfinite(complMax) && complMax > largestComp)
+          largestComp = complMax;
+      }
+    }
+    double factor =
+        (largestComp == 0.0) ? 0.0 : gausEncoder.MaxQuantity() / largestComp;
+    changeChannelFactor(data, metaBuffer, visIndex, factor);
+  }
+
+  for (size_t polIndex = 0; polIndex != _nPol; ++polIndex) {
+    bool isProgressing;
+    do {
+      // Find the factor that increasest the sum of values the most
+      double bestChannelIncrease = 0.0, channelFactor = 1.0;
+      size_t bestChannel = 0;
+      for (size_t channel = 0; channel != _nChannels; ++channel) {
+        // by how much can we increase this channel?
+        double largestComp = 0.0;
+        for (const DBufferRow &row : data) {
+          if (row.antenna1 != row.antenna2) {
+            const std::complex<double> *ptr =
+                &row.visibilities[channel * _nPol + polIndex];
+            double complMax = std::max(std::max(ptr->real(), ptr->imag()),
+                                       -std::min(ptr->real(), ptr->imag()));
+            if (std::isfinite(complMax) && complMax > largestComp)
+              largestComp = complMax;
+          }
+        }
+        double factor = (largestComp == 0.0)
+                            ? 0.0
+                            : (gausEncoder.MaxQuantity() / largestComp - 1.0);
+        // how much does this increase the total?
+        double thisIncrease = 0.0;
+        for (DBufferRow &row : data) {
+          if (row.antenna1 != row.antenna2) {
+            std::complex<double> v =
+                row.visibilities[channel * _nPol + polIndex] * double(factor);
+            double av = std::fabs(v.real()) + std::fabs(v.imag());
+            if (std::isfinite(av))
+              thisIncrease += av;
+          }
+        }
+        if (thisIncrease > bestChannelIncrease) {
+          bestChannelIncrease = thisIncrease;
+          bestChannel = channel;
+          channelFactor = factor + 1.0;
+        }
+      }
+
+      ao::uvector<double> maxCompPerAntenna(antennaCount, 0.0);
+      for (const DBufferRow &row : data) {
+        if (row.antenna1 != row.antenna2) {
+          for (size_t channel = 0; channel != _nChannels; ++channel) {
+            const std::complex<double> *ptr =
+                &row.visibilities[channel * _nPol + polIndex];
+            double complMax = std::max(std::max(ptr->real(), ptr->imag()),
+                                       -std::min(ptr->real(), ptr->imag()));
+            if (std::isfinite(complMax)) {
+              if (complMax > maxCompPerAntenna[row.antenna1])
+                maxCompPerAntenna[row.antenna1] = complMax;
+              if (complMax > maxCompPerAntenna[row.antenna2])
+                maxCompPerAntenna[row.antenna2] = complMax;
+            }
+          }
+        }
+      }
+      ao::uvector<double> increasePerAntenna(antennaCount, 0.0);
+      for (const DBufferRow &row : data) {
+        if (row.antenna1 != row.antenna2) {
+          double factor1 = (maxCompPerAntenna[row.antenna1] == 0.0)
+                               ? 0.0
+                               : (gausEncoder.MaxQuantity() /
+                                      maxCompPerAntenna[row.antenna1] -
+                                  1.0);
+          double factor2 = (maxCompPerAntenna[row.antenna2] == 0.0)
+                               ? 0.0
+                               : (gausEncoder.MaxQuantity() /
+                                      maxCompPerAntenna[row.antenna2] -
+                                  1.0);
+          for (size_t channel = 0; channel != _nChannels; ++channel) {
+            std::complex<double> v1 =
+                row.visibilities[channel * _nPol + polIndex] * factor1;
+            double av1 = std::fabs(v1.real()) + std::fabs(v1.imag());
+            if (std::isfinite(av1))
+              increasePerAntenna[row.antenna1] += av1;
+            std::complex<double> v2 =
+                row.visibilities[channel * _nPol + polIndex] * factor2;
+            double av2 = std::fabs(v2.real()) + std::fabs(v2.imag());
+            if (std::isfinite(av2))
+              increasePerAntenna[row.antenna2] += av2;
+          }
+        }
+      }
+      size_t bestAntenna = 0;
+      double bestAntennaIncrease = 0.0;
+      for (size_t a = 0; a != antennaCount; ++a) {
+        if (increasePerAntenna[a] > bestAntennaIncrease) {
+          bestAntennaIncrease = increasePerAntenna[a];
+          bestAntenna = a;
+        }
+      }
+      // The benefit was calculated for increasing an antenna and increasing a
+      // channel Select which of those two has the largest benefit and apply:
+      if (bestAntennaIncrease > bestChannelIncrease) {
+        double factor =
+            (maxCompPerAntenna[bestAntenna] == 0.0)
+                ? 0.0
+                : (gausEncoder.MaxQuantity() / maxCompPerAntenna[bestAntenna]);
+        isProgressing = factor > 1.01;
+        changeAntennaFactor(data, metaBuffer, bestAntenna, antennaCount,
+                            polIndex, factor);
+      } else {
+        changeChannelFactor(data, metaBuffer, bestChannel * _nPol + polIndex,
+                            channelFactor);
+        isProgressing = channelFactor > 1.001;
+      }
+    } while (isProgressing);
+  }
+}
+
+template <bool UseDithering>
+void AFTimeBlockEncoder::encode(
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    const TimeBlockBuffer<std::complex<float>> &buffer, float *metaBuffer,
+    symbol_t *symbolBuffer, size_t antennaCount, std::mt19937 *rnd) {
+  if (_rmsPerAntenna.size() < antennaCount)
+    _rmsPerAntenna.resize(antennaCount);
+  // Note that encoding is performed with doubles
+  std::vector<DBufferRow> data;
+  buffer.ConvertVector<std::complex<double>>(data);
+  const size_t visPerRow = _nPol * _nChannels;
+
+  // Normalize the channels
+  std::vector<RMSMeasurement> channelRMSes(_nChannels * _nPol);
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      channelRMSes[i].Include(row.visibilities[i]);
+    }
+  }
+  for (DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      double rms = channelRMSes[i].RMS();
+      row.visibilities[i] /= rms;
+      metaBuffer[i] = rms;
+    }
+  }
+
+  for (size_t p = 0; p != _nPol; ++p) {
+    // Normalize the antennae
+    calculateAntennaeRMS(data, p, antennaCount);
+    for (DBufferRow &row : data) {
+      double mul =
+          (_rmsPerAntenna[row.antenna1] * _rmsPerAntenna[row.antenna2]);
+      double fac = (mul == 0.0) ? 0.0 : 1.0 / mul;
+      for (size_t ch = 0; ch != _nChannels; ++ch) {
+        row.visibilities[ch * _nPol + p] *= fac;
+      }
+    }
+
+    size_t metaIndex = visPerRow + antennaCount * p;
+    for (size_t a = 0; a != antennaCount; ++a)
+      metaBuffer[metaIndex + a] = _rmsPerAntenna[a];
+  }
+
+  if (_fitToMaximum) {
+    fitToMaximum(data, metaBuffer, gausEncoder, antennaCount);
+  }
+
+  symbol_t *symbolBufferPtr = symbolBuffer;
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      if (UseDithering) {
+        symbolBufferPtr[i * 2] = gausEncoder.EncodeWithDithering(
+            row.visibilities[i].real(), _ditherDist(*rnd));
+        symbolBufferPtr[i * 2 + 1] = gausEncoder.EncodeWithDithering(
+            row.visibilities[i].imag(), _ditherDist(*rnd));
+      } else {
+        symbolBufferPtr[i * 2] = gausEncoder.Encode(row.visibilities[i].real());
+        symbolBufferPtr[i * 2 + 1] =
+            gausEncoder.Encode(row.visibilities[i].imag());
+      }
+    }
+    symbolBufferPtr += visPerRow * 2;
+  }
+}
+
+template void AFTimeBlockEncoder::encode<true>(
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    const TimeBlockBuffer<std::complex<float>> &buffer, float *metaBuffer,
+    symbol_t *symbolBuffer, size_t antennaCount, std::mt19937 *rnd);
+template void AFTimeBlockEncoder::encode<false>(
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    const TimeBlockBuffer<std::complex<float>> &buffer, float *metaBuffer,
+    symbol_t *symbolBuffer, size_t antennaCount, std::mt19937 *rnd);
+
+void AFTimeBlockEncoder::calculateAntennaeRMS(
+    const std::vector<DBufferRow> &data, size_t polIndex, size_t antennaCount) {
+  std::vector<RMSMeasurement> matrixMeas(antennaCount * antennaCount);
+  for (const DBufferRow &row : data) {
+    size_t a1 = row.antenna1, a2 = row.antenna2;
+    if (a1 != a2) {
+      if (a1 > a2)
+        std::swap(a1, a2);
+      size_t index = row.antenna1 * antennaCount + row.antenna2;
+      for (size_t ch = 0; ch != _nChannels; ++ch)
+        matrixMeas[index].Include(row.visibilities[ch * _nPol + polIndex]);
+    }
+  }
+
+  ao::uvector<double> matrix(matrixMeas.size());
+  for (size_t i = 0; i != antennaCount; ++i) {
+    for (size_t j = i; j != antennaCount; ++j) {
+      matrix[i * antennaCount + j] = matrixMeas[i * antennaCount + j].RMS();
+      matrix[j * antennaCount + i] = matrixMeas[i * antennaCount + j].RMS();
+    }
+  }
+
+  // (note that _rmsPerAntenna is larger, so don't use assign())
+  for (size_t i = 0; i != antennaCount; ++i)
+    _rmsPerAntenna[i] = 1.0;
+
+  double precision = 1.0;
+  for (size_t iteration = 0; iteration != 100 && precision > 1e-6;
+       ++iteration) {
+    ao::uvector<double> nextRMS(antennaCount, 0.0);
+    for (size_t i = 0; i != antennaCount; ++i) {
+      double weightSum = 0.0;
+      for (size_t j = 0; j != antennaCount; ++j) {
+        if (i != j && _rmsPerAntenna[j] != 0.0) {
+          double w = _rmsPerAntenna[j];
+          if (std::isfinite(matrix[i * antennaCount + j])) {
+            // matrix / estVec, but since we weight, just:
+            nextRMS[i] += matrix[i * antennaCount + j];
+            weightSum += w;
+          }
+        }
+      }
+      if (weightSum == 0.0)
+        nextRMS[i] = 0.0;
+      else
+        nextRMS[i] /= weightSum;
+    }
+
+    double maxVal = 0.0;
+    for (size_t i = 0; i != antennaCount; ++i) {
+      _rmsPerAntenna[i] = nextRMS[i] * 0.8 + _rmsPerAntenna[i] * 0.2;
+      maxVal = std::max(_rmsPerAntenna[i], maxVal);
+    }
+    precision = 0.0;
+    for (size_t i = 0; i != antennaCount; ++i) {
+      if (_rmsPerAntenna[i] < maxVal * 1e-5)
+        _rmsPerAntenna[i] = 0.0;
+      precision = std::max(precision,
+                           std::fabs(_rmsPerAntenna[i] - nextRMS[i]) / maxVal);
+    }
+  }
+}
+
+void AFTimeBlockEncoder::InitializeDecode(const float *metaBuffer, size_t nRow,
+                                          size_t nAntennae) {
+  if (_rmsPerAntenna.size() < nAntennae * _nPol)
+    _rmsPerAntenna.resize(nAntennae * _nPol);
+  const size_t visPerRow = _nPol * _nChannels;
+  for (size_t i = 0; i != visPerRow; ++i)
+    _rmsPerChannel[i] = metaBuffer[i];
+  metaBuffer += visPerRow;
+  for (size_t p = 0; p != _nPol; ++p) {
+    for (size_t a = 0; a != nAntennae; ++a)
+      _rmsPerAntenna[a * _nPol + p] = metaBuffer[a + p * nAntennae];
+  }
+}
+
+void AFTimeBlockEncoder::Decode(
+    const dyscostman::StochasticEncoder<float> &gausEncoder, FBuffer &buffer,
+    const AFTimeBlockEncoder::symbol_t *symbolBuffer, size_t blockRow,
+    size_t antenna1, size_t antenna2) {
+  ao::uvector<double> antFactors(_nPol);
+  for (size_t p = 0; p != _nPol; ++p)
+    antFactors[p] = _rmsPerAntenna[antenna1 * _nPol + p] *
+                    _rmsPerAntenna[antenna2 * _nPol + p];
+
+  FBufferRow &row = buffer[blockRow];
+  row.antenna1 = antenna1;
+  row.antenna2 = antenna2;
+  row.visibilities.resize(_nChannels * _nPol);
+  std::complex<float> *destination = row.visibilities.data();
+  const symbol_t *srcRowPtr = symbolBuffer + blockRow * SymbolsPerRow();
+  for (size_t ch = 0; ch != _nChannels; ++ch) {
+    for (size_t p = 0; p != _nPol; ++p) {
+      double chRMS = _rmsPerChannel[ch * _nPol + p];
+      double factor = chRMS * antFactors[p];
+      destination->real(double(gausEncoder.Decode(*srcRowPtr)) * factor);
+      ++srcRowPtr;
+      destination->imag(double(gausEncoder.Decode(*srcRowPtr)) * factor);
+      ++srcRowPtr;
+      ++destination;
+    }
+  }
+}

--- a/tables/Dysco/aftimeblockencoder.h
+++ b/tables/Dysco/aftimeblockencoder.h
@@ -1,0 +1,93 @@
+#ifndef DYSCO_AFTIME_BLOCK_ENCODER_H
+#define DYSCO_AFTIME_BLOCK_ENCODER_H
+
+#include "stochasticencoder.h"
+#include "timeblockbuffer.h"
+#include "uvector.h"
+
+#include <complex>
+#include <random>
+#include <vector>
+
+#include "timeblockencoder.h"
+
+class AFTimeBlockEncoder : public TimeBlockEncoder {
+public:
+  AFTimeBlockEncoder(size_t nPol, size_t nChannels, bool fitToMaximum);
+
+  virtual ~AFTimeBlockEncoder() override;
+
+  virtual void
+  EncodeWithDithering(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t antennaCount,
+                      std::mt19937 &rnd) final override {
+    encode<true>(gausEncoder, buffer, metaBuffer, symbolBuffer, antennaCount,
+                 &rnd);
+  }
+
+  virtual void EncodeWithoutDithering(
+      const dyscostman::StochasticEncoder<float> &gausEncoder, FBuffer &buffer,
+      float *metaBuffer, symbol_t *symbolBuffer,
+      size_t antennaCount) final override {
+    encode<false>(gausEncoder, buffer, metaBuffer, symbolBuffer, antennaCount,
+                  0);
+  }
+
+  virtual void InitializeDecode(const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) final override;
+
+  virtual void Decode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, const symbol_t *symbolBuffer,
+                      size_t blockRow, size_t antenna1,
+                      size_t antenna2) final override;
+
+  virtual size_t SymbolCount(size_t nRow, size_t nPol,
+                             size_t nChannels) const final override {
+    return nRow * nChannels * nPol * 2 /*complex*/;
+  }
+
+  virtual size_t SymbolCount(size_t nRow) const final override {
+    return nRow * _nChannels * _nPol * 2 /*complex*/;
+  }
+
+  virtual size_t SymbolsPerRow() const final override {
+    return _nChannels * _nPol * 2 /*complex*/;
+  }
+
+  virtual size_t MetaDataCount(size_t nRow, size_t nPol, size_t nChannels,
+                               size_t nAntennae) const final override {
+    return nPol * (nChannels + nAntennae);
+  }
+
+  void Normalize(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                 TimeBlockBuffer<std::complex<float>> &buffer,
+                 size_t antennaCount);
+
+private:
+  void calculateAntennaeRMS(const std::vector<DBufferRow> &data,
+                            size_t polIndex, size_t antennaCount);
+
+  template <bool UseDithering>
+  void encode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+              const FBuffer &buffer, float *metaBuffer, symbol_t *symbolBuffer,
+              size_t antennaCount, std::mt19937 *rnd);
+
+  void changeAntennaFactor(std::vector<DBufferRow> &data, float *metaBuffer,
+                           size_t antennaIndex, size_t antennaCount,
+                           size_t polIndex, double factor);
+  void changeChannelFactor(std::vector<DBufferRow> &data, float *metaBuffer,
+                           size_t visIndex, double factor);
+
+  void fitToMaximum(std::vector<DBufferRow> &data, float *metaBuffer,
+                    const dyscostman::StochasticEncoder<float> &gausEncoder,
+                    size_t antennaCount);
+
+  size_t _nPol, _nChannels;
+  bool _fitToMaximum;
+
+  ao::uvector<double> _rmsPerChannel, _rmsPerAntenna;
+  std::uniform_int_distribution<unsigned> _ditherDist;
+};
+
+#endif

--- a/tables/Dysco/bytepacker.h
+++ b/tables/Dysco/bytepacker.h
@@ -1,0 +1,736 @@
+#ifndef DYSCO_BYTE_PACKER_H
+#define DYSCO_BYTE_PACKER_H
+
+#include <stdexcept>
+
+namespace dyscostman {
+
+/**
+ * Class for bit packing of values into bytes.
+ *
+ * Contains several methods that can pack and unpack an array of unsigned
+ * values into a bit-packed array, using as few bytes as possible.
+ * The number of bits used is fixed for all values in the array. All methods
+ * assume that the specified output array has at least enough space to store
+ * the packed / unpacked data. When packing, the amount of space needed is
+ * ceil(symbolCount / bitCount).
+ *
+ * The @ref pack() and @ref unpack() methods can call the method with given
+ * bitcount at runtime. If the bitcount is known at compile time, one of the
+ * other methods can be used. For each of these calls, the input symbols are
+ * assumed to occupy at most the given number of bits. The number of bytes
+ * written during pack operations is ceil(symbolCount * bitCount / 8).
+ * unpack operations will write symbolCount symbols into the output buffer.
+ */
+class BytePacker {
+public:
+  /**
+   * Call a pack..() function for a given bit count. Will forward the pack
+   * operation to the one for the given bit count.
+   * @param bitCount the number of bits to use per symbol
+   * @param dest output buffer (see class desc for size)
+   * @param symbolBuffer the input buffer
+   * @param symbolCount number of symbols in @p symbolBuffer.
+   */
+  static void pack(unsigned bitCount, unsigned char *dest,
+                   const unsigned *symbolBuffer, size_t symbolCount);
+
+  /**
+   * Call an unpack..() function for a given bit count. Will forward the unpack
+   * operation to the one for the given bit count.
+   * @param bitCount the number of bits used per symbol
+   * @param symbolBuffer output buffer
+   * @param packedBuffer the input buffer with the packed symbols
+   * @param symbolCount number of symbols that will be unpacked into @p
+   * symbolBuffer.
+   */
+  static void unpack(unsigned bitCount, unsigned *symbolBuffer,
+                     unsigned char *packedBuffer, size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=2.
+   */
+  static void pack2(unsigned char *dest, const unsigned *symbolBuffer,
+                    size_t symbolCount);
+  /**
+   * Reverse of pack2(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack2(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                      size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=3.
+   */
+  static void pack3(unsigned char *dest, const unsigned *symbolBuffer,
+                    size_t symbolCount);
+  /**
+   * Reverse of pack3(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack3(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                      size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=4.
+   */
+  static void pack4(unsigned char *dest, const unsigned *symbolBuffer,
+                    size_t symbolCount);
+  /**
+   * Reverse of pack4(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack4(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                      size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=6.
+   */
+  static void pack6(unsigned char *dest, const unsigned *symbolBuffer,
+                    size_t symbolCount);
+
+  /**
+   * Reverse of pack6(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack6(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                      size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=8.
+   */
+  static void pack8(unsigned char *dest, const unsigned *symbolBuffer,
+                    size_t symbolCount);
+  /**
+   * Reverse of pack8(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack8(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                      size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=10.
+   */
+  static void pack10(unsigned char *dest, const unsigned *symbolBuffer,
+                     size_t symbolCount);
+  /**
+   * Reverse of pack10(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack10(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                       size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=12.
+   */
+  static void pack12(unsigned char *dest, const unsigned *symbolBuffer,
+                     size_t symbolCount);
+  /**
+   * Reverse of pack12(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack12(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                       size_t symbolCount);
+
+  /**
+   * Pack the symbols from symbolBuffer into the destination array using
+   * bitCount=16.
+   */
+  static void pack16(unsigned char *dest, const unsigned *symbolBuffer,
+                     size_t symbolCount);
+  /**
+   * Reverse of pack16(). Will write symbolCount items into the symbolBuffer.
+   */
+  static void unpack16(unsigned *symbolBuffer, unsigned char *packedBuffer,
+                       size_t symbolCount);
+
+  static size_t bufferSize(size_t nSymbols, size_t nBits) {
+    return (nSymbols * nBits + 7) / 8;
+  }
+};
+
+inline void BytePacker::pack(unsigned int bitCount, unsigned char *dest,
+                             const unsigned int *symbolBuffer,
+                             size_t symbolCount) {
+  switch (bitCount) {
+  case 2:
+    pack2(dest, symbolBuffer, symbolCount);
+    break;
+  case 3:
+    pack3(dest, symbolBuffer, symbolCount);
+    break;
+  case 4:
+    pack4(dest, symbolBuffer, symbolCount);
+    break;
+  case 6:
+    pack6(dest, symbolBuffer, symbolCount);
+    break;
+  case 8:
+    pack8(dest, symbolBuffer, symbolCount);
+    break;
+  case 10:
+    pack10(dest, symbolBuffer, symbolCount);
+    break;
+  case 12:
+    pack12(dest, symbolBuffer, symbolCount);
+    break;
+  case 16:
+    pack16(dest, symbolBuffer, symbolCount);
+    break;
+  default:
+    throw std::runtime_error("Unsupported packing size");
+  }
+}
+
+inline void BytePacker::unpack(unsigned int bitCount,
+                               unsigned int *symbolBuffer,
+                               unsigned char *packedBuffer,
+                               size_t symbolCount) {
+  switch (bitCount) {
+  case 2:
+    unpack2(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 3:
+    unpack3(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 4:
+    unpack4(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 6:
+    unpack6(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 8:
+    unpack8(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 10:
+    unpack10(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 12:
+    unpack12(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  case 16:
+    unpack16(symbolBuffer, packedBuffer, symbolCount);
+    break;
+  default:
+    throw std::runtime_error("Unsupported unpacking size");
+  }
+}
+
+inline void BytePacker::pack2(unsigned char *dest,
+                              const unsigned int *symbolBuffer,
+                              size_t symbolCount) {
+  const size_t limit = symbolCount / 4;
+  for (size_t i = 0; i != limit; i++) {
+    *dest = (*symbolBuffer); // bits 1-2 into 1-2
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 2; // bits 1-2 into 3-4
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 4; // bits 1-2 into 5-6
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 6; // bits 1-2 into 7-8
+    ++symbolBuffer;
+    ++dest;
+  }
+  size_t pos = limit * 4;
+  if (pos != symbolCount) {
+    *dest = (*symbolBuffer); // bits 1-2 into 1-2
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+      *dest |= (*symbolBuffer) << 2; // bits 1-2 into 3-4
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+        *dest |= (*symbolBuffer) << 4; // bits 1-2 into 5-6
+      }
+    }
+  }
+}
+
+inline void BytePacker::unpack2(unsigned *symbolBuffer,
+                                unsigned char *packedBuffer,
+                                size_t symbolCount) {
+  const size_t limit = symbolCount / 4;
+  for (size_t i = 0; i != limit; i++) {
+    *symbolBuffer = *packedBuffer & 0x03; // bits 1-2 into 1-2
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x0C) >> 2; // bits 3-4 into 1-2
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x30) >> 4; // bits 5-6 into 1-2
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0xC0) >> 6; // bits 7-8 into 1-2
+    ++symbolBuffer;
+    ++packedBuffer;
+  }
+  size_t pos = limit * 4;
+  if (pos != symbolCount) {
+    *symbolBuffer = *packedBuffer & 0x03; // bits 1-2 into 1-2
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+      *symbolBuffer = ((*packedBuffer) & 0x0C) >> 2; // bits 3-4 into 1-2
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+        *symbolBuffer = ((*packedBuffer) & 0x30) >> 4; // bits 5-6 into 1-2
+      }
+    }
+  }
+}
+
+inline void BytePacker::pack3(unsigned char *dest, const unsigned *symbolBuffer,
+                              size_t symbolCount) {
+  const size_t limit = symbolCount / 8;
+  for (size_t i = 0; i != limit; i++) {
+    *dest = *symbolBuffer; // 1. Bit 1-3 into 1-3
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 3; // 2. Bits 1-3 into 4-6
+    ++symbolBuffer;
+    *dest |= ((*symbolBuffer) & 0x3) << 6; // 3. Bits 1-2 into 7-8
+    ++dest;
+
+    *dest = ((*symbolBuffer) & 0x4) >> 2; // 3b. Bit 3 into 1
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 1; // 4. Bits 1-3 into 2-4
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 4; // 5. Bits 1-3 into 5-7
+    ++symbolBuffer;
+    *dest |= ((*symbolBuffer) & 0x1) << 7; // 6. Bit 1 into 8
+    ++dest;
+
+    *dest = ((*symbolBuffer) & 0x6) >> 1; // 6b. Bits 2-3 into 1-2
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 2; // 7. Bits 1-3 into bits 3-5
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 5; // 8. Bits 1-3 into bits 6-8
+    ++symbolBuffer;
+    ++dest;
+  }
+
+  size_t pos = limit * 8;
+  if (pos != symbolCount) {
+    *dest = *symbolBuffer; // 1. Bit 1-3 into 1-3
+    ++pos;
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+      *dest |= (*symbolBuffer) << 3; // 2. Bits 1-3 into 4-6
+      ++pos;
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+        *dest |= ((*symbolBuffer) & 0x3) << 6; // 3. Bits 1-2 into 7-8
+        ++dest;
+        *dest = ((*symbolBuffer) & 0x4) >> 2; // Bit 3 into 1
+        ++pos;
+        if (pos != symbolCount) {
+          ++symbolBuffer;
+          *dest |= (*symbolBuffer) << 1; // 4. Bits 1-3 into 2-4
+          ++pos;
+          if (pos != symbolCount) {
+            ++symbolBuffer;
+            *dest |= (*symbolBuffer) << 4; // 5. Bits 1-3 into 5-7
+            ++pos;
+            if (pos != symbolCount) {
+              ++symbolBuffer;
+              *dest |= ((*symbolBuffer) & 0x1) << 7; // 6. Bit 1 into 8
+              ++dest;
+              *dest = ((*symbolBuffer) & 0x6) >> 1; // Bits 2-3 into 1-2
+              ++pos;
+              if (pos != symbolCount) {
+                ++symbolBuffer;
+                *dest |= (*symbolBuffer) << 2; // 7. Bits 1-3 into bits 3-5
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+inline void BytePacker::unpack3(unsigned *symbolBuffer,
+                                unsigned char *packedBuffer,
+                                size_t symbolCount) {
+  const size_t limit = symbolCount / 8;
+  for (size_t i = 0; i != limit; i++) {
+    *symbolBuffer = (*packedBuffer) & 0x07; // 1. Bits 1-3 into 1-3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x38) >> 3; // 2. Bits 4-6 into 1-3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0xC0) >> 6; // 3. Bits 7-8 into 1-2
+    ++packedBuffer;
+
+    *symbolBuffer |= ((*packedBuffer) & 0x01) << 2; // 3b. Bit 1 into 3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x0e) >> 1; // 4. Bit 2-4 into 1-3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x70) >> 4; // 5. Bit 5-7 into 1-3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x80) >> 7; // 6. Bit 8 into 1
+    ++packedBuffer;
+
+    *symbolBuffer |= ((*packedBuffer) & 0x03) << 1; // 6b. Bit 1-2 into 2-3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0x1c) >> 2; // 7. Bit 3-5 into 1-3
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0xe0) >> 5; // 8. Bit 6-8 into 1-3
+    ++symbolBuffer;
+    ++packedBuffer;
+  }
+  size_t pos = limit * 8;
+  if (pos != symbolCount) {
+    *symbolBuffer = (*packedBuffer) & 0x07; // 1. Bits 1-3 into 1-3
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+      *symbolBuffer = ((*packedBuffer) & 0x38) >> 3; // 2. Bits 4-6 into 1-3
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+        *symbolBuffer = ((*packedBuffer) & 0xC0) >> 6; // 3. Bits 7-8 into 1-2
+        ++packedBuffer;
+        *symbolBuffer |= ((*packedBuffer) & 0x01) << 2; // 3b. Bit 1 into 3
+        ++pos;
+
+        if (pos != symbolCount) {
+          ++symbolBuffer;
+          *symbolBuffer = ((*packedBuffer) & 0x0e) >> 1; // 4. Bit 2-4 into 1-3
+          ++pos;
+
+          if (pos != symbolCount) {
+            ++symbolBuffer;
+            *symbolBuffer =
+                ((*packedBuffer) & 0x70) >> 4; // 5. Bit 5-7 into 1-3
+            ++pos;
+
+            if (pos != symbolCount) {
+              ++symbolBuffer;
+              *symbolBuffer = ((*packedBuffer) & 0x80) >> 7; // 6. Bit 8 into 1
+              ++packedBuffer;
+              *symbolBuffer |= ((*packedBuffer) & 0x03)
+                               << 1; // 6b. Bit 1-2 into 2-3
+              ++pos;
+
+              if (pos != symbolCount) {
+                ++symbolBuffer;
+                *symbolBuffer =
+                    ((*packedBuffer) & 0x1c) >> 2; // 7. Bit 3-5 into 1-3
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+inline void BytePacker::pack4(unsigned char *dest,
+                              const unsigned int *symbolBuffer,
+                              size_t symbolCount) {
+  const size_t limit = symbolCount / 2;
+  for (size_t i = 0; i != limit; i++) {
+    *dest = (*symbolBuffer); // bits 1-4 into 1-4
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer) << 4; // bits 1-4 into 5-8
+    ++symbolBuffer;
+    ++dest;
+  }
+  if (limit * 2 != symbolCount)
+    *dest = (*symbolBuffer); // bits 1-4 into 1-4
+}
+
+inline void BytePacker::unpack4(unsigned *symbolBuffer,
+                                unsigned char *packedBuffer,
+                                size_t symbolCount) {
+  const size_t limit = symbolCount / 2;
+  for (size_t i = 0; i != limit; i++) {
+    *symbolBuffer = *packedBuffer & 0x0F; // bits 1-4 into 1-4
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 0xF0) >> 4; // bits 5-8 into 1-4
+    ++symbolBuffer;
+    ++packedBuffer;
+  }
+  if (limit * 2 != symbolCount)
+    *symbolBuffer = *packedBuffer & 0x0F; // bits 1-4 into 1-4
+}
+
+inline void BytePacker::pack6(unsigned char *dest, const unsigned *symbolBuffer,
+                              size_t symbolCount) {
+  const size_t limit = symbolCount / 4;
+  for (size_t i = 0; i != limit; i++) {
+    *dest = *symbolBuffer; // Bit 1-6 into 1-6
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer & 3) << 6; // Bits 1-2 into 7-8
+    ++dest;
+
+    *dest = (*symbolBuffer & 60) >> 2; // Bits 3-6 into 1-4
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer & 15) << 4; // Bits 1-4 into 5-8
+    ++dest;
+
+    *dest = (*symbolBuffer & 48) >> 4; // Bits 5-6 into 1-2
+    ++symbolBuffer;
+    *dest |= *symbolBuffer << 2; // Bits 1-6 into bits 3-8
+    ++symbolBuffer;
+    ++dest;
+  }
+
+  size_t pos = limit * 4;
+  if (pos != symbolCount) {
+    *dest = *symbolBuffer; // Bit 1-6 into 1-6
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+
+      *dest |= (*symbolBuffer & 3) << 6; // Bits 1-2 into 7-8
+      ++dest;
+
+      *dest = (*symbolBuffer & 60) >> 2; // Bits 3-6 into 1-4
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+
+        *dest |= (*symbolBuffer & 15) << 4; // Bits 1-4 into 5-8
+        ++dest;
+
+        *dest = (*symbolBuffer & 48) >> 4; // Bits 5-6 into 1-2
+                                           //++symbolBuffer; ++pos;
+      }
+    }
+  }
+}
+
+inline void BytePacker::unpack6(unsigned *symbolBuffer,
+                                unsigned char *packedBuffer,
+                                size_t symbolCount) {
+  const size_t limit = symbolCount / 4;
+  for (size_t i = 0; i != limit; i++) {
+    *symbolBuffer = (*packedBuffer) & 63; // Bits 1-6 into 1-6
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 192) >> 6; // Bits 7-8 into 1-2
+    ++packedBuffer;
+
+    *symbolBuffer |= ((*packedBuffer) & 15) << 2; // Bits 1-4 into 3-6
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 240) >> 4; // Bits 5-8 into 1-4
+    ++packedBuffer;
+
+    *symbolBuffer |= ((*packedBuffer) & 3) << 4; // Bits 1-2 into 5-6
+    ++symbolBuffer;
+    *symbolBuffer = ((*packedBuffer) & 252) >> 2; // Bits 3-8 into 1-6
+    ++packedBuffer;
+    ++symbolBuffer;
+  }
+  size_t pos = limit * 4;
+  if (pos != symbolCount) {
+    *symbolBuffer = (*packedBuffer) & 63; // Bits 1-6 into 1-6
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+
+      *symbolBuffer = ((*packedBuffer) & 192) >> 6; // Bits 7-8 into 1-2
+      ++packedBuffer;
+
+      *symbolBuffer |= ((*packedBuffer) & 15) << 2; // Bits 1-4 into 3-6
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+        *symbolBuffer = ((*packedBuffer) & 240) >> 4; // Bits 5-8 into 1-4
+        ++packedBuffer;
+
+        *symbolBuffer |= ((*packedBuffer) & 3) << 4; // Bits 1-2 into 5-6
+      }
+    }
+  }
+}
+
+inline void BytePacker::pack8(unsigned char *dest, const unsigned *symbolBuffer,
+                              size_t symbolCount) {
+  for (size_t i = 0; i != symbolCount; ++i)
+    dest[i] = symbolBuffer[i];
+}
+
+inline void BytePacker::unpack8(unsigned *symbolBuffer,
+                                unsigned char *packedBuffer,
+                                size_t symbolCount) {
+  for (size_t i = 0; i != symbolCount; ++i)
+    symbolBuffer[i] = packedBuffer[i];
+}
+
+inline void BytePacker::pack10(unsigned char *dest,
+                               const unsigned int *symbolBuffer,
+                               size_t symbolCount) {
+  const size_t limit = symbolCount / 4;
+  for (size_t i = 0; i != limit; i++) {
+    *dest = (*symbolBuffer & 0x0FF); // Bit 1-8 into 1-8
+    ++dest;
+    *dest = (*symbolBuffer & 0x300) >> 8; // Bits 9-10 into 1-2
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer & 0x03F) << 2; // Bits 1-6 into 3-8
+    ++dest;
+    *dest = (*symbolBuffer & 0x3C0) >> 6; // Bits 7-10 into 1-4
+    ++symbolBuffer;
+
+    *dest |= (*symbolBuffer & 0x00F) << 4; // Bits 1-4 into 5-8
+    ++dest;
+    *dest = (*symbolBuffer & 0x3F0) >> 4; // Bits 5-10 into bits 1-6
+    ++symbolBuffer;
+    *dest |= (*symbolBuffer & 0x003) << 6; // Bits 1-2 into 7-8
+    ++dest;
+    *dest = (*symbolBuffer & 0x3FC) >> 2; // Bits 3-10 into bits 1-8
+    ++symbolBuffer;
+    ++dest;
+  }
+
+  size_t pos = limit * 4;
+  if (pos != symbolCount) {
+    *dest = (*symbolBuffer & 0x0FF); // Bit 1-8 into 1-8
+    ++dest;
+    *dest = (*symbolBuffer & 0x300) >> 8; // Bits 9-10 into 1-2
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+
+      *dest |= (*symbolBuffer & 0x03F) << 2; // Bits 1-6 into 3-8
+      ++dest;
+      *dest = (*symbolBuffer & 0x3C0) >> 6; // Bits 7-10 into 1-4
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+
+        *dest |= (*symbolBuffer & 0x00F) << 4; // Bits 1-4 into 5-8
+        ++dest;
+        *dest = (*symbolBuffer & 0x3F0) >> 4; // Bits 5-10 into bits 1-6
+                                              //++symbolBuffer; ++pos;
+      }
+    }
+  }
+}
+
+inline void BytePacker::unpack10(unsigned int *symbolBuffer,
+                                 unsigned char *packedBuffer,
+                                 size_t symbolCount) {
+  const size_t limit = symbolCount / 4;
+  for (size_t i = 0; i != limit; i++) {
+    *symbolBuffer = *packedBuffer; // Bits 1-8 into 1-8
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0x03) << 8; // Bits 1-2 into 9-10
+    ++symbolBuffer;
+
+    *symbolBuffer = ((*packedBuffer) & 0xFC) >> 2; // Bits 3-8 into 1-6
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0x0F) << 6; // Bits 1-4 into 7-10
+    ++symbolBuffer;
+
+    *symbolBuffer = ((*packedBuffer) & 0xF0) >> 4; // Bits 5-8 into 1-4
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0x3F) << 4; // Bits 1-6 into 5-10
+    ++symbolBuffer;
+
+    *symbolBuffer = ((*packedBuffer) & 0xC0) >> 6; // Bits 7-8 into 1-2
+    ++packedBuffer;
+    *symbolBuffer |= (*packedBuffer) << 2; // Bits 1-8 into 3-10
+    ++packedBuffer;
+    ++symbolBuffer;
+  }
+  size_t pos = limit * 4;
+  if (pos != symbolCount) {
+    *symbolBuffer = *packedBuffer; // Bits 1-8 into 1-8
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0x03) << 8; // Bits 1-2 into 9-10
+    ++pos;
+
+    if (pos != symbolCount) {
+      ++symbolBuffer;
+
+      *symbolBuffer = ((*packedBuffer) & 0xFC) >> 2; // Bits 3-8 into 1-6
+      ++packedBuffer;
+      *symbolBuffer |= ((*packedBuffer) & 0x0F) << 6; // Bits 1-4 into 7-10
+      ++pos;
+
+      if (pos != symbolCount) {
+        ++symbolBuffer;
+        *symbolBuffer = ((*packedBuffer) & 0xF0) >> 4; // Bits 5-8 into 1-4
+        ++packedBuffer;
+        *symbolBuffer |= ((*packedBuffer) & 0x3F) << 4; // Bits 1-6 into 5-10
+      }
+    }
+  }
+}
+
+inline void BytePacker::pack12(unsigned char *dest,
+                               const unsigned int *symbolBuffer,
+                               size_t symbolCount) {
+  const size_t limit = symbolCount / 2;
+  for (size_t i = 0; i != limit; i++) {
+    *dest = (*symbolBuffer) & 0x0FF; // bits 1-8 into 1-8
+    ++dest;
+
+    *dest = ((*symbolBuffer) & 0xF00) >> 8; // bits 9-12 into 1-4
+    ++symbolBuffer;
+    *dest |= ((*symbolBuffer) & 0x00F) << 4; // bits 1-4 into 5-8
+    ++dest;
+
+    *dest = ((*symbolBuffer) & 0xFF0) >> 4; // bits 5-12 into 1-8
+    ++symbolBuffer;
+    ++dest;
+  }
+  if (limit * 2 != symbolCount) {
+    *dest = (*symbolBuffer) & 0x0FF; // bits 1-8 into 1-8
+    ++dest;
+
+    *dest = ((*symbolBuffer) & 0xF00) >> 8; // bits 9-12 into 1-4
+  }
+}
+
+inline void BytePacker::unpack12(unsigned int *symbolBuffer,
+                                 unsigned char *packedBuffer,
+                                 size_t symbolCount) {
+  const size_t limit = symbolCount / 2;
+  for (size_t i = 0; i != limit; i++) {
+    *symbolBuffer = *packedBuffer; // bits 1-8 into 1-8
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0x0F) << 8; // bits 1-4 into 9-12
+    ++symbolBuffer;
+
+    *symbolBuffer = ((*packedBuffer) & 0xF0) >> 4; // bits 5-8 into 1-4
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0xFF) << 4; // bits 1-8 into 5-12
+    ++packedBuffer;
+    ++symbolBuffer;
+  }
+  if (limit * 2 != symbolCount) {
+    *symbolBuffer = *packedBuffer; // bits 1-8 into 1-8
+    ++packedBuffer;
+    *symbolBuffer |= ((*packedBuffer) & 0x0F) << 8; // bits 1-4 into 9-12
+  }
+}
+
+inline void BytePacker::pack16(unsigned char *dest,
+                               const unsigned *symbolBuffer,
+                               size_t symbolCount) {
+  for (size_t i = 0; i != symbolCount; ++i)
+    reinterpret_cast<uint16_t *>(dest)[i] = symbolBuffer[i];
+}
+
+inline void BytePacker::unpack16(unsigned *symbolBuffer,
+                                 unsigned char *packedBuffer,
+                                 size_t symbolCount) {
+  for (size_t i = 0; i != symbolCount; ++i)
+    symbolBuffer[i] = reinterpret_cast<uint16_t *>(packedBuffer)[i];
+}
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/dyscodatacolumn.cpp
+++ b/tables/Dysco/dyscodatacolumn.cpp
@@ -1,0 +1,117 @@
+#include "dyscodatacolumn.h"
+#include "aftimeblockencoder.h"
+#include "rftimeblockencoder.h"
+#include "rowtimeblockencoder.h"
+
+namespace dyscostman {
+
+void DyscoDataColumn::Prepare(DyscoDistribution distribution,
+                              Normalization normalization, double studentsTNu,
+                              double distributionTruncation) {
+  _distribution = distribution;
+  _studentsTNu = studentsTNu;
+  _normalization = normalization;
+  ThreadedDyscoColumn::Prepare(distribution, normalization, studentsTNu,
+                               distributionTruncation);
+  const size_t nPolarizations = shape()[0], nChannels = shape()[1];
+
+  switch (normalization) {
+  case Normalization::kAF:
+    _decoder.reset(new AFTimeBlockEncoder(nPolarizations, nChannels, true));
+    break;
+  case Normalization::kRF:
+    _decoder.reset(new RFTimeBlockEncoder(nPolarizations, nChannels));
+    break;
+  case Normalization::kRow:
+    _decoder.reset(new RowTimeBlockEncoder(nPolarizations, nChannels));
+    break;
+  }
+
+  switch (distribution) {
+  case GaussianDistribution:
+    _gausEncoder.reset(
+        new StochasticEncoder<float>(1 << getBitsPerSymbol(), 1.0, true));
+    break;
+  case UniformDistribution:
+    _gausEncoder.reset(
+        new StochasticEncoder<float>(1 << getBitsPerSymbol(), 1.0, false));
+    break;
+  case StudentsTDistribution:
+    _gausEncoder.reset(
+        new StochasticEncoder<float>(StochasticEncoder<float>::StudentTEncoder(
+            1 << getBitsPerSymbol(), studentsTNu, 1.0)));
+    break;
+  case TruncatedGaussianDistribution:
+    _gausEncoder.reset(new StochasticEncoder<float>(
+        StochasticEncoder<float>::TruncatedGausEncoder(
+            1 << getBitsPerSymbol(), distributionTruncation, 1.0)));
+    break;
+  }
+}
+
+void DyscoDataColumn::initializeDecode(TimeBlockBuffer<data_t> *buffer,
+                                       const float *metaBuffer, size_t nRow,
+                                       size_t nAntennae) {
+  _decoder->InitializeDecode(metaBuffer, nRow, nAntennae);
+}
+
+void DyscoDataColumn::decode(TimeBlockBuffer<data_t> *buffer,
+                             const unsigned int *data, size_t blockRow,
+                             size_t a1, size_t a2) {
+  _decoder->Decode(*_gausEncoder, *buffer, data, blockRow, a1, a2);
+}
+
+std::unique_ptr<ThreadedDyscoColumn<std::complex<float>>::ThreadDataBase>
+DyscoDataColumn::initializeEncodeThread() {
+  const size_t nPolarizations = shape()[0], nChannels = shape()[1];
+  std::unique_ptr<TimeBlockEncoder> encoder;
+  switch (_normalization) {
+  case Normalization::kAF:
+    encoder.reset(new AFTimeBlockEncoder(nPolarizations, nChannels, true));
+    break;
+  case Normalization::kRF:
+    encoder.reset(new RFTimeBlockEncoder(nPolarizations, nChannels));
+    break;
+  case Normalization::kRow:
+    encoder.reset(new RowTimeBlockEncoder(nPolarizations, nChannels));
+    break;
+  }
+  std::unique_ptr<ThreadData> newThreadData(new ThreadData(std::move(encoder)));
+  // Seed every thread from a random number
+  if (_randomize)
+    newThreadData->rnd.seed(_rnd());
+  else
+    std::cout << "Warning: New thread NOT seeded.\n";
+  return newThreadData;
+}
+
+void DyscoDataColumn::encode(ThreadDataBase *threadData,
+                             TimeBlockBuffer<data_t> *buffer, float *metaBuffer,
+                             symbol_t *symbolBuffer, size_t nAntennae) {
+  ThreadData &data = static_cast<ThreadData &>(*threadData);
+  data.encoder->EncodeWithDithering(*_gausEncoder, *buffer, metaBuffer,
+                                    symbolBuffer, nAntennae, data.rnd);
+}
+
+size_t DyscoDataColumn::metaDataFloatCount(size_t nRows, size_t nPolarizations,
+                                           size_t nChannels,
+                                           size_t nAntennae) const {
+  return _decoder->MetaDataCount(nRows, nPolarizations, nChannels, nAntennae);
+}
+
+size_t DyscoDataColumn::symbolCount(size_t nRowsInBlock, size_t nPolarizations,
+                                    size_t nChannels) const {
+  return _decoder->SymbolCount(nRowsInBlock, nPolarizations, nChannels);
+}
+
+size_t DyscoDataColumn::defaultThreadCount() const {
+  if (!_randomize) {
+    std::cout
+        << "Warning: using only one thread to avoid randomizing the results.\n";
+    return 1;
+  } else {
+    return ThreadedDyscoColumn::defaultThreadCount();
+  }
+}
+
+} // namespace dyscostman

--- a/tables/Dysco/dyscodatacolumn.h
+++ b/tables/Dysco/dyscodatacolumn.h
@@ -1,0 +1,89 @@
+#ifndef DYSCO_DATA_COLUMN_H
+#define DYSCO_DATA_COLUMN_H
+
+#include "threadeddyscocolumn.h"
+
+#include "stochasticencoder.h"
+#include "timeblockencoder.h"
+
+namespace dyscostman {
+
+class DyscoStMan;
+
+/**
+ * A column for storing compressed complex values with an approximate Gaussian
+ * distribution.
+ * @author André Offringa
+ */
+class DyscoDataColumn final : public ThreadedDyscoColumn<std::complex<float>> {
+public:
+  /**
+   * Create a new column. Internally called by DyscoStMan when creating a
+   * new column.
+   */
+  DyscoDataColumn(DyscoStMan *parent, int dtype)
+      : ThreadedDyscoColumn(parent, dtype), _rnd(std::random_device{}()),
+        _gausEncoder(), _distribution(GaussianDistribution),
+        _normalization(Normalization::kRF), _randomize(true) {}
+
+  DyscoDataColumn(const DyscoDataColumn &source) = delete;
+
+  void operator=(const DyscoDataColumn &source) = delete;
+
+  /** Destructor. */
+  virtual ~DyscoDataColumn() { shutdown(); }
+
+  virtual void Prepare(DyscoDistribution distribution,
+                       Normalization normalization, double studentsTNu,
+                       double distributionTruncation) override;
+
+  void SetStaticRandomizationSeed() {
+    std::cout
+        << "Warning: Initializing random number generator with static seed!\n";
+    _rnd = std::mt19937();
+    _randomize = false;
+  }
+
+protected:
+  virtual void initializeDecode(TimeBlockBuffer<data_t> *buffer,
+                                const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) override;
+
+  virtual void decode(TimeBlockBuffer<data_t> *buffer, const symbol_t *data,
+                      size_t blockRow, size_t a1, size_t a2) override;
+
+  virtual std::unique_ptr<ThreadDataBase> initializeEncodeThread() override;
+
+  virtual void encode(ThreadDataBase *threadData,
+                      TimeBlockBuffer<data_t> *buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t nAntennae) override;
+
+  virtual size_t metaDataFloatCount(size_t nRow, size_t nPolarizations,
+                                    size_t nChannels,
+                                    size_t nAntennae) const override;
+
+  virtual size_t symbolCount(size_t nRowsInBlock, size_t nPolarizations,
+                             size_t nChannels) const override;
+
+  virtual size_t defaultThreadCount() const override;
+
+private:
+  struct ThreadData final : public ThreadDataBase {
+    ThreadData(std::unique_ptr<TimeBlockEncoder> timeBlockEncoder)
+        : encoder(std::move(timeBlockEncoder)) {}
+    std::unique_ptr<TimeBlockEncoder> encoder;
+    std::mt19937 rnd;
+  };
+
+  std::mt19937 _rnd;
+  std::unique_ptr<StochasticEncoder<float>> _gausEncoder;
+  std::unique_ptr<TimeBlockEncoder> _decoder;
+  DyscoDistribution _distribution;
+  Normalization _normalization;
+  double _studentsTNu;
+  bool _randomize;
+};
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/dyscodistribution.h
+++ b/tables/Dysco/dyscodistribution.h
@@ -1,0 +1,13 @@
+#ifndef DYSCO_DISTRIBUTION_H
+#define DYSCO_DISTRIBUTION_H
+
+namespace dyscostman {
+enum DyscoDistribution {
+  GaussianDistribution,
+  UniformDistribution,
+  StudentsTDistribution,
+  TruncatedGaussianDistribution
+};
+}
+
+#endif

--- a/tables/Dysco/dysconormalization.h
+++ b/tables/Dysco/dysconormalization.h
@@ -1,0 +1,8 @@
+#ifndef DYSCO_NORMALIZATION_H
+#define DYSCO_NORMALIZATION_H
+
+namespace dyscostman {
+enum class Normalization { kAF, kRF, kRow };
+}
+
+#endif

--- a/tables/Dysco/dyscostman.cpp
+++ b/tables/Dysco/dyscostman.cpp
@@ -1,0 +1,420 @@
+#include "dyscostman.h"
+#include "dyscodatacolumn.h"
+#include "dyscostmancol.h"
+#include "dyscostmanerror.h"
+#include "dyscoweightcolumn.h"
+
+#include "header.h"
+
+void register_dyscostman() { dyscostman::DyscoStMan::registerClass(); }
+
+namespace dyscostman {
+
+const unsigned short DyscoStMan::VERSION_MAJOR = 1,
+                     DyscoStMan::VERSION_MINOR = 0;
+
+DyscoStMan::DyscoStMan(unsigned dataBitCount, unsigned weightBitCount,
+                       const casacore::String &name)
+    : DataManager(), _nRow(0), _nBlocksInFile(0), _rowsPerBlock(0),
+      _antennaCount(0), _blockSize(0), _headerSize(0), _name(name),
+      _dataBitCount(dataBitCount), _weightBitCount(weightBitCount),
+      _distribution(TruncatedGaussianDistribution),
+      _normalization(Normalization::kAF), _studentTNu(0.0),
+      _distributionTruncation(2.5), _staticSeed(false) {}
+
+DyscoStMan::DyscoStMan(const casacore::String &name,
+                       const casacore::Record &spec)
+    : DataManager(), _nRow(0), _nBlocksInFile(0), _rowsPerBlock(0),
+      _antennaCount(0), _blockSize(0), _headerSize(0), _name(name),
+      _dataBitCount(0), _weightBitCount(0), _distribution(GaussianDistribution),
+      _normalization(Normalization::kAF), _studentTNu(0.0),
+      _distributionTruncation(0.0), _staticSeed(false) {
+  setFromSpec(spec);
+}
+
+DyscoStMan::DyscoStMan(const DyscoStMan &source)
+    : DataManager(), _nRow(0), _nBlocksInFile(0), _rowsPerBlock(0),
+      _antennaCount(0), _blockSize(0), _headerSize(0), _name(source._name),
+      _dataBitCount(source._dataBitCount),
+      _weightBitCount(source._weightBitCount),
+      _distribution(source._distribution),
+      _normalization(source._normalization), _studentTNu(source._studentTNu),
+      _distributionTruncation(source._distributionTruncation),
+      _staticSeed(source._staticSeed) {}
+
+void DyscoStMan::setFromSpec(const casacore::Record &spec) {
+  // Here we need to load from _spec
+  int i = spec.description().fieldNumber("dataBitCount");
+  if (i >= 0) {
+    _dataBitCount = spec.asInt("dataBitCount");
+    if (_dataBitCount == 0)
+      throw DyscoStManError("Invalid error for data bit rate");
+
+    _weightBitCount = spec.asInt("weightBitCount");
+    if (_weightBitCount == 0)
+      throw DyscoStManError("Invalid error for weight bit rate");
+
+    std::string str = spec.asString("distribution");
+    if (str == "Uniform")
+      _distribution = UniformDistribution;
+    else if (str == "Gaussian")
+      _distribution = GaussianDistribution;
+    else if (str == "StudentT")
+      _distribution = StudentsTDistribution;
+    else if (str == "TruncatedGaussian")
+      _distribution = TruncatedGaussianDistribution;
+    else
+      throw DyscoStManError("Unsupported distribution specified");
+    str = spec.asString("normalization");
+    if (str == "RF")
+      _normalization = Normalization::kRF;
+    else if (str == "AF")
+      _normalization = Normalization::kAF;
+    else if (str == "Row")
+      _normalization = Normalization::kRow;
+    else
+      throw DyscoStManError("Unsupported normalization specified");
+    if (spec.description().fieldNumber("studentTNu") >= 0)
+      _studentTNu = spec.asDouble("studentTNu");
+    else
+      _studentTNu = 0.0;
+    _distributionTruncation = spec.asDouble("distributionTruncation");
+  }
+}
+
+void DyscoStMan::makeEmpty() {
+  for (std::unique_ptr<DyscoStManColumn> &col : _columns) {
+    col->shutdown();
+  }
+  _columns.clear();
+}
+
+DyscoStMan::~DyscoStMan() { makeEmpty(); }
+
+casacore::Record DyscoStMan::dataManagerSpec() const {
+  casacore::Record spec;
+  spec.define("dataBitCount", _dataBitCount);
+  spec.define("weightBitCount", _weightBitCount);
+  std::string distStr;
+  switch (_distribution) {
+  case GaussianDistribution:
+    distStr = "Gaussian";
+    break;
+  case UniformDistribution:
+    distStr = "Uniform";
+    break;
+  case StudentsTDistribution:
+    distStr = "StudentsT";
+    break;
+  case TruncatedGaussianDistribution:
+    distStr = "TruncatedGaussian";
+    break;
+  }
+  spec.define("distribution", distStr);
+  std::string normStr;
+  switch (_normalization) {
+  case Normalization::kAF:
+    normStr = "AF";
+    break;
+  case Normalization::kRF:
+    normStr = "RF";
+    break;
+  case Normalization::kRow:
+    normStr = "Row";
+    break;
+  }
+  spec.define("normalization", normStr);
+  spec.define("studentTNu", _studentTNu);
+  spec.define("distributionTruncation", _distributionTruncation);
+  return spec;
+}
+
+void DyscoStMan::registerClass() {
+  DataManager::registerCtor("DyscoStMan", makeObject);
+}
+
+casacore::Bool DyscoStMan::flush(casacore::AipsIO &, casacore::Bool doFsync) {
+  return false;
+}
+
+void DyscoStMan::create(casacore::uInt nRow) {
+  _nRow = nRow;
+  _fStream.reset(new std::fstream(fileName().c_str(),
+                                  std::ios_base::in | std::ios_base::out |
+                                      std::ios_base::trunc));
+  if (_fStream->fail())
+    throw DyscoStManError("I/O error: could not create new file '" +
+                          fileName() + "'");
+  _nBlocksInFile = 0;
+}
+
+void DyscoStMan::writeHeader() {
+  _fStream->seekp(0, std::ios_base::beg);
+  Header header;
+  header.columnCount = _columns.size();
+  header.storageManagerName = _name;
+  header.rowsPerBlock = _rowsPerBlock;
+  header.antennaCount = _antennaCount;
+  header.blockSize = _blockSize;
+  header.versionMajor = VERSION_MAJOR;
+  header.versionMinor = VERSION_MINOR;
+  header.dataBitCount = _dataBitCount;
+  header.weightBitCount = _weightBitCount;
+  header.distribution = _distribution;
+  header.normalization = static_cast<uint8_t>(_normalization);
+  header.studentTNu = _studentTNu;
+  header.distributionTruncation = _distributionTruncation;
+
+  header.columnHeaderOffset = header.calculateColumnHeaderOffset();
+  _headerSize = header.columnHeaderOffset;
+  for (std::unique_ptr<DyscoStManColumn> &col : _columns)
+    _headerSize += sizeof(GenericColumnHeader) + col->ExtraHeaderSize();
+  header.headerSize = _headerSize;
+
+  header.Serialize(*_fStream);
+
+  for (std::unique_ptr<DyscoStManColumn> &col : _columns) {
+    GenericColumnHeader cHeader;
+    cHeader.columnHeaderSize = cHeader.calculateSize() + col->ExtraHeaderSize();
+    cHeader.Serialize(*_fStream);
+    col->SerializeExtraHeader(*_fStream);
+  }
+  if (_fStream->fail())
+    throw DyscoStManError("I/O error: could not write to file");
+}
+
+void DyscoStMan::readHeader() {
+  Header header;
+  _fStream->seekg(0, std::ios_base::beg);
+  header.Unserialize(*_fStream);
+  if (_fStream->fail())
+    throw DyscoStManError("I/O error: could not read file '" + fileName() +
+                          "' -- is the file corrupted?");
+  _headerSize = header.headerSize;
+  size_t curColumnHeaderOffset = header.columnHeaderOffset;
+  size_t columnCount = header.columnCount;
+  _name = header.storageManagerName;
+  _dataBitCount = header.dataBitCount;
+  _weightBitCount = header.weightBitCount;
+  _distribution = (enum DyscoDistribution)header.distribution;
+  _normalization = (enum Normalization)header.normalization;
+  _studentTNu = header.studentTNu;
+  _distributionTruncation = header.distributionTruncation;
+  _rowsPerBlock = header.rowsPerBlock;
+  _antennaCount = header.antennaCount;
+  _blockSize = header.blockSize;
+
+  if (header.versionMajor != 1 || header.versionMinor != 0) {
+    std::stringstream s;
+    s << "The compressed file has file format version " << header.versionMajor
+      << "." << header.versionMinor
+      << ", but this version of Dysco can only open file format version 1.0. "
+         "Upgrade Dysco.\n";
+    throw DyscoStManError(s.str());
+  }
+
+  if (columnCount != _columns.size()) {
+    std::stringstream s;
+    s << "The column count in the DyscoStMan file (" << columnCount
+      << ") does not match with the measurement set (" << _columns.size()
+      << ")";
+    throw DyscoStManError(s.str());
+  }
+
+  for (size_t i = 0; i != _columns.size(); ++i) {
+    DyscoStManColumn &col = *_columns[i];
+    GenericColumnHeader cHeader;
+    _fStream->seekg(curColumnHeaderOffset, std::ios_base::beg);
+    cHeader.Unserialize(*_fStream);
+    col.UnserializeExtraHeader(*_fStream);
+    curColumnHeaderOffset += cHeader.columnHeaderSize;
+  }
+}
+
+void DyscoStMan::initializeRowsPerBlock(size_t rowsPerBlock,
+                                        size_t antennaCount,
+                                        bool writeToHeader) {
+  if (areOffsetsInitialized() &&
+      (rowsPerBlock != _rowsPerBlock || antennaCount != _antennaCount))
+    throw DyscoStManError("initializeRowsPerBlock() called with two different "
+                          "values; something is wrong");
+
+  _rowsPerBlock = rowsPerBlock;
+  _antennaCount = antennaCount;
+  _blockSize = 0;
+  for (std::unique_ptr<DyscoStManColumn> &col : _columns) {
+    size_t columnBlockSize =
+        col->CalculateBlockSize(rowsPerBlock, antennaCount);
+    col->SetOffsetInBlock(_blockSize);
+    _blockSize += columnBlockSize;
+
+    col->InitializeAfterNRowsPerBlockIsKnown();
+  }
+  if (writeToHeader)
+    writeHeader();
+}
+
+void DyscoStMan::open(casacore::uInt nRow, casacore::AipsIO &) {
+  _nRow = nRow;
+  _fStream.reset(new std::fstream(fileName().c_str(),
+                                  std::ios_base::in | std::ios_base::out));
+  if (_fStream->fail()) {
+    _fStream.reset(new std::fstream(fileName().c_str(), std::ios_base::in));
+    if (_fStream->fail())
+      throw DyscoStManError("I/O error: could not open file '" + fileName() +
+                            "', which should be an existing file");
+  }
+
+  readHeader();
+
+  _fStream->seekg(0, std::ios_base::end);
+  if (_fStream->fail())
+    throw DyscoStManError("I/O error: error reading file '" + fileName());
+  std::streampos size = _fStream->tellg();
+  if (size > _headerSize)
+    _nBlocksInFile = (size_t(size) - _headerSize) / _blockSize;
+  else
+    _nBlocksInFile = 0;
+}
+
+casacore::DataManagerColumn *
+DyscoStMan::makeScalarColumn(const casacore::String &name, int dataType,
+                             const casacore::String &dataTypeID) {
+  std::ostringstream s;
+  s << "Can not create scalar columns with DyscoStMan! (requested datatype: '"
+    << dataTypeID << "' (" << dataType << ")";
+  throw DyscoStManError(s.str());
+}
+
+casacore::DataManagerColumn *
+DyscoStMan::makeDirArrColumn(const casacore::String &name, int dataType,
+                             const casacore::String &dataTypeID) {
+  std::unique_ptr<DyscoStManColumn> col;
+
+  if (name == "WEIGHT_SPECTRUM") {
+    if (dataType == casacore::TpFloat)
+      col.reset(new DyscoWeightColumn(this, dataType));
+    else
+      throw DyscoStManError(
+          "Trying to create a Dysco weight column with wrong type");
+  } else if (dataType == casacore::TpComplex) {
+    col.reset(new DyscoDataColumn(this, dataType));
+    if (_staticSeed)
+      static_cast<DyscoDataColumn &>(*col).SetStaticRandomizationSeed();
+  } else
+    throw DyscoStManError(
+        "Trying to create a Dysco data column with wrong type");
+  _columns.push_back(std::move(col));
+  return _columns.back().get();
+}
+
+casacore::DataManagerColumn *
+DyscoStMan::makeIndArrColumn(const casacore::String &name, int dataType,
+                             const casacore::String &dataTypeID) {
+  throw DyscoStManError(
+      "makeIndArrColumn() called on DyscoStMan. DyscoStMan can only created "
+      "direct columns!\nUse casacore::ColumnDesc::Direct as option in your "
+      "column desc constructor");
+}
+
+void DyscoStMan::resync(casacore::uInt nRow) {}
+
+void DyscoStMan::deleteManager() { unlink(fileName().c_str()); }
+
+void DyscoStMan::prepare() {
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  if (_dataBitCount == 0 || _weightBitCount == 0)
+    throw DyscoStManError(
+        "One of the required parameters of the DyscoStMan was not "
+        "set!\nDyscoStMan was not correctly initialized by your program.");
+
+  for (std::unique_ptr<DyscoStManColumn> &col : _columns) {
+    DyscoDataColumn *dataCol = dynamic_cast<DyscoDataColumn *>(col.get());
+    if (dataCol)
+      dataCol->SetBitsPerSymbol(_dataBitCount);
+    else {
+      DyscoWeightColumn *wghtCol = dynamic_cast<DyscoWeightColumn *>(col.get());
+      if (wghtCol)
+        wghtCol->SetBitsPerSymbol(_weightBitCount);
+    }
+    col->Prepare(_distribution, _normalization, _studentTNu,
+                 _distributionTruncation);
+  }
+
+  // In case this is a new measurement set, we do not know the rowsPerBlock yet
+  // If this measurement set is opened, we do know it, and we have to call
+  // initializeRowsPerBlock() to let the columns know this value.
+  if (areOffsetsInitialized())
+    initializeRowsPerBlock(_rowsPerBlock, _antennaCount, false);
+}
+
+void DyscoStMan::reopenRW() {}
+
+void DyscoStMan::addRow(casacore::uInt nrrow) { _nRow += nrrow; }
+
+void DyscoStMan::removeRow(casacore::uInt rowNr) {
+  if (rowNr != _nRow - 1)
+    throw DyscoStManError("Trying to remove a row in the middle of the file: "
+                          "the DyscoStMan does not support this");
+  _nRow--;
+}
+
+void DyscoStMan::addColumn(casacore::DataManagerColumn * /*column*/) {
+  if (_nBlocksInFile != 0)
+    throw DyscoStManError(
+        "Can't add columns while data has been committed to table");
+
+  prepare();
+  writeHeader();
+}
+
+void DyscoStMan::removeColumn(casacore::DataManagerColumn *column) {
+  for (std::vector<std::unique_ptr<DyscoStManColumn>>::iterator i =
+           _columns.begin();
+       i != _columns.end(); ++i) {
+    if (i->get() == column) {
+      _columns.erase(i);
+      writeHeader();
+      return;
+    }
+  }
+  throw DyscoStManError(
+      "Trying to remove column that was not part of the storage manager");
+}
+
+void DyscoStMan::readCompressedData(size_t blockIndex,
+                                    const DyscoStManColumn *column,
+                                    unsigned char *dest, size_t size) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  size_t fileOffset = getFileOffset(blockIndex);
+
+  size_t columnOffset = column->OffsetInBlock();
+  _fStream->seekg(fileOffset + columnOffset, std::ios_base::beg);
+  _fStream->read(reinterpret_cast<char *>(dest), size);
+  if (_fStream->fail()) {
+    // This can be sort of ok ; row exists because other columns have written
+    // here, but no data had been written yet for this column
+    if (blockIndex + 1 != _nBlocksInFile)
+      throw DyscoStManError("I/O error: error while reading file '" +
+                            fileName() + "'");
+    _fStream->clear(); // reset fail bit
+  }
+}
+
+void DyscoStMan::writeCompressedData(size_t blockIndex,
+                                     const DyscoStManColumn *column,
+                                     const unsigned char *data, size_t size) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (_nBlocksInFile <= blockIndex) {
+    _nBlocksInFile = blockIndex + 1;
+  }
+  size_t fileOffset = getFileOffset(blockIndex);
+  _fStream->seekp(fileOffset + column->OffsetInBlock(), std::ios_base::beg);
+  _fStream->write(reinterpret_cast<const char *>(data), size);
+  if (_fStream->fail())
+    throw DyscoStManError("I/O error: error while writing file '" + fileName() +
+                          "'");
+}
+
+} // namespace dyscostman

--- a/tables/Dysco/dyscostman.h
+++ b/tables/Dysco/dyscostman.h
@@ -1,0 +1,405 @@
+#ifndef DYSCO_STORAGE_MANAGER_H
+#define DYSCO_STORAGE_MANAGER_H
+
+#include <casacore/tables/DataMan/DataManager.h>
+
+#include <casacore/casa/Containers/Record.h>
+
+#include <fstream>
+#include <vector>
+
+#include "dyscodistribution.h"
+#include "dysconormalization.h"
+#include "threadgroup.h"
+#include "uvector.h"
+
+/**
+ * @file
+ * Contains DyscoStMan and its global register function
+ * register_dyscostman().
+ *
+ * @defgroup Globals Global functions
+ * Contains the register_dyscostman() function.
+ */
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+extern "C" {
+#endif
+void register_dyscostman();
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+}
+#endif
+
+/**
+ * @author André Offringa
+ */
+namespace dyscostman {
+
+class DyscoStManColumn;
+
+/**
+ * The main class for the Dysco storage manager.
+ */
+class DyscoStMan : public casacore::DataManager {
+public:
+  /**
+   * Convience constructor to create a new storage manager with some settings
+   * without having to fill a 'spec' Record. The storage manager will be
+   * initialized to AF normalization with a truncated Gaussian distribution for
+   * the quantization, and a truncation of sigma = 2.5. To change the settings,
+   * use one of the Set...Distribution() methods and SetNormalization().
+   * @param databitRate The number of bits per float used for visibilities.
+   * @param weightBitRate The number of bits per float used for the weight
+   * column.
+   * @param name Storage manager name.
+   */
+  DyscoStMan(unsigned dataBitRate, unsigned weightBitRate,
+             const casacore::String &name = "DyscoStMan");
+
+  /**
+   * Initialize the storage manager to use a Gaussian distribution for the
+   * quantization. This method should only be called directly after creating
+   * DyscoStMan, before adding columns, and reading/writing data.
+   *
+   * In tests with MWA and LOFAR data, the Gaussian distribution showed lesser
+   * compression accuracy compared to the truncated Gaussian and uniform
+   * distributions.
+   * @see SetUniformDistribution(), SetTruncatedGaussianDistribution()
+   */
+  void SetGaussianDistribution() { _distribution = GaussianDistribution; }
+
+  /**
+   * Initialize the storage manager to use a Uniform distribution for the
+   * quantization (i.e., use a linear quantizer). This method should only be
+   * called directly after creating DyscoStMan, before adding columns, and
+   * reading/writing data.
+   *
+   * In tests with MWA and LOFAR data, the Uniform distribution showed very good
+   * results, only the truncated Gaussian distribution showed better results for
+   * some cases.
+   */
+  void SetUniformDistribution() { _distribution = UniformDistribution; }
+
+  /**
+   * Initialize the storage manager to use a Student T distribution for the
+   * quantization (i.e., use a linear quantizer). This method should only be
+   * called directly after creating DyscoStMan, before adding columns, and
+   * reading/writing data.
+   *
+   * The Student T distribution performed not very well on test sets, and was
+   * mainly added for testing.
+   */
+  void SetStudentsTDistribution(double nu) {
+    _distribution = StudentsTDistribution;
+    _studentTNu = nu;
+  }
+
+  /**
+   * Initialize the storage manager to use a Uniform distribution for the
+   * quantization (i.e., use a linear quantizer). This method should only be
+   * called directly after creating DyscoStMan, before adding columns, and
+   * reading/writing data.
+   *
+   * In tests with MWA and LOFAR data, the truncated Gaussian distribution with
+   * a sigma of 1.5 to 2.5 is the recommended distribution.
+   * @param truncationSigma At which point the distribution is truncated. Good
+   * values are 1.5 to 2.5.
+   */
+  void SetTruncatedGaussianDistribution(double truncationSigma) {
+    _distribution = TruncatedGaussianDistribution;
+    _distributionTruncation = truncationSigma;
+  }
+
+  /**
+   * Set the type of normalization.
+   * This method should only be called directly after creating DyscoStMan,
+   * before adding columns, and reading/writing data.
+   */
+  void SetNormalization(Normalization normalization) {
+    _normalization = normalization;
+  }
+
+  void SetStaticSeed(bool staticSeed) { _staticSeed = staticSeed; }
+
+  /**
+   * This constructor is called by Casa when it needs to create a DyscoStMan.
+   * Casa will call makeObject() that will call this constructor.
+   * When it loads an DyscoStMan for an existing MS, the "spec" parameter
+   * will be empty, thus the class should initialize its properties
+   * by reading them from the file.
+   * The @p spec is used to make a new storage manager with specs similar to
+   * another one.
+   * @param name Name of this storage manager.
+   * @param spec Specs to initialize this class with.
+   */
+  DyscoStMan(const casacore::String &name, const casacore::Record &spec);
+
+  /**
+   * Copy constructor that initializes a storage manager with similar specs.
+   * The columns are not copied: the new manager will be empty.
+   */
+  DyscoStMan(const DyscoStMan &source);
+
+  /** Destructor. */
+  ~DyscoStMan();
+
+  /** Assignment -- new dyscostman takes the settings of the source (but not the
+   * columns and/or data).
+   * @param source Source manager.
+   */
+  DyscoStMan &operator=(const DyscoStMan &source) = delete;
+
+  /** Polymorphical copy constructor, equal to DyscoStMan(const DyscoStMan&).
+   * @returns Empty manager with specs as the source.
+   */
+  virtual casacore::DataManager *clone() const final override {
+    return new DyscoStMan(*this);
+  }
+
+  /** Type of manager
+   * @returns "DyscoStMan". */
+  virtual casacore::String dataManagerType() const final override {
+    return "DyscoStMan";
+  }
+
+  /** Returns the name of this manager as specified during construction. */
+  virtual casacore::String dataManagerName() const final override {
+    return _name;
+  }
+
+  /** Get manager specifications. Includes method settings, etc. Can be used
+   * to make a second storage manager with
+   * @returns Record containing data manager specifications.
+   */
+  virtual casacore::Record dataManagerSpec() const final override;
+
+  /**
+   * Get the number of rows in the measurement set.
+   * @returns Number of rows in the measurement set.
+   */
+  uint getNRow() const { return _nRow; }
+
+  /**
+   * Whether rows can be added.
+   * @returns @c true
+   */
+  virtual casacore::Bool canAddRow() const final override { return true; }
+
+  /**
+   * Whether rows can be removed.
+   * @returns @c true (but only rows at the end can actually be removed)
+   */
+  virtual casacore::Bool canRemoveRow() const final override { return true; }
+
+  /**
+   * Whether columns can be added.
+   * @returns @c true (but restrictions apply; columns can only be added as long
+   * as no writes have been performed on the set).
+   */
+  virtual casacore::Bool canAddColumn() const final override { return true; }
+
+  /**
+   * Whether columns can be removed.
+   * @return @c true (but restrictions apply -- still to be checked)
+   * @todo Describe restrictons
+   */
+  virtual casacore::Bool canRemoveColumn() const final override { return true; }
+
+  /**
+   * Create an object with given name and spec.
+   * This methods gets registered in the DataManager "constructor" map.
+   * The caller has to delete the object. New class will be
+   * initialized via @ref DyscoStMan(const casacore::String& name, const
+   * casacore::Record& spec).
+   * @returns A DyscoStMan with given specs.
+   */
+  static casacore::DataManager *makeObject(const casacore::String &name,
+                                           const casacore::Record &spec) {
+    return new DyscoStMan(name, spec);
+  }
+
+  /**
+   * This function makes the DyscoStMan known to casacore. The function
+   * is necessary for loading the storage manager from a shared library. It
+   * should have this specific name ("register_" + storage manager's name in
+   * lowercase) to be able to be automatically called when the library is
+   * loaded. That function will forward the
+   * call here.
+   */
+  static void registerClass();
+
+protected:
+  /**
+   * The number of rows that are actually stored in the file.
+   * This method is synchronized (i.e., thread-safe).
+   */
+  uint64_t nBlocksInFile() const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _nBlocksInFile;
+  }
+
+  /**
+   * Number of rows in one "time-block", i.e. a sequence of rows that
+   * belong to the same timestep, spw and field.
+   * This value is only available after a first time block was written
+   * (see areOffsetsInitialized()).
+   * @returns Number of measurement set rows in one time block.
+   */
+  size_t nRowsInBlock() const { return _rowsPerBlock; }
+
+  /**
+   * Number of antennae used in a time block. This does not have to be equal
+   * to the number of antennae stored in the measurement set.
+   * This value is only available after a first time block was written
+   * (see areOffsetsInitialized()).
+   * @returns Number of antennae.
+   */
+  size_t nAntennae() const { return _antennaCount; }
+
+  /**
+   * Return index of block that contains the given measurement set row.
+   * This can only be calculated after a first time block was written
+   * (see areOffsetsInitialized()).
+   * @param row A measurement set row.
+   * @returns Block index.
+   */
+  size_t getBlockIndex(uint64_t row) const { return row / _rowsPerBlock; }
+
+  /**
+   * Return the offset of the row within the block.
+   * This can only be calculated after a first time block was written
+   * (see areOffsetsInitialized()).
+   * @see getBlockIndex().
+   * @param row A measurement set row.
+   * @returns offset of row within block.
+   */
+  size_t getRowWithinBlock(uint64_t row) const { return row % _rowsPerBlock; }
+
+  /**
+   * Calculate first measurement set row index of a given block index.
+   * @param block A block index
+   * @returns First measurement set row index of given block.
+   */
+  uint64_t getRowIndex(size_t block) const {
+    return uint64_t(block) * uint64_t(_rowsPerBlock);
+  }
+
+  /**
+   * This method returns @c true when the number of rows per block and the
+   * number of antennae per block are known. This is only the case once the
+   * first time- block was written to the file.
+   * @returns True when the nr of rows per block and antennae are available.
+   */
+  bool areOffsetsInitialized() const { return _rowsPerBlock != 0; }
+
+  /**
+   * To be called by a column once it determines rowsPerBlock and antennaCount.
+   * @param rowsPerBlock Number of measurement set rows in one time block.
+   * @param antennaCount Highest antenna index+1 used in a time block.
+   */
+  void initializeRowsPerBlock(size_t rowsPerBlock, size_t antennaCount,
+                              bool writeToHeader);
+
+private:
+  friend class DyscoStManColumn;
+
+  const static unsigned short VERSION_MAJOR, VERSION_MINOR;
+
+  void readCompressedData(size_t blockIndex, const DyscoStManColumn *column,
+                          unsigned char *dest, size_t size);
+
+  void writeCompressedData(size_t blockIndex, const DyscoStManColumn *column,
+                           const unsigned char *data, size_t size);
+
+  void readHeader();
+
+  void writeHeader();
+
+  void makeEmpty();
+
+  void setFromSpec(const casacore::Record &spec);
+
+  size_t getFileOffset(size_t blockIndex) const {
+    return _blockSize * blockIndex + _headerSize;
+  }
+
+  // Flush and optionally fsync the data.
+  // The AipsIO stream represents the main table file and can be
+  // used by virtual column engines to store SMALL amounts of data.
+  virtual casacore::Bool flush(casacore::AipsIO &,
+                               casacore::Bool doFsync) final override;
+
+  // Let the storage manager create files as needed for a new table.
+  // This allows a column with an indirect array to create its file.
+  virtual void create(casacore::uInt nRow) final override;
+
+  // Open the storage manager file for an existing table.
+  // Return the number of rows in the data file.
+  virtual void open(casacore::uInt nRow, casacore::AipsIO &) final override;
+
+  // Create a column in the storage manager on behalf of a table column.
+  // The caller will NOT delete the newly created object.
+  // Create a scalar column.
+  virtual casacore::DataManagerColumn *
+  makeScalarColumn(const casacore::String &name, int dataType,
+                   const casacore::String &dataTypeID) final override;
+
+  // Create a direct array column.
+  virtual casacore::DataManagerColumn *
+  makeDirArrColumn(const casacore::String &name, int dataType,
+                   const casacore::String &dataTypeID) final override;
+
+  // Create an indirect array column.
+  virtual casacore::DataManagerColumn *
+  makeIndArrColumn(const casacore::String &name, int dataType,
+                   const casacore::String &dataTypeID) final override;
+
+  virtual void resync(casacore::uInt nRow) final override;
+
+  virtual void deleteManager() final override;
+
+  // Prepare the columns, let the data manager initialize itself further.
+  // Prepare is called after create/open has been called for all
+  // columns. In this way one can be sure that referenced columns
+  // are read back and partly initialized.
+  virtual void prepare() final override;
+
+  // Reopen the storage manager files for read/write.
+  virtual void reopenRW() final override;
+
+  // Add rows to the storage manager.
+  virtual void addRow(casacore::uInt nrrow) final override;
+
+  // Delete a row from all columns.
+  virtual void removeRow(casacore::uInt rowNr) final override;
+
+  // Do the final addition of a column.
+  virtual void addColumn(casacore::DataManagerColumn *) final override;
+
+  // Remove a column from the data file.
+  virtual void removeColumn(casacore::DataManagerColumn *) final override;
+
+  uint64_t _nRow;
+  uint64_t _nBlocksInFile;
+  uint32_t _rowsPerBlock;
+  uint32_t _antennaCount;
+  uint32_t _blockSize;
+
+  unsigned _headerSize;
+  mutable std::mutex _mutex;
+  std::unique_ptr<std::fstream> _fStream;
+
+  std::string _name;
+  unsigned _dataBitCount;
+  unsigned _weightBitCount;
+  DyscoDistribution _distribution;
+  Normalization _normalization;
+  double _studentTNu, _distributionTruncation;
+  bool _staticSeed;
+
+  std::vector<std::unique_ptr<DyscoStManColumn>> _columns;
+};
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/dyscostmancol.h
+++ b/tables/Dysco/dyscostmancol.h
@@ -1,0 +1,171 @@
+#ifndef DYSCO_STORAGE_MAN_COLUMN_H
+#define DYSCO_STORAGE_MAN_COLUMN_H
+
+#include "dyscodistribution.h"
+#include "dysconormalization.h"
+
+#include <casacore/tables/DataMan/StManColumn.h>
+
+#include <casa/Arrays/IPosition.h>
+
+#include <map>
+
+#include <stdint.h>
+
+namespace dyscostman {
+
+class DyscoStMan;
+
+/**
+ * Base class for columns of the DyscoStMan.
+ * @author André Dysco
+ */
+class DyscoStManColumn : public casacore::StManColumn {
+public:
+  /**
+   * Constructor, to be overloaded by subclass.
+   * @param parent The parent stman to which this column belongs.
+   * @param dtype The column's type as defined by Casacore.
+   */
+  explicit DyscoStManColumn(DyscoStMan *parent, int dtype)
+      : casacore::StManColumn(dtype), _offsetInBlock(0),
+        _storageManager(parent) {}
+
+  /** Destructor */
+  virtual ~DyscoStManColumn() {}
+
+  /** To be called before destructing the class. */
+  virtual void shutdown() = 0;
+
+  /**
+   * Whether this column is writable
+   * @returns @c true
+   */
+  virtual casacore::Bool isWritable() const override { return true; }
+
+  virtual void Prepare(DyscoDistribution distribution,
+                       Normalization normalization, double studentsTNu,
+                       double distributionTruncation) = 0;
+
+  virtual void InitializeAfterNRowsPerBlockIsKnown() = 0;
+
+  virtual size_t CalculateBlockSize(size_t nRowsInBlock,
+                                    size_t nAntennae) const = 0;
+
+  /**
+   * Get number of bytes needed for column header of this column. This is
+   * excluding the generic column header.
+   * @returns Size of column header
+   */
+  virtual size_t ExtraHeaderSize() const { return 0; }
+
+  virtual void SerializeExtraHeader(std::ostream &stream) const = 0;
+
+  virtual void UnserializeExtraHeader(std::istream &stream) = 0;
+
+  size_t OffsetInBlock() const { return _offsetInBlock; }
+
+  void SetOffsetInBlock(size_t offsetInBlock) {
+    _offsetInBlock = offsetInBlock;
+  }
+
+protected:
+  /** Get the storage manager for this column */
+  DyscoStMan &storageManager() const { return *_storageManager; }
+
+  /**
+   * Read a row of compressed data from the stman file.
+   * @param rowIndex The index of the row to read.
+   * @param dest The destination buffer, should be at least of size Stride().
+   */
+  void readCompressedData(size_t blockIndex, unsigned char *dest, size_t size);
+
+  /**
+   * Write a row of compressed data to the stman file.
+   * @param rowIndex The index of the row to write.
+   * @param data The data buffer containing Stride() bytes.
+   */
+  void writeCompressedData(size_t blockIndex, const unsigned char *data,
+                           size_t size);
+
+  /**
+   * Get the actual number of blocks in the file.
+   */
+  uint64_t nBlocksInFile() const;
+
+  size_t getBlockIndex(uint64_t row) const;
+
+  size_t getRowWithinBlock(uint64_t row) const;
+
+  size_t nRowsInBlock() const;
+
+  size_t nAntennae() const;
+
+  uint64_t getRowIndex(size_t block) const;
+
+  bool areOffsetsInitialized() const;
+
+  void initializeRowsPerBlock(size_t rowsPerBlock, size_t antennaCount);
+
+private:
+  DyscoStManColumn(const DyscoStManColumn &source) = delete;
+  void operator=(const DyscoStManColumn &source) = delete;
+
+  size_t _offsetInBlock;
+  DyscoStMan *_storageManager;
+};
+
+} // namespace dyscostman
+
+#include "dyscostman.h"
+
+namespace dyscostman {
+
+inline void DyscoStManColumn::readCompressedData(size_t blockIndex,
+                                                 unsigned char *dest,
+                                                 size_t size) {
+  _storageManager->readCompressedData(blockIndex, this, dest, size);
+}
+
+inline void DyscoStManColumn::writeCompressedData(size_t blockIndex,
+                                                  const unsigned char *data,
+                                                  size_t size) {
+  _storageManager->writeCompressedData(blockIndex, this, data, size);
+}
+
+inline uint64_t DyscoStManColumn::nBlocksInFile() const {
+  return _storageManager->nBlocksInFile();
+}
+
+inline size_t DyscoStManColumn::getBlockIndex(uint64_t row) const {
+  return _storageManager->getBlockIndex(row);
+}
+
+inline size_t DyscoStManColumn::nRowsInBlock() const {
+  return _storageManager->nRowsInBlock();
+}
+
+inline size_t DyscoStManColumn::nAntennae() const {
+  return _storageManager->nAntennae();
+}
+
+inline uint64_t DyscoStManColumn::getRowIndex(size_t block) const {
+  return _storageManager->getRowIndex(block);
+}
+
+inline size_t DyscoStManColumn::getRowWithinBlock(uint64_t rowIndex) const {
+  return _storageManager->getRowWithinBlock(rowIndex);
+}
+
+inline bool DyscoStManColumn::areOffsetsInitialized() const {
+  return _storageManager->areOffsetsInitialized();
+}
+
+inline void DyscoStManColumn::initializeRowsPerBlock(size_t rowsPerBlock,
+                                                     size_t antennaCount) {
+  _storageManager->initializeRowsPerBlock(rowsPerBlock, antennaCount, true);
+}
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/dyscostmanerror.h
+++ b/tables/Dysco/dyscostmanerror.h
@@ -1,0 +1,24 @@
+#ifndef DYSCO_STMAN_ERROR_H
+#define DYSCO_STMAN_ERROR_H
+
+#include <casacore/tables/DataMan/DataManError.h>
+
+namespace dyscostman {
+
+/**
+ * Represents a runtime exception that occured within the DyscoStMan.
+ */
+class DyscoStManError : public casacore::DataManError {
+public:
+  /** Constructor */
+  DyscoStManError() : casacore::DataManError() {}
+  /** Construct with message.
+   * @param message The exception message. */
+  explicit DyscoStManError(const std::string &message)
+      : casacore::DataManError(
+            message + " -- Error occured inside the Dysco Storage Manager") {}
+};
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/dyscoweightcolumn.cpp
+++ b/tables/Dysco/dyscoweightcolumn.cpp
@@ -1,0 +1,34 @@
+#include "dyscoweightcolumn.h"
+
+namespace dyscostman {
+
+void DyscoWeightColumn::Prepare(DyscoDistribution distribution,
+                                Normalization normalization, double studentsTNu,
+                                double distributionTruncation) {
+  ThreadedDyscoColumn::Prepare(distribution, normalization, studentsTNu,
+                               distributionTruncation);
+  const size_t nPolarizations = shape()[0], nChannels = shape()[1];
+  _encoder.reset(new WeightBlockEncoder(nPolarizations, nChannels,
+                                        1 << getBitsPerSymbol()));
+}
+
+void DyscoWeightColumn::initializeDecode(TimeBlockBuffer<data_t> *buffer,
+                                         const float *metaBuffer, size_t nRow,
+                                         size_t nAntennae) {
+  _encoder->InitializeDecode(metaBuffer);
+}
+
+void DyscoWeightColumn::decode(TimeBlockBuffer<data_t> *buffer,
+                               const unsigned int *data, size_t blockRow,
+                               size_t a1, size_t a2) {
+  _encoder->Decode(*buffer, data, blockRow);
+}
+
+void DyscoWeightColumn::encode(ThreadDataBase *threadData,
+                               TimeBlockBuffer<data_t> *buffer,
+                               float *metaBuffer, symbol_t *symbolBuffer,
+                               size_t nAntennae) {
+  _encoder->Encode(*buffer, metaBuffer, symbolBuffer);
+}
+
+} // namespace dyscostman

--- a/tables/Dysco/dyscoweightcolumn.h
+++ b/tables/Dysco/dyscoweightcolumn.h
@@ -1,0 +1,70 @@
+#ifndef DYSCO_WEIGHT_COLUMN_H
+#define DYSCO_WEIGHT_COLUMN_H
+
+#include "stochasticencoder.h"
+#include "threadeddyscocolumn.h"
+#include "weightblockencoder.h"
+
+namespace dyscostman {
+
+class DyscoStMan;
+
+/**
+ * A column for storing compressed complex values with an approximate Gaussian
+ * distribution.
+ * @author André Offringa
+ */
+class DyscoWeightColumn final : public ThreadedDyscoColumn<float> {
+public:
+  /**
+   * Create a new column. Internally called by DyscoStMan when creating a
+   * new column.
+   */
+  DyscoWeightColumn(DyscoStMan *parent, int dtype)
+      : ThreadedDyscoColumn(parent, dtype) {}
+
+  DyscoWeightColumn(const DyscoWeightColumn &source) = delete;
+
+  void operator=(const DyscoWeightColumn &source) = delete;
+
+  /** Destructor. */
+  virtual ~DyscoWeightColumn() { shutdown(); }
+
+  virtual void Prepare(DyscoDistribution distribution,
+                       Normalization normalization, double studentsTNu,
+                       double distributionTruncation) override;
+
+protected:
+  virtual void initializeDecode(TimeBlockBuffer<data_t> *buffer,
+                                const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) override;
+
+  virtual void decode(TimeBlockBuffer<data_t> *buffer, const symbol_t *data,
+                      size_t blockRow, size_t a1, size_t a2) override;
+
+  virtual std::unique_ptr<ThreadDataBase> initializeEncodeThread() override {
+    return nullptr;
+  }
+
+  virtual void encode(ThreadDataBase *threadData,
+                      TimeBlockBuffer<data_t> *buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t nAntennae) override;
+
+  virtual size_t metaDataFloatCount(size_t nRows, size_t nPolarizations,
+                                    size_t nChannels,
+                                    size_t nAntennae) const override {
+    return _encoder->MetaDataFloatCount();
+  }
+
+  virtual size_t symbolCount(size_t nRowsInBlock, size_t nPolarizations,
+                             size_t nChannels) const override {
+    return _encoder->SymbolCount(nRowsInBlock);
+  }
+
+private:
+  std::unique_ptr<WeightBlockEncoder> _encoder;
+};
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/header.h
+++ b/tables/Dysco/header.h
@@ -1,0 +1,104 @@
+#ifndef DYSCO_HEADER_H
+#define DYSCO_HEADER_H
+
+#include "serializable.h"
+
+#include <stdint.h>
+
+namespace dyscostman {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+struct Header : public Serializable {
+  /** Size of the total header, including column subheaders */
+  uint32_t headerSize;
+  /** Start offset of the column headers */
+  uint32_t columnHeaderOffset;
+  /** Number of columns and column headers */
+  uint32_t columnCount;
+
+  std::string storageManagerName;
+
+  uint32_t rowsPerBlock;
+  uint32_t antennaCount;
+  uint32_t blockSize;
+
+  /** File version number */
+  uint16_t versionMajor, versionMinor;
+
+  uint8_t dataBitCount;
+  uint8_t weightBitCount;
+  uint8_t distribution;
+  uint8_t normalization;
+  double studentTNu, distributionTruncation;
+
+  uint32_t calculateColumnHeaderOffset() const {
+    return 7 * 4 +                             // 6 x uint32 + string length
+           storageManagerName.size() + 2 * 2 + // 2 x uint16
+           4 * 1 +                             // 4 x uint8
+           2 * 8;                              // 2 x double
+  }
+
+  virtual void Serialize(std::ostream &stream) const final override {
+    SerializeToUInt32(stream, headerSize);
+    SerializeToUInt32(stream, columnHeaderOffset);
+    SerializeToUInt32(stream, columnCount);
+    SerializeTo32bString(stream, storageManagerName);
+    SerializeToUInt32(stream, rowsPerBlock);
+    SerializeToUInt32(stream, antennaCount);
+    SerializeToUInt32(stream, blockSize);
+    SerializeToUInt16(stream, versionMajor);
+    SerializeToUInt16(stream, versionMinor);
+    SerializeToUInt8(stream, dataBitCount);
+    SerializeToUInt8(stream, weightBitCount);
+    SerializeToUInt8(stream, distribution);
+    SerializeToUInt8(stream, normalization);
+    SerializeToDouble(stream, studentTNu);
+    SerializeToDouble(stream, distributionTruncation);
+  }
+
+  virtual void Unserialize(std::istream &stream) final override {
+    headerSize = UnserializeUInt32(stream);
+    columnHeaderOffset = UnserializeUInt32(stream);
+    columnCount = UnserializeUInt32(stream);
+
+    Unserialize32bString(stream, storageManagerName);
+
+    rowsPerBlock = UnserializeUInt32(stream);
+    antennaCount = UnserializeUInt32(stream);
+    blockSize = UnserializeUInt32(stream);
+
+    /** File version number */
+    versionMajor = UnserializeUInt16(stream);
+    versionMinor = UnserializeUInt16(stream);
+
+    dataBitCount = UnserializeUInt8(stream);
+    weightBitCount = UnserializeUInt8(stream);
+    distribution = UnserializeUInt8(stream);
+    normalization = UnserializeUInt8(stream);
+    studentTNu = UnserializeDouble(stream);
+    distributionTruncation = UnserializeDouble(stream);
+  }
+
+  // the column headers start here (first generic header, then column specific
+  // header)
+};
+
+struct GenericColumnHeader : public Serializable {
+  /** size of generic header + column specific header */
+  uint32_t columnHeaderSize;
+
+  virtual void Serialize(std::ostream &stream) const override {
+    SerializeToUInt32(stream, columnHeaderSize);
+  }
+
+  virtual void Unserialize(std::istream &stream) override {
+    columnHeaderSize = UnserializeUInt32(stream);
+  }
+
+  virtual uint32_t calculateSize() const { return 4; }
+};
+}
+
+#endif
+
+#endif

--- a/tables/Dysco/rftimeblockencoder.cpp
+++ b/tables/Dysco/rftimeblockencoder.cpp
@@ -1,0 +1,129 @@
+#include "rftimeblockencoder.h"
+#include "stochasticencoder.h"
+
+#include <random>
+
+RFTimeBlockEncoder::RFTimeBlockEncoder(size_t nPol, size_t nChannels)
+    : _nPol(nPol), _nChannels(nChannels), _channelFactors(_nChannels * nPol),
+      _rowFactors(),
+      _ditherDist(
+          dyscostman::StochasticEncoder<double>::GetDitherDistribution()) {}
+
+RFTimeBlockEncoder::~RFTimeBlockEncoder() {}
+
+template <bool UseDithering>
+void RFTimeBlockEncoder::encode(
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    const TimeBlockEncoder::FBuffer &buffer, float *metaBuffer,
+    TimeBlockEncoder::symbol_t *symbolBuffer, size_t antennaCount,
+    std::mt19937 *rnd) {
+  // Note that encoding is performed with doubles
+  std::vector<DBufferRow> data;
+  buffer.ConvertVector<std::complex<double>>(data);
+  const size_t visPerRow = _nPol * _nChannels;
+
+  // Normalize the channels
+  std::vector<RMSMeasurement> channelRMSes(visPerRow);
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i)
+      channelRMSes[i].Include(row.visibilities[i]);
+  }
+  for (DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      double rms = channelRMSes[i].RMS();
+      row.visibilities[i] /= rms;
+    }
+  }
+
+  // Scale every maximum per row to the max level
+  const double maxLevel = gausEncoder.MaxQuantity();
+  for (size_t rowIndex = 0; rowIndex != data.size(); ++rowIndex) {
+    DBufferRow &row = data[rowIndex];
+    ao::uvector<double> maxValPerPol(_nPol, 0.0);
+    for (size_t i = 0; i != visPerRow; ++i) {
+      std::complex<double> v = row.visibilities[i];
+      double m = std::max(std::fabs(v.real()), std::fabs(v.imag()));
+      if (std::isfinite(m))
+        maxValPerPol[i % _nPol] = std::max(maxValPerPol[i % _nPol], m);
+    }
+    for (size_t i = 0; i != visPerRow; ++i) {
+      const double factor = maxValPerPol[i % _nPol] == 0.0
+                                ? 1.0
+                                : maxLevel / maxValPerPol[i % _nPol];
+      row.visibilities[i] *= factor;
+    }
+    for (size_t polIndex = 0; polIndex != _nPol; ++polIndex)
+      metaBuffer[visPerRow + rowIndex * _nPol + polIndex] =
+          maxValPerPol[polIndex] / maxLevel;
+  }
+
+  // Maximize channels
+  ao::uvector<double> maxima(visPerRow, 0.0);
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      std::complex<double> v = row.visibilities[i];
+      double m = std::max(std::fabs(v.real()), std::fabs(v.imag()));
+      if (std::isfinite(m))
+        maxima[i] = std::max(maxima[i], m);
+    }
+  }
+  // Convert the maxima to factors
+  for (size_t i = 0; i != visPerRow; ++i) {
+    if (maxima[i] == 0.0)
+      maxima[i] = 1.0;
+    else
+      maxima[i] = maxLevel / maxima[i];
+    metaBuffer[i] = channelRMSes[i].RMS() / maxima[i];
+  }
+  for (DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i)
+      row.visibilities[i] *= maxima[i];
+  }
+
+  symbol_t *symbolBufferPtr = symbolBuffer;
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      if (UseDithering) {
+        symbolBufferPtr[i * 2] = gausEncoder.EncodeWithDithering(
+            row.visibilities[i].real(), _ditherDist(*rnd));
+        symbolBufferPtr[i * 2 + 1] = gausEncoder.EncodeWithDithering(
+            row.visibilities[i].imag(), _ditherDist(*rnd));
+      } else {
+        symbolBufferPtr[i * 2] = gausEncoder.Encode(row.visibilities[i].real());
+        symbolBufferPtr[i * 2 + 1] =
+            gausEncoder.Encode(row.visibilities[i].imag());
+      }
+    }
+    symbolBufferPtr += visPerRow * 2;
+  }
+}
+
+void RFTimeBlockEncoder::InitializeDecode(const float *metaBuffer, size_t nRow,
+                                          size_t nAntennae) {
+  _channelFactors.assign(metaBuffer, metaBuffer + _nPol * _nChannels);
+  metaBuffer += _nPol * _nChannels;
+  _rowFactors.assign(metaBuffer, metaBuffer + _nPol * nRow);
+}
+
+void RFTimeBlockEncoder::Decode(
+    const dyscostman::StochasticEncoder<float> &gausEncoder,
+    TimeBlockEncoder::FBuffer &buffer,
+    const TimeBlockEncoder::symbol_t *symbolBuffer, size_t blockRow,
+    size_t antenna1, size_t antenna2) {
+  FBufferRow &row = buffer[blockRow];
+  row.antenna1 = antenna1;
+  row.antenna2 = antenna2;
+  row.visibilities.resize(_nChannels * _nPol);
+  std::complex<float> *destination = row.visibilities.data();
+  const symbol_t *srcRowPtr = symbolBuffer + blockRow * SymbolsPerRow();
+  const size_t visPerRow = _nPol * _nChannels;
+  for (size_t i = 0; i != visPerRow; ++i) {
+    double chFactor = _channelFactors[i];
+    double factor = chFactor * _rowFactors[blockRow * _nPol + i % _nPol];
+    destination->real(double(gausEncoder.Decode(*srcRowPtr)) * factor);
+    ++srcRowPtr;
+    destination->imag(double(gausEncoder.Decode(*srcRowPtr)) * factor);
+    ++srcRowPtr;
+    ++destination;
+  }
+}

--- a/tables/Dysco/rftimeblockencoder.h
+++ b/tables/Dysco/rftimeblockencoder.h
@@ -1,0 +1,88 @@
+#ifndef DYSCO_RFTIME_BLOCK_ENCODER_H
+#define DYSCO_RFTIME_BLOCK_ENCODER_H
+
+#include "stochasticencoder.h"
+#include "timeblockbuffer.h"
+#include "uvector.h"
+
+#include <complex>
+#include <random>
+#include <vector>
+
+#include "timeblockencoder.h"
+
+class RFTimeBlockEncoder : public TimeBlockEncoder {
+public:
+  RFTimeBlockEncoder(size_t nPol, size_t nChannels);
+
+  virtual ~RFTimeBlockEncoder() override;
+
+  virtual void
+  EncodeWithDithering(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t antennaCount,
+                      std::mt19937 &rnd) final override {
+    encode<true>(gausEncoder, buffer, metaBuffer, symbolBuffer, antennaCount,
+                 &rnd);
+  }
+
+  virtual void EncodeWithoutDithering(
+      const dyscostman::StochasticEncoder<float> &gausEncoder, FBuffer &buffer,
+      float *metaBuffer, symbol_t *symbolBuffer,
+      size_t antennaCount) final override {
+    encode<false>(gausEncoder, buffer, metaBuffer, symbolBuffer, antennaCount,
+                  0);
+  }
+
+  virtual void InitializeDecode(const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) final override;
+
+  virtual void Decode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, const symbol_t *symbolBuffer,
+                      size_t blockRow, size_t antenna1,
+                      size_t antenna2) final override;
+
+  virtual size_t SymbolCount(size_t nRow, size_t nPol,
+                             size_t nChannels) const final override {
+    return nRow * nChannels * nPol * 2 /*complex*/;
+  }
+
+  virtual size_t SymbolCount(size_t nRow) const final override {
+    return nRow * _nChannels * _nPol * 2 /*complex*/;
+  }
+
+  virtual size_t SymbolsPerRow() const final override {
+    return _nChannels * _nPol * 2 /*complex*/;
+  }
+
+  virtual size_t MetaDataCount(size_t nRow, size_t nPol, size_t nChannels,
+                               size_t nAntennae) const final override {
+    return nPol * (nChannels + nRow);
+  }
+
+  void Normalize(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                 TimeBlockBuffer<std::complex<float>> &buffer,
+                 size_t antennaCount);
+
+private:
+  void calculateAntennaeRMS(const std::vector<DBufferRow> &data,
+                            size_t polIndex, size_t antennaCount);
+
+  template <bool UseDithering>
+  void encode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+              const FBuffer &buffer, float *metaBuffer, symbol_t *symbolBuffer,
+              size_t antennaCount, std::mt19937 *rnd);
+
+  void changeChannelFactor(std::vector<DBufferRow> &data, float *metaBuffer,
+                           size_t visIndex, double factor);
+  void fitToMaximum(std::vector<DBufferRow> &data, float *metaBuffer,
+                    const dyscostman::StochasticEncoder<float> &gausEncoder,
+                    size_t antennaCount);
+
+  size_t _nPol, _nChannels;
+
+  ao::uvector<double> _channelFactors, _rowFactors;
+  std::uniform_int_distribution<unsigned> _ditherDist;
+};
+
+#endif

--- a/tables/Dysco/rowtimeblockencoder.cpp
+++ b/tables/Dysco/rowtimeblockencoder.cpp
@@ -1,0 +1,80 @@
+#include "rowtimeblockencoder.h"
+#include "stochasticencoder.h"
+
+using namespace dyscostman;
+
+RowTimeBlockEncoder::RowTimeBlockEncoder(size_t nPol, size_t nChannels)
+    : _nPol(nPol), _nChannels(nChannels),
+      _ditherDist(StochasticEncoder<float>::GetDitherDistribution()),
+      _rowFactors() {}
+
+void RowTimeBlockEncoder::InitializeDecode(const float *metaBuffer, size_t nRow,
+                                           size_t nAntennae) {
+  _rowFactors.assign(metaBuffer, metaBuffer + nRow);
+}
+
+void RowTimeBlockEncoder::Decode(const StochasticEncoder<float> &gausEncoder,
+                                 FBuffer &buffer, const symbol_t *symbolBuffer,
+                                 size_t blockRow, size_t antenna1,
+                                 size_t antenna2) {
+  FBufferRow &row = buffer[blockRow];
+  row.antenna1 = antenna1;
+  row.antenna2 = antenna2;
+  row.visibilities.resize(_nChannels * _nPol);
+  std::complex<float> *destination = row.visibilities.data();
+  const symbol_t *srcRowPtr = symbolBuffer + blockRow * SymbolsPerRow();
+  const size_t visPerRow = _nPol * _nChannels;
+  for (size_t i = 0; i != visPerRow; ++i) {
+    double factor = _rowFactors[blockRow];
+    destination->real(double(gausEncoder.Decode(*srcRowPtr)) * factor);
+    ++srcRowPtr;
+    destination->imag(double(gausEncoder.Decode(*srcRowPtr)) * factor);
+    ++srcRowPtr;
+    ++destination;
+  }
+}
+
+template <bool UseDithering>
+void RowTimeBlockEncoder::encode(const StochasticEncoder<float> &gausEncoder,
+                                 const FBuffer &buffer, float *metaBuffer,
+                                 symbol_t *symbolBuffer, size_t antennaCount,
+                                 std::mt19937 *rnd) {
+  // Note that encoding is performed with doubles
+  std::vector<DBufferRow> data;
+  buffer.ConvertVector<std::complex<double>>(data);
+  const size_t visPerRow = _nPol * _nChannels;
+
+  // Scale every maximum per row to the max level
+  const double maxLevel = gausEncoder.MaxQuantity();
+  for (size_t rowIndex = 0; rowIndex != data.size(); ++rowIndex) {
+    DBufferRow &row = data[rowIndex];
+    double maxVal = 0.0;
+    for (size_t i = 0; i != visPerRow; ++i) {
+      std::complex<double> v = row.visibilities[i];
+      double m = std::max(std::fabs(v.real()), std::fabs(v.imag()));
+      if (std::isfinite(m))
+        maxVal = std::max(maxVal, m);
+    }
+    const double factor = (maxVal == 0.0) ? 1.0 : maxLevel / maxVal;
+    for (size_t i = 0; i != visPerRow; ++i)
+      row.visibilities[i] *= factor;
+    metaBuffer[rowIndex] = maxVal / maxLevel;
+  }
+
+  symbol_t *symbolBufferPtr = symbolBuffer;
+  for (const DBufferRow &row : data) {
+    for (size_t i = 0; i != visPerRow; ++i) {
+      if (UseDithering) {
+        symbolBufferPtr[i * 2] = gausEncoder.EncodeWithDithering(
+            row.visibilities[i].real(), _ditherDist(*rnd));
+        symbolBufferPtr[i * 2 + 1] = gausEncoder.EncodeWithDithering(
+            row.visibilities[i].imag(), _ditherDist(*rnd));
+      } else {
+        symbolBufferPtr[i * 2] = gausEncoder.Encode(row.visibilities[i].real());
+        symbolBufferPtr[i * 2 + 1] =
+            gausEncoder.Encode(row.visibilities[i].imag());
+      }
+    }
+    symbolBufferPtr += visPerRow * 2;
+  }
+}

--- a/tables/Dysco/rowtimeblockencoder.h
+++ b/tables/Dysco/rowtimeblockencoder.h
@@ -1,0 +1,75 @@
+#ifndef DYSCO_ROW_TIME_BLOCK_ENCODER_H
+#define DYSCO_ROW_TIME_BLOCK_ENCODER_H
+
+#include "stochasticencoder.h"
+#include "timeblockbuffer.h"
+#include "uvector.h"
+
+#include <complex>
+#include <random>
+#include <vector>
+
+#include "timeblockencoder.h"
+
+class RowTimeBlockEncoder : public TimeBlockEncoder {
+public:
+  RowTimeBlockEncoder(size_t nPol, size_t nChannels);
+
+  virtual ~RowTimeBlockEncoder() override {}
+
+  virtual void
+  EncodeWithDithering(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t antennaCount,
+                      std::mt19937 &rnd) final override {
+    encode<true>(gausEncoder, buffer, metaBuffer, symbolBuffer, antennaCount,
+                 &rnd);
+  }
+
+  virtual void EncodeWithoutDithering(
+      const dyscostman::StochasticEncoder<float> &gausEncoder, FBuffer &buffer,
+      float *metaBuffer, symbol_t *symbolBuffer,
+      size_t antennaCount) final override {
+    encode<false>(gausEncoder, buffer, metaBuffer, symbolBuffer, antennaCount,
+                  0);
+  }
+
+  virtual void InitializeDecode(const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) final override;
+
+  virtual void Decode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, const symbol_t *symbolBuffer,
+                      size_t blockRow, size_t antenna1,
+                      size_t antenna2) final override;
+
+  virtual size_t SymbolCount(size_t nRow, size_t nPol,
+                             size_t nChannels) const final override {
+    return nRow * nChannels * nPol * 2 /*complex*/;
+  }
+
+  virtual size_t SymbolCount(size_t nRow) const final override {
+    return nRow * _nChannels * _nPol * 2 /*complex*/;
+  }
+
+  virtual size_t SymbolsPerRow() const final override {
+    return _nChannels * _nPol * 2 /*complex*/;
+  }
+
+  virtual size_t MetaDataCount(size_t nRow, size_t nPol, size_t nChannels,
+                               size_t nAntennae) const final override {
+    return nRow;
+  }
+
+private:
+  template <bool UseDithering>
+  void encode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+              const FBuffer &buffer, float *metaBuffer, symbol_t *symbolBuffer,
+              size_t antennaCount, std::mt19937 *rnd);
+
+  size_t _nPol, _nChannels;
+
+  std::uniform_int_distribution<unsigned> _ditherDist;
+  ao::uvector<double> _rowFactors;
+};
+
+#endif

--- a/tables/Dysco/serializable.h
+++ b/tables/Dysco/serializable.h
@@ -1,0 +1,132 @@
+#ifndef DYSCO_SERIALIZABLE_H
+#define DYSCO_SERIALIZABLE_H
+
+#include <complex>
+#include <iostream>
+
+#include <stdint.h>
+
+class Serializable {
+public:
+  virtual ~Serializable() {}
+  virtual void Serialize(std::ostream &stream) const = 0;
+  virtual void Unserialize(std::istream &stream) = 0;
+
+  template <typename T>
+  static void SerializeToUInt64(std::ostream &stream, T value) {
+    uint64_t val64t = value;
+    stream.write(reinterpret_cast<char *>(&val64t), sizeof(val64t));
+  }
+
+  template <typename T>
+  static void SerializeToUInt32(std::ostream &stream, T value) {
+    uint32_t val32t = value;
+    stream.write(reinterpret_cast<char *>(&val32t), sizeof(val32t));
+  }
+
+  template <typename T>
+  static void SerializeToUInt16(std::ostream &stream, T value) {
+    uint16_t val16t = value;
+    stream.write(reinterpret_cast<char *>(&val16t), sizeof(val16t));
+  }
+
+  template <typename T>
+  static void SerializeToUInt8(std::ostream &stream, T value) {
+    uint8_t val8t = value;
+    stream.write(reinterpret_cast<char *>(&val8t), sizeof(val8t));
+  }
+
+  static void SerializeToBool8(std::ostream &stream, bool value) {
+    uint8_t val8t = value;
+    stream.write(reinterpret_cast<char *>(&val8t), sizeof(val8t));
+  }
+
+  static void SerializeToFloat(std::ostream &stream, float value) {
+    stream.write(reinterpret_cast<char *>(&value), sizeof(value));
+  }
+
+  static void SerializeToDouble(std::ostream &stream, double value) {
+    stream.write(reinterpret_cast<char *>(&value), sizeof(value));
+  }
+
+  static void SerializeToLDouble(std::ostream &stream, long double value) {
+    stream.write(reinterpret_cast<char *>(&value), sizeof(value));
+  }
+
+  static void SerializeToLDoubleC(std::ostream &stream,
+                                  std::complex<long double> value) {
+    stream.write(reinterpret_cast<char *>(&value), sizeof(value));
+  }
+
+  static void SerializeToString(std::ostream &stream, const std::string &str) {
+    SerializeToUInt64(stream, str.size());
+    stream.write(str.c_str(), str.size());
+  }
+
+  static void SerializeTo32bString(std::ostream &stream,
+                                   const std::string &str) {
+    SerializeToUInt32(stream, str.size());
+    stream.write(str.c_str(), str.size());
+  }
+
+  static uint64_t UnserializeUInt64(std::istream &stream) {
+    return Unserialize<uint64_t>(stream);
+  }
+
+  static uint32_t UnserializeUInt32(std::istream &stream) {
+    return Unserialize<uint32_t>(stream);
+  }
+
+  static uint16_t UnserializeUInt16(std::istream &stream) {
+    return Unserialize<uint16_t>(stream);
+  }
+
+  static uint8_t UnserializeUInt8(std::istream &stream) {
+    return Unserialize<uint8_t>(stream);
+  }
+
+  static bool UnserializeBool8(std::istream &stream) {
+    return (bool)Unserialize<uint8_t>(stream);
+  }
+
+  static double UnserializeFloat(std::istream &stream) {
+    return Unserialize<float>(stream);
+  }
+
+  static double UnserializeDouble(std::istream &stream) {
+    return Unserialize<double>(stream);
+  }
+
+  static long double UnserializeLDouble(std::istream &stream) {
+    return Unserialize<long double>(stream);
+  }
+
+  static std::complex<long double> UnserializeLDoubleC(std::istream &stream) {
+    return Unserialize<std::complex<long double>>(stream);
+  }
+
+  static void UnserializeString(std::istream &stream, std::string &destStr) {
+    size_t size = UnserializeUInt64(stream);
+    char *str = new char[size];
+    stream.read(str, size);
+    destStr = std::string(str, size);
+    delete[] str;
+  }
+
+  static void Unserialize32bString(std::istream &stream, std::string &destStr) {
+    size_t size = UnserializeUInt32(stream);
+    char *str = new char[size];
+    stream.read(str, size);
+    destStr = std::string(str, size);
+    delete[] str;
+  }
+
+private:
+  template <typename T> static T Unserialize(std::istream &stream) {
+    T val;
+    stream.read(reinterpret_cast<char *>(&val), sizeof(val));
+    return val;
+  }
+};
+
+#endif

--- a/tables/Dysco/stochasticencoder.cpp
+++ b/tables/Dysco/stochasticencoder.cpp
@@ -1,0 +1,176 @@
+#include "stochasticencoder.h"
+
+#include <gsl/gsl_cdf.h>
+#include <gsl/gsl_sf_erf.h>
+
+#include <cmath>
+#include <limits>
+
+#ifndef M_SQRT2l
+#define M_SQRT2l 1.4142135623730950488016887242096981L
+#endif
+
+namespace dyscostman {
+
+template <typename ValueType>
+inline typename StochasticEncoder<ValueType>::num_t
+StochasticEncoder<ValueType>::cumulative(num_t x) {
+  return num_t(0.5) + num_t(0.5) * gsl_sf_erf(x / num_t(M_SQRT2l));
+}
+
+template <typename ValueType>
+typename StochasticEncoder<ValueType>::num_t
+StochasticEncoder<ValueType>::invCumulative(num_t c, num_t err) {
+  if (c < 0.5)
+    return (-invCumulative(1.0 - c, err));
+  else if (c == 0.5)
+    return 0.0;
+  else if (c == 1.0)
+    return std::numeric_limits<num_t>::infinity();
+  else if (c > 1.0)
+    return std::numeric_limits<num_t>::quiet_NaN();
+
+  num_t x = 1.0;
+  num_t fx = cumulative(x);
+  num_t xLow, xHi;
+  if (fx < c) {
+    do {
+      x *= 2.0;
+      fx = cumulative(x);
+    } while (fx < c);
+    xLow = x * 0.5;
+    xHi = x;
+  } else {
+    xLow = 0.0;
+    xHi = 1.0;
+  }
+  num_t error = xHi;
+  int notConverging = 0;
+  do {
+    x = (xLow + xHi) * 0.5;
+    fx = cumulative(x);
+    if (fx > c)
+      xHi = x;
+    else
+      xLow = x;
+    num_t currErr = std::fabs(fx - c);
+    if (currErr >= error) {
+      ++notConverging;
+      // not converging anymore; stop.
+      if (notConverging > 10)
+        return x;
+    } else
+      notConverging = 0;
+    error = currErr;
+  } while (error > err);
+  return x;
+}
+
+template <typename ValueType>
+StochasticEncoder<ValueType>::StochasticEncoder(size_t quantCount,
+                                                ValueType stddev,
+                                                bool gaussianMapping)
+    : _encDictionary(quantCount - 1), _decDictionary(quantCount - 1) {
+  // The minimum squared error is reached when each quantity gets an equal share
+  // of error The error of a single quantity is \int _-dist ^dist P(x) x^2 dx
+  // The integral of x^2 yields a third order term in the solutions.
+  // The consequence is that it is optimal to quantize to value as given by
+  // uniformly gridding the inverse cumulative normal distribution with a sigma
+  // of sqrt(3).
+  stddev = stddev * std::sqrt(3);
+
+  _decDictionary.reserve(quantCount);
+  typename Dictionary::iterator encItem = _encDictionary.begin();
+  typename Dictionary::iterator decItem = _decDictionary.begin();
+  if (gaussianMapping) {
+    for (size_t i = 0; i != quantCount - 1; ++i) {
+      if (i != 0) {
+        num_t rightBoundary = ((num_t)i) / (num_t)(quantCount - 1);
+        *encItem = stddev * invCumulative(rightBoundary);
+        ++encItem;
+      }
+
+      num_t val = ((num_t)i + num_t(0.5)) / (num_t)(quantCount - 1);
+      *decItem = stddev * invCumulative(val);
+      ++decItem;
+    }
+  } else {
+    for (size_t i = 0; i != quantCount - 1; ++i) {
+      if (i != 0) {
+        num_t rightBoundary = -1.0 + 2.0 * ((num_t)i) / (num_t)(quantCount - 1);
+        *encItem = stddev * rightBoundary;
+        ++encItem;
+      }
+
+      num_t val =
+          -1.0 + 2.0 * ((num_t)i + num_t(0.5)) / (num_t)(quantCount - 1);
+      *decItem = stddev * val;
+      // item.symbol = i;
+      ++decItem;
+    }
+  }
+
+  // Bounding element so that lower_bound always returns a valid symbol
+  // Note that if the input is max, it will be encoded as an inf.
+  *encItem = std::numeric_limits<ValueType>::max();
+
+  // The last encoding quantity will be used for representing non-finite
+  // values. This value is reserved, but outside of the size of the
+  // vector -- somewhat dirty but OK since a uvector is used, for which
+  // we know it behaves OK in this case. This will make sure that
+  // lower_bound() never sees the NaN.
+  *decItem = std::numeric_limits<ValueType>::quiet_NaN();
+}
+
+template <typename ValueType>
+void StochasticEncoder<ValueType>::initializeStudentT(double nu, double rms) {
+  size_t quantCount = _encDictionary.size() + 1;
+  _decDictionary.reserve(quantCount);
+  typename Dictionary::iterator encItem = _encDictionary.begin();
+  typename Dictionary::iterator decItem = _decDictionary.begin();
+  for (size_t i = 0; i != quantCount - 1; ++i) {
+    if (i != 0) {
+      num_t rightBoundary = ((num_t)i) / (num_t)(quantCount - 1);
+      *encItem = gsl_cdf_tdist_Pinv(rightBoundary, nu) * rms;
+      ++encItem;
+    }
+
+    num_t val = ((num_t)i + num_t(0.5)) / (num_t)(quantCount - 1);
+    *decItem = gsl_cdf_tdist_Pinv(val, nu) * rms;
+    ++decItem;
+  }
+  *encItem = std::numeric_limits<ValueType>::max();
+  *decItem = std::numeric_limits<ValueType>::quiet_NaN();
+}
+
+template <typename ValueType>
+void StochasticEncoder<ValueType>::initializeTruncatedGaussian(
+    double truncationValue, double rms) {
+  size_t quantCount = _encDictionary.size() + 1;
+  _decDictionary.reserve(quantCount);
+  typename Dictionary::iterator encItem = _encDictionary.begin();
+  typename Dictionary::iterator decItem = _decDictionary.begin();
+
+  double cdfValueAtTrunc = gsl_cdf_gaussian_P(-truncationValue, 1.0);
+  double factor = 1.0 - 2.0 * cdfValueAtTrunc;
+
+  for (size_t i = 0; i != quantCount - 1; ++i) {
+    if (i != 0) {
+      double rightBoundary = ((num_t)i) / (num_t)(quantCount - 1);
+      double cdfVal = rightBoundary * factor + cdfValueAtTrunc;
+      *encItem = gsl_cdf_gaussian_Pinv(cdfVal, rms);
+      ++encItem;
+    }
+
+    double val = ((num_t)i + num_t(0.5)) / (num_t)(quantCount - 1);
+    double cdfVal = val * factor + cdfValueAtTrunc;
+    *decItem = gsl_cdf_gaussian_Pinv(cdfVal, rms);
+    ++decItem;
+  }
+  *encItem = std::numeric_limits<ValueType>::max();
+  *decItem = std::numeric_limits<ValueType>::quiet_NaN();
+}
+
+template class StochasticEncoder<float>;
+
+} // namespace dyscostman

--- a/tables/Dysco/stochasticencoder.h
+++ b/tables/Dysco/stochasticencoder.h
@@ -1,0 +1,266 @@
+#ifndef DYSCO_STOCHASTIC_ENCODER_H
+#define DYSCO_STOCHASTIC_ENCODER_H
+
+#include "uvector.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace dyscostman {
+
+/**
+ * Lossy encoder for stochastic values.
+ *
+ * This encoder can encode a numeric value represented by a floating point
+ * number (float, double, ...) into an integer value with a given limit.
+ * It can be made to be the least-square error quantization for some
+ * distributions.
+ *
+ * Encoding and decoding have asymetric time complexity / speeds, as decoding
+ * is easier than encoding. Decoding is a single indexing into an array, thus
+ * extremely fast and with constant time complexity. Encoding is a binary
+ * search through the quantizaton values, thus takes O(log quantcount).
+ * Typical performance of encoding is 100 MB/s.
+ *
+ * If the values are encoded into a number of bits which are not divisible by
+ * eight, the BytePacker class can be used to pack the values.
+ *
+ * @author André Offringa (offringa@gmail.com)
+ */
+template <typename ValueType = float> class StochasticEncoder {
+public:
+  /**
+   * Construct encoder for given dictionary size and Gaussian stddev.
+   * This constructor initializes the lookup table, and is therefore
+   * quite slow.
+   * @param quantCount The number of quantization levels, i.e., the dictionary
+   * size. Normally this is 2^bitcount. One quantity will be saved for storing
+   * non-finite values (NaN and infinites).
+   * @param stddev The standard deviation of the data. The closer this value is
+   * to the real stddev, the more accurate the encoder will be.
+   * @param gaussianMapping Used for testing with non-gaussian distributions.
+   */
+  StochasticEncoder(size_t quantCount, ValueType stddev,
+                    bool gaussianMapping = true);
+
+  static StochasticEncoder StudentTEncoder(size_t quantCount, double nu,
+                                           double rms) {
+    StochasticEncoder<ValueType> encoder(quantCount);
+    encoder.initializeStudentT(nu, rms);
+    return encoder;
+  }
+
+  static StochasticEncoder TruncatedGausEncoder(size_t quantCount, double trunc,
+                                                double rms) {
+    StochasticEncoder<ValueType> encoder(quantCount);
+    encoder.initializeTruncatedGaussian(trunc, rms);
+    return encoder;
+  }
+
+  /**
+   * Unsigned integer type used for representing the encoded symbols.
+   */
+  typedef unsigned symbol_t;
+
+  /**
+   * Template type used for representing floating point values that
+   * are to be encoded.
+   */
+  typedef ValueType value_t;
+
+  /**
+   * Get the quantized symbol for the given floating point value.
+   * This method is implemented with a binary search, so takes
+   * O(log N), with N the dictionary size (2^bitcount).
+   * Use Decode() on the returned symbol to get
+   * the decoded value.
+   * @param value Floating point value to be encoded.
+   */
+  symbol_t Encode(ValueType value) const {
+    if (std::isfinite(value))
+      return _encDictionary.symbol(_encDictionary.lower_bound(value));
+    else
+      return QuantizationCount() - 1;
+  }
+
+  static std::uniform_int_distribution<unsigned> GetDitherDistribution() {
+    return std::uniform_int_distribution<unsigned>(0, ((1u << 31) - 1));
+  }
+
+  /**
+   * Get the quantized symbol for the given floating point value.
+   * Dithering is applied, which will cause the average error to
+   * converge to zero, assuming the error is uniformly distributed.
+   * This method is implemented with a binary search, so takes
+   * O(log N), with N the dictionary size (2^bitcount).
+   * Use Decode() on the returned symbol to get
+   * the decoded value.
+   * @param value Floating point value to be encoded.
+   */
+  symbol_t EncodeWithDithering(ValueType value, unsigned ditherValue) const {
+    if (std::isfinite(value)) {
+      const typename Dictionary::const_iterator lowerBound =
+          _decDictionary.lower_bound(value);
+      if (lowerBound == _decDictionary.begin())
+        return _decDictionary.symbol(lowerBound);
+      if (lowerBound == _decDictionary.end())
+        return _decDictionary.symbol(lowerBound - 1);
+      const ValueType rightValue = _decDictionary.value(lowerBound);
+      const ValueType leftValue = _decDictionary.value(lowerBound - 1);
+
+      ValueType ditherMark =
+          ValueType(1u << 31) * (value - leftValue) / (rightValue - leftValue);
+      if (ditherMark > ditherValue)
+        return _decDictionary.symbol(lowerBound);
+      else
+        return _decDictionary.symbol(lowerBound - 1);
+    } else {
+      return _encDictionary.size();
+    }
+  }
+
+  /**
+   * Will return the right boundary of the given symbol.
+   * The right boundary is the smallest value that would not be
+   * quantized to the given symbol anymore. If no such boundary
+   * exists, 0.0 is returned.
+   */
+  value_t RightBoundary(symbol_t symbol) const {
+    if (symbol != _encDictionary.size())
+      return _encDictionary.value(symbol);
+    else
+      return 0.0;
+  }
+
+  /**
+   * Get the centroid value that belongs to the given symbol.
+   * @param symbol Symbol to be decoded
+   * @returns The best estimate of the original value.
+   */
+  ValueType Decode(symbol_t symbol) const {
+    return _decDictionary.value(symbol);
+  }
+
+  size_t QuantizationCount() const { return _decDictionary.size() + 1; }
+
+  ValueType MaxQuantity() const { return _decDictionary.largest_value(); }
+
+  ValueType MinQuantity() const { return _decDictionary.smallest_value(); }
+
+private:
+  explicit StochasticEncoder(size_t quantCount)
+      : _encDictionary(quantCount - 1), _decDictionary(quantCount - 1) {}
+
+  void initializeStudentT(double nu, double rms);
+
+  void initializeTruncatedGaussian(double truncationValue, double rms);
+
+  class Dictionary {
+  public:
+    typedef value_t *iterator;
+    typedef const value_t *const_iterator;
+
+    Dictionary() : _values() {}
+
+    explicit Dictionary(size_t size) : _values(size) {}
+
+    void reserve(size_t size) { _values.reserve(size); }
+
+    void resize(size_t size) { _values.resize(size); }
+
+    /**
+     * Returns an iterator pointing to the first element in the dictionary
+     * that is not less than (i.e. greater or equal to) value.
+     *
+     * This implementation is like @ref lower_bound_fast(), but additionally
+     * assumes the dictionary has at least two elements, avoiding one
+     * comparison.
+     */
+    const_iterator lower_bound(value_t val) const {
+      size_t p = 0, q = _values.size();
+      size_t m = (p + q) / 2;
+      if (_values[m] <= val)
+        p = m;
+      else
+        q = m;
+      while (p + 1 != q) {
+        size_t m = (p + q) / 2;
+        if (_values[m] <= val)
+          p = m;
+        else
+          q = m;
+      }
+      return (_values[p] < val) ? (&_values[q]) : (&_values[p]);
+    }
+
+    /**
+     * Returns an iterator pointing to the first element in the dictionary
+     * that is not less than (i.e. greater or equal to) value.
+     *
+     * This implementation turns out to be slightly faster than the
+     * STL implementation. It performs 10.7 MB/s, vs. 9.0 MB/s for the
+     * STL. 18% faster. Using "unsigned" instead of "size_t" is 5% slower.
+     * (It's not a fair STL comparison, because this implementation
+     * does not check for empty vector).
+     */
+    const_iterator lower_bound_fast(value_t val) const {
+      size_t p = 0, q = _values.size();
+      while (p + 1 != q) {
+        size_t m = (p + q) / 2;
+        if (_values[m] <= val)
+          p = m;
+        else
+          q = m;
+      }
+      return (_values[p] < val) ? (&_values[q]) : (&_values[p]);
+    }
+
+    /**
+     * Below is the first failed result of an attempt to beat the STL in
+     * performance. It turns out to be 13% slower for larger dictionaries,
+     * compared to the STL implementation that is used in the class
+     * above. It performs 7.9 MB/s. 26% compared to the 'fastest' lower_bound.
+     */
+    const_iterator lower_bound_slow(value_t val) const {
+      const value_t *p = &*_values.begin(), *q = p + _values.size();
+      while (p + 1 != q) {
+        // This is a bit inefficient, but (p + q)/2 was not allowed, because
+        // operator+(ptr,ptr) is not allowed.
+        const value_t *m = p + (q - p) / 2;
+        if (*m <= val)
+          p = m;
+        else
+          q = m;
+      }
+      return p;
+    }
+
+    iterator begin() { return &*_values.begin(); }
+    const_iterator begin() const { return &*_values.begin(); }
+    const_iterator end() const { return &*_values.end(); }
+    symbol_t symbol(const_iterator iter) const { return (iter - begin()); }
+    symbol_t largest_symbol() const { return _values.size() - 1; }
+    value_t value(const_iterator iter) const { return *iter; }
+    value_t value(symbol_t sym) const { return _values[sym]; }
+    value_t largest_value() const { return _values.back(); }
+    value_t smallest_value() const { return _values.front(); }
+    size_t size() const { return _values.size(); }
+    size_t capacity(size_t) const { return _values.capacity(); }
+
+  private:
+    ao::uvector<value_t> _values;
+  };
+
+  typedef long double num_t;
+
+  static num_t cumulative(num_t x);
+  static num_t invCumulative(num_t c, num_t err = num_t(1e-13));
+
+  Dictionary _encDictionary;
+  Dictionary _decDictionary;
+};
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/tests/runtests.cpp
+++ b/tables/Dysco/tests/runtests.cpp
@@ -1,0 +1,5 @@
+#define BOOST_TEST_MODULE dysco
+//#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/included/unit_test.hpp>
+

--- a/tables/Dysco/tests/testbytepacking.cpp
+++ b/tables/Dysco/tests/testbytepacking.cpp
@@ -1,0 +1,135 @@
+#include "../bytepacker.h"
+#include "../uvector.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+
+using namespace dyscostman;
+
+BOOST_AUTO_TEST_SUITE(bytepacking)
+
+template<typename T>
+void assertEqualArray(const T *expected, const T *actual, size_t size, const std::string& msg)
+{
+	for(size_t i=0; i!=size; ++i)
+	{
+		if(expected[i] != actual[i])
+		{
+			std::ostringstream str;
+			str << "Failed assertEqualArray() for test " << msg << ": Expected: {" << (int) expected[0];
+			for(size_t j=1; j!=size; ++j)
+				str << ", " << (int) expected[j];
+			str << "} Actual: {" << (int) actual[0];
+			for(size_t j=1; j!=size; ++j)
+				str << ", " << (int) actual[j];
+			str << "}";
+			BOOST_REQUIRE_MESSAGE(expected[i] == actual[i], str.str());
+		}
+	}
+	BOOST_CHECK(expected[0] == actual[0]);
+}
+
+BOOST_AUTO_TEST_CASE( under_and_overflow )
+{
+	const size_t NBITSIZES=8;
+	size_t bitSizes[NBITSIZES] = {2, 3, 4, 6, 8, 10, 12, 16};
+	for(size_t i=0; i!=NBITSIZES; ++i)
+	{
+		for(size_t s=0; s!=12; ++s)
+		{
+			unsigned arr[12] = { 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31 };
+			unsigned expected[13] = {37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37};
+			for(size_t x=0;x!=12;++x)
+				arr[x] &= (1<<bitSizes[i]) - 1;
+	
+			unsigned result[13] = { 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37};
+			unsigned char packed[24], packedOr[24];
+			memset(packed, 39, 24);
+			memset(packedOr, 39, 24);
+			BytePacker::pack(bitSizes[i], packed, arr, s);
+			BytePacker::unpack(bitSizes[i], result, packed, s);
+			for(size_t x=0; x!=s; ++x)
+				expected[x] = arr[x];
+			std::stringstream msg;
+			msg<< "result of pack+unpack (l=" << s << ",bits=" << bitSizes[i] << ')';
+			assertEqualArray(expected, result, 13, msg.str());
+			size_t packedSize = BytePacker::bufferSize(s, bitSizes[i]);
+			assertEqualArray(packedOr, &packed[packedSize], 24-packedSize, "packed not overwritten past length");
+		}
+		
+		unsigned arr2[15];
+		for(size_t x=0; x!=15; ++x)
+			arr2[x] = (1<<bitSizes[i]) - 1;
+		unsigned char packed[30];
+		memset(packed, 0, 30);
+		unsigned result[15];
+		memset(result, 0, 15*sizeof(unsigned));
+		BytePacker::pack(bitSizes[i], packed, arr2, 15);
+		BytePacker::unpack(bitSizes[i], result, packed, 15);
+		std::stringstream msg;
+		msg<< "all bits set (bits=" << bitSizes[i] << ')';
+		assertEqualArray(arr2, result, 15, msg.str());
+	}
+	
+}
+
+
+void testSingle(const ao::uvector<unsigned int>& data, int bitCount)
+{
+	int limit = (1<<bitCount);
+	ao::uvector<unsigned int> trimmedData(data.size()), restoredData(data.size());
+	for(size_t i=0; i!=data.size(); ++i)
+		trimmedData[i] = data[i] % limit;
+	ao::uvector<unsigned char> buffer(BytePacker::bufferSize(trimmedData.size(), bitCount), 0);
+	
+// 	std::cout << "Tested array: [" << trimmedData[0];
+// 	for(size_t i=1; i!=std::min<size_t>(trimmedData.size(), 32); ++i)
+// 		std::cout << ", " << trimmedData[i];
+// 	if(trimmedData.size() > 32) std::cout << ", ...";
+// 	std::cout << "]\n";
+	
+	BytePacker::pack(bitCount, buffer.data(), trimmedData.data(), trimmedData.size());
+	BytePacker::unpack(bitCount, restoredData.data(), buffer.data(), restoredData.size());
+	
+	for(size_t i=0; i!=trimmedData.size(); ++i)
+	{
+		BOOST_REQUIRE_MESSAGE(restoredData[i] == trimmedData[i], "data[" << i << "] was incorrectly unpacked: was " << restoredData[i] << ", should be " << trimmedData[i]);
+	}
+}
+
+void testCombinations(const ao::uvector<unsigned int>& data, int bitCount)
+{
+	for(size_t dataSize=1; dataSize!=std::min<size_t>(32u, data.size()); ++dataSize)
+	{
+		ao::uvector<unsigned int> resizedData(data.begin(), data.begin()+dataSize);
+		testSingle(resizedData, bitCount);
+	}
+	testSingle(data, bitCount);
+	for(size_t dataSize=1; dataSize!=std::min<size_t>(32u, data.size()-1); ++dataSize)
+	{
+		ao::uvector<unsigned int> resizedData(data.begin()+1, data.begin()+dataSize+1);
+		testSingle(resizedData, bitCount);
+	}
+	ao::uvector<unsigned int> resizedData(data.begin()+1, data.end());
+	testSingle(resizedData, bitCount);
+}
+
+const int bitrates[] = {2, 3, 4, 6, 8, 10, 12, 16};
+
+BOOST_AUTO_TEST_CASE( pack_unpack )
+{
+	for(int sample : bitrates)
+	{
+		ao::uvector<unsigned int> testArray{1337, 2, 100, 0};
+		for(int i=0; i!=1000; ++i)
+		{
+			testArray.push_back(i);
+			testArray.push_back(i*37);
+			testArray.push_back(i*20000);
+		}
+		testCombinations(testArray, sample);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tables/Dysco/tests/testdithering.cpp
+++ b/tables/Dysco/tests/testdithering.cpp
@@ -1,0 +1,77 @@
+#include <cmath>
+#include <iostream>
+#include <fstream>
+#include <random>
+
+#include "../stochasticencoder.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace dyscostman;
+
+BOOST_AUTO_TEST_SUITE(dithering)
+
+std::unique_ptr<StochasticEncoder<float>> MakeEncoder()
+{
+	//GausEncoder<float> encoder(256, 1.0, !uniform);
+	return std::unique_ptr<StochasticEncoder<float>>(new StochasticEncoder<float>(StochasticEncoder<float>::StudentTEncoder(256, 1.0, 1.0)));
+}
+
+BOOST_AUTO_TEST_CASE( avg_deviation )
+{
+	std::unique_ptr<StochasticEncoder<float>> encoder = MakeEncoder();
+	
+	constexpr size_t N=12;
+	const double values[] = { -(M_PI), -(M_E), -(M_SQRT2), -1.0, -0.01, 0.0, 0.01, 1.0, M_SQRT2, M_E, M_PI, std::numeric_limits<double>::infinity() };
+	long double sumsUndithered[N];
+	long double sumsDithered[N];
+	for(size_t j=0; j!=N; ++j) {
+		sumsUndithered[j] = 0.0;
+		sumsDithered[j] = 0.0;
+	}
+	std::mt19937 mt;
+	std::uniform_int_distribution<unsigned> distribution = encoder->GetDitherDistribution();
+// 	std::cout << "Input: ";
+// 	for(size_t j=0; j!=N; ++j) std::cout << ' ' << values[j];
+// 	std::cout << "\nDecoded without dithering: ";
+// 	for(size_t j=0; j!=N; ++j) std::cout << ' ' << encoder.Decode(encoder.Encode(values[j]));
+// 	std::cout << "\nDecoded with dithering: ";
+// 	for(size_t j=0; j!=N; ++j) std::cout << ' ' << encoder.Decode(encoder.EncodeWithDithering(values[j], distribution(mt)));
+// 	std::cout << '\n';
+	ao::uvector<double> previousError(N, 10.0);
+	for(size_t i=0; i!=1000000; ++i)
+	{
+		for(size_t j=0; j!=N; ++j)
+		{
+			sumsUndithered[j] += encoder->Decode(encoder->Encode(values[j]));
+			sumsDithered[j] += encoder->Decode(encoder->EncodeWithDithering(values[j], distribution(mt)));
+		}
+		if(i==99 || i==9999 || i==999999)
+		{
+			for(size_t j=0; j!=N; ++j)
+			{
+				BOOST_CHECK_EQUAL(std::isfinite(values[j]), std::isfinite(sumsUndithered[j]));
+				
+				BOOST_CHECK_EQUAL(std::isfinite(values[j]), std::isfinite(sumsDithered[j]));
+				
+				if(std::isfinite(values[j]))
+				{
+					double unditheredError = std::fabs((sumsUndithered[j]/double(i))-values[j]);
+					BOOST_CHECK_LE(unditheredError, std::fabs(values[j]));
+					double ditheredError = std::fabs((sumsDithered[j]/double(i))-values[j]);
+					if(values[j] == 0.0)
+					{
+						BOOST_CHECK_LE(ditheredError, 0.0);
+					}
+					else {
+						BOOST_CHECK_LT(ditheredError, unditheredError);
+						BOOST_CHECK_LT(ditheredError, previousError[j]);
+					}
+					previousError[j] = ditheredError;
+				}
+			}
+		}
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tables/Dysco/tests/testdyscostman.cpp
+++ b/tables/Dysco/tests/testdyscostman.cpp
@@ -1,0 +1,200 @@
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem/operations.hpp>
+
+#include <casacore/tables/Tables/ArrayColumn.h>
+#include <casacore/tables/Tables/Table.h>
+#include <casacore/tables/Tables/TableDesc.h>
+#include <casacore/tables/Tables/SetupNewTab.h>
+#include <casacore/tables/Tables/ArrColDesc.h>
+#include <casacore/tables/Tables/ScaColDesc.h>
+
+#include "../dyscostman.h"
+
+using namespace casacore;
+using namespace dyscostman;
+
+BOOST_AUTO_TEST_SUITE(dyscostman)
+
+casacore::Record GetDyscoSpec()
+{
+	casacore::Record dyscoSpec;
+	dyscoSpec.define ("distribution", "TruncatedGaussian");
+	dyscoSpec.define ("normalization", "AF");
+	dyscoSpec.define ("distributionTruncation", 2.0);
+	dyscoSpec.define ("dataBitCount", 10);
+	dyscoSpec.define ("weightBitCount", 12);
+	return dyscoSpec;
+}
+
+struct TestTableFixture
+{
+	explicit TestTableFixture(size_t nAnt)
+	{
+		casacore::TableDesc tableDesc;
+		IPosition shape(2, 1, 1);
+		casacore::ArrayColumnDesc<casacore::Complex> columnDesc("DATA", "", "DyscoStMan", "", shape);
+		columnDesc.setOptions(casacore::ColumnDesc::Direct | casacore::ColumnDesc::FixedShape);
+		casacore::ScalarColumnDesc<int>
+			ant1Desc("ANTENNA1"),
+			ant2Desc("ANTENNA2"),
+			fieldDesc("FIELD_ID"),
+			dataDescIdDesc("DATA_DESC_ID");
+		casacore::ScalarColumnDesc<double>
+			timeDesc("TIME");
+		tableDesc.addColumn(columnDesc);
+		tableDesc.addColumn(ant1Desc);
+		tableDesc.addColumn(ant2Desc);
+		tableDesc.addColumn(fieldDesc);
+		tableDesc.addColumn(dataDescIdDesc);
+		tableDesc.addColumn(timeDesc);
+		casacore::SetupNewTable setupNewTable("TestTable", tableDesc, casacore::Table::New);
+		
+		register_dyscostman();
+		DataManagerCtor dyscoConstructor = DataManager::getCtor("DyscoStMan");
+		std::unique_ptr<DataManager> dysco(dyscoConstructor("DATA_dm", GetDyscoSpec()));
+		setupNewTable.bindColumn("DATA", *dysco);
+		casacore::Table newTable(setupNewTable);
+		
+		size_t a1 = 0, a2 = 1;
+		double time = 10.0;
+		const size_t nRow = 2*nAnt*(nAnt-1)/2;
+		newTable.addRow(nRow);
+		casacore::ScalarColumn<int>
+			a1Col(newTable, "ANTENNA1"),
+			a2Col(newTable, "ANTENNA2"),
+			fieldCol(newTable, "FIELD_ID"),
+			dataDescIdCol(newTable, "DATA_DESC_ID");
+		casacore::ScalarColumn<double> timeCol(newTable, "TIME");
+		for(size_t i=0; i!=nRow; ++i)
+		{
+			a1Col.put(i, a1);
+			a2Col.put(i, a2);
+			fieldCol.put(i, 0);
+			dataDescIdCol.put(i, 0);
+			timeCol.put(i, time);
+			a2++;
+			if(a2 == nAnt)
+			{
+				++a1;
+				a2=a1+1;
+				if(a2 == nAnt)
+				{
+					a1 = 0;
+					a2 = 1;
+					++time;
+				}
+			}
+		}
+		
+		casacore::ArrayColumn<casacore::Complex> dataCol(newTable, "DATA");
+		for(size_t i=0; i!=nRow; ++i)
+		{
+			casacore::Array<casacore::Complex> arr(shape);
+			*arr.cbegin() = i;
+			dataCol.put(i, arr);
+		}
+	}
+	~TestTableFixture()
+	{
+		boost::filesystem::remove_all("TestTable");
+	}
+};
+
+BOOST_AUTO_TEST_CASE( spec )
+{
+	DyscoStMan dysco(8, 12);
+	Record spec = dysco.dataManagerSpec();
+	BOOST_CHECK_EQUAL(spec.asInt("dataBitCount"), 8);
+	BOOST_CHECK_EQUAL(spec.asInt("weightBitCount"), 12);
+}
+
+BOOST_AUTO_TEST_CASE( name )
+{
+	DyscoStMan dysco1(8, 12, "withparameters");
+	BOOST_CHECK_EQUAL(dysco1.dataManagerType(), "DyscoStMan");
+	BOOST_CHECK_EQUAL(dysco1.dataManagerName(), "withparameters");
+
+	DyscoStMan dysco2("testname", GetDyscoSpec());
+	BOOST_CHECK_EQUAL(dysco2.dataManagerType(), "DyscoStMan");
+	BOOST_CHECK_EQUAL(dysco2.dataManagerName(), "testname");
+	
+	std::unique_ptr<DataManager> dysco3(dysco2.clone());
+	BOOST_CHECK_EQUAL(dysco3->dataManagerType(), "DyscoStMan");
+	BOOST_CHECK_EQUAL(dysco3->dataManagerName(), "testname");
+	
+	register_dyscostman();
+	DataManagerCtor dyscoConstructor = DataManager::getCtor("DyscoStMan");
+	std::unique_ptr<DataManager> dysco4(dyscoConstructor("Constructed", GetDyscoSpec()));
+	BOOST_CHECK_EQUAL(dysco4->dataManagerName(), "Constructed");
+	
+	TestTableFixture fixture(3);
+	casacore::Table table("TestTable");
+	casacore::ArrayColumn<casacore::Complex> dataCol(table, "DATA");
+	DataManager* dm = table.findDataManager("DATA",true);
+	BOOST_CHECK_EQUAL(dm->dataManagerName(), "DATA_dm");
+}
+
+BOOST_AUTO_TEST_CASE( makecolumn )
+{
+	DyscoStMan dysco(8, 12, "mydysco");
+	dysco.createDirArrColumn("DATA", casacore::DataType::TpComplex, "");
+	dysco.createDirArrColumn("WEIGHT_SPECTRUM", casacore::DataType::TpFloat, "");
+	dysco.createDirArrColumn("CORRECTED_DATA", casacore::DataType::TpComplex, "");
+	dysco.createDirArrColumn("ANYTHING", casacore::DataType::TpComplex, "");
+	BOOST_CHECK(true);
+}
+
+BOOST_AUTO_TEST_CASE( maketable )
+{
+	size_t nAnt = 3;
+	TestTableFixture fixture(nAnt);
+	
+	casacore::Table table("TestTable");
+	casacore::ArrayColumn<casacore::Complex> dataCol(table, "DATA");
+	for(size_t i=0; i!=table.nrow(); ++i)
+	{
+		BOOST_CHECK_CLOSE_FRACTION((*dataCol(i).cbegin()).real(), float(i), 1e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( read_past_end )
+{
+	/**
+	 * While reading past the end of a file might seem wrong in any case, it can
+	 * happen that a user reads a line that was not stored yet in the particular
+	 * column, but which does exist in the table. This is valid (and DPPP does this).
+	 */
+	size_t nAnt = 3;
+	TestTableFixture fixture(nAnt);
+	
+	casacore::Table table("TestTable");
+	casacore::ArrayColumn<casacore::Complex> dataCol(table, "DATA");
+	for(size_t i=table.nrow(); i!=table.nrow()*2; ++i)
+	{
+		BOOST_CHECK_CLOSE_FRACTION((*dataCol(i).cbegin()).real(), 0.0, 1e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( readonly )
+{
+	size_t nAnt = 3;
+	TestTableFixture fixture(nAnt);
+	
+	boost::filesystem::directory_iterator end_itr;
+
+	for (boost::filesystem::directory_iterator itr("TestTable/"); itr != end_itr; ++itr)
+	{
+		if (boost::filesystem::is_regular_file(itr->path())) {
+			boost::filesystem::permissions(itr->path(),
+				boost::filesystem::others_read|boost::filesystem::owner_read);
+		}
+	}	
+	casacore::Table table("TestTable");
+	casacore::ArrayColumn<casacore::Complex> dataCol(table, "DATA");
+	for(size_t i=0; i!=table.nrow(); ++i)
+	{
+		BOOST_CHECK_CLOSE_FRACTION((*dataCol(i).cbegin()).real(), float(i), 1e-4);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tables/Dysco/tests/testspecificcases.cpp
+++ b/tables/Dysco/tests/testspecificcases.cpp
@@ -1,0 +1,32 @@
+#include "../aftimeblockencoder.h"
+
+#include <random>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace dyscostman;
+
+BOOST_AUTO_TEST_SUITE(timeblock_encoder)
+
+BOOST_AUTO_TEST_CASE( row_normalization_per_row_accuracy )
+{
+  size_t nPol = 4, nChan = 10, nAntenna = 100, nRow = (nAntenna*(nAntenna+1))/2;
+  std::mt19937 rnd;
+	AFTimeBlockEncoder encoder(nPol, nChan, true);
+	StochasticEncoder<float> gausEncoder(1024, 1.0, false);
+  TimeBlockBuffer<std::complex<float>> buffer(nPol, nChan);
+  std::vector<float> metaBuffer(encoder.MetaDataCount(nRow, nPol, nChan, nAntenna));
+  std::vector<AFTimeBlockEncoder::symbol_t> symbolBuffer;
+  
+  for(size_t ant1=0; ant1!=nAntenna; ++ant1)
+  {
+    for(size_t ant2=ant1; ant2!=nAntenna; ++ant2)
+    {
+      buffer[row].visibilities;
+    }
+  }
+  
+  encoder.EncodeWithDithering(gausEncoder, buffer, metaBuffer.data(), symbolBuffer.data(), nAntenna, rnd);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tables/Dysco/tests/testtimeblockencoder.cpp
+++ b/tables/Dysco/tests/testtimeblockencoder.cpp
@@ -1,0 +1,226 @@
+#include "../aftimeblockencoder.h"
+#include "../dysconormalization.h"
+#include "../rftimeblockencoder.h"
+#include "../rowtimeblockencoder.h"
+#include "../stochasticencoder.h"
+
+#include <random>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace dyscostman;
+
+BOOST_AUTO_TEST_SUITE(timeblock_encoder)
+
+std::unique_ptr<TimeBlockEncoder> CreateEncoder(Normalization blockNormalization, size_t nPol, size_t nChan)
+{
+	switch(blockNormalization)
+	{
+		default:
+    case Normalization::kRF:
+			return std::unique_ptr<TimeBlockEncoder>(new RFTimeBlockEncoder(nPol, nChan));
+		case Normalization::kAF:
+			return std::unique_ptr<TimeBlockEncoder>(new AFTimeBlockEncoder(nPol, nChan, true));
+		case Normalization::kRow:
+			return std::unique_ptr<TimeBlockEncoder>(new RowTimeBlockEncoder(nPol, nChan));
+	}
+}
+
+void TestSimpleExample(Normalization blockNormalization)
+{
+	const size_t nAnt = 4, nChan = 1, nPol = 2, nRow = (nAnt*(nAnt+1)/2);
+	
+	TimeBlockBuffer<std::complex<float>> buffer(nPol, nChan);
+	
+	std::complex<float> data[nChan*nPol];
+	data[0] = 99.0; data[1] = 99.0;
+	buffer.SetData(0, 0, 0, data);
+	data[0] = 10.0; data[1] = std::complex<double>(9.0, 1.0);
+	buffer.SetData(1, 0, 1, data);
+	data[0] = 8.0; data[1] = std::complex<double>(7.0, 2.0);
+	buffer.SetData(2, 0, 2, data);
+	data[0] = 6.0; data[1] = std::complex<double>(5.0, 3.0);
+	buffer.SetData(3, 0, 3, data);
+	data[0] = 99.0; data[1] = 99.0;
+	buffer.SetData(4, 1, 1, data);
+	data[0] = 4.0; data[1] = std::complex<double>(3.0, 4.0);
+	buffer.SetData(5, 1, 2, data);
+	data[0] = 2.0; data[1] = std::complex<double>(1.0, 5.0);
+	buffer.SetData(6, 1, 3, data);
+	data[0] = 99.0; data[1] = 99.0;
+	buffer.SetData(7, 2, 2, data);
+	data[0] = 0.0; data[1] = std::numeric_limits<float>::quiet_NaN();
+	buffer.SetData(8, 2, 3, data);
+	data[0] = 99.0; data[1] = 99.0;
+	buffer.SetData(9, 3, 3, data);
+	const TimeBlockBuffer<std::complex<float>> input(buffer);
+	
+	StochasticEncoder<float> gausEncoder(256, 1.0, false);
+	std::unique_ptr<TimeBlockEncoder> encoder = CreateEncoder(blockNormalization, nPol, nChan);
+	
+	size_t metaDataCount = encoder->MetaDataCount(nRow, nPol, nChan, nAnt);
+	size_t symbolCount = encoder->SymbolCount(nRow);
+	ao::uvector<float> metaBuffer(metaDataCount);
+	ao::uvector<TimeBlockEncoder::symbol_t> symbolBuffer(symbolCount);
+	
+	encoder->EncodeWithoutDithering(gausEncoder, buffer, metaBuffer.data(), symbolBuffer.data(), nAnt);
+	TimeBlockBuffer<std::complex<float>> out(nPol, nChan);
+	out.resize(nRow);
+	std::unique_ptr<TimeBlockEncoder> decoder = CreateEncoder(blockNormalization, nPol, nChan);
+	decoder->InitializeDecode(metaBuffer.data(), nRow, nAnt);
+	size_t rIndex = 0;
+	for(size_t ant1=0; ant1!=nAnt; ++ant1) {
+		for(size_t ant2=ant1; ant2!=nAnt; ++ant2) {
+			decoder->Decode(gausEncoder, out, symbolBuffer.data(), rIndex, ant1, ant2);
+			++rIndex;
+		}
+	}
+	std::complex<float> dataFromOut[nChan*nPol], dataFromIn[nChan*nPol];
+	for(size_t row=0; row!=nRow; row++)
+	{
+		// skip auto-correlations of AF, since these are not saved.
+		out.GetData(row, dataFromOut);
+		input.GetData(row, dataFromIn);
+		if(blockNormalization!=Normalization::kAF || (row != 0 && row != 4 && row != 7 && row != 9))
+		{
+			for(size_t ch=0; ch!=nChan; ++ch)
+			{
+				BOOST_CHECK_MESSAGE(std::norm(dataFromOut[ch]-dataFromIn[ch]) < 0.1, "Output{" << dataFromOut[ch] << "} is close to input{" << dataFromIn[ch] << "} of row " << row << " with normalization " << int(blockNormalization));
+			}
+		}
+	}
+}
+
+void TestTimeBlockEncoder(Normalization blockNormalization)
+{
+	const size_t nAnt = 50, nChan = 64, nPol = 4, nRow = (nAnt*(nAnt+1)/2);
+	
+	TimeBlockBuffer<std::complex<float>> buffer(nPol, nChan);
+	std::mt19937 rnd;
+	std::normal_distribution<float> dist;
+	StochasticEncoder<float> gausEncoder(256, 1.0, false);
+	std::uniform_int_distribution<unsigned> dither = gausEncoder.GetDitherDistribution();
+	
+	dist(rnd);
+	
+	ao::uvector<std::complex<float>> data(nChan * nPol);
+	std::vector<ao::uvector<std::complex<float>>> allData;
+	
+	RMSMeasurement unscaledRMS;
+	double factorSum = 0.0;
+	size_t factorCount = 0;
+	size_t blockRow = 0;
+	for(size_t a1=0; a1!=nAnt; ++a1)
+	{
+		for(size_t a2=a1; a2!=nAnt; ++a2)
+		{
+			for(size_t ch=0; ch!=nChan; ++ch)
+			{
+				for(size_t p=0; p!=nPol; ++p)
+				{
+					std::complex<float> rndVal(dist(rnd), dist(rnd));
+					//std::complex<float> rndVal(1.0, 0.0);
+					float f = 1.0;
+					//float f = float(a1+1) * float(a2+1) * float(p+1);
+					factorSum += f;
+					factorCount++;
+					data[p + ch*nPol] = rndVal * f;
+					
+					std::complex<float> encodedVal(
+						gausEncoder.Decode(gausEncoder.EncodeWithDithering(rndVal.real(), dither(rnd))),
+						gausEncoder.Decode(gausEncoder.EncodeWithDithering(rndVal.imag(), dither(rnd)))
+					);
+					unscaledRMS.Include(encodedVal - rndVal);
+				}
+			}
+			buffer.SetData(blockRow, a1, a2, data.data());
+			allData.push_back(data);
+			++blockRow;
+		}
+	}
+	
+	std::unique_ptr<TimeBlockEncoder> encoder = CreateEncoder(blockNormalization, nPol, nChan);
+
+	const size_t nIter = 25;
+	ao::uvector<float> metaBuffer(encoder->MetaDataCount(nRow, nPol, nChan, nAnt));
+	ao::uvector<unsigned> symbolBuffer(encoder->SymbolCount(nAnt*(nAnt+1)/2));
+	
+	for(size_t i=0; i!=nIter; ++i)
+		encoder->EncodeWithDithering(gausEncoder, buffer, metaBuffer.data(), symbolBuffer.data(), nAnt, rnd);
+		
+	for(size_t i=0; i!=nIter; ++i)
+	{
+		encoder->InitializeDecode(metaBuffer.data(), nRow, nAnt);
+		blockRow = 0;
+		for(size_t a1=0; a1!=nAnt; ++a1)
+		{
+			for(size_t a2=a1; a2!=nAnt; ++a2)
+			{
+				ao::uvector<std::complex<float>> dataOut(nChan * nPol);
+				encoder->Decode(gausEncoder, buffer, symbolBuffer.data(), blockRow, a1, a2);
+				buffer.GetData(blockRow, dataOut.data());
+				++blockRow;
+			}
+		}
+	}
+	
+	RMSMeasurement mEncodingError, mData;
+	size_t index = 0;
+	encoder->InitializeDecode(metaBuffer.data(), nRow, nAnt);
+	blockRow = 0;
+	for(size_t a1=0; a1!=nAnt; ++a1)
+	{
+		for(size_t a2=a1; a2!=nAnt; ++a2)
+		{
+			ao::uvector<std::complex<float>> dataOut(nChan * nPol);
+			encoder->Decode(gausEncoder, buffer, symbolBuffer.data(), blockRow, a1, a2);
+			buffer.GetData(blockRow, dataOut.data());
+			
+			ao::uvector<std::complex<float>>& dataIn = allData[index];
+			for(size_t i=0; i!=nPol*nChan; ++i)
+			{
+				mEncodingError.Include(dataOut[i] - dataIn[i]);
+				mData.Include(dataIn[i]);
+			}
+			
+			++index;
+			++blockRow;
+		}
+	}
+	BOOST_CHECK_LT(mEncodingError.RMS(), mData.RMS()*0.1);
+	/*std::cout << "Gaussian encoding error for unscaled values: " << unscaledRMS.RMS() << '\n';
+	std::cout << "Average factor: " << factorSum / factorCount << '\n';
+	std::cout << "Effective RMS of error: " << mEncoded.RMS() / (factorSum / factorCount) << " ( " << (mEncoded.RMS() / (factorSum / factorCount)) / unscaledRMS.RMS() << " x theoretical)\n";*/
+}
+
+BOOST_AUTO_TEST_CASE( row_normalization_per_row_accuracy )
+{
+	TestSimpleExample(Normalization::kRow);
+}
+
+BOOST_AUTO_TEST_CASE( row_normalization_global_rms_accuracy )
+{
+	TestTimeBlockEncoder(Normalization::kRow);
+}
+
+BOOST_AUTO_TEST_CASE( af_normalization_per_row_accuracy )
+{
+	TestSimpleExample(Normalization::kAF);
+}
+
+BOOST_AUTO_TEST_CASE( af_normalization_global_rms_accuracy )
+{
+	TestTimeBlockEncoder(Normalization::kAF);
+}
+
+BOOST_AUTO_TEST_CASE( rf_normalization_per_row_accuracy )
+{
+	TestSimpleExample(Normalization::kRF);
+}
+
+BOOST_AUTO_TEST_CASE( rf_normalization_global_rms_accuracy )
+{
+	TestTimeBlockEncoder(Normalization::kRF);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tables/Dysco/threadeddyscocolumn.cpp
+++ b/tables/Dysco/threadeddyscocolumn.cpp
@@ -1,0 +1,374 @@
+#include "threadeddyscocolumn.h"
+
+#include "dyscostman.h"
+#include "dyscostmanerror.h"
+
+#include "bytepacker.h"
+#include "threadgroup.h"
+
+#include <casacore/ms/MeasurementSets/MeasurementSet.h>
+#include <casacore/tables/Tables/ScalarColumn.h>
+
+#include <algorithm>
+#include <limits>
+
+namespace dyscostman {
+
+template <typename DataType>
+ThreadedDyscoColumn<DataType>::ThreadedDyscoColumn(DyscoStMan *parent,
+                                                   int dtype)
+    : DyscoStManColumn(parent, dtype), _bitsPerSymbol(0), _ant1Col(),
+      _ant2Col(), _fieldCol(), _packedBlockReadBuffer(),
+      _unpackedSymbolReadBuffer(), _stopThreads(false),
+      _currentBlock(std::numeric_limits<size_t>::max()),
+      _isCurrentBlockChanged(false), _blockSize(0), _antennaCount(0),
+      _timeBlockBuffer() {}
+
+// prepare the class for destruction when the derived class is destructed.
+// this is necessary because the virtual function of the derived class might get
+// called to empty the cache.
+template <typename DataType> void ThreadedDyscoColumn<DataType>::shutdown() {
+  if (_isCurrentBlockChanged)
+    storeBlock();
+
+  stopThreads();
+}
+
+template <typename DataType>
+ThreadedDyscoColumn<DataType>::~ThreadedDyscoColumn() {
+  shutdown();
+}
+
+template <typename DataType> void ThreadedDyscoColumn<DataType>::stopThreads() {
+  std::unique_lock<std::mutex> lock(_mutex);
+
+  if (_threadGroup.empty()) {
+    if (!_cache.empty())
+      throw DyscoStManError(
+          "DyscoStMan is flushed before at least two timeblocks were stored. "
+          "DyscoStMan can not handle this situation.");
+  } else {
+    // Don't stop threads before cache is empty
+    while (!_cache.empty())
+      _cacheChangedCondition.wait(lock);
+
+    // Signal threads to stop
+    _stopThreads = true;
+    _cacheChangedCondition.notify_all();
+
+    // Wait for threads to end
+    lock.unlock();
+    _threadGroup.join_all();
+  }
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::setShapeColumn(
+    const casacore::IPosition &shape) {
+  _shape = shape;
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::loadBlock(size_t blockIndex) {
+  if (blockIndex < nBlocksInFile()) {
+    readCompressedData(blockIndex, _packedBlockReadBuffer.data(), _blockSize);
+    const size_t nPolarizations = _shape[0], nChannels = _shape[1],
+                 nRows = nRowsInBlock(),
+                 nMetaFloats = metaDataFloatCount(nRows, nPolarizations,
+                                                  nChannels, _antennaCount);
+    unsigned char *symbolStart =
+        _packedBlockReadBuffer.data() + nMetaFloats * sizeof(float);
+    BytePacker::unpack(_bitsPerSymbol, _unpackedSymbolReadBuffer.data(),
+                       symbolStart,
+                       symbolCount(nRows, nPolarizations, nChannels));
+    float *metaData = reinterpret_cast<float *>(_packedBlockReadBuffer.data());
+    initializeDecode(_timeBlockBuffer.get(), metaData, nRows, _antennaCount);
+    uint64_t startRow = getRowIndex(blockIndex);
+    _timeBlockBuffer->resize(nRows);
+    for (size_t blockRow = 0; blockRow != nRows; ++blockRow) {
+      int a1 = (*_ant1Col)(startRow + blockRow),
+          a2 = (*_ant2Col)(startRow + blockRow);
+      decode(_timeBlockBuffer.get(), _unpackedSymbolReadBuffer.data(), blockRow,
+             a1, a2);
+    }
+  }
+  _currentBlock = blockIndex;
+  _isCurrentBlockChanged = false;
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::getValues(
+    casacore::uInt rowNr, casacore::Array<DataType> *dataPtr) {
+  if (!areOffsetsInitialized()) {
+    // Trying to read before first block was written -- return zero
+    // TODO if a few rows were written of the first block, those are
+    // incorrectly returned. This is a rare case but can be fixed.
+    for (typename casacore::Array<DataType>::contiter i = dataPtr->cbegin();
+         i != dataPtr->cend(); ++i)
+      *i = DataType();
+  } else {
+    size_t blockIndex = getBlockIndex(rowNr);
+    if (blockIndex >= nBlocksInFile()) {
+      // Trying to read a row that was not stored yet -- return zero
+      for (typename casacore::Array<DataType>::contiter i = dataPtr->cbegin();
+           i != dataPtr->cend(); ++i)
+        *i = DataType();
+    } else {
+      std::unique_lock<std::mutex> lock(_mutex);
+      // Wait until the block to be read is not in the write cache
+      typename cache_t::const_iterator cacheItemPtr = _cache.find(blockIndex);
+      while (cacheItemPtr != _cache.end()) {
+        _cacheChangedCondition.wait(lock);
+        cacheItemPtr = _cache.find(blockIndex);
+      }
+      lock.unlock();
+
+      if (_currentBlock != blockIndex) {
+        if (_isCurrentBlockChanged)
+          storeBlock();
+        loadBlock(blockIndex);
+      }
+
+      // The time block encoder is now initialized and contains the unpacked
+      // block.
+      _timeBlockBuffer->GetData(getRowWithinBlock(rowNr), dataPtr->data());
+    }
+  }
+}
+
+template <typename DataType> void ThreadedDyscoColumn<DataType>::storeBlock() {
+  // Put the data of the current block into the cache so that the parallell
+  // threads can write them
+  std::unique_lock<std::mutex> lock(_mutex);
+  CacheItem *item = new CacheItem(std::move(_timeBlockBuffer));
+  // Wait until there is space available AND the row to be written is not in the
+  // cache
+  typename cache_t::iterator cacheItemPtr = _cache.find(_currentBlock);
+  while (_cache.size() >= maxCacheSize() || cacheItemPtr != _cache.end()) {
+    _cacheChangedCondition.wait(lock);
+    cacheItemPtr = _cache.find(_currentBlock);
+  }
+  _cache.insert(typename cache_t::value_type(_currentBlock, item));
+  _cacheChangedCondition.notify_all();
+  lock.unlock();
+
+  _isCurrentBlockChanged = false;
+  const size_t nPolarizations = _shape[0], nChannels = _shape[1];
+  _timeBlockBuffer.reset(
+      new TimeBlockBuffer<data_t>(nPolarizations, nChannels));
+  //_timeBlockBuffer->SetNAntennae(_antennaCount);
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::putValues(
+    casacore::uInt rowNr, const casacore::Array<DataType> *dataPtr) {
+  if (!areOffsetsInitialized()) {
+    // If the manager did not initialize its offsets yet, then it is determined
+    // from the first "time block" (a block with the same time, field and spw)
+    // that is written into the measurement set.
+    //
+    // This only happens when a new measurement
+    // set was created; if an existing measurement set is opened with at least
+    // one block, then the offsets will be read from the headers.
+    //
+    // A consequence of this is that the first blocks in a new measurement set
+    // are required to be written consecutively.
+    double time = (*_timeCol)(rowNr);
+    int fieldId = (*_fieldCol)(rowNr);
+    int dataDescId = (*_dataDescIdCol)(rowNr);
+    if (_timeBlockBuffer->Empty()) {
+      // This is the first row written
+      _currentBlock = 0;
+      _lastWrittenTime = time;
+      _lastWrittenField = fieldId;
+      _lastWrittenDataDescId = dataDescId;
+    } else if (time != _lastWrittenTime || fieldId != _lastWrittenField ||
+               dataDescId != _lastWrittenDataDescId) {
+      initializeRowsPerBlock(rowNr, _timeBlockBuffer->MaxAntennaIndex() + 1);
+    }
+  }
+
+  const int ant1 = (*_ant1Col)(rowNr), ant2 = (*_ant2Col)(rowNr);
+  if (areOffsetsInitialized()) {
+    const size_t blockIndex = getBlockIndex(rowNr),
+                 blockRow = getRowWithinBlock(rowNr);
+
+    // Is this the first row of a new block?
+    if (blockIndex != _currentBlock) {
+      if (_isCurrentBlockChanged)
+        storeBlock();
+
+      // Load new block
+      loadBlock(blockIndex);
+    }
+    _timeBlockBuffer->SetData(blockRow, ant1, ant2, dataPtr->data());
+  } else {
+    _timeBlockBuffer->SetData(rowNr, ant1, ant2, dataPtr->data());
+  }
+  _isCurrentBlockChanged = true;
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::Prepare(DyscoDistribution distribution,
+                                            Normalization normalization,
+                                            double studentsTNu,
+                                            double distributionTruncation) {
+  stopThreads();
+  casacore::Table &table = storageManager().table();
+  _ant1Col.reset(new casacore::ScalarColumn<int>(table, "ANTENNA1"));
+  _ant2Col.reset(new casacore::ScalarColumn<int>(table, "ANTENNA2"));
+  _fieldCol.reset(new casacore::ScalarColumn<int>(table, "FIELD_ID"));
+  _dataDescIdCol.reset(new casacore::ScalarColumn<int>(table, "DATA_DESC_ID"));
+  _timeCol.reset(new casacore::ScalarColumn<double>(table, "TIME"));
+
+  size_t nPolarizations = _shape[0], nChannels = _shape[1];
+  _timeBlockBuffer.reset(
+      new TimeBlockBuffer<data_t>(nPolarizations, nChannels));
+  if (_antennaCount != 0) {
+    // TODO _timeBlockEncoder->SetNAntennae(_antennaCount);
+  }
+  _currentBlock = std::numeric_limits<size_t>::max();
+}
+
+template <typename DataType>
+size_t ThreadedDyscoColumn<DataType>::defaultThreadCount() const {
+  // Don't spawn more than 8 threads; it causes problems in NDPPP
+  return std::min(8l, sysconf(_SC_NPROCESSORS_ONLN));
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::InitializeAfterNRowsPerBlockIsKnown() {
+  stopThreads();
+  if (_bitsPerSymbol == 0)
+    throw DyscoStManError(
+        "bitsPerSymbol not initialized in ThreadedDyscoColumn");
+
+  _antennaCount = nAntennae();
+  _blockSize = CalculateBlockSize(nRowsInBlock(), _antennaCount);
+  _packedBlockReadBuffer.resize(_blockSize);
+  const size_t nPolarizations = _shape[0], nChannels = _shape[1];
+  _unpackedSymbolReadBuffer.resize(
+      symbolCount(nRowsInBlock(), nPolarizations, nChannels));
+  // TODO _timeBlockEncoder->SetNAntennae(_antennaCount);
+
+  // start the threads
+  size_t threadCount = defaultThreadCount();
+  EncodingThreadFunctor functor;
+  functor.parent = this;
+  _stopThreads = false;
+  for (size_t i = 0; i != threadCount; ++i)
+    _threadGroup.create_thread(functor);
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::encodeAndWrite(
+    size_t blockIndex, const CacheItem &item, unsigned char *packedSymbolBuffer,
+    unsigned int *unpackedSymbolBuffer, ThreadDataBase *threadUserData) {
+  const size_t nPolarizations = _shape[0], nChannels = _shape[1];
+  const size_t metaDataSize =
+      sizeof(float) * metaDataFloatCount(nRowsInBlock(), nPolarizations,
+                                         nChannels, _antennaCount);
+  const size_t nSymbols =
+      symbolCount(nRowsInBlock(), nPolarizations, nChannels);
+
+  float *metaBuffer = reinterpret_cast<float *>(packedSymbolBuffer);
+  unsigned char *binaryBuffer = packedSymbolBuffer + metaDataSize;
+
+  encode(threadUserData, item.encoder.get(), metaBuffer, unpackedSymbolBuffer,
+         _antennaCount);
+
+  BytePacker::pack(_bitsPerSymbol, binaryBuffer, unpackedSymbolBuffer,
+                   nSymbols);
+
+  const size_t binarySize = BytePacker::bufferSize(nSymbols, _bitsPerSymbol);
+  writeCompressedData(blockIndex, packedSymbolBuffer,
+                      metaDataSize + binarySize);
+}
+
+// Continuously write items from the cache into the measurement
+// set untill asked to quit.
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::EncodingThreadFunctor::operator()() {
+  const size_t nPolarizations = parent->_shape[0],
+               nChannels = parent->_shape[1];
+  const size_t nSymbols =
+      parent->symbolCount(parent->nRowsInBlock(), nPolarizations, nChannels);
+
+  std::unique_lock<std::mutex> lock(parent->_mutex);
+  ao::uvector<unsigned char> packedSymbolBuffer(parent->_blockSize);
+  ao::uvector<unsigned> unpackedSymbolBuffer(nSymbols);
+  cache_t &cache = parent->_cache;
+
+  std::unique_ptr<ThreadDataBase> threadUserData =
+      parent->initializeEncodeThread();
+
+  while (!parent->_stopThreads) {
+    typename cache_t::iterator i;
+    bool isItemAvailable = parent->isWriteItemAvailable(i);
+    while (!isItemAvailable && !parent->_stopThreads) {
+      parent->_cacheChangedCondition.wait(lock);
+      isItemAvailable = parent->isWriteItemAvailable(i);
+    }
+
+    if (isItemAvailable) {
+      size_t blockIndex = i->first;
+      CacheItem &item = *i->second;
+      item.isBeingWritten = true;
+
+      lock.unlock();
+      parent->encodeAndWrite(blockIndex, item, &packedSymbolBuffer[0],
+                             &unpackedSymbolBuffer[0], threadUserData.get());
+
+      lock.lock();
+      delete &item;
+      cache.erase(i);
+      parent->_cacheChangedCondition.notify_all();
+    }
+  }
+}
+
+// This function should only be called with a locked mutex
+template <typename DataType>
+bool ThreadedDyscoColumn<DataType>::isWriteItemAvailable(
+    typename cache_t::iterator &i) {
+  i = _cache.begin();
+  while (i != _cache.end() && i->second->isBeingWritten)
+    ++i;
+  return (i != _cache.end());
+}
+
+template <typename DataType>
+size_t
+ThreadedDyscoColumn<DataType>::CalculateBlockSize(size_t nRowsInBlock,
+                                                  size_t nAntennae) const {
+  size_t nPolarizations = _shape[0], nChannels = _shape[1];
+  const size_t metaDataSize =
+      sizeof(float) *
+      metaDataFloatCount(nRowsInBlock, nPolarizations, nChannels, nAntennae);
+  const size_t nSymbols = symbolCount(nRowsInBlock, nPolarizations, nChannels);
+  const size_t binarySize = BytePacker::bufferSize(nSymbols, _bitsPerSymbol);
+  return metaDataSize + binarySize;
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::SerializeExtraHeader(
+    std::ostream &stream) const {
+  Header header;
+  header.antennaCount = _antennaCount;
+  header.blockSize = _blockSize;
+  header.Serialize(stream);
+}
+
+template <typename DataType>
+void ThreadedDyscoColumn<DataType>::UnserializeExtraHeader(
+    std::istream &stream) {
+  Header header;
+  header.Unserialize(stream);
+  _antennaCount = header.antennaCount;
+  _blockSize = header.blockSize;
+}
+
+template class ThreadedDyscoColumn<std::complex<float>>;
+template class ThreadedDyscoColumn<float>;
+
+} // namespace dyscostman

--- a/tables/Dysco/threadeddyscocolumn.h
+++ b/tables/Dysco/threadeddyscocolumn.h
@@ -1,0 +1,255 @@
+#ifndef DYSCO_THREADED_DYSCO_COLUMN_H
+#define DYSCO_THREADED_DYSCO_COLUMN_H
+
+#include <casacore/tables/DataMan/DataManError.h>
+
+#include <casacore/casa/Arrays/IPosition.h>
+#include <casacore/tables/Tables/ScalarColumn.h>
+
+#include <condition_variable>
+#include <cstdint>
+#include <map>
+#include <random>
+
+#include "dyscostmancol.h"
+#include "serializable.h"
+#include "stochasticencoder.h"
+#include "threadgroup.h"
+#include "timeblockbuffer.h"
+
+namespace dyscostman {
+
+class DyscoStMan;
+
+/**
+ * A column for storing compressed values in a threaded way, tailered for the
+ * data and weight columns that use a threaded approach for encoding.
+ * @author André Offringa
+ */
+template <typename DataType>
+class ThreadedDyscoColumn : public DyscoStManColumn {
+public:
+  typedef DataType data_t;
+
+  /**
+   * Create a new column. Internally called by DyscoStMan when creating a
+   * new column.
+   */
+  ThreadedDyscoColumn(DyscoStMan *parent, int dtype);
+
+  ThreadedDyscoColumn(const ThreadedDyscoColumn &source) = delete;
+
+  void operator=(const ThreadedDyscoColumn &source) = delete;
+
+  /** Destructor. */
+  virtual ~ThreadedDyscoColumn();
+
+  /** Set the dimensions of values in this column. */
+  virtual void setShapeColumn(const casacore::IPosition &shape) override;
+
+  /** Get the dimensions of the values in a particular row.
+   * @param rownr The row to get the shape for. */
+  virtual casacore::IPosition shape(casacore::uInt rownr) override {
+    return _shape;
+  }
+
+  /**
+   * Read the values for a particular row. This will read the required
+   * data and decode it.
+   * @param rowNr The row number to get the values for.
+   * @param dataPtr The array of values, which should be a contiguous array.
+   */
+  virtual void
+  getArrayComplexV(casacore::uInt rowNr,
+                   casacore::Array<casacore::Complex> *dataPtr) override {
+    // Note that this method is specialized for std::complex<float> -- the
+    // generic method won't do anything
+    return DyscoStManColumn::getArrayComplexV(rowNr, dataPtr);
+  }
+  virtual void getArrayfloatV(casacore::uInt rowNr,
+                              casacore::Array<float> *dataPtr) override {
+    // Note that this method is specialized for float -- the generic method
+    // won't do anything
+    return DyscoStManColumn::getArrayfloatV(rowNr, dataPtr);
+  }
+
+  /**
+   * Write values into a particular row. This will add the values into the cache
+   * and returns immediately afterwards. A pool of threads will encode the items
+   * in the cache and write them to disk.
+   * @param rowNr The row number to write the values to.
+   * @param dataPtr The data pointer, which should be a contiguous array.
+   */
+  virtual void
+  putArrayComplexV(casacore::uInt rowNr,
+                   const casacore::Array<casacore::Complex> *dataPtr) override {
+    // Note that this method is specialized for std::complex<float> -- the
+    // generic method won't do anything
+    return DyscoStManColumn::putArrayComplexV(rowNr, dataPtr);
+  }
+  virtual void putArrayfloatV(casacore::uInt rowNr,
+                              const casacore::Array<float> *dataPtr) override {
+    // Note that this method is specialized for float -- the generic method
+    // won't do anything
+    return DyscoStManColumn::putArrayfloatV(rowNr, dataPtr);
+  }
+
+  virtual void Prepare(DyscoDistribution distribution,
+                       Normalization normalization, double studentsTNu,
+                       double distributionTruncation) override;
+
+  /**
+   * Prepare this column for reading/writing. Used internally by the stman.
+   */
+  virtual void InitializeAfterNRowsPerBlockIsKnown() override;
+
+  /**
+   * Set the bits per symbol. Should only be called by DyscoStMan.
+   * @param bitsPerSymbol New number of bits per symbol.
+   */
+  void SetBitsPerSymbol(unsigned bitsPerSymbol) {
+    _bitsPerSymbol = bitsPerSymbol;
+  }
+
+  virtual size_t CalculateBlockSize(size_t nRowsInBlock,
+                                    size_t nAntennae) const final override;
+
+  virtual size_t ExtraHeaderSize() const override { return Header::Size(); }
+
+  virtual void SerializeExtraHeader(std::ostream &stream) const final override;
+
+  virtual void UnserializeExtraHeader(std::istream &stream) final override;
+
+protected:
+  class ThreadDataBase {
+  public:
+    virtual ~ThreadDataBase(){};
+  };
+
+  typedef typename TimeBlockBuffer<data_t>::symbol_t symbol_t;
+
+  virtual void initializeDecode(TimeBlockBuffer<data_t> *buffer,
+                                const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) = 0;
+
+  virtual void decode(TimeBlockBuffer<data_t> *buffer, const symbol_t *data,
+                      size_t blockRow, size_t a1, size_t a2) = 0;
+
+  virtual std::unique_ptr<ThreadDataBase> initializeEncodeThread() = 0;
+
+  virtual void encode(ThreadDataBase *threadData,
+                      TimeBlockBuffer<data_t> *buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t nAntennae) = 0;
+
+  virtual size_t metaDataFloatCount(size_t nRow, size_t nPolarizations,
+                                    size_t nChannels,
+                                    size_t nAntennae) const = 0;
+
+  virtual size_t symbolCount(size_t nRowsInBlock, size_t nPolarizations,
+                             size_t nChannels) const = 0;
+
+  virtual void shutdown() override final;
+
+  virtual size_t defaultThreadCount() const;
+
+  size_t getBitsPerSymbol() const { return _bitsPerSymbol; }
+
+  const casacore::IPosition &shape() const { return _shape; }
+
+private:
+  struct CacheItem {
+    CacheItem(std::unique_ptr<TimeBlockBuffer<data_t>> &&encoder_)
+        : encoder(std::move(encoder_)), isBeingWritten(false) {}
+
+    std::unique_ptr<TimeBlockBuffer<data_t>> encoder;
+    bool isBeingWritten;
+  };
+
+  struct EncodingThreadFunctor {
+    void operator()();
+    ThreadedDyscoColumn *parent;
+  };
+  struct Header : public Serializable {
+    uint32_t blockSize;
+    uint32_t antennaCount;
+
+    static uint32_t Size() { return 8; }
+
+    virtual void Serialize(std::ostream &stream) const override {
+      SerializeToUInt32(stream, blockSize);
+      SerializeToUInt32(stream, antennaCount);
+    }
+
+    virtual void Unserialize(std::istream &stream) override {
+      blockSize = UnserializeUInt32(stream);
+      antennaCount = UnserializeUInt32(stream);
+    }
+  };
+
+  typedef std::map<size_t, CacheItem *> cache_t;
+
+  void getValues(casacore::uInt rowNr, casacore::Array<data_t> *dataPtr);
+  void putValues(casacore::uInt rowNr, const casacore::Array<data_t> *dataPtr);
+
+  void stopThreads();
+  void encodeAndWrite(size_t blockIndex, const CacheItem &item,
+                      unsigned char *packedSymbolBuffer,
+                      unsigned int *unpackedSymbolBuffer,
+                      ThreadDataBase *threadUserData);
+  bool isWriteItemAvailable(typename cache_t::iterator &i);
+  void loadBlock(size_t blockIndex);
+  void storeBlock();
+  size_t maxCacheSize() const {
+    return ThreadedDyscoColumn::defaultThreadCount() * 12 / 10 + 1;
+  }
+
+  unsigned _bitsPerSymbol;
+  casacore::IPosition _shape;
+  std::unique_ptr<casacore::ScalarColumn<int>> _ant1Col, _ant2Col, _fieldCol,
+      _dataDescIdCol;
+  std::unique_ptr<casacore::ScalarColumn<double>> _timeCol;
+  double _lastWrittenTime;
+  int _lastWrittenField, _lastWrittenDataDescId;
+  ao::uvector<unsigned char> _packedBlockReadBuffer;
+  ao::uvector<unsigned int> _unpackedSymbolReadBuffer;
+  cache_t _cache;
+  bool _stopThreads;
+  std::mutex _mutex;
+  threadgroup _threadGroup;
+  std::condition_variable _cacheChangedCondition;
+  size_t _currentBlock;
+  bool _isCurrentBlockChanged;
+  size_t _blockSize;
+  size_t _antennaCount;
+
+  std::unique_ptr<TimeBlockBuffer<data_t>> _timeBlockBuffer;
+};
+
+template <>
+inline void ThreadedDyscoColumn<std::complex<float>>::getArrayComplexV(
+    casacore::uInt rowNr, casacore::Array<casacore::Complex> *dataPtr) {
+  getValues(rowNr, dataPtr);
+}
+template <>
+inline void ThreadedDyscoColumn<std::complex<float>>::putArrayComplexV(
+    casacore::uInt rowNr, const casacore::Array<casacore::Complex> *dataPtr) {
+  putValues(rowNr, dataPtr);
+}
+template <>
+inline void
+ThreadedDyscoColumn<float>::getArrayfloatV(casacore::uInt rowNr,
+                                           casacore::Array<float> *dataPtr) {
+  getValues(rowNr, dataPtr);
+}
+template <>
+inline void ThreadedDyscoColumn<float>::putArrayfloatV(
+    casacore::uInt rowNr, const casacore::Array<float> *dataPtr) {
+  putValues(rowNr, dataPtr);
+}
+
+extern template class ThreadedDyscoColumn<std::complex<float>>;
+extern template class ThreadedDyscoColumn<float>;
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/threadgroup.h
+++ b/tables/Dysco/threadgroup.h
@@ -1,0 +1,52 @@
+#ifndef DYSCO_THREADGROUP_H
+#define DYSCO_THREADGROUP_H
+
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace dyscostman {
+
+/**
+ * Group of threads.
+ */
+class threadgroup {
+public:
+  /** Constructor */
+  threadgroup() {}
+  /** Destructor. Will join all threads that have not been joined yet. */
+  ~threadgroup() { join_all(); }
+
+  /**
+   * Create a new thread that will execute the given functor. The new thread
+   * will be added to the group.
+   * @param threadFunc The functor to be called.
+   */
+  template <typename T> void create_thread(T threadFunc) {
+    _threads.emplace_back(threadFunc);
+  }
+
+  /**
+   * Join all threads in the group that have not yet been joined.
+   */
+  void join_all() {
+    for (std::thread &t : _threads) {
+      t.join();
+    }
+    _threads.clear();
+  }
+
+  /**
+   * Get state of thread group.
+   * @returns true when there are unjoined threads in the group. Not
+   * synchronized -- caller has to make sure that thread is safe.
+   */
+  bool empty() const { return _threads.empty(); }
+
+private:
+  std::vector<std::thread> _threads;
+};
+
+} // namespace dyscostman
+
+#endif

--- a/tables/Dysco/timeblockbuffer.h
+++ b/tables/Dysco/timeblockbuffer.h
@@ -1,0 +1,82 @@
+#ifndef DYSCO_TIME_BLOCK_BUFFER_H
+#define DYSCO_TIME_BLOCK_BUFFER_H
+
+#include "uvector.h"
+
+#include <complex>
+#include <vector>
+
+template <typename data_t> class TimeBlockBuffer {
+public:
+  typedef unsigned symbol_t;
+
+  TimeBlockBuffer(size_t nPol, size_t nChannels)
+      : _nPol(nPol), _nChannels(nChannels) {}
+
+  bool Empty() const { return _data.empty(); }
+
+  void resize(size_t nRows) { _data.resize(nRows); }
+
+  struct DataRow {
+    size_t antenna1, antenna2;
+    std::vector<data_t> visibilities;
+  };
+
+  DataRow &operator[](size_t rowIndex) { return _data[rowIndex]; }
+
+  void ResetData() { _data.clear(); }
+
+  void SetData(size_t blockRow, size_t antenna1, size_t antenna2,
+               const data_t *data) {
+    if (_data.size() <= blockRow)
+      _data.resize(blockRow + 1);
+    DataRow &newRow = _data[blockRow];
+    newRow.antenna1 = antenna1;
+    newRow.antenna2 = antenna2;
+    newRow.visibilities.resize(_nPol * _nChannels);
+    for (size_t i = 0; i != _nPol * _nChannels; ++i)
+      newRow.visibilities[i] = data[i];
+  }
+
+  void GetData(size_t blockRow, data_t *destination) const {
+    const data_t *srcPtr = _data[blockRow].visibilities.data();
+    memcpy(destination, srcPtr,
+           sizeof(data_t) * _data[blockRow].visibilities.size());
+  }
+
+  size_t NRows() const { return _data.size(); }
+
+  size_t MaxAntennaIndex() const {
+    size_t maxAntennaIndex = 0;
+    for (const DataRow &row : _data) {
+      maxAntennaIndex =
+          std::max(maxAntennaIndex, std::max(row.antenna1, row.antenna2));
+    }
+    return maxAntennaIndex;
+  }
+
+  const std::vector<DataRow> &GetVector() const { return _data; }
+  std::vector<DataRow> &GetVector() { return _data; }
+
+  template <typename other_t>
+  void ConvertVector(
+      std::vector<typename TimeBlockBuffer<other_t>::DataRow> &vector) const {
+    vector.resize(_data.size());
+    for (size_t i = 0; i != _data.size(); ++i) {
+      const DataRow &rowIn = _data[i];
+      typename TimeBlockBuffer<other_t>::DataRow &rowOut = vector[i];
+      rowOut.antenna1 = rowIn.antenna1;
+      rowOut.antenna2 = rowIn.antenna2;
+      rowOut.visibilities.assign(rowIn.visibilities.begin(),
+                                 rowIn.visibilities.end());
+    }
+  }
+
+private:
+  size_t _nPol, _nChannels;
+  std::vector<DataRow> _data;
+};
+
+template class TimeBlockBuffer<std::complex<float>>;
+
+#endif

--- a/tables/Dysco/timeblockencoder.h
+++ b/tables/Dysco/timeblockencoder.h
@@ -1,0 +1,76 @@
+#ifndef DYSCO_TIME_BLOCK_ENCODER_H
+#define DYSCO_TIME_BLOCK_ENCODER_H
+
+#include "stochasticencoder.h"
+#include "timeblockbuffer.h"
+#include "uvector.h"
+
+#include <complex>
+#include <random>
+#include <vector>
+
+class RMSMeasurement {
+public:
+  RMSMeasurement() : _count(0), _value(0.0) {}
+
+  void Include(const std::complex<double> &val) {
+    if (isfinite(val)) {
+      _count++;
+      _value += val.real() * val.real() + val.imag() * val.imag();
+    }
+  }
+
+  double RMS() const { return sqrt(_value / (_count * 2)); }
+
+private:
+  static bool isfinite(const std::complex<double> &val) {
+    return std::isfinite(val.real()) && std::isfinite(val.imag());
+  }
+
+  size_t _count;
+  double _value;
+};
+
+class TimeBlockEncoder {
+public:
+  typedef TimeBlockBuffer<std::complex<float>> FBuffer;
+  typedef typename TimeBlockBuffer<std::complex<float>>::DataRow FBufferRow;
+  typedef TimeBlockBuffer<std::complex<double>> DBuffer;
+  typedef typename TimeBlockBuffer<std::complex<double>>::DataRow DBufferRow;
+
+  typedef unsigned symbol_t;
+
+  virtual ~TimeBlockEncoder() {}
+
+  virtual void
+  EncodeWithDithering(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, float *metaBuffer,
+                      symbol_t *symbolBuffer, size_t antennaCount,
+                      std::mt19937 &rnd) = 0;
+
+  virtual void EncodeWithoutDithering(
+      const dyscostman::StochasticEncoder<float> &gausEncoder, FBuffer &buffer,
+      float *metaBuffer, symbol_t *symbolBuffer, size_t antennaCount) = 0;
+
+  virtual void InitializeDecode(const float *metaBuffer, size_t nRow,
+                                size_t nAntennae) = 0;
+
+  virtual void Decode(const dyscostman::StochasticEncoder<float> &gausEncoder,
+                      FBuffer &buffer, const symbol_t *symbolBuffer,
+                      size_t blockRow, size_t antenna1, size_t antenna2) = 0;
+
+  virtual size_t SymbolCount(size_t nRow, size_t nPol,
+                             size_t nChannels) const = 0;
+
+  virtual size_t SymbolCount(size_t nRow) const = 0;
+
+  virtual size_t SymbolsPerRow() const = 0;
+
+  virtual size_t MetaDataCount(size_t nRow, size_t nPol, size_t nChannels,
+                               size_t nAntennae) const = 0;
+
+protected:
+  TimeBlockEncoder() {}
+};
+
+#endif

--- a/tables/Dysco/uvector.h
+++ b/tables/Dysco/uvector.h
@@ -1,0 +1,1244 @@
+#ifndef AO_UVECTOR_H
+#define AO_UVECTOR_H
+
+#include <algorithm>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <stdexcept>
+
+/**
+ * @file uvector.h
+ * Header file for uvector and its relational and swap functions.
+ * @author André Offringa
+ * @copyright André Offringa, 2013, distributed under the GPL license version 3.
+ */
+
+namespace ao {
+
+/**
+ * @defgroup uvector Class uvector and related functions.
+ * @{
+ */
+
+/**
+ * @brief A container similar to std::vector, but one that allows construction without initializing its elements.
+ * @details This container is similar to a std::vector, except that it can be constructed without
+ * initializing its elements. This saves the overhead of initialization, hence the
+ * constructor @ref uvector(size_t) is significantly faster than the corresponding std::vector
+ * constructor, and has no overhead compared to a manually allocated array.
+ * 
+ * Probably its greatest strength lies in the construction of containers with a number of elements
+ * that is runtime defined, but that will be initialized later. For example:
+ * 
+ * @code
+ * // Open a file
+ * ifstream file("myfile.bin");
+ * 
+ * // Construct a buffer for this file
+ * uvector<char> buffer(buffer_size);
+ * 
+ * // Read some data into the buffer
+ * file.read(&buffer[0], buffer_size);
+ * @endcode
+ * 
+ * However, it has a few more use-cases with improved performance over std::vector. This is
+ * possible because of more strengent requirements on the element's type.
+ * 
+ * The container will behave correctly with any trivial type, but will not work for almost
+ * all non-trivial types.
+ * 
+ * The methods with different semantics compared to std::vector are:
+ * * @ref uvector(size_t n)
+ * * @ref resize(size_t n)
+ * 
+ * Also the following new members are introduced:
+ * * @ref insert_uninitialized(const_iterator position, size_t n)
+ * * @ref push_back(InputIterator first, InputIterator last)
+ * * @ref push_back(size_t n, const Tp& val)
+ * * @ref push_back(std::initializer_list<Tp> initlist)
+ * * @ref push_back_uninitialized(size_t n)
+ * 
+ * All other members work exactly like std::vector's members, although some are slightly faster because of
+ * the stricter requirements on the element type.
+ * 
+ * @tparam Tp Container's element type
+ * @tparam Alloc Allocator type. Default is to use the std::allocator.
+ * 
+ * @author André Offringa
+ * @copyright André Offringa, 2013, distributed under the GPL license version 3.
+ */
+template<typename Tp, typename Alloc = std::allocator<Tp> >
+class uvector : private Alloc
+{
+	static_assert(std::is_standard_layout<Tp>(), "A uvector can only hold classes with standard layout");
+private:
+#if __cplusplus > 201402L
+	typedef std::allocator_traits<allocator_type>::is_always_equal allocator_is_always_equal;
+#else
+	typedef std::false_type allocator_is_always_equal;
+#endif
+public:
+	/// Element type
+	typedef Tp value_type;
+	/// Type of allocator used to allocate and deallocate space
+	typedef Alloc allocator_type;
+	/// Reference to element type
+	typedef Tp& reference;
+	/// Constant reference to element type
+	typedef const Tp& const_reference;
+	/// Pointer to element type
+	typedef Tp* pointer;
+	/// Pointer to constant element type
+	typedef const Tp* const_pointer;
+	/// Iterator type
+	typedef Tp* iterator;
+	/// Iterator type of constant elements
+	typedef const Tp* const_iterator;
+	/// Reverse iterator type
+	typedef std::reverse_iterator<iterator> reverse_iterator;
+	/// Reverse iterator of constant elements
+	typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+	/// Difference between to iterators
+	typedef std::ptrdiff_t difference_type;
+	/// Type used for indexing elements
+	typedef std::size_t size_t;
+	/// Type used for indexing elements
+	typedef std::size_t size_type;
+	
+private:
+	pointer _begin, _end, _endOfStorage;
+	
+public:
+	/** @brief Construct an empty uvector.
+	 * @param allocator Allocator used for allocating and deallocating memory.
+	 */
+	explicit uvector(const allocator_type& allocator = Alloc()) noexcept
+	: Alloc(allocator), _begin(nullptr), _end(nullptr), _endOfStorage(nullptr)
+	{
+	}
+	
+	/** @brief Construct a vector with given amount of elements, without initializing these.
+	 * @details This constructor deviates from std::vector's behaviour, because it will not
+	 * value construct its elements. It is therefore faster than the corresponding constructor
+	 * of std::vector.
+	 * @param n Number of elements that the uvector will be initialized with.
+	 */
+	explicit uvector(size_t n) :
+		_begin(allocate(n)),
+		_end(_begin + n),
+		_endOfStorage(_end)
+	{
+	}
+	
+	/** @brief Construct a vector with given amount of elements and set these to a specific value.
+	 * @details This constructor will initialize its members with the given value. 
+	 * @param n Number of elements that the uvector will be initialized with.
+	 * @param val Value to initialize all elements with
+	 * @param allocator Allocator used for allocating and deallocating memory.
+	 */
+	uvector(size_t n, const value_type& val, const allocator_type& allocator = Alloc()) :
+		Alloc(allocator),
+		_begin(allocate(n)),
+		_end(_begin + n),
+		_endOfStorage(_end)
+	{
+		std::uninitialized_fill_n<Tp*,size_t>(_begin, n, val);
+	}
+	
+	/** @brief Construct a vector by copying elements from a range.
+	 * @param first Iterator to range start
+	 * @param last Iterator to range end
+	 * @param allocator Allocator used for allocating and deallocating memory.
+	 */
+	template<class InputIterator>
+	uvector(InputIterator first, InputIterator last, const allocator_type& allocator = Alloc()) :
+		Alloc(allocator)
+	{
+		construct_from_range<InputIterator>(first, last, std::is_integral<InputIterator>());
+	}
+	
+	/** @brief Copy construct a uvector.
+	 * @details The allocator of the new uvector will be initialized from
+	 * @c std::allocator_traits<Alloc>::select_on_container_copy_construction(other).
+	 * @param other Source uvector to be copied from.
+	 */
+	uvector(const uvector<Tp,Alloc>& other) :
+		Alloc(std::allocator_traits<Alloc>::select_on_container_copy_construction(static_cast<allocator_type>(other))),
+		_begin(allocate(other.size())),
+		_end(_begin + other.size()),
+		_endOfStorage(_end)
+	{
+		std::copy(other._begin, other._end, _begin);
+	}
+	
+	/** @brief Copy construct a uvector with custom allocator.
+	 * @param other Source uvector to be copied from.
+	 * @param allocator Allocator used for allocating and deallocating memory.
+	 */
+	uvector(const uvector<Tp,Alloc>& other, const allocator_type& allocator) :
+		Alloc(allocator),
+		_begin(allocate(other.size())),
+		_end(_begin + other.size()),
+		_endOfStorage(_end)
+	{
+		std::copy(other._begin, other._end, _begin);
+	}
+	
+	/** @brief Move construct a uvector.
+	 * @param other Source uvector to be moved from.
+	 */
+	uvector(uvector<Tp,Alloc>&& other) noexcept :
+		Alloc(std::move(other)),
+		_begin(other._begin),
+		_end(other._end),
+		_endOfStorage(other._endOfStorage)
+	{
+		other._begin = nullptr;
+		other._end = nullptr;
+		other._endOfStorage = nullptr;
+	}
+	
+	/** @brief Move construct a uvector with custom allocator.
+	 * @param other Source uvector to be moved from.
+	 * @param allocator Allocator used for allocating and deallocating memory.
+	 */
+	uvector(uvector<Tp,Alloc>&& other, const allocator_type& allocator) noexcept :
+		Alloc(allocator),
+		_begin(other._begin),
+		_end(other._end),
+		_endOfStorage(other._endOfStorage)
+	{
+		other._begin = nullptr;
+		other._end = nullptr;
+		other._endOfStorage = nullptr;
+	}
+	
+	/** @brief Construct a uvector from a initializer list.
+	 * @param initlist Initializer list used for initializing the new uvector.
+	 * @param allocator Allocator used for allocating and deallocating memory.
+	 */
+	uvector(std::initializer_list<Tp> initlist, const allocator_type& allocator = Alloc()) :
+		Alloc(allocator),
+		_begin(allocate(initlist.size())),
+		_end(_begin + initlist.size()),
+		_endOfStorage(_end)
+	{
+		iterator destIter = _begin;
+		for(typename std::initializer_list<Tp>::const_iterator i=initlist.begin(); i!=initlist.end(); ++i)
+		{
+			*destIter = *i;
+			++destIter;
+		}
+	}
+	
+	/** @brief Destructor. */
+	~uvector() noexcept
+	{
+		deallocate();
+	}
+	
+	/** @brief Assign another uvector to this uvector.
+	 * @details The allocator of the uvector will be assigned to @p other when
+	 * std::allocator_traits<Alloc>::propagate_on_container_copy_assignment() is of true_type.
+	 */
+	uvector& operator=(const uvector<Tp,Alloc>& other)
+	{
+		return assign_copy_from(other, typename std::allocator_traits<Alloc>::propagate_on_container_copy_assignment());
+	}
+	
+	/** @brief Assign another uvector to this uvector.
+	 * @details The allocator of the uvector will be assigned to @p other when
+	 * std::allocator_traits<Alloc>::propagate_on_container_move_assignment() is of true_type.
+	 */
+	uvector& operator=(uvector<Tp,Alloc>&& other) noexcept(
+		std::allocator_traits<Alloc>::propagate_on_container_move_assignment::value||
+		allocator_is_always_equal::value)
+	{
+		return assign_move_from(std::move(other), typename std::allocator_traits<Alloc>::propagate_on_container_move_assignment());
+	}
+	
+	/** @brief Get iterator to first element. */
+	iterator begin() noexcept { return _begin; }
+	
+	/** @brief Get constant iterator to first element. */
+	const_iterator begin() const noexcept { return _begin; }
+	
+	/** @brief Get iterator to element past last element. */
+	iterator end() noexcept { return _end; }
+	
+	/** @brief Get constant iterator to element past last element. */
+	const_iterator end() const noexcept { return _end; }
+	
+	/** @brief Get reverse iterator to last element. */
+	reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+	
+	/** @brief Get constant reverse iterator to last element. */
+	const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
+	
+	/** @brief Get reverse iterator to element before first element. */
+	reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+	
+	/** @brief Get constant reverse iterator to element before first element. */
+	const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+	
+	/** @brief Get constant iterator to first element. */
+	const_iterator cbegin() const noexcept { return _begin; }
+	
+	/** @brief Get constant iterator to element past last element. */
+	const_iterator cend() const noexcept { return _end; }
+	
+	/** @brief Get constant reverse iterator to last element. */
+	const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
+	
+	/** @brief Get constant reverse iterator to element before first element. */
+	const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
+	
+	/** @brief Get number of elements in container. */
+	size_t size() const noexcept { return _end - _begin; }
+	
+	/** @brief Get maximum number of elements that this container can hold. */ 
+	size_t max_size() const noexcept { return Alloc::max_size(); }
+	
+	/** @brief Change the number of elements in the container.
+	 * @details If the new size is larger than the current size, new values will be
+	 * left uninitialized. Therefore, it is more efficient than @c resize(size_t) in
+	 * @c std::vector, as well as @ref resize(size_t, const Tp&).
+	 * If the new size is smaller than the current size, the container will be
+	 * truncated and elements past the new size will be removed. No destructor of the
+	 * removed elements will be called.
+	 * @param n The new size of the container.
+	 */
+	void resize(size_t n)
+	{
+		if(capacity() < n)
+		{
+			size_t newSize = enlarge_size(n);
+			pointer newStorage = allocate(newSize);
+			std::move(_begin, _end, newStorage);
+			deallocate();
+			_begin = newStorage;
+			_endOfStorage = _begin + newSize;
+		}
+		_end = _begin + n;
+	}
+	
+	/** @brief Change the number of elements in the container.
+	 * @details If the new size is larger than the current size, new values will be
+	 * initialized by the given value.
+	 * If the new size is smaller than the current size, the container will be
+	 * truncated and elements past the new size will be removed. No destructor of the
+	 * removed elements will be called.
+	 * @param n The new size of the container.
+	 * @param val New value of elements that get added to the container.
+	 */
+	void resize(size_t n, const Tp& val)
+	{
+		size_t oldSize = size();
+		if(capacity() < n)
+		{
+			pointer newStorage = allocate(n);
+			std::move(_begin, _end, newStorage);
+			deallocate();
+			_begin = newStorage;
+			_endOfStorage = _begin + n;
+		}
+		_end = _begin + n;
+		if(oldSize < n)
+			std::uninitialized_fill<Tp*,size_t>(_begin + oldSize, _end, val);
+	}
+	
+	/** @brief Get the number of elements the container can currently hold without reallocating storage. */
+	size_t capacity() const noexcept { return _endOfStorage - _begin; }
+	
+	/** @brief Determine if the container is currently empty.
+	 * @returns @c true if @ref size() == 0. */
+	bool empty() const noexcept { return _begin == _end; }
+	
+	/** @brief Reserve space for a number of elements, to prevent the overhead of extra
+	 * reallocations.
+	 * @details This has no effect on the working of the uvector, except that it might change
+	 * the current capacity. This can enhance performance when a large number of elements are added,
+	 * and an approximate size is known a priori.
+	 * 
+	 * This method might cause a reallocation, causing iterators to be invalidated.
+	 * @param n Number of elements to reserve space for.
+	 */
+	void reserve(size_t n)
+	{
+		if(capacity() < n)
+		{
+			const size_t curSize = size();
+			pointer newStorage = allocate(n);
+			std::move(_begin, _begin + curSize, newStorage);
+			deallocate();
+			_begin = newStorage;
+			_end = newStorage + curSize;
+			_endOfStorage = _begin + n;
+		}
+	}
+	
+	/** @brief Change the capacity of the container such that no extra space is hold.
+	 * @details This has no effect on the working of the uvector, except that it might change
+	 * the current capacity. This can reduce the current memory usage of the container.
+	 * 
+	 * This method might cause a reallocation, causing iterators to be invalidated.
+	 */
+	void shrink_to_fit()
+	{
+		const size_t curSize = size();
+		if(curSize == 0)
+		{
+			deallocate();
+			_begin = nullptr;
+			_end = nullptr;
+			_endOfStorage = nullptr;
+		}
+		else if(curSize < capacity()) {
+			pointer newStorage = allocate(curSize);
+			std::move(_begin, _begin + curSize, newStorage);
+			deallocate();
+			_begin = newStorage;
+			_end = newStorage + curSize;
+			_endOfStorage = _begin + curSize;
+		}
+	}
+	
+	/** @brief Get a reference to the element at the given index. */
+	Tp& operator[](size_t index) noexcept { return _begin[index]; }
+	
+	/** @brief Get a constant reference to the element at the given index. */
+	const Tp& operator[](size_t index) const noexcept { return _begin[index]; }
+	
+	/** @brief Get a reference to the element at the given index with bounds checking.
+	 * @throws std::out_of_range when given index is past the last element.
+	 */
+	Tp& at(size_t index)
+	{
+		check_bounds(index);
+		return _begin[index];
+	}
+	
+	/** @brief Get a constant reference to the element at the given index with bounds checking.
+	 * @throws std::out_of_range when given index is past the last element.
+	 */
+	const Tp& at(size_t index) const
+	{
+		check_bounds(index);
+		return _begin[index];
+	}
+	
+	/** @brief Get reference to first element in container. */ 
+	Tp& front() noexcept { return *_begin; }
+	
+	/** @brief Get constant reference to first element in container. */ 
+	const Tp& front() const noexcept { return *_begin; }
+	
+	/** @brief Get reference to last element in container. */ 
+	Tp& back() noexcept { return *(_end - 1); }
+	
+	/** @brief Get constant reference to last element in container. */ 
+	const Tp& back() const noexcept { return *(_end - 1); }
+	
+	/** @brief Get pointer to internal storage. */ 
+	Tp* data() noexcept { return _begin; }
+	
+	/** @brief Get constant pointer to internal storage. */ 
+	const Tp* data() const noexcept { return _begin; }
+	
+	/** @brief Assign this container to be equal to the given range.
+	 * @details The container will be resized to fit the length of the given
+	 * range. Iterators are invalidated.
+	 * @param first Iterator to the beginning of the range.
+	 * @param last Iterator past the end of the range.
+	 */ 
+	template<class InputIterator>
+  void assign(InputIterator first, InputIterator last)
+	{
+		assign_from_range<InputIterator>(first, last, std::is_integral<InputIterator>());
+	}
+	
+	/** @brief Resize the container and assign the given value to all elements.
+	 * @details Iterators are invalidated.
+	 * @param n New size of container
+	 * @param val Value to be assigned to all elements.
+	 */
+	void assign(size_t n, const Tp& val)
+	{
+		if(n > capacity())
+		{
+			iterator newStorage = allocate(n);
+			deallocate();
+			_begin = newStorage;
+			_endOfStorage = _begin + n;
+		}
+		_end = _begin + n;
+		std::uninitialized_fill_n<Tp*,size_t>(_begin, n, val);
+	}
+	
+	/** @brief Assign this container to an initializer list.
+	 * @details The container will be resized to fit the length of the given
+	 * initializer list. Iterators are invalidated.
+	 * @param initlist List of values to assign to the container.
+	 */ 
+	void assign(std::initializer_list<Tp> initlist)
+	{
+		if(initlist.size() > capacity())
+		{
+			iterator newStorage = allocate(initlist.size());
+			deallocate();
+			_begin = newStorage;
+			_endOfStorage = _begin + initlist.size();
+		}
+		_end = _begin + initlist.size();
+		iterator destIter = _begin;
+		for(typename std::initializer_list<Tp>::const_iterator i=initlist.begin(); i!=initlist.end(); ++i)
+		{
+			*destIter = *i;
+			++destIter;
+		}
+	}
+	
+	/** @brief Add the given value to the end of the container.
+	 * @details Iterators are invalidated.
+	 * @param item Value of new element.
+	 */
+	void push_back(const Tp& item)
+	{
+		if(_end == _endOfStorage)
+			enlarge(enlarge_size(1));
+		*_end = item;
+		++_end;
+	}
+	
+	/** @brief Add the given value to the end of the container by moving it in.
+	 * @details Iterators are invalidated.
+	 * 
+	 * Note that this container can only hold simple types that do not perform allocations. Therefore,
+	 * there is probably no benefit in moving the new item in over copying it in with @ref push_back(const Tp&).
+	 * @param item Value of new element.
+	 */
+	void push_back(Tp&& item)
+	{
+		if(_end == _endOfStorage)
+			enlarge(enlarge_size(1));
+		*_end = std::move(item);
+		++_end;
+	}
+	
+	/** @brief Remove the last element from the container. */
+	void pop_back()
+	{
+		--_end;
+	}
+	
+	/** @brief Insert an element at a given position.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive.
+	 * @param position Position of the new element. The new element will be added before the old element
+	 * at that position.
+	 * @param item Value of the new item.
+	 * @return Position of the new element.
+	 */
+	iterator insert(const_iterator position, const Tp& item)
+	{
+		if(_end == _endOfStorage)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(1), index, 1);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+1);
+			++_end;
+		}
+		*const_cast<iterator>(position) = item;
+		return const_cast<iterator>(position);
+	}
+
+	/** @brief Insert elements at a given position and initialize them with a value.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive.
+	 * @param position Position of the new elements. The new elements will be added before the old element
+	 * at that position.
+	 * @param n Number of elements to add.
+	 * @param val Value of the new item. 
+	 * @return Position of the first new element.
+	 */
+	iterator insert(const_iterator position, size_t n, const Tp& val)
+	{
+		if(capacity() < size() + n)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(n), index, n);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+n);
+			_end += n;
+		}
+		std::uninitialized_fill_n<Tp*,size_t>(const_cast<iterator>(position), n, val);
+		return const_cast<iterator>(position);
+	}
+	
+	/** @brief Insert elements at a given position and initialize them from a range.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive.
+	 * @param position Position of the new elements. The new elements will be added before the old element
+	 * at that position.
+	 * @param first Iterator to the beginning of the range.
+	 * @param last Iterator past the end of the range.
+	 * @return Position of the first new element.
+	 */
+	template <class InputIterator>
+	iterator insert(const_iterator position, InputIterator first, InputIterator last)
+	{
+		return insert_from_range<InputIterator>(position, first, last, std::is_integral<InputIterator>());
+	}
+	
+	/** @brief Insert an element at a given position by moving it in.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive.
+	 * 
+	 * Note that this container can only hold simple types that do not perform allocations. Therefore,
+	 * there is probably no benefit in moving the new item in over copying it in with
+	 * @ref insert(const_iterator, const Tp&).
+	 * @param position Position of the new element. The new element will be added before the old element
+	 * at that position.
+	 * @param item Value of the new item.
+	 * @return Position of the new element.
+	 */
+	iterator insert(const_iterator position, Tp&& item)
+	{
+		if(_end == _endOfStorage)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(1), index, 1);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+1);
+			++_end;
+		}
+		*const_cast<iterator>(position) = std::move(item);
+		return const_cast<iterator>(position);
+	}
+	
+	/** @brief Insert elements at a given position and initialize them from a initializer list.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive.
+	 * @param position Position of the new elements. The new elements will be added before the old element
+	 * at that position.
+	 * @param initlist List of items to insert.
+	 * @return Position of the first new element.
+	 */
+	iterator insert(const_iterator position, std::initializer_list<Tp> initlist)
+	{
+		if(capacity() < size() + initlist.size())
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(initlist.size()), index, initlist.size());
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+initlist.size());
+			_end += initlist.size();
+		}
+		iterator destIter = const_cast<iterator>(position);
+		for(typename std::initializer_list<Tp>::const_iterator i=initlist.begin(); i!=initlist.end(); ++i)
+		{
+			*destIter = *i;
+			++destIter;
+		}
+		return const_cast<iterator>(position);
+	}
+	
+	/** @brief Delete an element from the container.
+	 * @details This operation moves all elements past the removed element, and can therefore be
+	 * expensive.
+	 * @param position Position of element to be removed.
+	 * @return Iterator pointing to the first element past the delete element.
+	 */
+	iterator erase(const_iterator position)
+	{
+		std::move(const_cast<iterator>(position)+1, _end, const_cast<iterator>(position));
+		--_end;
+		return const_cast<iterator>(position);
+	}
+	
+	/** @brief Delete a range of elements from the container.
+	 * @details This operation moves all elements past the removed elements, and can therefore be
+	 * expensive.
+	 * @param first Position of first element to be removed.
+	 * @param last Position past last element to be removed.
+	 * @return Iterator pointing to the first element past the delete element.
+	 */
+	iterator erase(const_iterator first, const_iterator last)
+	{
+		std::move(const_cast<iterator>(last), _end, const_cast<iterator>(first));
+		_end -= last - first;
+		return const_cast<iterator>(first);
+	}
+	
+	/** @brief Swap the contents of this uvector with the given uvector.
+	 * @details Iterators to both vectors will remain valid and will point into
+	 * to the swapped container afterwards. This function will never reallocate
+	 * space.
+	 * 
+	 * The allocator will be swapped when the @c propagate_on_container_swap
+	 * of the respective @c allocator_trait is @c true_type.
+	 * Its behaviour is undefined when the allocators do not compare equal and
+	 * @c propagate_on_container_swap is false.
+	 * @param other Other uvector whose contents it to be swapped with this.
+	 */
+	void swap(uvector<Tp, Alloc>& other) noexcept
+	{
+		swap(other, typename std::allocator_traits<Alloc>::propagate_on_container_swap());
+	}
+	
+	/** @brief Remove all elements from the container. */
+	void clear()
+	{
+		_end = _begin;
+	}
+	
+	/** @brief Insert an element at a given position by constructing it in place.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive.
+	 * @param position Position of the new element. The new element will be added before the old element
+	 * at that position.
+	 * @param args List of arguments to be forwarded to construct the new element.
+	 * @return Position of the new element.
+	 */
+	template<typename... Args>
+	iterator emplace(const_iterator position, Args&&... args)
+	{
+		if(_end == _endOfStorage)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(1), index, 1);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+1);
+			++_end;
+		}
+		*const_cast<iterator>(position) = Tp(std::forward<Args>(args)...);
+		return const_cast<iterator>(position);
+	}
+	
+	/** @brief Add the given value to the end of the container by constructing it in place.
+	 * @details Iterators are invalidated.
+	 * @param args List of arguments to be forwarded to construct the new element.
+	 */
+	template<typename... Args>
+	void emplace_back(Args&&... args)
+	{
+		if(_end == _endOfStorage)
+			enlarge(enlarge_size(1));
+		*_end = Tp(std::forward<Args>(args)...);
+		++_end;
+	}
+	
+	/** @brief Get a copy of the allocator. */
+	allocator_type get_allocator() const noexcept
+	{
+		return *this;
+	}
+	
+	// --- NON STANDARD METHODS ---
+	
+	/** @brief Insert elements at a given position without initializing them.
+	 * @details All iterators will be invalidated. This operation needs to move all elements after
+	 * the new element, and can therefore be expensive. It will not initialize the new elements,
+	 * and is therefore faster than @ref insert(const_iterator, size_t, const Tp&).
+	 * 
+	 * This method is non-standard: it is not present in std::vector.
+	 * @param position Position of the new elements. The new elements will be added before the old element
+	 * at that position.
+	 * @param n Number of elements to add.
+	 */
+	iterator insert_uninitialized(const_iterator position, size_t n)
+	{
+		if(capacity() < size() + n)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(n), index, n);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+n);
+			_end += n;
+		}
+		return const_cast<iterator>(position);
+	}
+	
+	/** @brief Add a range of items to the end of the container.
+	 * @details All iterators will be invalidated.
+	 * 
+	 * This method is non-standard: it is not present in std::vector.
+	 * @param first Iterator to the beginning of the range.
+	 * @param last Iterator past the end of the range.
+	 */
+	template <class InputIterator>
+	void push_back(InputIterator first, InputIterator last)
+	{
+		push_back_range<InputIterator>(first, last, std::is_integral<InputIterator>());
+	}
+	
+	/** @brief Add elements at the end and initialize them with a value.
+	 * @details All iterators will be invalidated. 
+	 * 
+	 * This method is non-standard: it is not present in std::vector.
+	 * @param n Number of elements to add.
+	 * @param val Value of the new items. 
+	 */
+	void push_back(size_t n, const Tp& val)
+	{
+		if(capacity() - size() < n)
+		{
+			enlarge(enlarge_size(n));
+		}
+		std::uninitialized_fill_n<Tp*,size_t>(_end, n, val);
+		_end += n;
+	}
+	
+	/** @brief Add elements from an initializer list to the end of the container.
+	 * @details All iterators will be invalidated. 
+	 * 
+	 * This method is non-standard: it is not present in std::vector.
+	 * @param initlist The list with values to add.
+	 */
+	void push_back(std::initializer_list<Tp> initlist)
+	{
+		if(capacity() - size() < initlist.size())
+		{
+			enlarge(enlarge_size(initlist.size()));
+		}
+		for(typename std::initializer_list<Tp>::iterator i = initlist.begin(); i != initlist.end(); ++i)
+		{
+			*_end = *i;
+			++_end;
+		}
+	}
+	
+	/** @brief Add elements at the end without initializing them.
+	 * @details All iterators will be invalidated. 
+	 * 
+	 * This method is non-standard: it is not present in std::vector.
+	 * @param n Number of elements to add.
+	 */
+	void push_back_uninitialized(size_t n)
+	{
+		resize(size() + n);
+	}
+	
+private:
+	
+	pointer allocate(size_t n)
+	{
+		return Alloc::allocate(n);
+	}
+	
+	void deallocate() noexcept
+	{
+		deallocate(_begin, capacity());
+	}
+	
+	void deallocate(pointer begin, size_t n) noexcept
+	{
+		if(begin != nullptr)
+			Alloc::deallocate(begin, n);
+	}
+	
+	template<typename InputIterator>
+	void construct_from_range(InputIterator first, InputIterator last, std::false_type)
+	{
+		construct_from_range<InputIterator>(first, last, typename std::iterator_traits<InputIterator>::iterator_category());
+	}
+	
+	template<typename Integral>
+	void construct_from_range(Integral n, Integral val, std::true_type)
+	{
+		_begin = allocate(n);
+		_end = _begin + n;
+		_endOfStorage = _end;
+		std::uninitialized_fill_n<Tp*,size_t>(_begin, n, val);
+	}
+	
+	template<typename InputIterator>
+	void construct_from_range(InputIterator first, InputIterator last, std::forward_iterator_tag)
+	{
+		size_t n = std::distance(first, last);
+		_begin = allocate(n);
+		_end = _begin + n;
+		_endOfStorage = _begin + n;
+		Tp* destIter = _begin;
+		while(first != last)
+		{
+			*destIter = *first;
+			++destIter; ++first;
+		}
+	}
+	
+	template<typename InputIterator>
+	void assign_from_range(InputIterator first, InputIterator last, std::false_type)
+	{
+		assign_from_range<InputIterator>(first, last, typename std::iterator_traits<InputIterator>::iterator_category());
+	}
+	
+	// This function is called from assign(iter,iter) when Tp is an integral. In that case,
+	// the user tried to call assign(n, &val), but it got caught by the wrong overload.
+	template<typename Integral>
+	void assign_from_range(Integral n, Integral val, std::true_type)
+	{
+		if(size_t(n) > capacity())
+		{
+			iterator newStorage = allocate(n);
+			deallocate();
+			_begin = newStorage;
+			_endOfStorage = _begin + n;
+		}
+		_end = _begin + n;
+		std::uninitialized_fill_n<Tp*,size_t>(_begin, n, val);
+	}
+	
+	template<typename InputIterator>
+	void assign_from_range(InputIterator first, InputIterator last, std::forward_iterator_tag)
+	{
+		size_t n = std::distance(first, last);
+		if(n > capacity())
+		{
+			iterator newStorage = allocate(n);
+			deallocate();
+			_begin = newStorage;
+			_endOfStorage = _begin + n;
+		}
+		_end = _begin + n;
+		Tp* destIter = _begin;
+		while(first != last)
+		{
+			*destIter = *first;
+			++destIter; ++first;
+		}
+	}
+	
+	template<typename InputIterator>
+	iterator insert_from_range(const_iterator position, InputIterator first, InputIterator last, std::false_type)
+	{
+		return insert_from_range<InputIterator>(position, first, last,
+			typename std::iterator_traits<InputIterator>::iterator_category());
+	}
+	
+	template<typename Integral>
+	iterator insert_from_range(const_iterator position, Integral n, Integral val, std::true_type)
+	{
+		if(capacity() < size() + n)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(n), index, n);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+n);
+			_end += n;
+		}
+		std::uninitialized_fill_n<Tp*,size_t>(const_cast<iterator>(position), n, val);
+		return const_cast<iterator>(position);
+	}
+	
+	template<typename InputIterator>
+	iterator insert_from_range(const_iterator position, InputIterator first, InputIterator last, std::forward_iterator_tag)
+	{
+		size_t n = std::distance(first, last);
+		if(capacity() < size() + n)
+		{
+			size_t index = position - _begin;
+			enlarge_for_insert(enlarge_size(n), index, n);
+			position = _begin + index;
+		}
+		else {
+			std::move_backward(const_cast<iterator>(position), _end, _end+n);
+			_end += n;
+		}
+		Tp* destIter = const_cast<iterator>(position);
+		while(first != last)
+		{
+			*destIter = *first;
+			++destIter; ++first;
+		}
+		return const_cast<iterator>(position);
+	}
+	
+	void check_bounds(size_t index) const
+	{
+		if(index >= size())
+			throw std::out_of_range("Access to element in uvector past end");
+	}
+	
+	size_t enlarge_size(size_t extra_space_needed) const noexcept
+	{
+		return size() + std::max(size(), extra_space_needed);
+	}
+	
+	void enlarge(size_t newSize)
+	{
+		pointer newStorage = allocate(newSize);
+		std::copy(_begin, _end, newStorage);
+		deallocate();
+		_end = newStorage + size();
+		_begin = newStorage;
+		_endOfStorage = _begin + newSize;
+	}
+	
+	void enlarge_for_insert(size_t newSize, size_t insert_position, size_t insert_count)
+	{
+		pointer newStorage = allocate(newSize);
+		std::copy(_begin, _begin + insert_position, newStorage);
+		std::copy(_begin + insert_position, _end, newStorage + insert_position + insert_count);
+		deallocate();
+		_end = newStorage + size() + insert_count;
+		_begin = newStorage;
+		_endOfStorage = _begin + newSize;
+	}
+	
+	// implementation of operator=(const&) without propagate_on_container_copy_assignment
+	uvector& assign_copy_from(const uvector<Tp,Alloc>& other, std::false_type)
+	{
+		const size_t n = other.size();
+		if(n > capacity()) {
+			iterator newStorage = allocate(n);
+			deallocate();
+			_begin = newStorage;
+			_end = _begin + n;
+			_endOfStorage = _end;
+		}
+		std::copy(other._begin, other._begin + n, _begin);
+		return *this;
+	}
+	
+	// implementation of operator=(const&) with propagate_on_container_copy_assignment
+	uvector& assign_copy_from(const uvector<Tp,Alloc>& other, std::true_type)
+	{
+		if(allocator_is_always_equal() || static_cast<Alloc&>(other) == static_cast<Alloc&>(*this))
+		{
+			assign_copy_from(other, std::false_type());
+		}
+		else {
+			const size_t n = other.size();
+			iterator newStorage = static_cast<Alloc&>(other).allocate(n);
+			deallocate();
+			_begin = newStorage;
+			_end = _begin + n;
+			_endOfStorage = _end;
+			std::copy(other._begin, other._begin + n, _begin);
+			Alloc::operator=(static_cast<Alloc&>(other));
+		}
+		return *this;
+	}
+	
+	// implementation of operator=() without propagate_on_container_move_assignment
+	uvector& assign_move_from(uvector<Tp,Alloc>&& other, std::false_type) noexcept(allocator_is_always_equal::value)
+	{
+		if(allocator_is_always_equal::value || static_cast<Alloc&>(other) == static_cast<Alloc&>(*this))
+		{
+			deallocate();
+			_begin = other._begin;
+			_end = other._end;
+			_endOfStorage = other._endOfStorage;
+			other._begin = nullptr;
+			other._end = nullptr;
+			other._endOfStorage = nullptr;
+		}
+		else {
+			// We should not propagate the allocator and the allocators are different.
+			// This means we can not swap the allocated space, since then we would
+			// deallocate the space with a different allocator type. Therefore, we
+			// need to copy:
+			assign_copy_from(other, std::false_type());
+		}
+		return *this;
+	}
+	
+	// implementation of operator=() with propagate_on_container_move_assignment
+	uvector& assign_move_from(uvector<Tp,Alloc>&& other, std::true_type) noexcept
+	{
+		deallocate();
+		Alloc::operator=(std::move(static_cast<Alloc&>(other)));
+		_begin = other._begin;
+		_end = other._end;
+		_endOfStorage = other._endOfStorage;
+		other._begin = nullptr;
+		other._end = nullptr;
+		other._endOfStorage = nullptr;
+		return *this;
+	}
+	
+	// implementation of swap with propagate_on_container_swap
+	void swap(uvector<Tp,Alloc>& other, std::true_type) noexcept
+	{
+		std::swap(_begin, other._begin);
+		std::swap(_end, other._end);
+		std::swap(_endOfStorage, other._endOfStorage);
+		std::swap(static_cast<Alloc&>(other), static_cast<Alloc&>(*this));
+	}
+	
+	// implementation of swap without propagate_on_container_swap
+	void swap(uvector<Tp,Alloc>& other, std::false_type) noexcept
+	{
+		std::swap(_begin, other._begin);
+		std::swap(_end, other._end);
+		std::swap(_endOfStorage, other._endOfStorage);
+		/**
+		 * We have two choices here:
+		 * - Do not swap the allocators. For stateful allocators, we would need to
+		 *   reallocate memory, and iterators would not be valid UNLESS
+		 *   they were stored as indices. However, containers with stateful allocators
+		 *   are not allowed to be swapped unless the allocators are equal, in which case swapping
+		 *   is not necessary.
+		 * - Swap the allocators. This would not reallocate memory and
+		 *   iterators remain valid, but the trait ignores propagate_on_container_swap.
+		 * 
+		 * The standard says:
+		 * "Allocator replacement is performed by copy assignment, move assignment, or
+		 * swapping of the allocator only if allocator_traits<allocatortype>::
+		 * propagate_on_container_copy_assignment::value,
+		 * allocator_traits<allocatortype>::propagate_on_container_move_assignment::value,
+		 * or allocator_traits<allocatortype>::propagate_on_container_swap::value is true
+		 * within the implementation of the corresponding container operation. The behavior
+		 * of a call to a container’s swap function is undefined unless the objects being
+		 * swapped have allocators that compare equal or
+		 * allocator_traits<allocatortype>::propagate_on_container_swap::value is true."
+		 */
+	}
+	
+	template<typename InputIterator>
+	void push_back_range(InputIterator first, InputIterator last, std::false_type)
+	{
+		push_back_range<InputIterator>(first, last, typename std::iterator_traits<InputIterator>::iterator_category());
+	}
+	
+	// This function is called from push_back(iter,iter) when Tp is an integral. In that case,
+	// the user tried to call push_back(n, &val), but it got caught by the wrong overload.
+	template<typename Integral>
+	void push_back_range(Integral n, Integral val, std::true_type)
+	{
+		if(capacity() - size() < size_t(n))
+		{
+			enlarge(enlarge_size(n));
+		}
+		std::uninitialized_fill_n<Tp*,size_t>(_end, n, val);
+		_end += n;
+	}
+	
+	template<typename InputIterator>
+	void push_back_range(InputIterator first, InputIterator last, std::forward_iterator_tag)
+	{
+		size_t n = std::distance(first, last);
+		if(n > capacity() - size())
+		{
+			enlarge(enlarge_size(n));
+		}
+		while(first != last)
+		{
+			*_end = *first;
+			++_end;
+			++first;
+		}
+	}
+	
+};
+
+/** @brief Compare two uvectors for equality. */
+template<class Tp, class Alloc>
+inline bool operator==(const uvector<Tp,Alloc>& lhs, const uvector<Tp,Alloc>& rhs) noexcept
+{
+	return lhs.size()==rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
+/** @brief Compare two uvectors for inequality. */
+template<class Tp, class Alloc>
+inline bool operator!=(const uvector<Tp,Alloc>& lhs, const uvector<Tp,Alloc>& rhs) noexcept
+{
+	return !(lhs == rhs);
+}
+
+/** @brief Compare two uvectors for smaller than.
+ * @details If two uvectors compare equal up to the length of one, the uvector with
+ * the smallest size is consider to be smaller.
+ */
+template <class Tp, class Alloc>
+inline bool operator<(const uvector<Tp,Alloc>& lhs, const uvector<Tp,Alloc>& rhs) noexcept
+{
+	const size_t minSize = std::min(lhs.size(), rhs.size());
+	for(size_t i=0; i!=minSize; ++i)
+	{
+		if(lhs[i] < rhs[i])
+			return true;
+		else if(lhs[i] > rhs[i])
+			return false;
+	}
+	return lhs.size() < rhs.size();
+}
+
+/** @brief Compare two uvectors for smaller than or equal.
+ * @details If two uvectors compare equal up to the length of one, the uvector with
+ * the smallest size is consider to be smaller.
+ */
+template <class Tp, class Alloc>
+inline bool operator<=(const uvector<Tp,Alloc>& lhs, const uvector<Tp,Alloc>& rhs) noexcept
+{
+	const size_t minSize = std::min(lhs.size(), rhs.size());
+	for(size_t i=0; i!=minSize; ++i)
+	{
+		if(lhs[i] < rhs[i])
+			return true;
+		else if(lhs[i] > rhs[i])
+			return false;
+	}
+	return lhs.size() <= rhs.size();
+}
+
+/** @brief Compare two uvectors for larger than.
+ * @details If two uvectors compare equal up to the length of one, the uvector with
+ * the smallest size is consider to be smaller.
+ */
+template <class Tp, class Alloc>
+inline bool operator>(const uvector<Tp,Alloc>& lhs, const uvector<Tp,Alloc>& rhs) noexcept
+{
+	return rhs < lhs;
+}
+
+/** @brief Compare two uvectors for larger than or equal.
+ * @details If two uvectors compare equal up to the length of one, the uvector with
+ * the smallest size is consider to be smaller.
+ */
+template <class Tp, class Alloc>
+inline bool operator>=(const uvector<Tp,Alloc>& lhs, const uvector<Tp,Alloc>& rhs) noexcept
+{
+	return rhs <= lhs;
+}
+
+/** @brief Swap the contents of the two uvectors.
+	* @details Iterators to both vectors will remain valid and will point into
+	* to the swapped container afterwards. This function will never reallocate
+	* space.
+	* 
+	* The allocator will be swapped when the @c propagate_on_container_swap
+	* of the respective @c allocator_trait is @c true_type.
+	* Its behaviour is undefined when the allocators do not compare equal and
+	* @c propagate_on_container_swap is false.
+	*/
+template <class Tp, class Alloc>
+inline void swap(uvector<Tp,Alloc>& x, uvector<Tp,Alloc>& y)
+{
+	x.swap(y);
+}
+
+/** @} */
+
+} // end of namespace ao
+
+#endif // AO_UVECTOR_H
+

--- a/tables/Dysco/weightblockencoder.h
+++ b/tables/Dysco/weightblockencoder.h
@@ -1,0 +1,81 @@
+#ifndef DYSCO_WEIGHT_BLOCK_ENCODER_H
+#define DYSCO_WEIGHT_BLOCK_ENCODER_H
+
+#include <cmath>
+#include <cstring>
+
+#include "timeblockbuffer.h"
+
+class WeightBlockEncoder {
+public:
+  WeightBlockEncoder(size_t nPolarizations, size_t nChannels, size_t quantCount)
+      : _nPolarizations(nPolarizations), _nChannels(nChannels),
+        _quantCount(quantCount) {}
+
+  size_t MetaDataFloatCount() const { return 1.0; }
+
+  size_t SymbolCount(size_t nRowsInBlock) const {
+    return nRowsInBlock * _nChannels;
+  }
+
+  void InitializeDecode(const float *metaBuffer) {
+    _decodeMaxValue = metaBuffer[0];
+  }
+
+  void Decode(TimeBlockBuffer<float> &buffer, const unsigned int *symbolBuffer,
+              size_t blockRow) const {
+    double scaleValue = _decodeMaxValue / (double(_quantCount - 1));
+    TimeBlockBuffer<float>::DataRow &row = buffer[blockRow];
+    const unsigned int *rowBuffer = &symbolBuffer[blockRow * _nChannels];
+    for (size_t ch = 0; ch != _nChannels; ++ch) {
+      float value = *rowBuffer * scaleValue;
+      row.visibilities.resize(_nChannels * _nPolarizations);
+      float *chPtr = &row.visibilities[ch * _nPolarizations];
+      for (size_t p = 0; p != _nPolarizations; ++p)
+        chPtr[p] = value;
+      ++rowBuffer;
+    }
+  }
+
+  void Encode(TimeBlockBuffer<float> &buffer, float *metaBuffer,
+              unsigned int *symbolBuffer) const {
+    float maxValue = 0.0;
+    for (const TimeBlockBuffer<float>::DataRow &row : buffer.GetVector()) {
+      for (size_t ch = 0; ch != _nChannels; ++ch) {
+        const float *visPtr = &row.visibilities[ch * _nPolarizations];
+        float weight = *visPtr;
+        for (size_t p = 1; p != _nPolarizations; ++p)
+          if (visPtr[p] < weight)
+            weight = visPtr[p];
+        if (weight > maxValue)
+          maxValue = weight;
+      }
+    }
+    if (maxValue == 0.0)
+      maxValue = 1.0;
+    metaBuffer[0] = maxValue;
+
+    double scaleValue = double(_quantCount - 1) / maxValue;
+
+    for (const TimeBlockBuffer<float>::DataRow &row : buffer.GetVector()) {
+      for (size_t ch = 0; ch != _nChannels; ++ch) {
+        const float *visPtr = &row.visibilities[ch * _nPolarizations];
+        float weight = *visPtr;
+        for (size_t p = 1; p != _nPolarizations; ++p)
+          if (visPtr[p] < weight)
+            weight = visPtr[p];
+
+        *symbolBuffer = roundf(double(weight) * scaleValue);
+        ++symbolBuffer;
+      }
+    }
+  }
+
+private:
+  const size_t _nPolarizations;
+  const size_t _nChannels;
+  const size_t _quantCount;
+  float _decodeMaxValue;
+};
+
+#endif

--- a/tables/Dysco/weightencoder.cpp
+++ b/tables/Dysco/weightencoder.cpp
@@ -1,0 +1,1 @@
+#include "weightencoder.h"

--- a/tables/Dysco/weightencoder.h
+++ b/tables/Dysco/weightencoder.h
@@ -1,0 +1,85 @@
+#ifndef DYSCO_WEIGHT_ENCODER_H
+#define DYSCO_WEIGHT_ENCODER_H
+
+#include <cmath>
+#include <vector>
+
+namespace dyscostman {
+
+/**
+ * Encoder for visibility weights. It's a linear quantizer for
+ * non-negative values, with a single scaling factor. The scaling
+ * factor will be such that the max value will still fit.
+ * @author André Offringa
+ */
+template <typename T> class WeightEncoder {
+public:
+  /** Value type of the original weights (a floating point value).*/
+  typedef T value_t;
+  /** Value type of the symbols to which the weights are encoded. */
+  typedef unsigned symbol_t;
+
+  /** Construct a new encoder with the given quantization count.
+   * @param quantCount The number of quantization levels.
+   */
+  explicit WeightEncoder(unsigned quantCount) : _quantCount(quantCount) {}
+
+  /**
+   * Encodes a vector of values. Will return a vector of symbols and a
+   * scaling value. Together, these can be used to get the original values
+   * back (with some loss due to quantization), by using @ref Decode().
+   * @param scaleVal Will receive the scale value for the vector of values
+   * @param dest The destinal vector with symbols. It is assumed that it
+   * is already of the right size, i.e., equal to input.size().
+   * @param input The input array of values to be encoded.
+   */
+  void Encode(value_t &scaleVal, std::vector<symbol_t> &dest,
+              const std::vector<value_t> &input) const {
+    // Find max value (implicit assumption input is not empty)
+    typename std::vector<value_t>::const_iterator i = input.begin();
+    scaleVal = *i;
+    ++i;
+    while (i != input.end()) {
+      if (*i > scaleVal)
+        scaleVal = *i;
+      ++i;
+    }
+
+    i = input.begin();
+    typename std::vector<symbol_t>::iterator d = dest.begin();
+    const value_t scaleFact = value_t(_quantCount - 1) / scaleVal;
+    while (i != input.end()) {
+      *d = roundf(scaleFact * (*i));
+
+      ++i;
+      ++d;
+    }
+  }
+
+  /**
+   * Decode a previously encoded value.
+   * @param dest The destination for the decoded weight values.
+   * @param scaleVal The scale value for the vector of values.
+   * @param input The input symbols to be decoded.
+   * @see Encode()
+   */
+  void Decode(std::vector<value_t> &dest, value_t scaleVal,
+              const std::vector<symbol_t> &input) const {
+    typename std::vector<symbol_t>::const_iterator i = input.begin();
+    typename std::vector<value_t>::iterator d = dest.begin();
+    const value_t scaleFact = scaleVal / value_t(_quantCount - 1);
+    while (i != input.end()) {
+      *d = (*i) * scaleFact;
+
+      ++i;
+      ++d;
+    }
+  }
+
+private:
+  unsigned _quantCount;
+};
+
+} // namespace dyscostman
+
+#endif


### PR DESCRIPTION
A much requested feature, this MR imports the Dysco source into casacore and makes sure that it gets installed along. This avoids binary incompatibility between Casa and Dysco, which so far has prevented users to make use of Casa on modern LOFAR sets (which are always compressed). It includes the source from https://github.com/aroffringa/dysco literally. It can be switched off with the BUILD_DYSCO cmake variable, that is ON by default.

This fixes #876.