### PR TITLE
fix insufficient precision issue in T+dT syntax

### DIFF
--- a/ms/MSSel/MSTimeGram.yy
+++ b/ms/MSSel/MSTimeGram.yy
@@ -174,11 +174,12 @@ rangetimeexpr: yeartimeexpr DASH yeartimeexpr
 
 		   Time time0($1.year,$1.month,$1.day,$1.hour,$1.minute,s0);
 		   Time time1($3.year,$3.month,$3.day,$3.hour,$3.minute,s1);
-		   Double mjd=time1.modifiedJulianDay()*86400.0;
-
-		   time1 = time0 + mjd;
-		   const MEpoch *t0=new MEpoch(MVEpoch(time0.modifiedJulianDay()));
-		   const MEpoch *t1=new MEpoch(MVEpoch(time1.modifiedJulianDay()));
+		   Double mjd0 = time0.modifiedJulianDay();
+		   Double mjd1 = time1.modifiedJulianDay();
+		   MVEpoch mve0(mjd0);
+		   MVEpoch mve1(mjd0, mjd1);
+		   const MEpoch *t0=new MEpoch(mve0);
+		   const MEpoch *t1=new MEpoch(mve1);
 
 		   $$ = MSTimeParse::thisMSTParser->selectTimeRange(t0,t1,MSTimeEdgeInclusiveRange,MSTimeEdgeBuffer);
 		   MSTGgarbageCollector(t0);

--- a/ms/MSSel/MSTimeGram.yy
+++ b/ms/MSSel/MSTimeGram.yy
@@ -169,11 +169,11 @@ rangetimeexpr: yeartimeexpr DASH yeartimeexpr
 		   MSTimeParse::thisMSTParser->setDefaults($3,false);
 		   MSTimeParse::thisMSTParser->validate($1);
 		   MSTimeParse::thisMSTParser->validate($3);
-		   Double s;
-		   s=$3.sec;
+		   Double s0 = Double($1.sec) + Double($1.fsec) / 1000.0;
+		   Double s1 = Double($3.sec) + Double($3.fsec) / 1000.0;
 
-		   Time time0($1.year,$1.month,$1.day,$1.hour,$1.minute,(Double)$1.sec);
-		   Time time1($3.year,$3.month,$3.day,$3.hour,$3.minute,s);
+		   Time time0($1.year,$1.month,$1.day,$1.hour,$1.minute,s0);
+		   Time time1($3.year,$3.month,$3.day,$3.hour,$3.minute,s1);
 		   Double mjd=time1.modifiedJulianDay()*86400.0;
 
 		   time1 = time0 + mjd;

--- a/ms/MSSel/test/tMSTimeGram.out
+++ b/ms/MSSel/test/tMSTimeGram.out
@@ -1,0 +1,8 @@
+Original table has rows 1058
+TableExprNode has rows = 1058
+After mssel constructor called
+selected table has rows 46
+Original table has rows 1058
+TableExprNode has rows = 1058
+After mssel constructor called
+selected table has rows 46

--- a/ms/MSSel/test/tMSTimeGram.run
+++ b/ms/MSSel/test/tMSTimeGram.run
@@ -1,3 +1,41 @@
 #! /bin/sh
-echo "UNTESTED"
-exit 3
+# -----------------------------------------------------------------------------
+# Usage: tMSTimeGram.run
+# -----------------------------------------------------------------------------
+# This script executes the program tMSTimeGram to test the
+# MSTimeGram module.
+#
+# $Id$
+#-----------------------------------------------------------------------------
+
+  MS=$CASADEMO"mssel_test_small.ms"
+
+  runCmd(){
+      # Uncomment following line to generate an output close to a
+      # script to run the tests
+      #echo "#Test:$1"; echo $3;
+
+      eval "$2 $3"
+  }
+
+  getTestMS() {
+      tar zxf $testsrcdir/$MS.tgz
+  }
+
+  cleanup() {
+      \rm -rf $MS
+  }
+
+  # Get the test MS (un-tar it from $testsrcdir).
+  getTestMS;
+
+  # T1~T2 syntax: selects single timestamp, 2014/09/20/10:37:51.360000
+  runCmd 1 "$casa_checktool" " ./tMSTimeGram $MS '2014/09/20/10:37:51.0~10:37:51.5'";
+
+  # T+dT syntax: selects single timestamp, 2014/09/20/10:37:51.360000
+  runCmd 2 "$casa_checktool" " ./tMSTimeGram $MS '2014/09/20/10:37:51.0+0:0:0.5'";
+
+  #
+  # Remove the test MS and any other cleanup required.
+  #
+  cleanup;


### PR DESCRIPTION
I noticed that timerange selection by "T+dT" syntax omits the sub-seconds value. More specifically, if we write "HH:MM:SS.ss", ".ss" part is omitted in parsing "T+dT" string. I think this is a bug because "T1~T2" syntax handles sub-seconds value properly. This pull request is possible fix for the bug.