### PR TITLE
Add operator parameters in Adios2StMan for data compression

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -46,12 +46,6 @@ constexpr const char *Adios2StMan::impl::SPEC_FIELD_OPERATOR_PARAMS;
 // Adios2StMan implementation in terms of the impl class
 //
 
-Adios2StMan::Adios2StMan(MPI_Comm mpiComm)
-    : DataManager(),
-    pimpl(std::unique_ptr<impl>(new impl(*this, mpiComm)))
-{
-}
-
 Adios2StMan::Adios2StMan(MPI_Comm mpiComm, std::string engineType,
     std::map<std::string, std::string> engineParams,
     std::vector<std::map<std::string, std::string>> transportParams,
@@ -147,13 +141,6 @@ rownr_t Adios2StMan::getNrRows()
 //
 // impl class implementation using ADIOS2
 //
-
-Adios2StMan::impl::impl(Adios2StMan &parent, MPI_Comm mpiComm)
-    : parent(parent)
-{
-    itsMpiComm = mpiComm;
-    Adios2StMan(mpiComm, "", {}, {}, {});
-}
 
 Adios2StMan::impl::impl(
         Adios2StMan &parent, MPI_Comm mpiComm, std::string engineType,

--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -361,7 +361,7 @@ Record Adios2StMan::impl::dataManagerSpec() const
             }
             operator_params_record.defineRecord(itVar->second, to_record(params));
         }
-        record.defineRecord(SPEC_FIELD_TRANSPORT_PARAMS, operator_params_record);
+        record.defineRecord(SPEC_FIELD_OPERATOR_PARAMS, operator_params_record);
     }
     return record;
 }

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -48,9 +48,12 @@ class Adios2StMan : public DataManager
     template<typename T> friend class Adios2StManColumnT;
 public:
     Adios2StMan(MPI_Comm mpiComm = MPI_COMM_WORLD);
-    Adios2StMan(MPI_Comm mpiComm, std::string engineType,
+
+    Adios2StMan(MPI_Comm mpiComm,
+            std::string engineType,
             std::map<std::string, std::string> engineParams,
-            std::vector<std::map<std::string, std::string>> transportParams);
+            std::vector<std::map<std::string, std::string>> transportParams,
+            std::vector<std::map<std::string, std::string>> operatorParams);
 
     virtual ~Adios2StMan();
 

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -57,6 +57,8 @@ public:
             std::vector<std::map<std::string, std::string>> operatorParams
                 = std::vector<std::map<std::string, std::string>>());
 
+    Adios2StMan(std::string xmlFile, MPI_Comm mpiComm = MPI_COMM_WORLD);
+
     virtual ~Adios2StMan();
 
     virtual DataManager *clone() const;

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -47,13 +47,15 @@ class Adios2StMan : public DataManager
     friend class Adios2StManColumn;
     template<typename T> friend class Adios2StManColumnT;
 public:
-    Adios2StMan(MPI_Comm mpiComm = MPI_COMM_WORLD);
 
-    Adios2StMan(MPI_Comm mpiComm,
-            std::string engineType,
-            std::map<std::string, std::string> engineParams,
-            std::vector<std::map<std::string, std::string>> transportParams,
-            std::vector<std::map<std::string, std::string>> operatorParams);
+    Adios2StMan(MPI_Comm mpiComm = MPI_COMM_WORLD,
+            std::string engineType = std::string(),
+            std::map<std::string, std::string> engineParams
+                = std::map<std::string, std::string>(),
+            std::vector<std::map<std::string, std::string>> transportParams
+                = std::vector<std::map<std::string, std::string>>(),
+            std::vector<std::map<std::string, std::string>> operatorParams
+                = std::vector<std::map<std::string, std::string>>());
 
     virtual ~Adios2StMan();
 

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -43,17 +43,17 @@ class Adios2StMan::impl
 public:
 
     impl(Adios2StMan &parent,
-            MPI_Comm mpiComm = MPI_COMM_WORLD,
-            std::string engineType = std::string(),
-            std::map<std::string, std::string> engineParams
-                = std::map<std::string, std::string>(),
-            std::vector<std::map<std::string, std::string>> transportParams
-                = std::vector<std::map<std::string, std::string>>(),
-            std::vector<std::map<std::string, std::string>> operatorParams
-                = std::vector<std::map<std::string, std::string>>());
+         MPI_Comm mpiComm,
+         std::string engineType,
+         std::map<std::string, std::string> engineParams,
+         std::vector<std::map<std::string, std::string>> transportParams,
+         std::vector<std::map<std::string, std::string>> operatorParams);
+
+    impl(Adios2StMan &parent, std::string xmlFile, MPI_Comm mpiComm);
 
     ~impl();
 
+    void checkMPI() const;
     DataManager *clone() const;
     String dataManagerType() const;
     String dataManagerName() const;
@@ -61,7 +61,8 @@ public:
     rownr_t open64(rownr_t aRowNr, AipsIO &ios);
     rownr_t resync64(rownr_t aRowNr);
     Bool flush(AipsIO &ios, Bool doFsync);
-    DataManagerColumn *makeColumnCommon(const String &aName, int aDataType,
+    DataManagerColumn *makeColumnCommon(const String &aName,
+                                        int aDataType,
                                         const String &aDataTypeID);
     DataManagerColumn *makeScalarColumn(const String &aName,
                                         int aDataType,
@@ -89,27 +90,31 @@ private:
     std::shared_ptr<adios2::IO> itsAdiosIO;
     std::shared_ptr<adios2::Engine> itsAdiosEngine;
 
-    // The ADIOS2 I/O Engine type
-    std::string itsAdiosEngineType;
-    // Parameters for the ADIOS2 I/O engine
-    adios2::Params itsAdiosEngineParams;
-    // Parameters for the ADIOS2 I/O transports
-    std::vector<adios2::Params> itsAdiosTransportParamsVec;
-    // Parameters for the ADIOS2 I/O operators (compressors)
-    std::vector<adios2::Params> itsAdiosOperatorParamsVec;
-
     // MPI communicator to be used by all instances of this storage manager
     static MPI_Comm itsMpiComm;
 
+    // The ADIOS2 XML configuration file
+    std::string itsAdiosXmlFile;
+    // The ADIOS2 Engine type
+    std::string itsAdiosEngineType;
+    // Parameters for the ADIOS2 engine
+    adios2::Params itsAdiosEngineParams;
+    // Parameters for the ADIOS2 transports
+    std::vector<adios2::Params> itsAdiosTransportParamsVec;
+    // Parameters for the ADIOS2 operators (compressors)
+    std::vector<adios2::Params> itsAdiosOperatorParamsVec;
+
     // The type of this storage manager
     static constexpr const char *DATA_MANAGER_TYPE = "Adios2StMan";
-    // The name of the specification field for the I/O engine type
+    // The name of the specification field for the ADIOS2 XML configuration file
+    static constexpr const char *SPEC_FIELD_XML_FILE = "XMLFILE";
+    // The name of the specification field for the ADIOS2 engine type
     static constexpr const char *SPEC_FIELD_ENGINE_TYPE = "ENGINETYPE";
-    // The name of the specification field for the I/O engine parameters
+    // The name of the specification field for the ADIOS2 engine parameters
     static constexpr const char *SPEC_FIELD_ENGINE_PARAMS = "ENGINEPARAMS";
-    // The name of the specification field for the transport parameters
+    // The name of the specification field for the ADIOS2 transport parameters
     static constexpr const char *SPEC_FIELD_TRANSPORT_PARAMS = "TRANSPORTPARAMS";
-    // The name of the specification field for the operator parameters
+    // The name of the specification field for the ADIOS2 operator parameters
     static constexpr const char *SPEC_FIELD_OPERATOR_PARAMS = "OPERATORPARAMS";
 
     uInt ncolumn() const { return parent.ncolumn(); }

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -41,12 +41,16 @@ class Adios2StManColumn;
 class Adios2StMan::impl
 {
 public:
-    impl(Adios2StMan &parent, MPI_Comm mpiComm = MPI_COMM_WORLD);
 
-    impl(Adios2StMan &parent, MPI_Comm mpiComm, std::string engineType,
-            std::map<std::string, std::string> engineParams,
-            std::vector<std::map<std::string, std::string>> transportParams,
-            std::vector<std::map<std::string, std::string>> operatorParams);
+    impl(Adios2StMan &parent,
+            MPI_Comm mpiComm = MPI_COMM_WORLD,
+            std::string engineType = std::string(),
+            std::map<std::string, std::string> engineParams
+                = std::map<std::string, std::string>(),
+            std::vector<std::map<std::string, std::string>> transportParams
+                = std::vector<std::map<std::string, std::string>>(),
+            std::vector<std::map<std::string, std::string>> operatorParams
+                = std::vector<std::map<std::string, std::string>>());
 
     ~impl();
 
@@ -105,7 +109,7 @@ private:
     static constexpr const char *SPEC_FIELD_ENGINE_PARAMS = "ENGINEPARAMS";
     // The name of the specification field for the transport parameters
     static constexpr const char *SPEC_FIELD_TRANSPORT_PARAMS = "TRANSPORTPARAMS";
-    // The name of the specification field for the transport parameters
+    // The name of the specification field for the operator parameters
     static constexpr const char *SPEC_FIELD_OPERATOR_PARAMS = "OPERATORPARAMS";
 
     uInt ncolumn() const { return parent.ncolumn(); }

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -42,9 +42,11 @@ class Adios2StMan::impl
 {
 public:
     impl(Adios2StMan &parent, MPI_Comm mpiComm = MPI_COMM_WORLD);
+
     impl(Adios2StMan &parent, MPI_Comm mpiComm, std::string engineType,
             std::map<std::string, std::string> engineParams,
-            std::vector<std::map<std::string, std::string>> transportParams);
+            std::vector<std::map<std::string, std::string>> transportParams,
+            std::vector<std::map<std::string, std::string>> operatorParams);
 
     ~impl();
 
@@ -87,8 +89,10 @@ private:
     std::string itsAdiosEngineType;
     // Parameters for the ADIOS2 I/O engine
     adios2::Params itsAdiosEngineParams;
-    // Parameters for the ADIOS2 I/O Transports
+    // Parameters for the ADIOS2 I/O transports
     std::vector<adios2::Params> itsAdiosTransportParamsVec;
+    // Parameters for the ADIOS2 I/O operators (compressors)
+    std::vector<adios2::Params> itsAdiosOperatorParamsVec;
 
     // MPI communicator to be used by all instances of this storage manager
     static MPI_Comm itsMpiComm;

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -105,6 +105,8 @@ private:
     static constexpr const char *SPEC_FIELD_ENGINE_PARAMS = "ENGINEPARAMS";
     // The name of the specification field for the transport parameters
     static constexpr const char *SPEC_FIELD_TRANSPORT_PARAMS = "TRANSPORTPARAMS";
+    // The name of the specification field for the transport parameters
+    static constexpr const char *SPEC_FIELD_OPERATOR_PARAMS = "OPERATORPARAMS";
 
     uInt ncolumn() const { return parent.ncolumn(); }
     String fileName() const { return parent.fileName(); }

--- a/tables/DataMan/test/tAdios2StMan.cc
+++ b/tables/DataMan/test/tAdios2StMan.cc
@@ -273,7 +273,7 @@ void doCopyTable(std::string inTable, std::string outTable, std::string column)
 void doReadCopiedTable(std::string filename, std::string column, uInt rows, IPosition array_pos)
 {
     Table tab(filename);
-    VerifyArrayColumn<Complex>(tab, "array_Complex", rows, array_pos);
+    VerifyArrayColumn<Complex>(tab, column, rows, array_pos);
 }
 
 int main(int argc, char **argv){


### PR DESCRIPTION
@rtobar Please help review.

After experimenting various data compression techniques in ADIOS2 for a while, we want to finalize the API so the ASKAP DINGO project can incorporate this into their production workflow.

This PR adds a std::vector<std::map<std::string, std::string>> typed container of parameters into Adios2StMan::Adios2StMan(), to pass data compression parameters from user applications down to the ADIOS2 library. Each element in std::vector<std::map<std::string, std::string>> is a map containing necessary information to add an ADIOS2 operator (data compressor in this case). A parameter map must have the key *Operator* to specify the data compressor, and the key *Variable* to specify the CTDS column (ADIOS2 variable) that this operator is attaching to. 

So far, the Bzip2, Blosc lossless compressors, and the ZFP and SZ lossy compressors have been tested with this feature. For more information about all available compressors and parameters, please refer to the ADIOS2 docs https://adios2.readthedocs.io/en/latest/

An example code: https://github.com/JasonRuonanWang/SparseTableCopy/blob/main/tableCopy.cc

This PR also fixes a bug for parsing transport parameters.