### PR TITLE
Replace leftofer Mutex/ScopedMutexLock with std::mutex

### DIFF
--- a/casa/Exceptions/Error2.cc
+++ b/casa/Exceptions/Error2.cc
@@ -96,11 +96,11 @@ AipsError::~AipsError() noexcept
   // stack trace from last exception
   static String lastStackTrace = "*no-stack-trace*";
   // protects the lastMessage and lastStackTrace statics
-  static Mutex  lastErrorMutex;
+  static std::mutex  lastErrorMutex;
 
   void AipsError::getLastInfo (String & message, String & stackTrace)
   {
-    ScopedMutexLock lock(lastErrorMutex);
+    std::lock_guard<std::mutex> lock(lastErrorMutex);
     message = getLastMessage();
     stackTrace = getLastStackTrace();
   }
@@ -110,7 +110,7 @@ AipsError::~AipsError() noexcept
     { return CasaErrorTools::replaceStackAddresses (lastStackTrace); }
   void AipsError::clearLastInfo ()
   {
-    ScopedMutexLock lock(lastErrorMutex);
+    std::lock_guard<std::mutex> lock(lastErrorMutex);
     lastMessage = "*none*";
     lastStackTrace = "*no-stack-trace*";
   }
@@ -121,7 +121,7 @@ AipsError::~AipsError() noexcept
     // for later retrieval via casapy
     stackTrace = CasaErrorTools::generateStackTrace();
     {
-      ScopedMutexLock lock(lastErrorMutex);
+      std::lock_guard<std::mutex> lock(lastErrorMutex);
       lastMessage = message;
       lastStackTrace = stackTrace;
     }

--- a/measures/Measures/MeasTable.cc
+++ b/measures/Measures/MeasTable.cc
@@ -91,7 +91,7 @@ Double MeasTable::firstIGRF = 0;
 std::vector<Vector<Double> > MeasTable::coefIGRF;
 std::vector<Vector<Double> > MeasTable::dIGRF;
   ///#if !defined(USE_THREADS) || defined(__APPLE__)
-  ///Mutex MeasTable::theirdUT1Mutex;
+  ///std::mutex MeasTable::theirdUT1Mutex;
   ///#endif
 
 //# Member functions
@@ -4407,7 +4407,7 @@ Double MeasTable::dUT1(Double utc) {
   static thread_local Double res = 0.0;
   static thread_local Double checkT = -1e6;
   ///#else // !USE_THREADS (empty Mutex impl) or __APPLE__
-  ///  ScopedMutexLock lock(theirdUT1Mutex); // Pity. Try to narrow blunt __APPLE__ cond.
+  ///  std::lock_guard<std::mutex> lock(theirdUT1Mutex); // Pity. Try to narrow blunt __APPLE__ cond.
   ///  static Double res = 0.0;
   ///  static Double checkT = -1e6;
   ///#endif

--- a/measures/Measures/MeasTable.h
+++ b/measures/Measures/MeasTable.h
@@ -571,7 +571,7 @@ private:
   // </group>
 
   ///#if !defined(USE_THREADS) || defined(__APPLE__)
-  ///  static Mutex theirdUT1Mutex;
+  ///  static std::mutex theirdUT1Mutex;
   ///#endif
 };
 


### PR DESCRIPTION
Fixes #1126
I also did the same change for a few commented out Mutex instances in other files, to prevent future confusion.