### PR TITLE
Explicit include of mutex in Error2.cc

### DIFF
--- a/casa/Exceptions/Error2.cc
+++ b/casa/Exceptions/Error2.cc
@@ -31,7 +31,6 @@
 #include <casacore/casa/iostream.h>
 #include <casacore/casa/string.h>      //# needed for strerror_r
 
-
 //# Stacktracing requires some extra includes.
 #ifdef USE_STACKTRACE
 # include <casacore/casa/System/AipsrcValue.h>


### PR DESCRIPTION
This is a follow up on #1126.
Added an explicit include of <mutex> (following discussion from PR #1127). Not strictly needed but probably more clear, and less dependent on what AipsrcValue.h decides to include.
