### PR TITLE
Remove assertion that does (time&0xff)!=0

### DIFF
--- a/casa/System/test/tObjectID.cc
+++ b/casa/System/test/tObjectID.cc
@@ -39,10 +39,10 @@ void assert_hash(const ObjectID &id)
 {
 	if (!id.isNull()) {
 		// Hash bytes are: seq number, pid, creation time and hostname
-		// The sequence number starts at zero, and PIDs can be multiples of 256,
-		// but at least the other two fields will always have a bit set
+		// The sequence number starts at zero, and PIDs and creation time
+    // can be multiples of 256. At least the other field will always have
+    // a bit set
 		auto hash = hashFunc(id);
-		AlwaysAssertExit(((hash >> 16) & 0xff) != 0);
 		AlwaysAssertExit(((hash >> 24) & 0xff) != 0);
 	}
 }


### PR DESCRIPTION
This fails one out of 256 times. Fixes #1130.