### PR TITLE
Add -std=legacy compiler option for scimath_f

### DIFF
--- a/scimath_f/CMakeLists.txt
+++ b/scimath_f/CMakeLists.txt
@@ -37,7 +37,7 @@ if (BUILD_FFTPACK_DEPRECATED)
 endif ()
 
 add_library (casa_scimath_f ${buildfiles})
-
+target_compile_options (casa_scimath_f PRIVATE -std=legacy)
 target_link_libraries (casa_scimath_f casa_tables ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${CASACORE_ARCH_LIBS})
 
 install (


### PR DESCRIPTION
Compiling `fftpak.f` with newer versions of gcc (>= 10?) gfortran results in compile time errors. This change allows builds to complete.  I realize that fftpack is deprecated, but some versions of CASA still require it. A more targeted option to try is `-fallow-argument-mismatch`. Testing fortran compiler options in CMake seems not to be possible with the minimum CMake version for casacore, and I'm not sure how to deal with that possibility. I'm also not sure how much effort is warranted here --- I wouldn't mind if the PR were not merged.