### PR TITLE
Fixed clang warnings

### DIFF
--- a/casa/BasicSL/STLMath.h
+++ b/casa/BasicSL/STLMath.h
@@ -99,7 +99,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     std::vector<T> result(left.size());
     std::transform (left.begin(), left.end(), result.begin(),
-                    std::bind(std::divides<T>(), std::placeholders::_1, right));
+                    [right](T x) { return x / right; });
     return result;
   }
 

--- a/casa/BasicSL/STLMath.h
+++ b/casa/BasicSL/STLMath.h
@@ -99,7 +99,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     std::vector<T> result(left.size());
     std::transform (left.begin(), left.end(), result.begin(),
-                    std::bind2nd(std::divides<T>(), right));
+                    std::bind(std::divides<T>(), std::placeholders::_1, right));
     return result;
   }
 

--- a/casa/BasicSL/String.h
+++ b/casa/BasicSL/String.h
@@ -64,6 +64,8 @@ public:
   friend class String;
   // Make a string
   operator const string() const { return string(ref_p, pos_p, len_p); }
+  // Default copy constructor.
+  SubString (const SubString&) = default;
   // Assignment
   // <group>
   SubString &operator=(const SubString &str);

--- a/casa/Containers/test/tBlock.cc
+++ b/casa/Containers/test/tBlock.cc
@@ -299,7 +299,8 @@ void doit()
     for(i=0; i < 200; i++) {
 	AlwaysAssertExit(bi2[i] == 5);
     }
-    bi2 = bi2;
+    const Block<Int>& bi2ref(bi2);         // Use ref in self-assigment
+    bi2 = bi2ref;                          // to avoid compiler warning
     AlwaysAssertExit(bi2.nelements() == 200);
     for(i=0; i < 200; i++) {
 	AlwaysAssertExit(bi2[i] == 5);

--- a/casa/OS/test/tFile.cc
+++ b/casa/OS/test/tFile.cc
@@ -69,7 +69,8 @@ void doIt (Bool doExcp)
     // Test assignment.
     File isFile2;
     isFile2 = isFile;
-    exist2 = exist2;
+    const File& exist2ref(exist2);
+    exist2 = exist2ref;
     
     AlwaysAssertExit (isFile.isRegular());
     AlwaysAssertExit (isDir.isDirectory());

--- a/casa/OS/test/tPath.cc
+++ b/casa/OS/test/tPath.cc
@@ -159,7 +159,8 @@ void doIt (Bool doExcp, Bool& success)
     AlwaysAssertExit (test3.originalName() == test2.originalName());
     AlwaysAssertExit (test3.expandedName() == test2.expandedName());
     AlwaysAssertExit (test3.absoluteName() == test2.absoluteName());
-    test3 = test3;
+    const Path& test3ref(test3);
+    test3 = test3ref;
     AlwaysAssertExit (test3.originalName() == test2.originalName());
     AlwaysAssertExit (test3.expandedName() == test2.expandedName());
     AlwaysAssertExit (test3.absoluteName() == test2.absoluteName());

--- a/casa/OS/test/tRegularFile.cc
+++ b/casa/OS/test/tRegularFile.cc
@@ -79,7 +79,8 @@ void doIt (Bool doExcp)
 	} 
     }
     // Assignment.
-    risLink1 = risLink1;
+    const RegularFile& risLink1ref(risLink1);
+    risLink1 = risLink1ref;
     AlwaysAssertExit (risLink1.path().originalName() ==
                                              "tRegularFile_tmp/isLink1");
     rFile5 = risFile;

--- a/lattices/LatticeMath/LattStatsSpecialize.cc
+++ b/lattices/LatticeMath/LattStatsSpecialize.cc
@@ -106,8 +106,8 @@ void LattStatsSpecialize::accumulate (
 	DComplex& nPts, DComplex& sum,
 	DComplex& mean, DComplex& nvariance, DComplex& variance,
 	DComplex& sumSq, Complex& dataMin,
-	Complex& dataMax, const Int&,
-	const Int&, Bool& minMaxInit,
+	Complex& dataMax, Int&,
+        Int&, Bool& minMaxInit,
 	const Bool fixedMinMax, const Complex datum,
 	const uInt&, const Complex useIt
 ) {

--- a/lattices/LatticeMath/LattStatsSpecialize.h
+++ b/lattices/LatticeMath/LattStatsSpecialize.h
@@ -90,8 +90,8 @@ public:
    static void accumulate (DComplex& nPts, DComplex& sum,
 						   DComplex& mean, DComplex& nvariance,DComplex& variance,
                            DComplex& sumSq, Complex& dataMin,
-                           Complex& dataMax, const Int& minPos,
-                           const Int& maxPos, Bool& minMaxInit,
+                           Complex& dataMax, Int& minPos,
+                           Int& maxPos, Bool& minMaxInit,
                            const Bool fixedMinMax, const Complex datum,
                            const uInt& pos, const Complex useIt);
 

--- a/lattices/Lattices/test/tPixelCurve1D.cc
+++ b/lattices/Lattices/test/tPixelCurve1D.cc
@@ -129,7 +129,8 @@ int main()
   // Copy constructor and self assignment.
   PixelCurve1D pcurve3(pcurve);
   AlwaysAssertExit (pcurve3.npoints() == 9);
-  pcurve3 = pcurve3;
+  const PixelCurve1D& pcurve3ref(pcurve3);
+  pcurve3 = pcurve3ref;
   AlwaysAssertExit (pcurve3.npoints() == 9);
   pcurve3.getPixelCoord (x, y, 0, 8);
   cout << x << y << endl;
@@ -169,7 +170,8 @@ int main()
     yp[0]=2; yp[1]=6; yp[2]=9; yp[3]=6; yp[4]=6;
     PixelCurve1D pcurve4(xp,yp,21);
     AlwaysAssertExit (pcurve4.npoints() == 21);
-    pcurve4 = pcurve4;
+    const PixelCurve1D& pcurve4ref(pcurve4);
+    pcurve4 = pcurve4ref;
     AlwaysAssertExit (pcurve4.npoints() == 21);
     pcurve4.getPixelCoord (x, y, 0, 20);
     cout << x << y << endl;

--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -289,6 +289,10 @@ void MSLister::listHeader()
     // logStream_p << "dataColSel = " << dataColSel << LogIO::POST;
     // cout << "dataColSel = " << dataColSel << endl;
 
+    // Fill unused variables to avoid compiler warnings.
+    nchan = 0;
+    start = 0;
+    step  = 0;
     selectvis(timerange, newSpw, scan, field, antenna, uvrange, chanmode,
               nchan, start, step, mStart,  mStep, correlation,
               // IGNORE PARAMETERS THAT ARE NOT YET IMPLEMENTED
@@ -298,7 +302,7 @@ void MSLister::listHeader()
     // List the data
     listData(pagerows, listfile);
   }
-  catch (std::exception& x) {
+  catch (const std::exception& x) {
     logStream_p << LogOrigin("MSLister","list",WHERE)
             << LogIO::SEVERE << "Caught exception: " << x.what()
             << LogIO::POST;

--- a/msfits/MSFits/MSFitsOutput.cc
+++ b/msfits/MSFits/MSFitsOutput.cc
@@ -2625,7 +2625,7 @@ Bool MSFitsOutput::_writeSY(
         ANTENNA_ID, FEED_ID, SPECTRAL_WINDOW_ID, TIME, "INTERVAL",
         "SWITCHED_DIFF", "SWITCHED_SUM", "REQUANTIZER_GAIN"
     };
-    for (const auto cname: expColNames) {
+    for (const String& cname: expColNames) {
         if (! td.isColumn(cname)) {
             os << LogIO::WARN << "Required column " << cname
                 << " not found in SYSPOWER table" << LogIO::POST;

--- a/scimath/Mathematics/test/dSparseDiff.cc
+++ b/scimath/Mathematics/test/dSparseDiff.cc
@@ -178,9 +178,12 @@ int main() {
   {
    SparseDiff<Double> a(3,0), b(5,1), x(7);
    Double y(11);
-   a -= a;
-   b -= b;
-   x -= x;
+   const SparseDiff<Double> aref(a);
+   const SparseDiff<Double> bref(b);
+   const SparseDiff<Double> xref(x);
+   a -= aref;
+   b -= bref;
+   x -= xref;
    y -= y;
    cout << "a-=a: " << a << endl;
    cout << "b-=b: " << b << endl;
@@ -222,9 +225,12 @@ int main() {
   {
    SparseDiff<Double> a(3,0), b(5,1), x(7);
    Double y(11);
-   a /= a;
-   b /= b;
-   x /= x;
+   const SparseDiff<Double> aref(a);
+   const SparseDiff<Double> bref(b);
+   const SparseDiff<Double> xref(x);
+   a /= aref;
+   b /= bref;
+   x /= xref;
    y /= y;
    cout << "a/=a: " << a << endl;
    cout << "b/=b: " << b << endl;

--- a/scimath/Mathematics/test/tFFTServer.cc
+++ b/scimath/Mathematics/test/tFFTServer.cc
@@ -216,13 +216,13 @@ Array<T> shift(const Array<T> &input,
 template <class T, class S>
 class R2C1Deven1 {
   public:
-    static Array<T> input() {
+    static Vector<T> input() {
         Vector<T> input(8, 0.0f);
         input(0) = 1.0f;
         return input;
     }
     
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         return Vector<S>(5, Complex(1,0));
     }
 };
@@ -230,7 +230,7 @@ class R2C1Deven1 {
 template <class T, class S>
 class R2C1Deven2 {
 public:
-  static Array<T> input() {
+  static Vector<T> input() {
     Vector<T> input(8, 0.0f);
     input(0) = 1.0f;
     input(2) = -1.0f;
@@ -239,7 +239,7 @@ public:
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Vector<S> expectedResult() {
     Vector<S> expectedResult(5, Complex(0,0));
     expectedResult(2) = Complex(4,0);
     return expectedResult;
@@ -249,7 +249,7 @@ public:
 template <class T, class S>
 class R2C1Deven3 {
 public:
-  static Array<T> input() {
+  static Vector<T> input() {
     Vector<T> input(8, 0.0f);
     input(1) = 1.0f;
     input(3) = -1.0f;
@@ -258,7 +258,7 @@ public:
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Vector<S> expectedResult() {
     Vector<S> expectedResult(5, Complex(0,0));
     expectedResult(2) = Complex(0, -4);
     return expectedResult;
@@ -268,7 +268,7 @@ public:
 template <class T, class S>
 class R2C1Deven4 {
 public:
-  static Array<T> input() {
+  static Vector<T> input() {
     Vector<T> input(8, 0.0f);
     input(1) = 1.0f;
     input(3) = 1.0f;
@@ -277,7 +277,7 @@ public:
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Vector<S> expectedResult() {
     Vector<S> expectedResult(5, Complex(0,0));
     expectedResult(0) = Complex(4, 0);
     expectedResult(4) = Complex(-4, 0);
@@ -290,13 +290,13 @@ public:
 template <class T, class S>
 class R2C1Dodd1 {
 public:
-  static Array<T> input() {
+  static Vector<T> input() {
     Vector<T> input(9, 0.0f);
     input(0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Vector<S> expectedResult() {
     return Vector<S>(5, Complex(1,0));
   }
 };
@@ -305,11 +305,11 @@ public:
 template <class T, class S>
 class R2C1Dodd2 {
 public:
-  static Array<T> input() {
+  static Vector<T> input() {
     return Vector<T>(9, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Vector<S> expectedResult() {
     Vector<S> expectedResult(5, Complex(0,0));
     expectedResult(0) = Complex(9,0);
     return expectedResult;
@@ -319,7 +319,7 @@ public:
 template <class T, class S>
 class R2C1Dodd3 {
 public:
-  static Array<T> input() {
+  static Vector<T> input() {
     Vector<T> input(9, 1.0f);
     input(1) = 0.0f;
     input(3) = 0.0f;
@@ -328,7 +328,7 @@ public:
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Vector<S> expectedResult() {
     Vector<S> expectedResult(5, Complex(0,0));
     expectedResult(0) = Complex(5,0);
     expectedResult(1) = Complex(0.5, 0.181985117133101);
@@ -341,25 +341,25 @@ public:
 template <class T, class S>
 class R2C2Deveneven1 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
     Matrix<T> input(4, 6);
     input = 0.0f;
     input(0, 0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
     return Matrix<S>(3, 6, Complex(1, 0));
   }
 };
 template <class T, class S>
 class R2C2Deveneven2 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
     return Matrix<T>(4, 6, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
     Matrix<S> expectedResult(3, 6, Complex(0,0));
     expectedResult(0, 0) = Complex(24, 0);
     return expectedResult;
@@ -368,16 +368,15 @@ public:
 template <class T, class S>
 class R2C2Deveneven3 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
     Matrix<T> input(4, 6, 0.0f);
     input(1,1) = 1.0f;
     input(1,3) = 1.0f;
     input(1,5) = 1.0f;
-    
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
     Matrix<S> expectedResult(3, 6, Complex(0,0));
     expectedResult(0,0) = expectedResult(2,3) = Complex(3,0);
     expectedResult(0,3) = expectedResult(2,0) = Complex(-3,0);
@@ -392,13 +391,13 @@ public:
 template <class T, class S>
 class R2C2Devenodd1 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
     Matrix<T> input(4, 5, 0.0f);
     input(0, 0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
       return Matrix<S>(3, 5, Complex(1, 0));
   }
 };
@@ -406,11 +405,11 @@ public:
 template <class T, class S>
 class R2C2Devenodd2 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
       return Matrix<T>(4, 5, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
       Matrix<S> expectedResult(3, 5, Complex(0,0));
       expectedResult(0,0) = Complex(20,0);
       return expectedResult;
@@ -421,13 +420,13 @@ public:
 template <class T, class S>
 class R2C2Doddeven1 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
     Matrix<T> input(3, 6, 0.0f);
     input(0, 0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
       return Matrix<S>(2, 6, Complex(1, 0));
   }
 };
@@ -435,11 +434,11 @@ public:
 template <class T, class S>
 class R2C2Doddeven2 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
       return Matrix<T>(3, 6, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
       Matrix<S> expectedResult(2, 6, Complex(0,0));
       expectedResult(0,0) = Complex(18,0);
       return expectedResult;
@@ -449,13 +448,13 @@ public:
 template <class T, class S>
 class R2C2Doddodd1 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
     Matrix<T> input(3, 5, 0.0f);
     input(0, 0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
       return Matrix<S>(2, 5, Complex(1, 0));
   }
 };
@@ -463,11 +462,11 @@ public:
 template <class T, class S>
 class R2C2Doddodd2 {
 public:
-  static Array<T> input() {
+  static Matrix<T> input() {
       return Matrix<T>(3, 5, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Matrix<S> expectedResult() {
       Matrix<S> expectedResult(2, 5, Complex(0,0));
       expectedResult(0,0) = Complex(15,0);
       return expectedResult;
@@ -478,24 +477,24 @@ public:
 template <class T, class S>
 class R2C3Deveneveneven1 {
 public:
-  static Array<T> input() {
+  static Cube<T> input() {
     Cube<T> input(4, 6, 8, 0.0f);
     input(0, 0, 0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Cube<S> expectedResult() {
       return Cube<S>(3, 6, 8, Complex(1, 0));
   }
 };
 template <class T, class S>
 class R2C3Deveneveneven2 {
 public:
-  static Array<T> input() {
+  static Cube<T> input() {
       return Cube<T>(4, 6, 8, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Cube<S> expectedResult() {
       Cube<S> expectedResult(3, 6, 8, Complex(0,0));
       expectedResult(0, 0, 0) = Complex(4*6*8,0);
       return expectedResult;
@@ -505,13 +504,13 @@ public:
 template <class T, class S>
 class R2C3Doddoddodd1 {
 public:
-  static Array<T> input() {
+  static Cube<T> input() {
     Cube<T> input(3,5,7, 0.0f);
     input(0, 0, 0) = 1.0f;
     return input;
   }
 
-  static Array<S> expectedResult() {
+  static Cube<S> expectedResult() {
       return Cube<S>(2,5,7, Complex(1, 0));
   }
 };
@@ -519,11 +518,11 @@ public:
 template <class T, class S>
 class R2C3Doddoddodd2 {
 public:
-  static Array<T> input() {
+  static Cube<T> input() {
       return Cube<T>(3,5,7, 1.0f);
   }
 
-  static Array<S> expectedResult() {
+  static Cube<S> expectedResult() {
       Cube<S> expectedResult(2,5,7, Complex(0,0));
       expectedResult(0, 0, 0) = Complex(3*5*7,0);
       return expectedResult;
@@ -570,13 +569,13 @@ public:
 template <class S, class T>
 class C2R1Deven1 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
     Vector<S> input(5, Complex(0, 0));
     input(0) = Complex(8, 0);
     return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       return Vector<T>(8, 1.0f);
   }
 };
@@ -584,14 +583,14 @@ public:
 template <class S, class T>
 class C2R1Deven2 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
       Vector<S> input(5, S(0, 0));
       input(0) = S(16.0f, 0.0f);
       input(2) = S(8.0f, 0.0f);
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       Vector<T> expectedResult(8, T(2.0));
       expectedResult(0) = 4.0f;
       expectedResult(2) = 0.0f;
@@ -604,14 +603,14 @@ public:
 template <class S, class T>
 class C2R1Deven3 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
       Vector<S> input(5, S(0, 0));
       input(0) = Complex(0.0f, 0.0f);
       input(2) = Complex(0.0f, 4.0f);
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       Vector<T> expectedResult(8, T(0.0));
       expectedResult(1) = -1.0f;
       expectedResult(3) = 1.0f;
@@ -623,12 +622,12 @@ public:
 template <class S, class T>
 class C2R1Deven4 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
       Vector<S> input(5, S(1, 0));
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       Vector<T> expectedResult(8, T(0.0));
       expectedResult(0) = 1.0f;
       return expectedResult;
@@ -637,14 +636,14 @@ public:
 template <class S, class T>
 class C2R1Deven5 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
       Vector<S> input(5, S(1, 0));
       input(1) = Complex(0,0);
       input(3) = Complex(0,0);
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       Vector<T> expectedResult(8, T(0.0));
       expectedResult(0) = 0.5f;
       expectedResult(4) = 0.5f;
@@ -656,13 +655,13 @@ public:
 template <class S, class T>
 class C2R1Dodd1 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
     Vector<S> input(5, S(0, 0));
     input(0) = Complex(9, 0);
     return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       return Vector<T>(9, T(1.0));
   }
 };
@@ -670,12 +669,12 @@ public:
 template <class S, class T>
 class C2R1Dodd2 {
 public:
-  static Array<S> input() {
+  static Vector<S> input() {
       Vector<S> input(5, S(1, 0));
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Vector<T> expectedResult() {
       Vector<T> expectedResult(9, T(0.0));
       expectedResult(0) = 1.0f;
       return expectedResult;
@@ -685,13 +684,13 @@ public:
 template <class S, class T>
 class C2R2Deveneven1 {
 public:
-  static Array<S> input() {
+  static Matrix<S> input() {
       Matrix<S> input(3, 6, S(0, 0));
       input(0,0) = Complex(4*6,0);
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Matrix<T> expectedResult() {
       Matrix<T> expectedResult(4, 6, T(1.0));
       return expectedResult;
   }
@@ -699,12 +698,12 @@ public:
 template <class S, class T>
 class C2R2Deveneven2 {
 public:
-  static Array<S> input() {
+  static Matrix<S> input() {
       Matrix<S> input(3, 6, S(1, 0));
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Matrix<T> expectedResult() {
       Matrix<T> expectedResult(4, 6, T(0.0));
       expectedResult(0,0) = 1.0f;
       return expectedResult;
@@ -713,7 +712,7 @@ public:
 template <class S, class T>
 class C2R2Deveneven3 {
 public:
-  static Array<S> input() {
+  static Matrix<S> input() {
       Matrix<S> input(3, 6, S(0, 0));
       input(0,0) = Complex(24,0);
       input(2,0) = Complex(-24,0);
@@ -725,7 +724,7 @@ public:
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Matrix<T> expectedResult() {
       Matrix<T> expectedResult(4, 6, T(0.0));
       expectedResult(0,0) = expectedResult(0,1) = expectedResult(0,2) 
         = expectedResult(0,4) = expectedResult(0,5) = -1.0f;
@@ -746,13 +745,13 @@ public:
 template <class S, class T>
 class C2R2Doddodd1 {
 public:
-  static Array<S> input() {
+  static Matrix<S> input() {
       Matrix<S> input(2, 5, S(0, 0));
       input(0, 0) = S(3*5, 0);
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Matrix<T> expectedResult() {
       Matrix<T> expectedResult(3, 5, T(1.0));
       return expectedResult;
   }
@@ -761,12 +760,12 @@ public:
 template <class S, class T>
 class C2R2Doddodd2 {
 public:
-  static Array<S> input() {
+  static Matrix<S> input() {
       Matrix<S> input(2, 5, S(1, 0));
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Matrix<T> expectedResult() {
       Matrix<T> expectedResult(3, 5, T(0.0));
       expectedResult(0,0) = 1.0f;
       return expectedResult;
@@ -776,7 +775,7 @@ public:
 template <class S, class T>
 class C2R2Doddodd3 {
 public:
-  static Array<S> input() {
+  static Matrix<S> input() {
       Matrix<S> input(2, 5, S(0, 0));
       input(1,0) = Complex(0,45);
       input(1,1) = Complex(0,45);
@@ -786,7 +785,7 @@ public:
       return input;
   }
 
-  static Array<T> expectedResult() {
+  static Matrix<T> expectedResult() {
       Matrix<T> expectedResult(3, 5, T(0.0));
       expectedResult(1,0) = -25.9808f;
       expectedResult(2,0) = 25.9808f;
@@ -798,13 +797,13 @@ public:
 template <class S, class T>
 class C2R2Devenodd1 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(3, 5, S(0, 0));
         input(0,0) = Complex(4*5, 0);
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Matrix<T> expectedResult() {
         Matrix<T> expectedResult(4, 5, T(1.0));
         return expectedResult;
     }
@@ -813,12 +812,12 @@ class C2R2Devenodd1 {
 template <class S, class T>
 class C2R2Devenodd2 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(3, 5, S(1, 0));
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Matrix<T> expectedResult() {
         Matrix<T> expectedResult(4, 5, T(0.0));
         expectedResult(0,0) = 1.0f;
         return expectedResult;
@@ -829,13 +828,13 @@ class C2R2Devenodd2 {
 template <class S, class T>
 class C2R2Doddeven1 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(2, 6, S(0, 0));
         input(0,0) = Complex(3*6, 0);
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Matrix<T> expectedResult() {
         Matrix<T> expectedResult(3, 6, T(1.0));
         return expectedResult;
     }
@@ -844,12 +843,12 @@ class C2R2Doddeven1 {
 template <class S, class T>
 class C2R2Doddeven2 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(2, 6, S(1, 0));
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Matrix<T> expectedResult() {
         Matrix<T> expectedResult(3, 6, T(0.0));
         expectedResult(0,0) = 1.0f;
         return expectedResult;
@@ -859,13 +858,13 @@ class C2R2Doddeven2 {
 template <class S, class T>
 class C2R3Deveneveneven1 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(3, 6, 2, S(0, 0));
         input(0,0,0) = Complex(4*6*2,0);
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Cube<T> expectedResult() {
         Cube<T> expectedResult(4, 6, 2, T(1.0));
         return expectedResult;
     }
@@ -873,12 +872,12 @@ class C2R3Deveneveneven1 {
 template <class S, class T>
 class C2R3Deveneveneven2 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(3, 6, 2, S(1, 0));
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Cube<T> expectedResult() {
         Cube<T> expectedResult(4, 6, 2, T(0.0));
         expectedResult(0,0,0) = 1.0f;
         return expectedResult;
@@ -888,13 +887,13 @@ class C2R3Deveneveneven2 {
 template <class S, class T>
 class C2R3Doddoddodd1 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(2, 5, 7, S(0, 0));
         input(0,0,0) = Complex(3*5*7,0);
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Cube<T> expectedResult() {
         Cube<T> expectedResult(3, 5, 7, T(1.0));
         return expectedResult;
     }
@@ -902,12 +901,12 @@ class C2R3Doddoddodd1 {
 template <class S, class T>
 class C2R3Doddoddodd2 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(2, 5, 7, S(1, 0));
         return input;
     }
     
-    static Array<T> expectedResult() {
+    static Cube<T> expectedResult() {
         Cube<T> expectedResult(3, 5, 7, T(0.0));
         expectedResult(0,0,0) = 1.0f;
         return expectedResult;
@@ -960,13 +959,13 @@ class C2R4Doddoddoddeven2 {
 template <class S>
 class C2C1Deven1 {
   public:
-    static Array<S> input() {
+    static Vector<S> input() {
         Vector<S> input(8, S(0, 0));
         input(0) = Complex(1.0f, 0.0f);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         Vector<S> expectedResult(8, S(1, 0));
         return expectedResult;
     }
@@ -975,12 +974,12 @@ class C2C1Deven1 {
 template <class S>
 class C2C1Deven2 {
   public:
-    static Array<S> input() {
+    static Vector<S> input() {
         Vector<S> input(8, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         Vector<S> expectedResult(8, S(0, 0));
         expectedResult(0) = Complex(8,0);
         return expectedResult;
@@ -990,7 +989,7 @@ class C2C1Deven2 {
 template <class S>
 class C2C1Deven3 {
   public:
-    static Array<S> input() {
+    static Vector<S> input() {
         Vector<S> input(8, S(-1, 0));
         input(0) = Complex(1, 0);
         input(2) = Complex(1, 0);
@@ -999,7 +998,7 @@ class C2C1Deven3 {
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         Vector<S> expectedResult(8, S(0, 0));
         expectedResult(4) = Complex(8,0);
         return expectedResult;
@@ -1009,7 +1008,7 @@ class C2C1Deven3 {
 template <class S>
 class C2C1Deven4 {
   public:
-    static Array<S> input() {
+    static Vector<S> input() {
         Vector<S> input(8, S(0, 0));
         input(1) = Complex(1, 0);
         input(3) = Complex(-1,0);
@@ -1018,7 +1017,7 @@ class C2C1Deven4 {
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         Vector<S> expectedResult(8, S(0, 0));
         expectedResult(2) = Complex(0,-4);
         expectedResult(6) = Complex(0,4);
@@ -1031,13 +1030,13 @@ class C2C1Deven4 {
 template <class S>
 class C2C1Dodd1 {
   public:
-    static Array<S> input() {
+    static Vector<S> input() {
         Vector<S> input(7, S(0, 0));
         input(0) = Complex(1.0f, 0.0f);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         Vector<S> expectedResult(7, S(1, 0));
         return expectedResult;
     }
@@ -1046,12 +1045,12 @@ class C2C1Dodd1 {
 template <class S>
 class C2C1Dodd2 {
   public:
-    static Array<S> input() {
+    static Vector<S> input() {
         Vector<S> input(7, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Vector<S> expectedResult() {
         Vector<S> expectedResult(7, S(0, 0));
         expectedResult(0) = Complex(7,0);
         return expectedResult;
@@ -1061,13 +1060,13 @@ class C2C1Dodd2 {
 template <class S>
 class C2C2Deveneven1 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(4, 6, S(0, 0));
         input(0,0) = Complex(1,0);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(4, 6, S(1, 0));
         return expectedResult;
     }
@@ -1075,12 +1074,12 @@ class C2C2Deveneven1 {
 template <class S>
 class C2C2Deveneven2 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(4, 6, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(4, 6, S(0, 0));
         expectedResult(0,0) = Complex(24,0);
         return expectedResult;
@@ -1089,15 +1088,14 @@ class C2C2Deveneven2 {
 template <class S>
 class C2C2Deveneven3 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(4, 6, S(0, 0));
         input(1,1) = Complex(1,1);
         input(1,3) = Complex(1,1);
         input(1,5) = Complex(1,1);
-        return input;
-    }
+        return input;    }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(4, 6, S(0, 0));
         expectedResult(0,0) = expectedResult(2,3) = Complex(3,3);
         expectedResult(0,3) = expectedResult(2,0) = Complex(-3,-3);
@@ -1111,13 +1109,13 @@ class C2C2Deveneven3 {
 template <class S>
 class C2C2Doddodd1 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(3, 5, S(0, 0));
         input(0,0) = Complex(1,0);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(3, 5, S(1, 0));
         return expectedResult;
     }
@@ -1125,12 +1123,12 @@ class C2C2Doddodd1 {
 template <class S>
 class C2C2Doddodd2 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(3, 5, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(3, 5, S(0, 0));
         expectedResult(0,0) = Complex(15,0);
         return expectedResult;
@@ -1140,13 +1138,13 @@ class C2C2Doddodd2 {
 template <class S>
 class C2C2Devenodd1 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(4, 5, S(0, 0));
         input(0,0) = Complex(1,0);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(4, 5, S(1, 0));
         return expectedResult;
     }
@@ -1154,12 +1152,12 @@ class C2C2Devenodd1 {
 template <class S>
 class C2C2Devenodd2 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(4, 5, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(4, 5, S(0, 0));
         expectedResult(0,0) = Complex(20,0);
         return expectedResult;
@@ -1169,13 +1167,13 @@ class C2C2Devenodd2 {
 template <class S>
 class C2C2Doddeven1 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(3, 6, Complex(0, 0));
         input(0,0) = Complex(1,0);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(3, 6, Complex(1, 0));
         return expectedResult;
     }
@@ -1183,12 +1181,12 @@ class C2C2Doddeven1 {
 template <class S>
 class C2C2Doddeven2 {
   public:
-    static Array<S> input() {
+    static Matrix<S> input() {
         Matrix<S> input(3, 6, Complex(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Matrix<S> expectedResult() {
         Matrix<S> expectedResult(3, 6, Complex(0, 0));
         expectedResult(0,0) = Complex(18,0);
         return expectedResult;
@@ -1198,13 +1196,13 @@ class C2C2Doddeven2 {
 template <class S>
 class C2C3Doddeveneven1 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(4, 6, 8, Complex(0, 0));
         input(0,0,0) = Complex(1,0);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Cube<S> expectedResult() {
         Cube<S> expectedResult(4, 6, 8, Complex(1, 0));
         return expectedResult;
     }
@@ -1212,12 +1210,12 @@ class C2C3Doddeveneven1 {
 template <class S>
 class C2C3Doddeveneven2 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(4, 6, 8, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Cube<S> expectedResult() {
         Cube<S> expectedResult(4, 6, 8, S(0, 0));
         expectedResult(0,0,0) = Complex(4*6*8,0);
         return expectedResult;
@@ -1227,13 +1225,13 @@ class C2C3Doddeveneven2 {
 template <class S>
 class C2C3Doddoddodd1 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(3, 5, 7, S(0, 0));
         input(0,0,0) = Complex(1,0);
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Cube<S> expectedResult() {
         Cube<S> expectedResult(3, 5, 7, S(1, 0));
         return expectedResult;
     }
@@ -1241,12 +1239,12 @@ class C2C3Doddoddodd1 {
 template <class S>
 class C2C3Doddoddodd2 {
   public:
-    static Array<S> input() {
+    static Cube<S> input() {
         Cube<S> input(3, 5, 7, S(1, 0));
         return input;
     }
 
-    static Array<S> expectedResult() {
+    static Cube<S> expectedResult() {
         Cube<S> expectedResult(3, 5, 7, S(0, 0));
         expectedResult(0,0,0) = Complex(3*5*7,0);
         return expectedResult;

--- a/tables/TaQL/ExprNodeRep.cc
+++ b/tables/TaQL/ExprNodeRep.cc
@@ -409,12 +409,13 @@ Array<Bool>     TableExprNodeRep::getColumnBool
 {
     TableExprId id;
     rownr_t nrrow = rownrs.size();
-    Vector<Bool> vec (nrrow);
+    Array<Bool> arr (IPosition(1,nrrow));
+    Bool* vec = arr.data();
     for (rownr_t i=0; i<nrrow; i++) {
       id.setRownr   (rownrs[i]);
       vec[i] = getBool (id);
     }
-    return vec;
+    return arr;
 }
 Array<uChar>    TableExprNodeRep::getColumnuChar
 (const Vector<rownr_t>&)
@@ -439,12 +440,13 @@ Array<Int>      TableExprNodeRep::getColumnInt
 {
     TableExprId id;
     rownr_t nrrow = rownrs.size();
-    Vector<Int> vec (nrrow);
+    Array<Int> arr (IPosition(1,nrrow));
+    Int* vec = arr.data();
     for (rownr_t i=0; i<nrrow; i++) {
       id.setRownr   (rownrs[i]);
       vec[i] = getInt (id);
     }
-    return vec;
+    return arr;
 }
 Array<uInt>     TableExprNodeRep::getColumnuInt
 (const Vector<rownr_t>&)
@@ -457,12 +459,13 @@ Array<Int64>    TableExprNodeRep::getColumnInt64
 {
     TableExprId id;
     rownr_t nrrow = rownrs.size();
-    Vector<Int64> vec (nrrow);
+    Array<Int64> arr (IPosition(1,nrrow));
+    Int64* vec = arr.data();
     for (rownr_t i=0; i<nrrow; i++) {
       id.setRownr   (rownrs[i]);
       vec[i] = getInt (id);
     }
-    return vec;
+    return arr;
 }
 Array<Float>    TableExprNodeRep::getColumnFloat
 (const Vector<rownr_t>&)
@@ -475,12 +478,13 @@ Array<Double>   TableExprNodeRep::getColumnDouble
 {
     TableExprId id;
     rownr_t nrrow = rownrs.size();
-    Vector<Double> vec (nrrow);
+    Array<Double> arr (IPosition(1,nrrow));
+    Double* vec = arr.data();
     for (rownr_t i=0; i<nrrow; i++) {
       id.setRownr   (rownrs[i]);
       vec[i] = getDouble (id);
     }
-    return vec;
+    return arr;
 }
 Array<Complex>  TableExprNodeRep::getColumnComplex
 (const Vector<rownr_t>&)
@@ -493,24 +497,26 @@ Array<DComplex> TableExprNodeRep::getColumnDComplex
 {
     TableExprId id;
     rownr_t nrrow = rownrs.size();
-    Vector<DComplex> vec (nrrow);
+    Array<DComplex> arr (IPosition(1,nrrow));
+    DComplex* vec = arr.data();
     for (rownr_t i=0; i<nrrow; i++) {
       id.setRownr   (rownrs[i]);
       vec[i] = getDComplex (id);
     }
-    return vec;
+    return arr;
 }
 Array<String>   TableExprNodeRep::getColumnString
 (const Vector<rownr_t>& rownrs)
 {
     TableExprId id;
     rownr_t nrrow = rownrs.size();
-    Vector<String> vec (nrrow);
+    Array<String> arr (IPosition(1,nrrow));
+    String* vec = arr.data();
     for (rownr_t i=0; i<nrrow; i++) {
       id.setRownr   (rownrs[i]);
       vec[i] = getString (id);
     }
-    return vec;
+    return arr;
 }
 
 // The following can be implemented one time.

--- a/tables/Tables/NullTable.cc
+++ b/tables/Tables/NullTable.cc
@@ -252,9 +252,11 @@ Bool NullTable::adjustRownrs (rownr_t, Vector<rownr_t>&,
 }
 
 BaseTable* NullTable::doSort (PtrBlock<BaseColumn*>&,
-			      const Block<CountedPtr<BaseCompare> >&,
-			      const Block<Int>&,
-			      int)
+                             const Block<CountedPtr<BaseCompare> >&,
+                             const Block<Int>&,
+                             int,
+                             std::shared_ptr<Vector<rownr_t>>,
+                             std::shared_ptr<Vector<size_t>>)
 {
   throw makeError ("doSort");
 }

--- a/tables/Tables/NullTable.h
+++ b/tables/Tables/NullTable.h
@@ -131,9 +131,11 @@ public:
   virtual Bool adjustRownrs (rownr_t nrrow, Vector<rownr_t>& rownrs,
 			     Bool determineOrder) const;
   virtual BaseTable* doSort (PtrBlock<BaseColumn*>&,
-			     const Block<CountedPtr<BaseCompare> >&,
-			     const Block<Int>& sortOrder,
-			     int sortOption);
+                             const Block<CountedPtr<BaseCompare> >&,
+                             const Block<Int>& sortOrder,
+                             int sortOption,
+                             std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
+                             std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange);
   virtual void renameSubTables (const String& newName,
 				const String& oldName);
   // </group>

--- a/tables/Tables/NullTable.h
+++ b/tables/Tables/NullTable.h
@@ -74,70 +74,70 @@ public:
   virtual ~NullTable();
 
   // The table is a null table.
-  virtual Bool isNull() const;
+  virtual Bool isNull() const override;
 
   // All functions throw a "null table" exception.
   // <group>
-  virtual void reopenRW();
-  virtual Bool asBigEndian() const;
-  virtual const StorageOption& storageOption() const;
-  virtual Bool isMultiUsed (Bool checkSubTable) const;
-  virtual const TableLock& lockOptions() const;
-  virtual void mergeLock (const TableLock& lockOptions);
-  virtual Bool hasLock (FileLocker::LockType) const;
-  virtual Bool lock (FileLocker::LockType, uInt nattempts);
-  virtual void unlock();
-  virtual void flush (Bool fsync, Bool recursive);
-  virtual void resync();
-  virtual uInt getModifyCounter() const;
-  virtual Bool isWritable() const;
+  virtual void reopenRW() override;
+  virtual Bool asBigEndian() const override;
+  virtual const StorageOption& storageOption() const override;
+  virtual Bool isMultiUsed (Bool checkSubTable) const override;
+  virtual const TableLock& lockOptions() const override;
+  virtual void mergeLock (const TableLock& lockOptions) override;
+  virtual Bool hasLock (FileLocker::LockType) const override;
+  virtual Bool lock (FileLocker::LockType, uInt nattempts) override;
+  virtual void unlock() override;
+  virtual void flush (Bool fsync, Bool recursive) override;
+  virtual void resync() override;
+  virtual uInt getModifyCounter() const override;
+  virtual Bool isWritable() const override;
   virtual void deepCopy (const String& newName,
 			 const Record& dataManagerInfo,
                          const StorageOption&,
 			 int tableOption,
 			 Bool valueCopy,
 			 int endianFormat,
-			 Bool noRows) const;
-  virtual TableDesc actualTableDesc() const;
-  virtual Record dataManagerInfo() const;
-  virtual TableRecord& keywordSet();
-  virtual TableRecord& rwKeywordSet();
-  virtual BaseColumn* getColumn (uInt columnIndex) const;
-  virtual BaseColumn* getColumn (const String& columnName) const;
-  virtual Bool canAddRow() const;
-  virtual void addRow (rownr_t nrrow, Bool initialize);
-  virtual Bool canRemoveRow() const;
-  virtual void removeRow (rownr_t rownr);
+			 Bool noRows) const override;
+  virtual TableDesc actualTableDesc() const override;
+  virtual Record dataManagerInfo() const override;
+  virtual TableRecord& keywordSet() override;
+  virtual TableRecord& rwKeywordSet() override;
+  virtual BaseColumn* getColumn (uInt columnIndex) const override;
+  virtual BaseColumn* getColumn (const String& columnName) const override;
+  virtual Bool canAddRow() const override;
+  virtual void addRow (rownr_t nrrow, Bool initialize) override;
+  virtual Bool canRemoveRow() const override;
+  virtual void removeRow (rownr_t rownr) override;
   virtual DataManager* findDataManager (const String& name,
-                                        Bool byColumn) const;
-  virtual void addColumn (const ColumnDesc& columnDesc, Bool addToParent);
+                                        Bool byColumn) const override;
+  virtual void addColumn (const ColumnDesc& columnDesc, Bool addToParent) override;
   virtual void addColumn (const ColumnDesc& columnDesc,
 			  const String& dataManager, Bool byName,
-                          Bool addToParent);
+                          Bool addToParent) override;
   virtual void addColumn (const ColumnDesc& columnDesc,
-			  const DataManager& dataManager, Bool addToParent);
+			  const DataManager& dataManager, Bool addToParent) override;
   virtual void addColumn (const TableDesc& tableDesc,
-			  const DataManager& dataManager, Bool addToParent);
-  virtual Bool canRemoveColumn (const Vector<String>& columnNames) const;
-  virtual void removeColumn (const Vector<String>& columnNames);
-  virtual Bool canRenameColumn (const String& columnName) const;
-  virtual void renameColumn (const String& newName, const String& oldName);
+			  const DataManager& dataManager, Bool addToParent) override;
+  virtual Bool canRemoveColumn (const Vector<String>& columnNames) const override;
+  virtual void removeColumn (const Vector<String>& columnNames) override;
+  virtual Bool canRenameColumn (const String& columnName) const override;
+  virtual void renameColumn (const String& newName, const String& oldName) override;
   virtual void renameHypercolumn (const String& newName,
-				    const String& oldName);
-  virtual Vector<rownr_t> rowNumbers() const;
-  virtual BaseTable* root();
-  virtual Bool rowOrder() const;
-  virtual Vector<rownr_t>* rowStorage();
+				    const String& oldName) override;
+  virtual Vector<rownr_t> rowNumbers() const override;
+  virtual BaseTable* root() override;
+  virtual Bool rowOrder() const override;
+  virtual Vector<rownr_t>* rowStorage() override;
   virtual Bool adjustRownrs (rownr_t nrrow, Vector<rownr_t>& rownrs,
-			     Bool determineOrder) const;
+			     Bool determineOrder) const override;
   virtual BaseTable* doSort (PtrBlock<BaseColumn*>&,
                              const Block<CountedPtr<BaseCompare> >&,
                              const Block<Int>& sortOrder,
                              int sortOption,
                              std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
-                             std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange);
+                             std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange) override;
   virtual void renameSubTables (const String& newName,
-				const String& oldName);
+				const String& oldName) override;
   // </group>
 
 private:


### PR DESCRIPTION
Apple clang version 13.0.0 (clang-1300.0.29.3) gave several warnings which have been fixed.
Most warnings were about using std::move (if e.g. a Vector is returned as Array) or about self-assignment in test programs.

Close #1136