### PR TITLE
Addition of Table failover mode

### DIFF
--- a/casa/IO/FiledesIO.cc
+++ b/casa/IO/FiledesIO.cc
@@ -96,8 +96,8 @@ void FiledesIO::write (Int64 size, const void* buf)
 {
     // Throw an exception if not writable.
     if (!itsWritable) {
-	throw AipsError ("FiledesIO " + itsFileName
-                         + "is not writable");
+	throw AipsError ("FiledesIO::write - " + itsFileName
+                         + " is not writable");
     }
     if (::traceWRITE(itsFile, (Char *)buf, size) != size) {
         int error = errno;
@@ -111,8 +111,8 @@ void FiledesIO::pwrite (Int64 size, Int64 offset, const void* buf)
 {
     // Throw an exception if not writable.
     if (!itsWritable) {
-	throw AipsError ("FiledesIO " + itsFileName
-                         + "is not writable");
+	throw AipsError ("FiledesIO::pwrite - " + itsFileName
+                         + " is not writable");
     }
     if (::tracePWRITE(itsFile, (Char *)buf, size, offset) != size) {
         int error = errno;

--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -80,12 +80,12 @@ void Adios2StMan::create64(rownr_t aNrRows)
     pimpl->create64(aNrRows);
 }
 
-rownr_t Adios2StMan::open64(rownr_t aRowNr, AipsIO &ios)
+Fallible<rownr_t> Adios2StMan::open64(rownr_t aRowNr, AipsIO &ios)
 {
     return pimpl->open64(aRowNr, ios);
 }
 
-rownr_t Adios2StMan::resync64(rownr_t aRowNr)
+Fallible<rownr_t> Adios2StMan::resync64(rownr_t aRowNr)
 {
     return pimpl->resync64(aRowNr);
 }

--- a/tables/DataMan/Adios2StMan.h
+++ b/tables/DataMan/Adios2StMan.h
@@ -58,8 +58,8 @@ public:
     virtual String dataManagerType() const;
     virtual String dataManagerName() const;
     virtual void create64(rownr_t aNrRows);
-    virtual rownr_t open64(rownr_t aRowNr, AipsIO &ios);
-    virtual rownr_t resync64(rownr_t aRowNr);
+    virtual Fallible<rownr_t> open64(rownr_t aRowNr, AipsIO &ios);
+    virtual Fallible<rownr_t> resync64(rownr_t aRowNr);
     virtual Bool flush(AipsIO &, Bool doFsync);
     virtual DataManagerColumn *makeScalarColumn(const String &aName,
                                                 int aDataType,

--- a/tables/DataMan/DataManAccessor.cc
+++ b/tables/DataMan/DataManAccessor.cc
@@ -32,6 +32,9 @@
 #include <casacore/tables/DataMan/DataManError.h>
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/IO/AipsIO.h>
+#include <casacore/casa/IO/MemoryIO.h>
+#include <casacore/casa/IO/RawIO.h>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -46,6 +49,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   RODataManAccessor::~RODataManAccessor()
   {}
+
+  void RODataManAccessor::flush (Bool fsync)
+  {
+    if (itsDataManager) {
+      // The possible data in the AipsIO object will be neglected.
+      MemoryIO membuf;
+      RawIO rawio(&membuf);
+      AipsIO ios(&rawio);
+      itsDataManager->flush (ios, fsync);
+    } else {
+      throw DataManError ("setProperties cannot be used on a default "
+                          "empty RODataManAccessor object");
+    }
+  }
 
   void RODataManAccessor::setProperties (const Record& prop) const
   {

--- a/tables/DataMan/DataManAccessor.h
+++ b/tables/DataMan/DataManAccessor.h
@@ -90,6 +90,10 @@ public:
 
     virtual ~RODataManAccessor();
 
+    // Let the data manager flush its data to disk.
+    // It cannot write meta data to the AipsIO stream in the table.dat file.
+    void flush (Bool fsync = False);
+  
     // Set data manager properties using the fields in the record.
     // Each data manager has its specific set of properties.
     void setProperties (const Record&) const;

--- a/tables/DataMan/DataManager.cc
+++ b/tables/DataMan/DataManager.cc
@@ -68,6 +68,7 @@ DataManager::DataManager()
 : nrcol_p       (0),
   seqnr_p       (0),
   asBigEndian_p (False),
+  failoverMode_p(False),
   tsmOption_p   (TSMOption::Buffer, 0, 0),
   multiFile_p   (0),
   clone_p       (0)
@@ -100,6 +101,8 @@ void DataManager::setProperties (const Record&)
 Bool DataManager::isStorageManager() const
     { return True; }
 
+Bool DataManager::checkFailover (DataType, uInt) const
+    { return ! isStorageManager(); }
 
 
 void DataManager::create64 (rownr_t nrrow)
@@ -108,12 +111,15 @@ void DataManager::create64 (rownr_t nrrow)
   create (uInt(nrrow));
 }
   
-rownr_t DataManager::open64 (rownr_t nrrow, AipsIO& ios)
+Fallible<rownr_t> DataManager::open64 (rownr_t nrrow, AipsIO& ios)
 {
   return open1 (uInt(nrrow), ios);
 }
 
-rownr_t DataManager::resync64 (rownr_t nrrow)
+void DataManager::repairNrow (rownr_t)
+{}
+  
+Fallible<rownr_t> DataManager::resync64 (rownr_t nrrow)
 {
   AlwaysAssert (nrrow < std::numeric_limits<uInt>::max(), AipsError);
   return resync1 (uInt(nrrow));

--- a/tables/DataMan/ISMBase.cc
+++ b/tables/DataMan/ISMBase.cc
@@ -591,7 +591,7 @@ Bool ISMBase::flush (AipsIO& ios, Bool fsync)
     return changed;
 }
 
-rownr_t ISMBase::resync64 (rownr_t nrrow)
+Fallible<rownr_t> ISMBase::resync64 (rownr_t nrrow)
 {
     nrrow_p = nrrow;
     if (index_p != 0) {
@@ -618,7 +618,7 @@ void ISMBase::create64 (rownr_t nrrow)
     addRow64 (nrrow);
 }
 
-rownr_t ISMBase::open64 (rownr_t tabNrrow, AipsIO& ios)
+Fallible<rownr_t> ISMBase::open64 (rownr_t tabNrrow, AipsIO& ios)
 {
     nrrow_p = tabNrrow;
     // Do not check the bucketsize for an existing table.

--- a/tables/DataMan/ISMBase.h
+++ b/tables/DataMan/ISMBase.h
@@ -262,11 +262,11 @@ private:
 
     // Open the storage manager file for an existing table, read in
     // the data, and let the ISMColumn objects read their data.
-    virtual rownr_t open64 (rownr_t nrrow, AipsIO&);
+    virtual Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO&);
 
     // Resync the storage manager with the new file contents.
     // This is done by clearing the cache.
-    virtual rownr_t resync64 (rownr_t nrrow);
+  virtual Fallible<rownr_t> resync64 (rownr_t nrrow);
 
     // Reopen the storage manager files for read/write.
     virtual void reopenRW();

--- a/tables/DataMan/MSMBase.cc
+++ b/tables/DataMan/MSMBase.cc
@@ -262,7 +262,7 @@ void MSMBase::create64 (rownr_t nrrow)
   nrrowCreate_p = nrrow;
 }
 
-rownr_t MSMBase::open64 (rownr_t tabNrrow, AipsIO&)
+Fallible<rownr_t> MSMBase::open64 (rownr_t tabNrrow, AipsIO&)
 {
   nrrow_p = tabNrrow;
   //# Create the required nr of rows and initialize them.
@@ -272,7 +272,7 @@ rownr_t MSMBase::open64 (rownr_t tabNrrow, AipsIO&)
   return nrrow_p;
 }
 
-rownr_t MSMBase::resync64 (rownr_t nrrow)
+Fallible<rownr_t> MSMBase::resync64 (rownr_t nrrow)
 {
   // Add or remove rows if it has changed.
   // Note that removing decreases the row number, so the same row number

--- a/tables/DataMan/MSMBase.h
+++ b/tables/DataMan/MSMBase.h
@@ -127,11 +127,11 @@ private:
   virtual Bool flush (AipsIO&, Bool fsync);
 
   // Let the storage manager create the nr of rows needed.
+  // It fills the rows with 0 values.
   virtual void create64 (rownr_t nrrow);
 
   // Open the storage manager file for an existing table.
-  // It fills the rows with 0 values.
-  virtual rownr_t open64 (rownr_t nrrow, AipsIO&);
+  virtual Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO&);
 
   // Let the data manager initialize itself further.
   // It creates nr of rows (given to create) if needed.
@@ -142,7 +142,7 @@ private:
   // It adds or removes rows as needed.
   // It cannot know which rows are deleted, so it always deletes
   // the last rows.
-  virtual rownr_t resync64 (rownr_t nrrow);
+  virtual Fallible<rownr_t> resync64 (rownr_t nrrow);
 
   // The data manager will be deleted (because all its columns are
   // requested to be deleted).

--- a/tables/DataMan/SSMIndex.h
+++ b/tables/DataMan/SSMIndex.h
@@ -135,7 +135,7 @@ public:
   // It returns the bucket nr if it gets empty, otherwise -1.
   Int deleteRow (rownr_t aRowNumber);
 
-  // Get the number of rows that fits in ach bucket.
+  // Get the number of rows that fits in each bucket.
   uInt getRowsPerBucket() const;
 
   // Find the bucket containing the given row.
@@ -143,6 +143,12 @@ public:
   // It also sets the first and last row number fitting in that bucket.
   void find (rownr_t aRowNumber, uInt& aBucketNr, rownr_t& aStartRow,
 	     rownr_t& anEndRow, const String& colName) const;
+
+  // Check if the buckets are fully sequential (for Failover mode).
+  void checkSeqIndex() const;
+
+  // Generate the index (for table created in Failover mode).
+  void generate (rownr_t nrows, uInt ncolumns);
 
 private:
   // Get the index of the bucket containing the given row.

--- a/tables/DataMan/StManAipsIO.cc
+++ b/tables/DataMan/StManAipsIO.cc
@@ -323,11 +323,11 @@ void StManAipsIO::create64 (rownr_t nrrow)
     setHasPut();
 }
 
-rownr_t StManAipsIO::open64 (rownr_t tabNrrow, AipsIO&)
+Fallible<rownr_t> StManAipsIO::open64 (rownr_t tabNrrow, AipsIO&)
 {
     return resync64 (tabNrrow);
 }
-rownr_t StManAipsIO::resync64 (rownr_t nrrow)
+Fallible<rownr_t> StManAipsIO::resync64 (rownr_t nrrow)
 {
     if (iosfile_p != 0) {
         iosfile_p->resync();

--- a/tables/DataMan/StManAipsIO.h
+++ b/tables/DataMan/StManAipsIO.h
@@ -251,11 +251,11 @@ private:
 
     // Open the storage manager file for an existing table and read in
     // the data and let the StManColumnAipsIO objects read their data.
-    virtual rownr_t open64 (rownr_t nrrow, AipsIO&);
+    virtual Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO&);
 
     // Resync the storage manager with the new file contents.
     // This is done by clearing the cache.
-    virtual rownr_t resync64 (rownr_t nrrow);
+    virtual Fallible<rownr_t> resync64 (rownr_t nrrow);
 
     // Reopen the storage manager files for read/write.
     virtual void reopenRW();

--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -137,7 +137,6 @@ TSMCube::~TSMCube()
     delete [] cachedTile_p;
 }
 
-
 void TSMCube::clearCache (Bool doFlush)
 {
     if (doFlush) {
@@ -327,6 +326,15 @@ Int TSMCube::getObject (AipsIO& ios)
         ios >> fileOffset_p;
     }
     return fileSeqnr;
+}
+
+Int64 TSMCube::repairNrow (rownr_t nrrow)
+{
+    // Adjust the nr of rows in the cube shape for repaired TiledColumnStMan file.
+    cubeShape_p[nrdim_p-1] = nrrow;
+    setupNrTiles();
+    resyncCache();
+    return nrTiles_p * bucketSize_p;
 }
 
 void TSMCube::resync (AipsIO& ios)

--- a/tables/DataMan/TSMCube.h
+++ b/tables/DataMan/TSMCube.h
@@ -119,6 +119,7 @@ public:
     // <br>If the cubeshape is empty, the hypercube is still undefined and
     // can be added later with setShape. That is only used by TiledCellStMan.
     // <br> The fileOffset argument is meant for class TiledFileAccess.
+    // <br> The useDerived flag is meant for derived classes such as TSMCubeMMap.
     TSMCube (TiledStMan* stman, TSMFile* file,
 	     const IPosition& cubeShape,
 	     const IPosition& tileShape,
@@ -129,6 +130,7 @@ public:
     // Reconstruct the hypercube by reading its data from the AipsIO stream.
     // It will link itself to the correct TSMFile. The TSMFile objects
     // must have been reconstructed in advance.
+    // <br> The useDerived flag is meant for derived classes such as TSMCubeMMap.
     TSMCube (TiledStMan* stman, AipsIO& ios,
              Bool useDerived = False);
 
@@ -157,6 +159,10 @@ public:
     // It returns the data manager sequence number, which is -1 if
     // no file is attached to the cube (for cells without a value).
     Int getObject (AipsIO& ios);
+
+    // Fix the cube shape for a repaired TiledColumnStMan.
+    // It returns the size (in bytes) of all tiles.
+    Int64 repairNrow (rownr_t nrrow);
 
     // Resync the object with the data file.
     // It reads the object, and adjusts the cache.

--- a/tables/DataMan/TSMFile.h
+++ b/tables/DataMan/TSMFile.h
@@ -115,6 +115,10 @@ public:
     // Return the logical file length.
     Int64 length() const;
 
+    // Get the actual length of the file.
+    Int64 fileSize() const
+      { return file_p->fileSize(); }
+  
     // Return the file sequence number.
     uInt sequenceNumber() const;
 

--- a/tables/DataMan/TiledCellStMan.cc
+++ b/tables/DataMan/TiledCellStMan.cc
@@ -171,7 +171,7 @@ void TiledCellStMan::readHeader (rownr_t tabNrrow, Bool firstTime)
     headerFile->getstart ("TiledCellStMan");
     *headerFile >> defaultTileShape_p;
     // Let the base class read and initialize its data.
-    headerFileGet (*headerFile, tabNrrow, firstTime, 0);
+    headerFileGet (*headerFile, tabNrrow, firstTime, 0, False);
     headerFile->getend();
     headerFileClose (headerFile);
 }

--- a/tables/DataMan/TiledColumnStMan.cc
+++ b/tables/DataMan/TiledColumnStMan.cc
@@ -99,7 +99,12 @@ Bool TiledColumnStMan::canAccessColumn () const
 {
     return True;
 }
-
+ 
+Bool TiledColumnStMan::checkFailover (DataType, uInt) const
+{
+    return True;
+}
+  
 
 void TiledColumnStMan::create64 (rownr_t nrrow)
 {
@@ -125,6 +130,17 @@ void TiledColumnStMan::create64 (rownr_t nrrow)
 }
 	    
 
+void TiledColumnStMan::repairNrow (rownr_t nrrow)
+{
+  nrrow_p = nrrow;
+  AlwaysAssert (fileSet_p.size() == 1, AipsError);
+  AlwaysAssert (cubeSet_p.size() == 1, AipsError);
+  Int64 length = cubeSet_p[0]->repairNrow (nrrow);
+  // Increment the file length.
+  fileSet_p[0]->extend (length - fileSet_p[0]->length());
+}
+
+ 
 Bool TiledColumnStMan::flush (AipsIO&, Bool fsync)
 {
     // Flush the caches.
@@ -150,7 +166,8 @@ void TiledColumnStMan::readHeader (rownr_t tabNrrow, Bool firstTime)
     headerFile->getstart ("TiledColumnStMan");
     *headerFile >> tileShape_p;
     // Let the base class read and initialize its data.
-    headerFileGet (*headerFile, tabNrrow, firstTime, 1);
+    // Guess the nr of rows from the file size and compare to given nr.
+    headerFileGet (*headerFile, tabNrrow, firstTime, 1, True);
     headerFile->getend();
     headerFileClose (headerFile);
 }

--- a/tables/DataMan/TiledColumnStMan.h
+++ b/tables/DataMan/TiledColumnStMan.h
@@ -188,6 +188,9 @@ public:
     // Get the type name of the data manager (i.e. TiledColumnStMan).
     virtual String dataManagerType() const;
 
+    // TiledColumnStMan supports failover mode except for string columns.
+    virtual Bool checkFailover (DataType dtype, uInt maxLen) const;
+
     // Make the object from the type name string.
     // This function gets registered in the DataManager "constructor" map.
     static DataManager* makeObject (const String& dataManagerType,
@@ -231,6 +234,10 @@ private:
     // This allows a column with an indirect array to create its file.
     virtual void create64 (rownr_t nrrow);
 
+    // Fix the the storage manager using the given nr of rows.
+    // It is called in case a Failover table needs to be repaired.
+    virtual void repairNrow (rownr_t nrrow);
+  
     // Read the header info.
     virtual void readHeader (rownr_t nrrow, Bool firstTime);
 

--- a/tables/DataMan/TiledDataStMan.cc
+++ b/tables/DataMan/TiledDataStMan.cc
@@ -122,7 +122,7 @@ void TiledDataStMan::readHeader (rownr_t tabNrrow, Bool firstTime)
     AipsIO* headerFile = headerFileOpen();
     headerFile->getstart ("TiledDataStMan");
     // Let the base class read and initialize its data.
-    headerFileGet (*headerFile, tabNrrow, firstTime, -1);
+    headerFileGet (*headerFile, tabNrrow, firstTime, -1, False);
     // Read the data for this object.
     *headerFile >> nrrowLast_p;
     *headerFile >> nrUsedRowMap_p;

--- a/tables/DataMan/TiledShapeStMan.cc
+++ b/tables/DataMan/TiledShapeStMan.cc
@@ -232,7 +232,7 @@ void TiledShapeStMan::readHeader (rownr_t tabNrrow, Bool firstTime)
     AipsIO* headerFile = headerFileOpen();
     headerFile->getstart ("TiledShapeStMan");
     // Let the base class read and initialize its data.
-    headerFileGet (*headerFile, tabNrrow, firstTime, 1);
+    headerFileGet (*headerFile, tabNrrow, firstTime, 1, False);
     // Read the data for this object.
     *headerFile >> defaultTileShape_p;
     *headerFile >> nrUsedRowMap_p;

--- a/tables/DataMan/TiledStMan.h
+++ b/tables/DataMan/TiledStMan.h
@@ -319,10 +319,10 @@ public:
     TSMFile* getFile (uInt sequenceNumber);
 
     // Open the storage manager for an existing table.
-    virtual rownr_t open64 (rownr_t nrrow, AipsIO&);
+    virtual Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO&);
 
     // Resync the storage manager with the new file contents.
-    virtual rownr_t resync64 (rownr_t nrrow);
+    virtual Fallible<rownr_t> resync64 (rownr_t nrrow);
 
     // Reopen all files used in this storage manager for read/write access.
     virtual void reopenRW();
@@ -462,8 +462,9 @@ protected:
     // Read the data from the header file.
     // When done for the first time, setup() is called to initialize
     // the various variables (using the extraNdim variable).
+    // If given, the nr of rows is guessed to repair prematurely ended tables.
     void headerFileGet (AipsIO& headerFile, rownr_t tabNrrow, Bool firstTime,
-			Int extraNdim);
+			Int extraNdim, Bool doGuess);
 
     // Close the header file.
     // It deletes the AipsIO object.
@@ -484,6 +485,9 @@ protected:
     // This function is temporary and can disappear when the ColumnDesc
     // classes use type TpArray*.
     int arrayDataType (int dataType) const;
+
+    // Guess the nr of rows from the file size (only for TiledColumnStMan).
+    rownr_t guessNrow();
 
 
     //# Declare all data members.

--- a/tables/DataMan/VirtColEng.cc
+++ b/tables/DataMan/VirtColEng.cc
@@ -53,10 +53,10 @@ Bool VirtualColumnEngine::flush (AipsIO&, Bool)
 { return False; }
 void VirtualColumnEngine::create64 (rownr_t)
 {}
-rownr_t VirtualColumnEngine::open64 (rownr_t nrow, AipsIO&)
-  { return nrow; }
-rownr_t VirtualColumnEngine::resync64 (rownr_t nrow)
-  { return nrow; }
+Fallible<rownr_t> VirtualColumnEngine::open64 (rownr_t, AipsIO&)
+  { return Fallible<rownr_t>(); }
+Fallible<rownr_t> VirtualColumnEngine::resync64 (rownr_t)
+  { return Fallible<rownr_t>(); }
 void VirtualColumnEngine::prepare()
 {}
 void VirtualColumnEngine::deleteManager()

--- a/tables/DataMan/VirtColEng.h
+++ b/tables/DataMan/VirtColEng.h
@@ -171,8 +171,9 @@ private:
 
     // Resync the storage manager with the new file contents.
     // This is done by clearing the cache.
-    // The default implementation does nothing.
-    virtual rownr_t resync64 (rownr_t nrrow);
+    // The default implementation returns an invalid Fallible object indicating
+    // that it does not know the nr of rows.
+    virtual Fallible<rownr_t> resync64 (rownr_t nrrow);
 
     // Initialize the object for a new table containing initially nrrow rows.
     // It can be used to initialize variables (possibly using data
@@ -184,8 +185,9 @@ private:
     // It can be used to read values back (written by close) and/or
     // to initialize variables (possibly using data from other columns
     // in the table).
-    // The default implementation does nothing.
-    virtual rownr_t open64 (rownr_t nrrow, AipsIO& mainTableFile);
+    // The default implementation returns an invalid Fallible object indicating
+    // that it does not know the nr of rows.
+    virtual Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO& mainTableFile);
 
     // Let the data manager initialize itself further.
     // Prepare is called after create/open has been called for all

--- a/tables/DataMan/test/dVirtColEng.cc
+++ b/tables/DataMan/test/dVirtColEng.cc
@@ -91,11 +91,11 @@ Bool DummyVirtualEngine::flush (AipsIO& ios, Bool)
 }
 void DummyVirtualEngine::create64 (rownr_t)
 {}
-rownr_t DummyVirtualEngine::open64 (rownr_t nrrow, AipsIO& ios)
+Fallible<rownr_t> DummyVirtualEngine::open64 (rownr_t, AipsIO& ios)
 {
     data1_p.open (ios);
     data2_p.open (ios);
-    return nrrow;
+    return Fallible<rownr_t>();
 }
 void DummyVirtualEngine::prepare ()
 {

--- a/tables/DataMan/test/dVirtColEng.h
+++ b/tables/DataMan/test/dVirtColEng.h
@@ -343,7 +343,7 @@ private:
     // Initialize the object for an existing table with the given number
     // of rows.
     // It will read back the data written by close.
-    rownr_t open64 (rownr_t nrrow, AipsIO& ios);
+    Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO& ios);
 
     // Initialize the engine.
     void prepare();

--- a/tables/DataMan/test/tExternalStManNew.cc
+++ b/tables/DataMan/test/tExternalStManNew.cc
@@ -131,14 +131,14 @@ namespace casacore {
   
     // Open the storage manager file for an existing table.
     // Return the number of rows in the data file.
-    virtual rownr_t open64 (rownr_t nrrow, AipsIO&);
+    virtual Fallible<rownr_t> open64 (rownr_t nrrow, AipsIO&);
 
     // Prepare the columns.
     virtual void prepare();
 
     // Resync the storage manager with the new file contents.
     // It does nothing.
-    virtual rownr_t resync64 (rownr_t nrrow);
+    virtual Fallible<rownr_t> resync64 (rownr_t nrrow);
   
     // Reopen the storage manager files for read/write.
     // It does nothing.
@@ -688,7 +688,7 @@ namespace casacore {
   void LofarStMan::create64 (rownr_t)
   {}
 
-  rownr_t LofarStMan::open64 (rownr_t, AipsIO&)
+  Fallible<rownr_t> LofarStMan::open64 (rownr_t, AipsIO&)
   {
     return getNRow();
   }
@@ -696,7 +696,7 @@ namespace casacore {
   void LofarStMan::prepare()
   {}
 
-  rownr_t LofarStMan::resync64 (rownr_t)
+  Fallible<rownr_t> LofarStMan::resync64 (rownr_t)
   {
     return getNRow();
   }

--- a/tables/DataMan/test/tStManAll.cc
+++ b/tables/DataMan/test/tStManAll.cc
@@ -81,7 +81,7 @@
   { \
     Table tab(table); \
     if (! keepTable) { \
-      tab = Table("tStMan_tmp.data", Table::Update); \
+      tab = Table("tStManAll_tmp.data", Table::Update); \
     } \
     ExecFunc(funcName, tab, String()); \
   } \
@@ -567,7 +567,7 @@ void bindVirtual (SetupNewTable& newtab, const String& name)
 }
 
 // Create a new table and fill a few cells with an empty array.
-// An empty table name defaults to tStMan_tmp.data.
+// An empty table name defaults to tStManAll_tmp.data.
 Table maketab (uInt nrrow, const DataManager& stman, Bool tiled,
                const String& tabName=String(), Bool addVirtual=False)
 {
@@ -587,7 +587,7 @@ Table maketab (uInt nrrow, const DataManager& stman, Bool tiled,
   addColDesc<String> (td, "sv", addVirtual);           // variable length string
   addColDesc<String> (td, "sf", addVirtual, 40);       // fixed length string
   // Now create a new table from the description.
-  String tname(tabName.empty() ? "tStMan_tmp.data" : tabName);
+  String tname(tabName.empty() ? "tStManAll_tmp.data" : tabName);
   SetupNewTable newtab(tname, td, Table::New);
   // Bind all columns to the storage manager and set the fixed shapes.
   newtab.bindAll (stman);
@@ -678,7 +678,7 @@ void checknewtab (const Table& table, uInt nrrow, Bool tiled)
 {
   Table tab(table);
   if (tab.isNull()) {
-    tab = Table("tStMan_tmp.data");
+    tab = Table("tStManAll_tmp.data");
   }
   AlwaysAssertExit (tab.nrow() == nrrow);
   // Make a subset of all except the last row, because the float and DComplex
@@ -713,7 +713,7 @@ void checktab (const Table& table)
 {
   Table tab(table);
   if (tab.isNull()) {
-    tab = Table("tStMan_tmp.data");
+    tab = Table("tStManAll_tmp.data");
   }
   ExecFunc(checkAll, tab, String());
 }
@@ -799,7 +799,7 @@ int main (int argc, const char* argv[])
       cout << "Testing ForwardColumnEngine ..." << endl;
       // Test ForwardColumn.
       StandardStMan stman(2000);
-      Table tab = maketab (nrrow, stman, False, "tStMan_tmp.datafc");
+      Table tab = maketab (nrrow, stman, False, "tStManAll_tmp.datafc");
       ForwardColumnEngine dataman(tab, "forwardcolumn");
       doTest (nrrow, dataman, True, False);
     }

--- a/tables/TaQL/TaQLShow.cc
+++ b/tables/TaQL/TaQLShow.cc
@@ -749,12 +749,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   const char* convFuncHelp[] = {
     "Conversion functions",
     "",
-    "  string HMS       (real RAD)    convert angles to e.g. 12h34m56.789",
-    "  string DMS       (real RAD)    convert angles to e.g. 12d34m56.789",
-    "  string HDMS      (realarray)   convert angles alternately to HMS and DMS",
-    "  string STR       (string, int WIDTH)    make string WIDTH long",
-    "  string STR       (numeric, )    make string WIDTH long",
-    "  string STR       (string, int WIDTH)    make string WIDTH long"
+    "  string HMS       (real RAD)    convert angles to string, e.g. 12h34m56.789",
+    "  string DMS       (real RAD)    convert angles to string, e.g. 12d34m56.789",
+    "  string HDMS      (realarray)   convert angles alternately to HMS and DMS string",
+    "  string STR(ING)  (any, real WIDTH.PREC)  convert to string using width and/or precision",
+    "  string STR(ING)  (string, string fmt)    convert to string using C-style format",
+    "  string STR(ING)  (string, string fmt)    convert to string using C-style format"
   };
 
   const char* logicalFuncHelp[] = {

--- a/tables/Tables/ColumnSet.h
+++ b/tables/Tables/ColumnSet.h
@@ -110,6 +110,10 @@ public:
     const StorageOption& storageOption() const
       { return storageOpt_p; }
 
+    // Is the table in Failover mode?
+    Bool failoverMode() const
+      { return storageOpt_p.option() == StorageOption::Failover; }
+  
     // Are subtables used in other processes.
     Bool areTablesMultiUsed() const;
 
@@ -251,8 +255,10 @@ public:
     // correct datamanagers when they are read back.
     DataManager* getDataManager (uInt seqnr) const;
 
-    // Check if no double data manager names have been given.
-    void checkDataManagerNames (const String& tableName) const;
+    // Check the data managers.
+    // It checks if no equal names have been given and
+    // if they match the possible failover mode.
+    void checkDataManagers (const String& tableName) const;
 
     // Find the data manager with the given name or for the given column.
     // If the data manager or column is unknown, an exception is thrown.

--- a/tables/Tables/MemoryTable.cc
+++ b/tables/Tables/MemoryTable.cc
@@ -62,7 +62,7 @@ MemoryTable::MemoryTable (SetupNewTable& newtab, rownr_t nrrow, Bool initialize)
     }
   }
   //# Check if there are no data managers with equal names.
-  newtab.columnSetPtr()->checkDataManagerNames ("MemoryTable");
+  newtab.columnSetPtr()->checkDataManagers ("MemoryTable");
   //# Get the data from the SetupNewTable object.
   //# Set SetupNewTable object to in use.
   tdescPtr_p  = tdescPtr;

--- a/tables/Tables/PlainColumn.cc
+++ b/tables/Tables/PlainColumn.cc
@@ -55,6 +55,12 @@ PlainColumn::~PlainColumn()
 {}
 
 
+Bool PlainColumn::checkFailover() const
+{
+  return dataManPtr_p->checkFailover (columnDesc().dataType(),
+                                      columnDesc().maxLength());
+}
+
 rownr_t PlainColumn:: nrow() const
     { return colSetPtr_p->nrow(); }
 

--- a/tables/Tables/PlainColumn.h
+++ b/tables/Tables/PlainColumn.h
@@ -97,6 +97,9 @@ public:
     // Test if the column is stored (otherwise it is virtual).
     virtual Bool isStored() const;
 
+    // Check if Failover is supported.
+    Bool checkFailover() const;
+  
     // Get access to the column keyword set.
     // <group>
     TableRecord& rwKeywordSet();

--- a/tables/Tables/PlainTable.h
+++ b/tables/Tables/PlainTable.h
@@ -301,8 +301,8 @@ private:
     // Determine and set the endian format (big or little).
     void setEndian (int endianFormat);
 
-    // Throw an exception if the table is not writable.
-    void checkWritable (const char* func) const;
+    // Throw an exception if the table is not writable or if Failover is used.
+    void checkWritable (const char* func, Bool checkFailover=True) const;
 
 
     CountedPtr<ColumnSet> colSetPtr_p;        //# pointer to set of columns

--- a/tables/Tables/SetupNewTab.cc
+++ b/tables/Tables/SetupNewTab.cc
@@ -296,14 +296,14 @@ void SetupNewTableRep::handleUnbound()
 	    col->bind (dataManPtr);
 	    //# Bind this data manager to all other unbound columns with
 	    //# the same group and default data manager type name.
-		for (uInt j=i+1; j<tdescPtr_p->ncolumn(); j++) {
-		    PlainColumn* cp = colSetPtr_p->getColumn(j);
-		    const ColumnDesc& cd = cp->columnDesc();
-		    if (!cp->isBound()
-		    &&  cd.dataManagerGroup() == coldes.dataManagerGroup()
-		    &&  cd.dataManagerType()  == coldes.dataManagerType()) {
-			//# Great, bind the column to the data manager.
-			cp->bind (dataManPtr);
+            for (uInt j=i+1; j<tdescPtr_p->ncolumn(); j++) {
+                PlainColumn* cp = colSetPtr_p->getColumn(j);
+                const ColumnDesc& cd = cp->columnDesc();
+                if (!cp->isBound()
+		&&  cd.dataManagerGroup() == coldes.dataManagerGroup()
+		&&  cd.dataManagerType()  == coldes.dataManagerType()) {
+                  //# Great, bind the column to the data manager.
+                    cp->bind (dataManPtr);
 		}
 	    }
 	}

--- a/tables/Tables/StorageOption.cc
+++ b/tables/Tables/StorageOption.cc
@@ -51,6 +51,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         itsOption = StorageOption::MultiHDF5;
       } else if (opt == "sepfile") {
         itsOption = StorageOption::SepFile;
+      } else if (opt == "failover") {
+        itsOption = StorageOption::Failover;
       } else {
         itsOption = StorageOption::Default;
       }

--- a/tables/Tables/StorageOption.h
+++ b/tables/Tables/StorageOption.h
@@ -84,6 +84,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       MultiHDF5,
       // Let storage managers use separate files.
       SepFile,
+      // Use failover mode to ensure a new table is readable in case of a crash.
+      // It uses separate files with storage manager restrictions.
+      Failover,
       // Use default (currently SepFile).
       Default,
       // Use as defined in the aipsrc file.

--- a/tables/Tables/test/CMakeLists.txt
+++ b/tables/Tables/test/CMakeLists.txt
@@ -28,6 +28,7 @@ tConcatRows
 tConcatTable
 tConcatTable2
 tConcatTable3
+tFailoverTable
 tMemoryTable
 tReadAsciiTable
 tReadAsciiTable2

--- a/tables/Tables/test/tFailoverTable.cc
+++ b/tables/Tables/test/tFailoverTable.cc
@@ -1,0 +1,203 @@
+//# tFailoverTable.cc: Test program for failover tables
+//# Copyright (C) 2020
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This program is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU General Public License as published by the Free
+//# Software Foundation; either version 2 of the License, or (at your option)
+//# any later version.
+//#
+//# This program is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+//# more details.
+//#
+//# You should have received a copy of the GNU General Public License along
+//# with this program; if not, write to the Free Software Foundation, Inc.,
+//# 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/tables/Tables/TableDesc.h>
+#include <casacore/tables/Tables/ScaColDesc.h>
+#include <casacore/tables/Tables/ArrColDesc.h>
+#include <casacore/tables/Tables/Table.h>
+#include <casacore/tables/Tables/SetupNewTab.h>
+#include <casacore/tables/Tables/ScalarColumn.h>
+#include <casacore/tables/Tables/ArrayColumn.h>
+#include <casacore/tables/DataMan/StandardStMan.h>
+#include <casacore/tables/DataMan/TiledColumnStMan.h>
+#include <casacore/tables/DataMan/VirtualTaQLColumn.h>
+#include <casacore/tables/DataMan/StandardStManAccessor.h>
+#include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/Arrays/ArrayLogical.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/iostream.h>
+#include <casacore/casa/sstream.h>
+#include <cstdlib>    // sleep
+
+using namespace casacore;
+
+// This program tests the table failover mode.
+// It creates a description and a table.
+// It reads back the table.
+
+// Create the description of the table.
+// Optionally a variable length string column is added (which is not failover proof).
+TableDesc credes (Bool addString)
+{
+  TableDesc txp;
+  txp.addColumn (ScalarColumnDesc<Int> ("col1"));
+  txp.addColumn (ScalarColumnDesc<double> ("col2"));
+  txp.addColumn (ScalarColumnDesc<float> ("col3"));
+  txp.addColumn (ScalarColumnDesc<Complex> ("col4"));
+  ScalarColumnDesc<String> col5("col5");
+  col5.setMaxLength (10);
+  txp.addColumn (col5);
+  txp.addColumn (ArrayColumnDesc<Int> ("arr1", IPosition(2,3,4)));
+  if (addString) {
+    txp.addColumn (ScalarColumnDesc<String> ("col6"));
+  }
+  txp.addColumn (ScalarColumnDesc<String> ("col7"));
+  return txp;
+}
+
+// Write data into the table.
+Bool cretab (Bool addString, uInt nrrow, uInt ssmNrow,
+             const String& nameExt, Bool wait)
+{
+  SetupNewTable newtab ("tFailoverTable_tmp.tab" + nameExt, credes(addString),
+                        Table::New, StorageOption::Failover);
+  StandardStMan ssm("ssm", -Int(ssmNrow));
+  TiledColumnStMan tcs("tcs", IPosition(3,3,4,5));
+  VirtualTaQLColumn vtc("'str1'");
+  newtab.bindAll (ssm);
+  newtab.bindColumn ("arr1", tcs);
+  newtab.bindColumn ("col7", vtc);
+  Table tab;
+  try {
+    tab = Table(newtab);
+  } catch (const TableError& x) {
+    cout << x.what() << endl;
+    return False;
+  }
+  ROStandardStManAccessor acc(tab, "col1", True);
+  acc.showBaseStatistics (cout);
+  acc.showIndexStatistics (cout);
+  AlwaysAssertExit (! tab.canRemoveRow());
+  AlwaysAssertExit (! tab.canRemoveColumn(Vector<String>(1, "col1")));
+  AlwaysAssertExit (! tab.canRenameColumn("newname"));
+  ScalarColumn<Int>     col1 (tab, "col1");
+  ScalarColumn<double>  col2 (tab, "col2");
+  ScalarColumn<float>   col3 (tab, "col3");
+  ScalarColumn<Complex> col4 (tab, "col4");
+  ScalarColumn<String>  col5 (tab, "col5");
+  ArrayColumn<Int>      cola (tab, "arr1");
+  String s("0123456789");
+  Array<Int> arr1(IPosition(2,3,4));
+  indgen(arr1);
+  for (uInt i=0; i<nrrow; i++) {
+    tab.addRow (1);
+    col1.put (i, (100000+i) % 10);
+    col2.put (i, (i+1) % 105);
+    col3.put (i, (i+2) % 75);
+    col4.put (i, i+3);
+    col5.put (i, s.substr(0,i%10));
+    cola.put (i, arr1);
+    arr1 += 1;
+  }
+  cout << "  Filling done" << endl;
+  acc.showBaseStatistics (cout);
+  acc.showIndexStatistics (cout);
+  RODataManAccessor acca(tab, "arr1", True);
+  acca.showCacheStatistics (cout);
+  if (wait) {
+    cerr << "Waiting 10 seconds to be killed to get improperly ended table ..." << endl;
+    sleep(10);
+  }
+  // Row removal should fail.
+  try {
+    tab.removeRow (0);
+  } catch (const TableError& x) {
+    cout << x.what() << endl;
+  }
+  return True;
+}
+
+void readtab (uInt nrrow, const String& nameExt)
+{
+  Table tab("tFailoverTable_tmp.tab" + nameExt, Table::Old);
+  cout << "Table opened with " << tab.nrow() << " rows out of " << nrrow << endl;
+  ScalarColumn<Int>     col1 (tab, "col1");
+  ScalarColumn<double>  col2 (tab, "col2");
+  ScalarColumn<float>   col3 (tab, "col3");
+  ScalarColumn<Complex> col4 (tab, "col4");
+  ScalarColumn<String>  col5 (tab, "col5");
+  ScalarColumn<String>  col7 (tab, "col7");
+  ArrayColumn<Int>      cola (tab, "arr1");
+  ROStandardStManAccessor acc(tab, "col1", True);
+  acc.showBaseStatistics (cout);
+  acc.showIndexStatistics (cout);
+  RODataManAccessor acca(tab, "arr1", True);
+  acca.showCacheStatistics (cout);
+  String s("0123456789");
+  Array<Int> arr1(IPosition(2,3,4));
+  indgen(arr1);
+  for (uInt i=0; i<tab.nrow(); i++) {
+    AlwaysAssertExit (col1(i) == (100000+i) % 10);
+    AlwaysAssertExit (col2(i) == (i+1) % 105);
+    AlwaysAssertExit (col3(i) == (i+2) % 75);
+    AlwaysAssertExit (col4(i) == Complex(i+3));
+    AlwaysAssertExit (col5(i) == s.substr(0,i%10));
+    AlwaysAssertExit (col7(i) == "str1");
+    AlwaysAssertExit (allEQ (cola(i), arr1));
+    arr1 += 1;
+  }
+}
+
+int main (int argc, const char* argv[])
+{
+  // This program tests the table failover mode.
+  // It writes a table in a normal way and read it back.
+  // Thereafter it writes all rows, but waits until killed, so the table is
+  // not closed properly.
+  // A next run in readonly mode will read back that table to see if failover works.
+  // 
+  // It can be run as:
+  //   tFailoverTable [arg]
+  // If arg starts with 'r', the program will only read back tFailoverTable_tmp.tab3
+  // which is the output from the killed run.
+  // Otherwise if arg is given, it contains the nr of rows to write in an SSM bucket.
+  // This can be used to create an improperly closed table where one of the
+  // storage managers contains 0 rows.
+  uInt nrow = 500;
+  uInt ssmNrow = 32;
+  Bool readOnly = False;
+  if (argc > 1) {
+    if (argv[1][0] == 'r') {
+      readOnly = True;
+    } else {
+      ssmNrow = atoi(argv[1]);
+    }
+  }
+  if (! readOnly) {
+    // Create failover table with variable length strings that will fail.
+    AlwaysAssertExit (! cretab(True, nrow, ssmNrow, "1", False));
+    // Create failover table without such strings with proper end.
+    AlwaysAssertExit (cretab(False, nrow, ssmNrow, "2", False));
+    readtab (nrow, "2");
+    // Create failover table without such strings that waits till killed, so
+    // the table is not ended properly. The SSM bucket is small, so most of the
+    // rows are written into it.
+    AlwaysAssertExit (cretab(False, nrow, ssmNrow, "3", True));
+  }
+  readtab (nrow, "3");
+  return 0;          // successfully executed
+}

--- a/tables/Tables/test/tFailoverTable.out
+++ b/tables/Tables/test/tFailoverTable.out
@@ -1,0 +1,435 @@
+Run with small nr of rows in SSM ...
+Invalid Table operation: Table tFailoverTable_tmp.tab1 cannot be created; storage manager of column col6 does not support Failover mode
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 0
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 128
+ ColIndex[2]           : 0 ColOffset[2]          : 384
+ ColIndex[3]           : 0 ColOffset[3]          : 512
+ ColIndex[4]           : 0 ColOffset[4]          : 768
+CacheSize                   : 1
+Size of buckets             : 1088
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 0
+Rows Per bucket    : 32
+Nr of Columns      : 5
+Freespace entries: 0
+
+
+  Filling done
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 500
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 128
+ ColIndex[2]           : 0 ColOffset[2]          : 384
+ ColIndex[3]           : 0 ColOffset[3]          : 512
+ ColIndex[4]           : 0 ColOffset[4]          : 768
+CacheSize                   : 1
+Size of buckets             : 1088
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 16
+Rows Per bucket    : 32
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 31
+BucketNr[1]  : 1 - LastRow[1]   : 63
+BucketNr[2]  : 2 - LastRow[2]   : 95
+BucketNr[3]  : 3 - LastRow[3]   : 127
+BucketNr[4]  : 4 - LastRow[4]   : 159
+BucketNr[5]  : 5 - LastRow[5]   : 191
+BucketNr[6]  : 6 - LastRow[6]   : 223
+BucketNr[7]  : 7 - LastRow[7]   : 255
+BucketNr[8]  : 8 - LastRow[8]   : 287
+BucketNr[9]  : 9 - LastRow[9]   : 319
+BucketNr[10]  : 10 - LastRow[10]   : 351
+BucketNr[11]  : 11 - LastRow[11]   : 383
+BucketNr[12]  : 12 - LastRow[12]   : 415
+BucketNr[13]  : 13 - LastRow[13]   : 447
+BucketNr[14]  : 14 - LastRow[14]   : 479
+BucketNr[15]  : 15 - LastRow[15]   : 499
+Freespace entries: 0
+
+
+>>> TSMCube cache statistics:
+cubeShape: [3, 4, 500]
+tileShape: [3, 4, 5]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  100
+#inits:    100
+#writes:   99
+#accesses: 500        hit-rate:  80%
+<<<
+Invalid Table operation: Table::removeRow cannot be done; table tFailoverTable_tmp.tab2 is in Failover mode
+Table opened with 500 rows out of 500
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 500
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 128
+ ColIndex[2]           : 0 ColOffset[2]          : 384
+ ColIndex[3]           : 0 ColOffset[3]          : 512
+ ColIndex[4]           : 0 ColOffset[4]          : 768
+CacheSize                   : 2
+Size of buckets             : 1088
+Total buckets               : 17
+Total Index buckets         : 1
+1st Index bucket            : 16
+Index bucket offset         : 8
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 16
+Rows Per bucket    : 32
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 31
+BucketNr[1]  : 1 - LastRow[1]   : 63
+BucketNr[2]  : 2 - LastRow[2]   : 95
+BucketNr[3]  : 3 - LastRow[3]   : 127
+BucketNr[4]  : 4 - LastRow[4]   : 159
+BucketNr[5]  : 5 - LastRow[5]   : 191
+BucketNr[6]  : 6 - LastRow[6]   : 223
+BucketNr[7]  : 7 - LastRow[7]   : 255
+BucketNr[8]  : 8 - LastRow[8]   : 287
+BucketNr[9]  : 9 - LastRow[9]   : 319
+BucketNr[10]  : 10 - LastRow[10]   : 351
+BucketNr[11]  : 11 - LastRow[11]   : 383
+BucketNr[12]  : 12 - LastRow[12]   : 415
+BucketNr[13]  : 13 - LastRow[13]   : 447
+BucketNr[14]  : 14 - LastRow[14]   : 479
+BucketNr[15]  : 15 - LastRow[15]   : 499
+Freespace entries: 0
+
+
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 0
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 128
+ ColIndex[2]           : 0 ColOffset[2]          : 384
+ ColIndex[3]           : 0 ColOffset[3]          : 512
+ ColIndex[4]           : 0 ColOffset[4]          : 768
+CacheSize                   : 1
+Size of buckets             : 1088
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 0
+Rows Per bucket    : 32
+Nr of Columns      : 5
+Freespace entries: 0
+
+
+  Filling done
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 500
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 128
+ ColIndex[2]           : 0 ColOffset[2]          : 384
+ ColIndex[3]           : 0 ColOffset[3]          : 512
+ ColIndex[4]           : 0 ColOffset[4]          : 768
+CacheSize                   : 1
+Size of buckets             : 1088
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 16
+Rows Per bucket    : 32
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 31
+BucketNr[1]  : 1 - LastRow[1]   : 63
+BucketNr[2]  : 2 - LastRow[2]   : 95
+BucketNr[3]  : 3 - LastRow[3]   : 127
+BucketNr[4]  : 4 - LastRow[4]   : 159
+BucketNr[5]  : 5 - LastRow[5]   : 191
+BucketNr[6]  : 6 - LastRow[6]   : 223
+BucketNr[7]  : 7 - LastRow[7]   : 255
+BucketNr[8]  : 8 - LastRow[8]   : 287
+BucketNr[9]  : 9 - LastRow[9]   : 319
+BucketNr[10]  : 10 - LastRow[10]   : 351
+BucketNr[11]  : 11 - LastRow[11]   : 383
+BucketNr[12]  : 12 - LastRow[12]   : 415
+BucketNr[13]  : 13 - LastRow[13]   : 447
+BucketNr[14]  : 14 - LastRow[14]   : 479
+BucketNr[15]  : 15 - LastRow[15]   : 499
+Freespace entries: 0
+
+
+>>> TSMCube cache statistics:
+cubeShape: [3, 4, 500]
+tileShape: [3, 4, 5]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  100
+#inits:    100
+#writes:   99
+#accesses: 500        hit-rate:  80%
+<<<
+Waiting 10 seconds to be killed to get improperly ended table ...
+Table opened with 480 rows out of 500
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 480
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 128
+ ColIndex[2]           : 0 ColOffset[2]          : 384
+ ColIndex[3]           : 0 ColOffset[3]          : 512
+ ColIndex[4]           : 0 ColOffset[4]          : 768
+CacheSize                   : 2
+Size of buckets             : 1088
+Total buckets               : 15
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 15
+Rows Per bucket    : 32
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 31
+BucketNr[1]  : 1 - LastRow[1]   : 63
+BucketNr[2]  : 2 - LastRow[2]   : 95
+BucketNr[3]  : 3 - LastRow[3]   : 127
+BucketNr[4]  : 4 - LastRow[4]   : 159
+BucketNr[5]  : 5 - LastRow[5]   : 191
+BucketNr[6]  : 6 - LastRow[6]   : 223
+BucketNr[7]  : 7 - LastRow[7]   : 255
+BucketNr[8]  : 8 - LastRow[8]   : 287
+BucketNr[9]  : 9 - LastRow[9]   : 319
+BucketNr[10]  : 10 - LastRow[10]   : 351
+BucketNr[11]  : 11 - LastRow[11]   : 383
+BucketNr[12]  : 12 - LastRow[12]   : 415
+BucketNr[13]  : 13 - LastRow[13]   : 447
+BucketNr[14]  : 14 - LastRow[14]   : 479
+Freespace entries: 0
+
+
+
+Run with large nr of rows in SSM ...
+Invalid Table operation: Table tFailoverTable_tmp.tab1 cannot be created; storage manager of column col6 does not support Failover mode
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 0
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 2400
+ ColIndex[2]           : 0 ColOffset[2]          : 7200
+ ColIndex[3]           : 0 ColOffset[3]          : 9600
+ ColIndex[4]           : 0 ColOffset[4]          : 14400
+CacheSize                   : 1
+Size of buckets             : 20400
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 0
+Rows Per bucket    : 600
+Nr of Columns      : 5
+Freespace entries: 0
+
+
+  Filling done
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 500
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 2400
+ ColIndex[2]           : 0 ColOffset[2]          : 7200
+ ColIndex[3]           : 0 ColOffset[3]          : 9600
+ ColIndex[4]           : 0 ColOffset[4]          : 14400
+CacheSize                   : 1
+Size of buckets             : 20400
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 1
+Rows Per bucket    : 600
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 499
+Freespace entries: 0
+
+
+>>> TSMCube cache statistics:
+cubeShape: [3, 4, 500]
+tileShape: [3, 4, 5]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  100
+#inits:    100
+#writes:   99
+#accesses: 500        hit-rate:  80%
+<<<
+Invalid Table operation: Table::removeRow cannot be done; table tFailoverTable_tmp.tab2 is in Failover mode
+Table opened with 500 rows out of 500
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 500
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 2400
+ ColIndex[2]           : 0 ColOffset[2]          : 7200
+ ColIndex[3]           : 0 ColOffset[3]          : 9600
+ ColIndex[4]           : 0 ColOffset[4]          : 14400
+CacheSize                   : 2
+Size of buckets             : 20400
+Total buckets               : 2
+Total Index buckets         : 1
+1st Index bucket            : 1
+Index bucket offset         : 8
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 1
+Rows Per bucket    : 600
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 499
+Freespace entries: 0
+
+
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 0
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 2400
+ ColIndex[2]           : 0 ColOffset[2]          : 7200
+ ColIndex[3]           : 0 ColOffset[3]          : 9600
+ ColIndex[4]           : 0 ColOffset[4]          : 14400
+CacheSize                   : 1
+Size of buckets             : 20400
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 0
+Rows Per bucket    : 600
+Nr of Columns      : 5
+Freespace entries: 0
+
+
+  Filling done
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 500
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 2400
+ ColIndex[2]           : 0 ColOffset[2]          : 7200
+ ColIndex[3]           : 0 ColOffset[3]          : 9600
+ ColIndex[4]           : 0 ColOffset[4]          : 14400
+CacheSize                   : 1
+Size of buckets             : 20400
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 1
+Rows Per bucket    : 600
+Nr of Columns      : 5
+BucketNr[0]  : 0 - LastRow[0]   : 499
+Freespace entries: 0
+
+
+>>> TSMCube cache statistics:
+cubeShape: [3, 4, 500]
+tileShape: [3, 4, 5]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  100
+#inits:    100
+#writes:   99
+#accesses: 500        hit-rate:  80%
+<<<
+Waiting 10 seconds to be killed to get improperly ended table ...
+Table opened with 0 rows out of 500
+StandardStMan Base statistics:
+Nr of columns               : 5
+Nr of rows in the columns   : 0
+ ColIndex[0]           : 0 ColOffset[0]          : 0
+ ColIndex[1]           : 0 ColOffset[1]          : 2400
+ ColIndex[2]           : 0 ColOffset[2]          : 7200
+ ColIndex[3]           : 0 ColOffset[3]          : 9600
+ ColIndex[4]           : 0 ColOffset[4]          : 14400
+CacheSize                   : 2
+Size of buckets             : 20400
+Total buckets               : 0
+Total Index buckets         : 0
+1st Index bucket            : -1
+Index bucket offset         : 0
+last String bucket used     : -1
+Total free buckets          : 0
+1st free bucket             : -1
+
+StandardStMan index: 0 statistics:
+Index statistics: 
+Entries used       : 0
+Rows Per bucket    : 600
+Nr of Columns      : 5
+Freespace entries: 0
+
+

--- a/tables/Tables/test/tFailoverTable.run
+++ b/tables/Tables/test/tFailoverTable.run
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# $Id$
+
+# Run in the background and kill after 2 seconds to get a failed table.
+echo "Run with small nr of rows in SSM ..."
+./tFailoverTable >& tFailoverTable_tmp.out1 &
+pid=$!
+sleep 2
+kill -9 $pid
+cat tFailoverTable_tmp.out1
+
+# Now read and check the aborted table.
+$casa_checktool ./tFailoverTable r
+
+# Do the same for a table where all rows fit in a single SSM bucket,
+# so no SSM data are written.
+echo
+echo "Run with large nr of rows in SSM ..."
+./tFailoverTable 600 >& tFailoverTable_tmp.out2 &
+pid=$!
+sleep 2
+kill -9 $pid
+cat tFailoverTable_tmp.out2
+
+# Now read and check the aborted table.
+$casa_checktool ./tFailoverTable r


### PR DESCRIPTION
Tables can now be created in failover mode, so no or only few data are lost in case of a crash. It comes with restrictions as explained in the documentation of Tables.h.

Close #1142