### PR TITLE
Fix handling of FITS-IDI GAIN_CURVE tables

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -3863,7 +3863,7 @@ bool FITSIDItoMS1::readFitsFile(const String& msFile)
       firstWeather=False;
     }
 
-    if (firstWeather && extname == "GAIN_CURVE") {
+    if (firstGainCurve && extname == "GAIN_CURVE") {
       addGainCurve=True;
       firstGainCurve=False;
     }


### PR DESCRIPTION
Fix a pasto that may affect importing GAIN_CURVE tables.  The code was
inspecting the wrang class variable to decide whether the GAIN_CURVE
table should be added to the MeasurementSet.  Fortunately the impact
of this bug was limited since the way the CASA importfitsidi task
uses the code results in the GAIN_CURVE tables getting created anyway.