### PR TITLE
Added support for row tiling

### DIFF
--- a/tables/DataMan/TiledColumnStMan.cc
+++ b/tables/DataMan/TiledColumnStMan.cc
@@ -55,6 +55,15 @@ TiledColumnStMan::TiledColumnStMan ()
 
 TiledColumnStMan::TiledColumnStMan (const String& hypercolumnName,
 				    const IPosition& tileShape,
+				    const IPosition& rowShape,
+				    uInt64 maximumCacheSize)
+: TiledStMan  (hypercolumnName, maximumCacheSize),
+  tileShape_p (tileShape),
+  rowShape_p  (rowShape)
+{}
+
+TiledColumnStMan::TiledColumnStMan (const String& hypercolumnName,
+				    const IPosition& tileShape,
 				    uInt64 maximumCacheSize)
 : TiledStMan  (hypercolumnName, maximumCacheSize),
   tileShape_p (tileShape)
@@ -66,6 +75,9 @@ TiledColumnStMan::TiledColumnStMan (const String& hypercolumnName,
 {
     if (spec.isDefined ("DEFAULTTILESHAPE")) {
         tileShape_p = IPosition (spec.toArrayInt ("DEFAULTTILESHAPE"));
+    }
+    if (spec.isDefined ("ROWSHAPE")) {
+        rowShape_p = IPosition (spec.toArrayInt ("ROWSHAPE"));
     }
     if (spec.isDefined ("MAXIMUMCACHESIZE")) {
         setPersMaxCacheSize (spec.asInt64 ("MAXIMUMCACHESIZE"));
@@ -79,6 +91,7 @@ DataManager* TiledColumnStMan::clone() const
 {
     TiledColumnStMan* smp = new TiledColumnStMan (hypercolumnName_p,
 						  tileShape_p,
+                                                  rowShape_p,
 						  maximumCacheSize());
     return smp;
 }
@@ -95,28 +108,38 @@ String TiledColumnStMan::dataManagerType() const
     return "TiledColumnStMan";
 }
 
-Bool TiledColumnStMan::canAccessColumn () const
+Bool TiledColumnStMan::canAccessColumn() const
 {
-    return True;
+    // This is only possible if an integral nr of rows fit the hypercube.
+    return nrrow_p % rowMap_p[rowMap_p.size() - 1] == 0;
 }
 
 
 void TiledColumnStMan::create64 (rownr_t nrrow)
 {
+    // Make the hypercube extendible.
+    if (rowShape_p.empty()) {
+      rowShape_p = IPosition(1,0);
+    } else {
+      rowShape_p.last() = 0;
+    }
     // Set up the various things.
-    setup(1);
+    setupRowMap();
+    setup (rowShape_p.size());
     // Create the one and single TSMFile object.
     createFile (0);
     // Create the hypercube object.
     // Its shape is the cell shape plus an extensible last dimension.
     // Check if the hypercube dimensionality is one extra.
-    if (nrdim_p != fixedCellShape_p.nelements() + 1) {
+    if (nrdim_p != fixedCellShape_p.nelements() + rowShape_p.size()) {
 	throw (TSMError ("TiledColumnStMan: hypercube dimensionality "
-			 "has to be 1 + cell dimensionality"));
+			 "has to be row shape + cell dimensionality"));
     }
     IPosition cubeShape (fixedCellShape_p);
     cubeShape.resize (nrdim_p);
-    cubeShape(nrdim_p - 1) = 0;
+    for (uInt i=0; i<rowShape_p.size(); ++i) {
+      cubeShape(nrdim_p - rowShape_p.size() +  i) = rowShape_p(i);
+    }
     cubeSet_p.resize (1);
     cubeSet_p[0] = makeTSMCube (fileSet_p[0],
 				cubeShape, tileShape_p, emptyRecord);
@@ -132,10 +155,17 @@ Bool TiledColumnStMan::flush (AipsIO&, Bool fsync)
     if (! flushCaches (fsync)) {
 	return False;
     }
-    // Create the header file and write data in it.
+    // Create the header file and write data into it.
+    // Use version 1 if rowshape has 1 dim, so it can be used by older casacore.
     AipsIO* headerFile = headerFileCreate();
-    headerFile->putstart ("TiledColumnStMan", 1);
-    *headerFile << tileShape_p;
+    if (rowShape_p.size() == 1) {
+        headerFile->putstart ("TiledColumnStMan", 1);
+        *headerFile << tileShape_p;
+    } else {
+        headerFile->putstart ("TiledColumnStMan", 2);
+        *headerFile << tileShape_p;
+        *headerFile << rowShape_p;
+    }
     // Let the base class write its data; there is only one TSMCube to write.
     headerFilePut (*headerFile, 1);
     headerFile->putend();
@@ -147,22 +177,50 @@ void TiledColumnStMan::readHeader (rownr_t tabNrrow, Bool firstTime)
 {
     // Open the header file and read data from it.
     AipsIO* headerFile = headerFileOpen();
-    headerFile->getstart ("TiledColumnStMan");
+    uInt version = headerFile->getstart ("TiledColumnStMan");
     *headerFile >> tileShape_p;
+    if (version == 2) {
+        *headerFile >> rowShape_p;
+    } else {
+        AlwaysAssert (version==1, AipsError);
+        rowShape_p = IPosition(1,0);
+    }
+    setupRowMap();
     // Let the base class read and initialize its data.
-    headerFileGet (*headerFile, tabNrrow, firstTime, 1);
+    headerFileGet (*headerFile, tabNrrow, firstTime, rowShape_p.size());
     headerFile->getend();
     headerFileClose (headerFile);
 }
 
+void TiledColumnStMan::setupRowMap()
+{
+  rowMap_p.resize (rowShape_p.size());
+  ssize_t sz = 1;
+  for (uInt i=0; i<rowShape_p.size(); ++i) {
+    rowMap_p[i] = sz;
+    sz *= rowShape_p[i];
+  }
+}
+
+void TiledColumnStMan::rowToPosition (IPosition& pos, rownr_t row) const
+{
+  DebugAssert (pos.size() >= rowMap_p.size(), AipsError);
+  uInt st = pos.size() - rowMap_p.size();
+  ssize_t inx = row;
+  for (uInt i=rowMap_p.size()-1; i>0; --i) {
+    pos[st + i] = inx / rowMap_p[i];
+    inx -= pos[st + i] * rowMap_p[i];
+  }
+  pos[st] = inx;
+}
 
 void TiledColumnStMan::setupCheck (const TableDesc& tableDesc,
 				   const Vector<String>& dataNames) const
 {
     // The data columns may only contain arrays with the correct
-    // dimensionality, which should be one less than the hypercube
+    // dimensionality, which should be less than the hypercube
     // dimensionality.
-    Int ndim = nrdim_p - 1;
+    Int ndim = nrdim_p - rowShape_p.size();
     for (uInt i=0; i<dataNames.nelements(); i++) {
 	const ColumnDesc& columnDesc = tableDesc.columnDesc (dataNames(i));
 	if (columnDesc.isScalar()) {
@@ -174,7 +232,9 @@ void TiledColumnStMan::setupCheck (const TableDesc& tableDesc,
 	} else {
 	    if (! columnDesc.isArray()  ||  ndim != columnDesc.ndim()) {
 	        throw (TSMError ("Dimensionality of column " + dataNames(i) +
-				 " should be one less than hypercolumn"
+				 " should be " +
+                                 String::toString(rowShape_p.size()) +
+                                 " less than hypercolumn"
 				 " definition when used in TiledColumnStMan"));
 	    }
 	    // The data columns in a column hypercube must be fixed shape.
@@ -199,7 +259,15 @@ IPosition TiledColumnStMan::defaultTileShape() const
 
 void TiledColumnStMan::addRow64 (rownr_t nrow)
 {
-    cubeSet_p[0]->extend (nrow, emptyRecord, coordColSet_p[nrdim_p - 1]);
+    // Extend the last dimension as much as needed.
+    ssize_t nnew  = (nrrow_p+nrow) / rowMap_p.last() - nrrow_p / rowMap_p.last();
+    // Make sure at least 1 is added if still empty.
+    if (nrrow_p == 0  &&  nrow > 0  &&  nnew == 0) {
+        nnew = 1;
+    }
+    if (nnew > 0) {
+        cubeSet_p[0]->extend (nnew, emptyRecord, coordColSet_p[nrdim_p - 1]);
+    }
     nrrow_p += nrow;
     setDataChanged();
 }
@@ -219,10 +287,10 @@ TSMCube* TiledColumnStMan::getHypercube (rownr_t rownr, IPosition& position)
     if (rownr >= nrrow_p) {
 	throw (TSMError ("getHypercube: rownr is too high"));
     }
-    // The rownr is the position in the hypercube.
+    // The rownr determines the position in the hypercube.
     position.resize (0);
     position = cubeSet_p[0]->cubeShape();
-    position(nrdim_p-1) = rownr;
+    rowToPosition (position, rownr);
     return cubeSet_p[0];
 }
 

--- a/tables/DataMan/test/CMakeLists.txt
+++ b/tables/DataMan/test/CMakeLists.txt
@@ -26,6 +26,7 @@ tTiledBool
 tTiledCellStM_1
 tTiledCellStMan
 tTiledColumnStMan
+tTiledColumnStManPerf
 tTiledDataStM_1
 tTiledDataStMan
 tTiledEmpty

--- a/tables/DataMan/test/tExternalStMan.cc
+++ b/tables/DataMan/test/tExternalStMan.cc
@@ -772,7 +772,7 @@ void createTable()
   td.addColumn (ArrayColumnDesc<Bool>("FLAG"));
   td.addColumn (ArrayColumnDesc<Bool>("FLAG_CATEGORY"));
   // Now create a new table from the description.
-  SetupNewTable newtab("tLofarStMan_tmp.data", td, Table::New);
+  SetupNewTable newtab("tExternalStMan_tmp.data", td, Table::New);
   // Create the storage manager and bind all columns to it.
   LofarStMan sm1;
   newtab.bindAll (sm1);
@@ -786,7 +786,7 @@ void createTable()
 void readTable()
 {
   // Open the table and check if #rows is as expected.
-  Table tab("tLofarStMan_tmp.data");
+  Table tab("tExternalStMan_tmp.data");
   uInt nrow = tab.nrow();
   uInt nbasel = nant*nant;
   AlwaysAssertExit (nrow = ntime*nbasel);
@@ -898,7 +898,7 @@ void readTable()
 void updateTable()
 {
   // Open the table for write.
-  Table tab("tLofarStMan_tmp.data", Table::Update);
+  Table tab("tExternalStMan_tmp.data", Table::Update);
   // Create object for DATA column.
   ArrayColumn<Complex> dataCol(tab, "DATA");
   // Check we can write the column, but not change the shape.
@@ -912,9 +912,9 @@ void updateTable()
 
 void copyTable()
 {
-  Table tab("tLofarStMan_tmp.data");
+  Table tab("tExternalStMan_tmp.data");
   // Deep copy the table.
-  tab.deepCopy ("tLofarStMan_tmp.datcp", Table::New, true);
+  tab.deepCopy ("tExternalStMan_tmp.datcp", Table::New, true);
 }
 
 

--- a/tables/DataMan/test/tExternalStManNew.cc
+++ b/tables/DataMan/test/tExternalStManNew.cc
@@ -760,7 +760,7 @@ void createTable()
   td.addColumn (ArrayColumnDesc<Bool>("FLAG"));
   td.addColumn (ArrayColumnDesc<Bool>("FLAG_CATEGORY"));
   // Now create a new table from the description.
-  SetupNewTable newtab("tLofarStMan_tmp.data", td, Table::New);
+  SetupNewTable newtab("tExternalStManNew_tmp.data", td, Table::New);
   // Create the storage manager and bind all columns to it.
   LofarStMan sm1;
   newtab.bindAll (sm1);
@@ -774,7 +774,7 @@ void createTable()
 void readTable()
 {
   // Open the table and check if #rows is as expected.
-  Table tab("tLofarStMan_tmp.data");
+  Table tab("tExternalStManNew_tmp.data");
   rownr_t nrow = tab.nrow();
   uInt nbasel = nant*nant;
   AlwaysAssertExit (nrow = ntime*nbasel);
@@ -886,7 +886,7 @@ void readTable()
 void updateTable()
 {
   // Open the table for write.
-  Table tab("tLofarStMan_tmp.data", Table::Update);
+  Table tab("tExternalStManNew_tmp.data", Table::Update);
   // Create object for DATA column.
   ArrayColumn<Complex> dataCol(tab, "DATA");
   // Check we can write the column, but not change the shape.
@@ -900,9 +900,9 @@ void updateTable()
 
 void copyTable()
 {
-  Table tab("tLofarStMan_tmp.data");
+  Table tab("tExternalStManNew_tmp.data");
   // Deep copy the table.
-  tab.deepCopy ("tLofarStMan_tmp.datcp", Table::New, true);
+  tab.deepCopy ("tExternalStManNew_tmp.datcp", Table::New, true);
 }
 
 

--- a/tables/DataMan/test/tIncrementalStMan.cc
+++ b/tables/DataMan/test/tIncrementalStMan.cc
@@ -531,7 +531,7 @@ void testWithLocking()
     uInt time_rows = 10000;
     TableDesc td;
     td.addColumn(ScalarColumnDesc<Int>("TIME"));
-    SetupNewTable newtab("tIn.tab", td, Table::New);
+    SetupNewTable newtab("tIncrementalStMan_tmp.tab", td, Table::New);
     IncrementalStMan ism;
     newtab.bindAll (ism);
     Table tab(newtab, nrow);
@@ -549,7 +549,7 @@ void testWithLocking()
   // which invalidates the cache.
   // Do it twice with a size less and greater than 10000.
   for (uInt time_rows=3333; time_rows<=33333; time_rows+=30000) {
-    Table tab("tIn.tab", TableLock::UserLocking);
+    Table tab("tIncrementalStMan_tmp.tab", TableLock::UserLocking);
     uInt nrow = tab.nrow();
     uInt row = 0;
     while (row < nrow) {

--- a/tables/DataMan/test/tStManAll.cc
+++ b/tables/DataMan/test/tStManAll.cc
@@ -81,7 +81,7 @@
   { \
     Table tab(table); \
     if (! keepTable) { \
-      tab = Table("tStMan_tmp.data", Table::Update); \
+      tab = Table("tStManAll_tmp.data", Table::Update); \
     } \
     ExecFunc(funcName, tab, String()); \
   } \
@@ -567,7 +567,7 @@ void bindVirtual (SetupNewTable& newtab, const String& name)
 }
 
 // Create a new table and fill a few cells with an empty array.
-// An empty table name defaults to tStMan_tmp.data.
+// An empty table name defaults to tStManAll_tmp.data.
 Table maketab (uInt nrrow, const DataManager& stman, Bool tiled,
                const String& tabName=String(), Bool addVirtual=False)
 {
@@ -587,7 +587,7 @@ Table maketab (uInt nrrow, const DataManager& stman, Bool tiled,
   addColDesc<String> (td, "sv", addVirtual);           // variable length string
   addColDesc<String> (td, "sf", addVirtual, 40);       // fixed length string
   // Now create a new table from the description.
-  String tname(tabName.empty() ? "tStMan_tmp.data" : tabName);
+  String tname(tabName.empty() ? "tStManAll_tmp.data" : tabName);
   SetupNewTable newtab(tname, td, Table::New);
   // Bind all columns to the storage manager and set the fixed shapes.
   newtab.bindAll (stman);
@@ -678,7 +678,7 @@ void checknewtab (const Table& table, uInt nrrow, Bool tiled)
 {
   Table tab(table);
   if (tab.isNull()) {
-    tab = Table("tStMan_tmp.data");
+    tab = Table("tStManAll_tmp.data");
   }
   AlwaysAssertExit (tab.nrow() == nrrow);
   // Make a subset of all except the last row, because the float and DComplex
@@ -713,7 +713,7 @@ void checktab (const Table& table)
 {
   Table tab(table);
   if (tab.isNull()) {
-    tab = Table("tStMan_tmp.data");
+    tab = Table("tStManAll_tmp.data");
   }
   ExecFunc(checkAll, tab, String());
 }
@@ -799,7 +799,7 @@ int main (int argc, const char* argv[])
       cout << "Testing ForwardColumnEngine ..." << endl;
       // Test ForwardColumn.
       StandardStMan stman(2000);
-      Table tab = maketab (nrrow, stman, False, "tStMan_tmp.datafc");
+      Table tab = maketab (nrrow, stman, False, "tStManAll_tmp.datafc");
       ForwardColumnEngine dataman(tab, "forwardcolumn");
       doTest (nrrow, dataman, True, False);
     }

--- a/tables/DataMan/test/tTiledColumnStMan.cc
+++ b/tables/DataMan/test/tTiledColumnStMan.cc
@@ -33,6 +33,7 @@
 #include <casacore/tables/Tables/ScalarColumn.h>
 #include <casacore/tables/Tables/ArrayColumn.h>
 #include <casacore/tables/DataMan/TiledColumnStMan.h>
+#include <casacore/tables/DataMan/StandardStMan.h>
 #include <casacore/tables/DataMan/TiledStManAccessor.h>
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Arrays/Vector.h>
@@ -49,6 +50,9 @@
 #include <casacore/casa/iostream.h>
 
 #include <casacore/casa/namespace.h>
+
+rownr_t NROW = 551;
+
 // <summary>
 // Test program for the TiledColumnStMan class.
 // </summary>
@@ -57,19 +61,29 @@
 // The results are written to stdout. The script executing this program,
 // compares the results with the reference output file.
 
-void writeFixed(const TSMOption&);
-void readTable(const TSMOption&, Bool readKeys);
+void writeFixed(const TSMOption&, const IPosition&);
+void readTable(const TSMOption&, Bool readKeys, const IPosition&);
 void writeNoHyper(const TSMOption&);
 void extendOnly(const TSMOption&);
 
 int main () {
     try {
-        writeFixed(TSMOption::Cache);
-	readTable(TSMOption::MMap, True);
+      {
+        IPosition rowShape(2,13,1);
+        writeFixed(TSMOption::Cache, rowShape);
+	readTable(TSMOption::MMap, True, rowShape);
+      }
+      {
+        IPosition rowShape(3,13,15,0);
+        writeFixed(TSMOption::Cache, rowShape);
+	readTable(TSMOption::MMap, True, rowShape);
+      }
+        writeFixed(TSMOption::Cache, IPosition(1,0));
+	readTable(TSMOption::Cache, True, IPosition());
 	writeNoHyper(TSMOption::MMap);
-	readTable(TSMOption::Buffer, False);
-        writeFixed(TSMOption::Buffer);
-	readTable(TSMOption::Cache, False);
+	readTable(TSMOption::Buffer, False, IPosition());
+        writeFixed(TSMOption::Buffer, IPosition(1,0));
+	readTable(TSMOption::Cache, False, IPosition());
         extendOnly(TSMOption::Cache);
     } catch (std::exception& x) {
 	cout << "Caught an exception: " << x.what() << endl;
@@ -78,60 +92,113 @@ int main () {
     return 0;                           // exit with success status
 }
 
-// First build a description.
-void writeFixed(const TSMOption& tsmOpt)
+
+void incrXYZ (float& x, float& y, float& z, uInt rownr, const IPosition& rowShape)
 {
+  if (rownr == 0) {
+    // Initialize at first time.
+    x = 34;
+    y = 3;
+    z = -2;
+  } else {
+    x += 5;
+    if (rowShape.size() <= 1) {
+      // No hypercube, so normal increment.
+      y += -2;
+      z += 0.5;
+    } else {
+      // hypercube, so X repeats every n rows and Y increments after n rows.
+      if (rownr % rowShape[0] == 0) {
+        x = 34;
+        y += -2;
+        // Same logic for Z.
+        if (rowShape.size() == 2) {
+          z += 0.5;
+        } else {
+          if (rownr % (rowShape[0]*rowShape[1]) == 0) {
+            y = 3;
+            z += 0.5;
+          }
+        }
+      }
+    }
+  }
+}
+  
+// First build a description.
+void writeFixed(const TSMOption& tsmOpt, const IPosition& rowShape)
+{
+  cout << endl << "Test writeFixed " << rowShape << endl;
     // Build the table description.
     TableDesc td ("", "1", TableDesc::Scratch);
     td.addColumn (ArrayColumnDesc<float>  ("Pol", IPosition(1,16),
 					   ColumnDesc::FixedShape));
     td.addColumn (ArrayColumnDesc<float>  ("Freq", 1, ColumnDesc::FixedShape));
-    td.addColumn (ScalarColumnDesc<float> ("Time"));
+    td.addColumn (ScalarColumnDesc<float> ("X"));
+    td.addColumn (ScalarColumnDesc<float> ("Y"));
+    td.addColumn (ScalarColumnDesc<float> ("Z"));
     td.addColumn (ArrayColumnDesc<float>  ("Data", 2, ColumnDesc::FixedShape));
     td.addColumn (ArrayColumnDesc<float>  ("Weight", IPosition(2,16,20),
 					   ColumnDesc::FixedShape));
+    Vector<String> allCoords (stringToVector("Pol,Freq,X,Y,Z"));
     td.defineHypercolumn ("TSMExample",
-			  3,
+			  rowShape.size() + 2,
 			  stringToVector ("Data,Weight"),
-			  stringToVector ("Pol,Freq,Time"));
+                          allCoords(Slice(0, rowShape.size()+2)));
     
     // Now create a new table from the description.
     SetupNewTable newtab("tTiledColumnStMan_tmp.data", td, Table::New);
-    // Create a storage manager for it.
-    TiledColumnStMan sm1 ("TSMExample", IPosition(3,5,6,1));
+    // Create a storage manager for it. First fill the tile shape.
+    IPosition tileShape(2 + rowShape.size());
+    tileShape[0] = 5;
+    tileShape[1] = 6;
+    for (uInt i=0; i<rowShape.size(); ++i) {
+      tileShape[i+2] = rowShape[i] / (i+2);
+      if (tileShape[i+2] <= 0) tileShape[i+2] = 1;
+    }
+    TiledColumnStMan sm1 ("TSMExample", tileShape, rowShape);
     newtab.setShapeColumn ("Freq", IPosition(1,20));
     newtab.setShapeColumn ("Data", IPosition(2,16,20));
     newtab.bindAll (sm1);
+    StandardStMan ssm;
+    if (tileShape.size() < 5) newtab.bindColumn ("Z", ssm);
+    if (tileShape.size() < 4) newtab.bindColumn ("Y", ssm);
     Table table(newtab, 0, False, Table::LittleEndian, tsmOpt);
 
     Vector<float> freqValues(20);
     Vector<float> polValues(16);
     indgen (freqValues, float(200));
     indgen (polValues, float(300));
-    float timeValue;
-    timeValue = 34;
+    float xValue = 0;
+    float yValue = 0;
+    float zValue = 0;
     ArrayColumn<float> freq (table, "Freq");
     ArrayColumn<float> pol (table, "Pol");
     ArrayColumn<float> data (table, "Data");
     ArrayColumn<float> weight (table, "Weight");
-    ScalarColumn<float> time (table, "Time");
+    ScalarColumn<float> x (table, "X");
+    ScalarColumn<float> y (table, "Y");
+    ScalarColumn<float> z (table, "Z");
     Matrix<float> array(IPosition(2,16,20));
     Matrix<float> result(IPosition(2,16,20));
     uInt i;
     indgen (array);
-    for (i=0; i<51; i++) {
+    for (i=0; i<NROW; i++) {
+        incrXYZ (xValue, yValue, zValue, i, rowShape);
 	table.addRow();
 	data.put (i, array);
 	weight.put (i, array+float(100));
-	time.put (i, timeValue);
+	x.put (i, xValue);
+	y.put (i, yValue);
+	z.put (i, zValue);
 	array += float(200);
-	timeValue += 5;
     }
     freq.put (0, freqValues);
     pol.put (0, polValues);
-    timeValue = 34;
+    // Now read it back and check it.
     indgen (array);
     for (i=0; i<table.nrow(); i++) {
+        incrXYZ (xValue, yValue, zValue, i, rowShape);
 	data.get (i, result);
 	if (! allEQ (array, result)) {
 	    cout << "mismatch in data row " << i << endl;
@@ -146,45 +213,53 @@ void writeFixed(const TSMOption& tsmOpt)
 	if (! allEQ (pol(i), polValues)) {
 	    cout << "mismatch in pol row " << i << endl;
 	}
-	if (time(i) != timeValue) {
-	    cout << "mismatch in time row " << i << endl;
+	if (x(i) != xValue) {
+	    cout << "mismatch in X row " << i << endl;
+	}
+	if (y(i) != yValue) {
+	    cout << "mismatch in Y row " << i << endl;
+	}
+	if (z(i) != zValue) {
+	    cout << "mismatch in Z row " << i << endl;
 	}
 	array += float(200);
-	timeValue += 5;
     }
     ROTiledStManAccessor accessor (table, "TSMExample");
     accessor.showCacheStatistics (cout);
+    cout << "hypercubeShape = " << accessor.getHypercubeShape(0) << endl;
+    cout << "tileShape = " << accessor.getTileShape(0) << endl;
     AlwaysAssertExit (accessor.nhypercubes() == 1);
-    AlwaysAssertExit (accessor.hypercubeShape(2) == IPosition(3,16,20,
-							      table.nrow()));
-    AlwaysAssertExit (accessor.tileShape(2) == IPosition(3,5,6,1));
-    AlwaysAssertExit (accessor.getHypercubeShape(0) == IPosition(3,16,20,
-								table.nrow()));
-    AlwaysAssertExit (accessor.getTileShape(0) == IPosition(3,5,6,1));
+    AlwaysAssertExit (accessor.hypercubeShape(2) == accessor.getHypercubeShape(0));
+    AlwaysAssertExit (accessor.tileShape(2) == accessor.getTileShape(0));
     AlwaysAssertExit (accessor.getBucketSize(0) == accessor.bucketSize(2));
     AlwaysAssertExit (accessor.getCacheSize(0) == accessor.cacheSize(2));
 }
 
-void readTable (const TSMOption& tsmOpt, Bool readKeys)
+void readTable (const TSMOption& tsmOpt, Bool readKeys, const IPosition& rowShape)
 {
-  Table table("tTiledColumnStMan_tmp.data", Table::Old, tsmOpt);
+    cout << endl << "Test readTable " << rowShape << endl;
+    Table table("tTiledColumnStMan_tmp.data", Table::Old, tsmOpt);
     ROTiledStManAccessor accessor (table, "TSMExample");
     ArrayColumn<float> freq (table, "Freq");
     ArrayColumn<float> pol (table, "Pol");
     ArrayColumn<float> data (table, "Data");
     ArrayColumn<float> weight (table, "Weight");
-    ScalarColumn<float> time (table, "Time");
+    ScalarColumn<float> x (table, "X");
+    ScalarColumn<float> y (table, "Y");
+    ScalarColumn<float> z (table, "Z");
     Vector<float> freqValues(20);
     Vector<float> polValues(16);
     indgen (freqValues, float(200));
     indgen (polValues, float(300));
-    float timeValue;
-    timeValue = 34;
+    float xValue = 0;
+    float yValue = 0;
+    float zValue = 0;
     Matrix<float> array(IPosition(2,16,20));
     Matrix<float> result(IPosition(2,16,20));
     uInt i;
     indgen (array);
     for (i=0; i<table.nrow(); i++) {
+        incrXYZ (xValue, yValue, zValue, i, rowShape);
 	data.get (i, result);
 	if (! allEQ (array, result)) {
 	    cout << "mismatch in data row " << i << endl;
@@ -199,11 +274,16 @@ void readTable (const TSMOption& tsmOpt, Bool readKeys)
 	if (! allEQ (pol(i), polValues)) {
 	    cout << "mismatch in pol row " << i << endl;
 	}
-	if (time(i) != timeValue) {
-	    cout << "mismatch in time row " << i << endl;
+	if (x(i) != xValue) {
+	    cout << "mismatch in X row " << i << endl;
+	}
+	if (y(i) != yValue) {
+	    cout << "mismatch in Y row " << i << endl;
+	}
+	if (z(i) != zValue) {
+	    cout << "mismatch in Z row " << i << endl;
 	}
 	array += float(200);
-	timeValue += 5;
     }
     accessor.showCacheStatistics (cout);
     accessor.clearCaches();
@@ -212,8 +292,13 @@ void readTable (const TSMOption& tsmOpt, Bool readKeys)
 			       freqValues));
       AlwaysAssertExit (allEQ (accessor.getValueRecord(0).asArrayFloat("Pol"),
 			       polValues));
-      AlwaysAssertExit (allEQ (accessor.getValueRecord(0).asArrayFloat("Time"),
-			       time.getColumn()));
+      if (rowShape.size() > 1) {
+        cout << "X = " << accessor.getValueRecord(0).asArrayFloat("X") << endl;
+      }
+      if (rowShape.size() > 2) {
+        cout << "Y = " << accessor.getValueRecord(0).asArrayFloat("Y") << endl;
+        cout << "Z = " << accessor.getValueRecord(0).asArrayFloat("Z") << endl;
+      }
     }
     cout << "get's have been done" << endl;
 
@@ -222,7 +307,7 @@ void readTable (const TSMOption& tsmOpt, Bool readKeys)
     {
 	Array<float> result;
 	data.getColumn (result);
-	if (result.shape() != IPosition (3,16,20,51)) {
+	if (result.shape() != IPosition (3,16,20,NROW)) {
 	    cout << "shape of getColumn result is incorrect" << endl;
 	}else{
 	    indgen (array);
@@ -245,8 +330,8 @@ void readTable (const TSMOption& tsmOpt, Bool readKeys)
     // Get slices in the entire column.
     {
 	uInt i, j;
-	Cube<float> array(1,1,51);
-	for (i=0; i<51; i++) {
+	Cube<float> array(1,1,NROW);
+	for (i=0; i<NROW; i++) {
 	    array(0,0,i) = 200*i;
 	}
 	Array<float> result;
@@ -268,8 +353,8 @@ void readTable (const TSMOption& tsmOpt, Bool readKeys)
     // Get strided slices in the entire column.
     {
 	uInt i, j;
-	Cube<float> array(2,2,51);
-	for (i=0; i<51; i++) {
+	Cube<float> array(2,2,NROW);
+	for (i=0; i<NROW; i++) {
 	    array(0,0,i) = 200*i;
 	    array(1,0,i) = 200*i + 16/2;
 	    array(0,1,i) = 200*i + 16*20/2;
@@ -362,12 +447,15 @@ void readTable (const TSMOption& tsmOpt, Bool readKeys)
 // First build a description.
 void writeNoHyper(const TSMOption& tsmOpt)
 {
+    cout << endl << "Test writeNoHyper " << endl;
     // Build the table description.
     TableDesc td ("", "1", TableDesc::Scratch);
     td.addColumn (ArrayColumnDesc<float>  ("Pol", IPosition(1,16),
 					   ColumnDesc::FixedShape));
     td.addColumn (ArrayColumnDesc<float>  ("Freq", 1, ColumnDesc::FixedShape));
-    td.addColumn (ScalarColumnDesc<float> ("Time"));
+    td.addColumn (ScalarColumnDesc<float> ("X"));
+    td.addColumn (ScalarColumnDesc<float> ("Y"));
+    td.addColumn (ScalarColumnDesc<float> ("Z"));
     td.addColumn (ArrayColumnDesc<float>  ("Data", 2, ColumnDesc::FixedShape));
     td.addColumn (ArrayColumnDesc<float>  ("Weight", IPosition(2,16,20),
 					   ColumnDesc::FixedShape));
@@ -386,30 +474,35 @@ void writeNoHyper(const TSMOption& tsmOpt)
     Vector<float> polValues(16);
     indgen (freqValues, float(200));
     indgen (polValues, float(300));
-    float timeValue;
-    timeValue = 34;
+    float xValue = 0;
+    float yValue = 0;
+    float zValue = 0;
     ArrayColumn<float> freq (table, "Freq");
     ArrayColumn<float> pol (table, "Pol");
     ArrayColumn<float> data (table, "Data");
     ArrayColumn<float> weight (table, "Weight");
-    ScalarColumn<float> time (table, "Time");
+    ScalarColumn<float> x (table, "X");
+    ScalarColumn<float> y (table, "Y");
+    ScalarColumn<float> z (table, "Z");
     Matrix<float> array(IPosition(2,16,20));
     Matrix<float> result(IPosition(2,16,20));
     uInt i;
     indgen (array);
-    for (i=0; i<51; i++) {
+    for (i=0; i<NROW; i++) {
+        incrXYZ (xValue, yValue, zValue, i, IPosition());
 	table.addRow();
 	data.put (i, array);
 	weight.put (i, array+float(100));
-	time.put (i, timeValue);
+	x.put (i, xValue);
+	y.put (i, yValue);
+	z.put (i, zValue);
 	array += float(200);
-	timeValue += 5;
 	freq.put (i, freqValues);
 	pol.put (i, polValues);
     }
-    timeValue = 34;
     indgen (array);
     for (i=0; i<table.nrow(); i++) {
+        incrXYZ (xValue, yValue, zValue, i, IPosition());
 	data.get (i, result);
 	if (! allEQ (array, result)) {
 	    cout << "mismatch in data row " << i << endl;
@@ -424,21 +517,24 @@ void writeNoHyper(const TSMOption& tsmOpt)
 	if (! allEQ (pol(i), polValues)) {
 	    cout << "mismatch in pol row " << i << endl;
 	}
-	if (time(i) != timeValue) {
-	    cout << "mismatch in time row " << i << endl;
+	if (x(i) != xValue) {
+	    cout << "mismatch in X row " << i << endl;
+	}
+	if (y(i) != yValue) {
+	    cout << "mismatch in Y row " << i << endl;
+	}
+	if (z(i) != zValue) {
+	    cout << "mismatch in Z row " << i << endl;
 	}
 	array += float(200);
-	timeValue += 5;
     }
     ROTiledStManAccessor accessor (table, "TSMExample");
     accessor.showCacheStatistics (cout);
+    cout << "hypercubeShape = " << accessor.getHypercubeShape(0) << endl;
+    cout << "tileShape = " << accessor.getTileShape(0) << endl;
     AlwaysAssertExit (accessor.nhypercubes() == 1);
-    AlwaysAssertExit (accessor.hypercubeShape(2) == IPosition(3,16,20,
-							      table.nrow()));
-    AlwaysAssertExit (accessor.tileShape(2) == IPosition(3,5,6,1));
-    AlwaysAssertExit (accessor.getHypercubeShape(0) == IPosition(3,16,20,
-								table.nrow()));
-    AlwaysAssertExit (accessor.getTileShape(0) == IPosition(3,5,6,1));
+    AlwaysAssertExit (accessor.hypercubeShape(2) == accessor.getHypercubeShape(0));
+    AlwaysAssertExit (accessor.tileShape(2) == accessor.getTileShape(0));
     AlwaysAssertExit (accessor.getBucketSize(0) == accessor.bucketSize(2));
     AlwaysAssertExit (accessor.getCacheSize(0) == accessor.cacheSize(2));
 }
@@ -446,32 +542,30 @@ void writeNoHyper(const TSMOption& tsmOpt)
 // First build a description.
 void extendOnly(const TSMOption& tsmOpt)
 {
+    cout << endl << "Test extendOnly " << endl;
     // Build the table description.
     TableDesc td ("", "1", TableDesc::Scratch);
     td.addColumn (ArrayColumnDesc<float>  ("Weight", IPosition(2,16,20),
 					   ColumnDesc::FixedShape));
     
     // Now create a new table from the description.
-    SetupNewTable newtab("tTiledColumnStMan_tm2p.data", td, Table::New);
+    SetupNewTable newtab("tTiledColumnStMan_tmp2.data", td, Table::New);
     // Create a storage manager for it.
-    TiledColumnStMan sm1 ("TSMExample", IPosition(3,5,6,1));
+    TiledColumnStMan sm1 ("TSMExample", IPosition(3,5,6,420));
     newtab.bindColumn ("Weight", sm1);
     Table table(newtab, 0, False, Table::LocalEndian, tsmOpt);
 
     ArrayColumn<float> weight (table, "Weight");
-    uInt i;
-    for (i=0; i<51; i++) {
-	table.addRow();
-    }
+    table.addRow (34);
+    table.addRow (387);
+    table.flush();
     ROTiledStManAccessor accessor (table, "TSMExample");
     accessor.showCacheStatistics (cout);
+    cout << "hypercubeShape = " << accessor.getHypercubeShape(0) << endl;
+    cout << "tileShape = " << accessor.getTileShape(0) << endl;
     AlwaysAssertExit (accessor.nhypercubes() == 1);
-    AlwaysAssertExit (accessor.hypercubeShape(2) == IPosition(3,16,20,
-							      table.nrow()));
-    AlwaysAssertExit (accessor.tileShape(2) == IPosition(3,5,6,1));
-    AlwaysAssertExit (accessor.getHypercubeShape(0) == IPosition(3,16,20,
-								table.nrow()));
-    AlwaysAssertExit (accessor.getTileShape(0) == IPosition(3,5,6,1));
+    AlwaysAssertExit (accessor.hypercubeShape(2) == accessor.getHypercubeShape(0));
+    AlwaysAssertExit (accessor.tileShape(2) == accessor.getTileShape(0));
     AlwaysAssertExit (accessor.getBucketSize(0) == accessor.bucketSize(2));
     AlwaysAssertExit (accessor.getCacheSize(0) == accessor.cacheSize(2));
 }

--- a/tables/DataMan/test/tTiledColumnStMan.out
+++ b/tables/DataMan/test/tTiledColumnStMan.out
@@ -1,16 +1,23 @@
+
+Test writeFixed [13, 1]
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
-tileShape: [5, 6, 1]
-maxCacheSz:0
-cacheSize: 1 (*240)
-#buckets:  816         (<  #reads + #writes!)
-#reads:    2448
-#inits:    816
-#writes:   1632
-#accesses: 3264        hit-rate:  0%
+cubeShape: [16, 20, 13, 44]
+tileShape: [5, 6, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 16 (*1440)
+#buckets:  2032         (<  #reads + #writes!)
+#reads:    2032
+#inits:    2032
+#writes:   2032
+#accesses: 35264        hit-rate:  88.4755%
 <<<
+hypercubeShape = [16, 20, 13, 44]
+tileShape = [5, 6, 6, 1]
+
+Test readTable [13, 1]
 >>> No TSMCube cache statistics (uses mmap)
 <<<
+X = [34, 39, 44, 49, 54, 59, 64, 69, 74, 79, 84, 89, 94]
 get's have been done
 >>> No TSMCube cache statistics (uses mmap)
 <<<
@@ -27,10 +34,28 @@ getSlice's have been done
 >>> No TSMCube cache statistics (uses mmap)
 <<<
 getSlice's with strides have been done
+
+Test writeFixed [13, 15, 0]
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 13, 15, 4]
+tileShape: [5, 6, 6, 5, 1]
+maxCacheSz:0 MiB
+cacheSize: 48 (*7200)
+#buckets:  432         (<  #reads + #writes!)
+#reads:    432
+#inits:    432
+#writes:   432
+#accesses: 35264        hit-rate:  97.5499%
+<<<
+hypercubeShape = [16, 20, 13, 15, 4]
+tileShape = [5, 6, 6, 5, 1]
+
+Test readTable [13, 15, 0]
 >>> No TSMCube cache statistics (uses mmap)
 <<<
->>> No TSMCube cache statistics (uses mmap)
-<<<
+X = [34, 39, 44, 49, 54, 59, 64, 69, 74, 79, 84, 89, 94]
+Y = [3, 1, -1, -3, -5, -7, -9, -11, -13, -15, -17, -19, -21, -23, -25]
+Z = [-2, -1.5, -1, 0]
 get's have been done
 >>> No TSMCube cache statistics (uses mmap)
 <<<
@@ -47,65 +72,188 @@ getSlice's have been done
 >>> No TSMCube cache statistics (uses mmap)
 <<<
 getSlice's with strides have been done
->>> No TSMCube cache statistics (uses mmap)
-<<<
+
+Test writeFixed [0]
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
+cubeShape: [16, 20, 552]
 tileShape: [5, 6, 1]
-maxCacheSz:0
+maxCacheSz:0 MiB
 cacheSize: 1 (*240)
-#buckets:  816         (<  #reads + #writes!)
-#reads:    1632
-#accesses: 1632        hit-rate:  0%
+#buckets:  8816         (<  #reads + #writes!)
+#reads:    26448
+#inits:    8816
+#writes:   17632
+#accesses: 35264        hit-rate:  0%
+<<<
+hypercubeShape = [16, 20, 552]
+tileShape = [5, 6, 1]
+
+Test readTable []
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    17632
+#accesses: 17632        hit-rate:  0%
 <<<
 get's have been done
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
+cubeShape: [16, 20, 552]
 tileShape: [5, 6, 1]
-maxCacheSz:0
+maxCacheSz:0 MiB
 cacheSize: 1 (*240)
-#buckets:  816
-#reads:    816
-#accesses: 816        hit-rate:  0%
+#buckets:  8832
+#reads:    8832
+#accesses: 8832        hit-rate:  0%
 <<<
 getColumn has been done
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
+cubeShape: [16, 20, 552]
 tileShape: [5, 6, 1]
-maxCacheSz:0
-cacheSize: 204 (*240)
-#buckets:  816
-#reads:    816
-#accesses: 16320        hit-rate:  95%
+maxCacheSz:0 MiB
+cacheSize: 2208 (*240)
+#buckets:  8832
+#reads:    8832
+#accesses: 176640        hit-rate:  95%
 <<<
 getColumnSlice's have been done
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
+cubeShape: [16, 20, 552]
 tileShape: [5, 6, 1]
-maxCacheSz:0
-cacheSize: 204 (*240)
-#buckets:  816         (<  #reads + #writes!)
-#reads:    5100
-#accesses: 16320        hit-rate:  68.75%
+maxCacheSz:0 MiB
+cacheSize: 2208 (*240)
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    55200
+#accesses: 176640        hit-rate:  68.75%
 <<<
 strided getColumnSlice's have been done
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
+cubeShape: [16, 20, 552]
 tileShape: [5, 6, 1]
-maxCacheSz:0
+maxCacheSz:0 MiB
 cacheSize: 4 (*240)
-#buckets:  816         (<  #reads + #writes!)
-#reads:    1224
-#accesses: 3570        hit-rate:  65.7143%
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    13224
+#accesses: 38570        hit-rate:  65.7143%
 <<<
 getSlice's have been done
 >>> TSMCube cache statistics:
-cubeShape: [16, 20, 51]
+cubeShape: [16, 20, 552]
 tileShape: [5, 6, 1]
-maxCacheSz:0
+maxCacheSz:0 MiB
 cacheSize: 4 (*240)
-#buckets:  816         (<  #reads + #writes!)
-#reads:    4998
-#accesses: 4998        hit-rate:  0%
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    53998
+#accesses: 53998        hit-rate:  0%
 <<<
 getSlice's with strides have been done
+
+Test writeNoHyper 
+>>> No TSMCube cache statistics (uses mmap)
+<<<
+hypercubeShape = [16, 20, 552]
+tileShape = [5, 6, 1]
+
+Test readTable []
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+get's have been done
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+getColumn has been done
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+getColumnSlice's have been done
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+strided getColumnSlice's have been done
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+getSlice's have been done
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+getSlice's with strides have been done
+
+Test writeFixed [0]
+>>> No TSMCube cache statistics (uses buffered IO)
+<<<
+hypercubeShape = [16, 20, 552]
+tileShape = [5, 6, 1]
+
+Test readTable []
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    17632
+#accesses: 17632        hit-rate:  0%
+<<<
+get's have been done
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 1 (*240)
+#buckets:  8832
+#reads:    8832
+#accesses: 8832        hit-rate:  0%
+<<<
+getColumn has been done
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 2208 (*240)
+#buckets:  8832
+#reads:    8832
+#accesses: 176640        hit-rate:  95%
+<<<
+getColumnSlice's have been done
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 2208 (*240)
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    55200
+#accesses: 176640        hit-rate:  68.75%
+<<<
+strided getColumnSlice's have been done
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 4 (*240)
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    13224
+#accesses: 38570        hit-rate:  65.7143%
+<<<
+getSlice's have been done
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 552]
+tileShape: [5, 6, 1]
+maxCacheSz:0 MiB
+cacheSize: 4 (*240)
+#buckets:  8832         (<  #reads + #writes!)
+#reads:    53998
+#accesses: 53998        hit-rate:  0%
+<<<
+getSlice's with strides have been done
+
+Test extendOnly 
+>>> TSMCube cache statistics:
+cubeShape: [16, 20, 389]
+tileShape: [5, 6, 420]
+maxCacheSz:0 MiB
+cacheSize: 1 (*50400)
+#buckets:  16
+#inits:    16
+#writes:   16
+#accesses: 0
+<<<
+hypercubeShape = [16, 20, 389]
+tileShape = [5, 6, 420]

--- a/tables/DataMan/test/tTiledColumnStManPerf.cc
+++ b/tables/DataMan/test/tTiledColumnStManPerf.cc
@@ -1,0 +1,272 @@
+//# tTiledColumnStManPerf.cc: Test program for TiledColumnStMan performance
+//# Copyright (C) 2022
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This program is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU General Public License as published by the Free
+//# Software Foundation; either version 2 of the License, or (at your option)
+//# any later version.
+//#
+//# This program is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+//# more details.
+//#
+//# You should have received a copy of the GNU General Public License along
+//# with this program; if not, write to the Free Software Foundation, Inc.,
+//# 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id$
+
+#include <casacore/tables/Tables/TableDesc.h>
+#include <casacore/tables/Tables/SetupNewTab.h>
+#include <casacore/tables/Tables/Table.h>
+#include <casacore/tables/Tables/TableIter.h>
+#include <casacore/tables/Tables/ScaColDesc.h>
+#include <casacore/tables/Tables/ArrColDesc.h>
+#include <casacore/tables/Tables/ScalarColumn.h>
+#include <casacore/tables/Tables/ArrayColumn.h>
+#include <casacore/tables/DataMan/TiledColumnStMan.h>
+#include <casacore/tables/DataMan/TiledStManAccessor.h>
+#include <casacore/casa/Containers/Record.h>
+#include <casacore/casa/Arrays/Matrix.h>
+#include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/Arrays/ArrayLogical.h>
+#include <casacore/casa/Utilities/Assert.h>
+#include <casacore/casa/Exceptions/Error.h>
+#include <casacore/casa/OS/Timer.h>
+#include <casacore/casa/iostream.h>
+
+#include <casacore/casa/namespace.h>
+
+
+// <summary>
+// Test program for the TiledColumnStMan performance.
+// </summary>
+
+// This program writes a Data column using TiledColumnStMan. It simulates the
+// data in a MeasurementSet (including TIME and ANTENNA1/2).
+// The rows in it are written in a tiled and non-tiled way to compare the two.
+// The data are read back in sequential and baseline order to test performance.
+// The shapes can be given on the command line.
+
+
+void createTable (const IPosition& dataShape, const IPosition& tileShape,
+                  const IPosition& rowShape, uInt nant, uInt ntime,
+                  Bool useSSM, Bool useMF)
+{
+  uInt nbl = nant*(nant+1)/2;
+  cout << "Create data table with " << nbl*ntime << " rows" << endl;
+  if (useMF) {
+    cout << " using MultiFile  ";
+  }
+  cout << " DATA column is stored using ";
+  if (useSSM) {
+    cout << "StandardStMan" << endl;
+  } else {
+    cout << "TiledColumnStMan" << endl;
+  }
+  cout << "  npol  = " << dataShape[0] << endl;
+  cout << "  nfreq = " << dataShape[1] << endl;
+  cout << "  nant  = " << nant <<  "   (nbl = " << nbl << ')' << endl;
+  cout << "  ntime = " << ntime << endl;
+  if (! useSSM) {
+    cout << "  tileShape = " << tileShape << "   rowShape = " << rowShape << endl;
+  }
+  Timer timer;
+  // Build the table description.
+  TableDesc td ("", "1", TableDesc::Scratch);
+  td.addColumn (ScalarColumnDesc<uInt> ("ANT1"));
+  td.addColumn (ScalarColumnDesc<uInt> ("ANT2"));
+  td.addColumn (ScalarColumnDesc<double> ("TIME"));
+  td.addColumn (ArrayColumnDesc<Complex>  ("DATA", dataShape));
+  // Now create a new table from the description.
+  StorageOption stopt (useMF ? StorageOption::MultiFile : StorageOption::SepFile);
+  SetupNewTable newtab("tTiledColumnStManPerf_tmp.tab", td, Table::New, stopt);
+  // Create a storage manager for it. First fill the tile shape.
+  if (! useSSM) {
+    TiledColumnStMan tcs ("TSM", tileShape, rowShape);
+    newtab.bindColumn ("DATA", tcs);
+  }
+  // Create the table.
+  Table tab (newtab, nbl*ntime);
+  // Fill the table.
+  Matrix<Complex> data(dataShape);
+  indgen(data);
+  ArrayColumn<Complex> dataCol(tab, "DATA");
+  ScalarColumn<uInt>   ant1Col(tab, "ANT1");
+  ScalarColumn<uInt>   ant2Col(tab, "ANT2");
+  ScalarColumn<double> timeCol(tab, "TIME");
+  // Write all rows.
+  rownr_t rownr = 0;
+  for (uInt t=0; t<ntime; ++t) {
+    for (uInt a2=0; a2<nant; ++a2) {
+      for (uInt a1=a2; a1<nant; ++a1) {
+        data += Complex(1,2);
+        dataCol.put (rownr, data);
+        ant1Col.put (rownr, a1);
+        ant2Col.put (rownr, a2);
+        timeCol.put (rownr, t + 0.5);
+        ++rownr;
+      }
+    }
+  }
+  AlwaysAssertExit (tab.nrow() == nbl*ntime);
+  timer.show ("Create table");
+  if (! useSSM) {
+    ROTiledStManAccessor acc(tab, "TSM");
+    acc.showCacheStatistics (cout);
+  }
+}
+
+void readSequential (Bool useMMap)
+{
+  cout << "Read in sequential order";
+  if (useMMap) cout << " using memory-mapped files";
+  cout << endl;
+  Timer timer;
+  TSMOption tsmOpt (useMMap ? TSMOption::MMap : TSMOption::Cache);
+  Table tab("tTiledColumnStManPerf_tmp.tab", Table::Old, tsmOpt);
+  ArrayColumn<Complex> dataCol(tab, "DATA");
+  Matrix<Complex> data(dataCol.shape(0));
+  indgen(data);
+  // Write all rows.
+  uInt ndone = 0;
+  for (rownr_t rownr=0; rownr<tab.nrow(); ++rownr) {
+    //data += Complex(1,2);
+    ndone++;
+    AlwaysAssertExit (allNear (dataCol(rownr),
+                               data + float(ndone)*Complex(1,2), 1e-3));
+  }
+  timer.show ("Read sequentially");
+  try {
+    ROTiledStManAccessor acc(tab, "TSM");
+    acc.showCacheStatistics (cout);
+  } catch (std::exception&) {
+  }
+}
+
+void readBaseline (Bool useMMap)
+{
+  cout << "Read in baseline order";
+  if (useMMap) cout << " using memory-mapped files";
+  cout << endl;
+  Timer timer;
+  TSMOption tsmOpt (useMMap ? TSMOption::MMap : TSMOption::Cache);
+  Table tab("tTiledColumnStManPerf_tmp.tab", Table::Old, tsmOpt);
+  // Iterate on baseline
+  Block<String> columns(2);
+  columns[0] = "ANT2";
+  columns[1] = "ANT1";
+  TableIterator tabIter(tab, columns);
+  uInt nbl = tab.nrow() / tabIter.table().nrow();
+  uInt nant = round((-1 + sqrt(1 + 8*nbl)) / 2);
+  cout << "  nant  = " << nant <<  "   (nbl = " << nbl << ')' << endl;
+  cout << "  ntime = " << tabIter.table().nrow() << endl;
+  uInt ndone = 0;
+  for (uInt a2=0; a2<nant; ++a2) {
+    for (uInt a1=a2; a1<nant; ++a1) {
+      ndone++;
+      ArrayColumn<Complex> dataCol(tabIter.table(), "DATA");
+      ScalarColumn<uInt>   ant1Col(tabIter.table(), "ANT1");
+      ScalarColumn<uInt>   ant2Col(tabIter.table(), "ANT2");
+      ScalarColumn<double> timeCol(tabIter.table(), "TIME");
+      Matrix<Complex> data(dataCol.shape(0));
+      indgen(data, float(ndone)*Complex(1,2));
+      Double tm = 0.5;
+      // Read all rows.
+      for (rownr_t rownr=0; rownr<tabIter.table().nrow(); ++rownr) {
+        AlwaysAssertExit (ant1Col(rownr) == a1);
+        AlwaysAssertExit (ant2Col(rownr) == a2);
+        AlwaysAssertExit (near (timeCol(rownr), tm));
+        if (! (allNear (dataCol(rownr), data, 1e-3))) {
+          cout<<dataCol(rownr)<<data<<rownr<<' '<<a1<<' '<<a2<<' '<<tm<<endl;
+        }
+        AlwaysAssertExit (allNear (dataCol(rownr), data, 1e-3));
+        tm += 1;
+        data += float(nbl)*Complex(1,2);
+      }
+      tabIter.next();
+    }
+  }
+  AlwaysAssertExit (tabIter.pastEnd());
+  timer.show ("Read in bl order ");
+  try {
+    ROTiledStManAccessor acc(tab, "TSM");
+    acc.showCacheStatistics (cout);
+  } catch (std::exception&) {
+  }
+}
+
+void showHelp()
+{
+  cerr << "This program tests MS access performance by creating and reading back an"
+       << endl;
+  cerr << "MS-like table. The table rows can be stored in a tiled way to optimize"
+       << endl;
+  cerr << "for access in order of baseline." << endl;
+  cerr << "Reading back can be done in sequential or baseline order." << endl;
+  cerr << "It is also possible to use memory-mapped data access using mmap." << endl;
+  cerr << endl;
+  cerr << "Run as:   tTiledColumnStManPerf np nf na nt ntp ntf ntb ntt [ssm/mf]";
+  cerr << "      to create" << endl;
+  cerr << "      where nx gives the data size and ntx the tile size" << endl;
+  cerr << "      and in nx and ntx:  p=pol  f=freq  a=antenna  b=baseline  t=time"
+       << endl;
+  cerr << "      ntt<=0  means that rows are not tiled on baseline/time" << endl;
+  cerr << "      If 'ssm' is given, StandardStMan instead of TiledColumnStMan is used."
+       << endl;
+  cerr << "      If 'mf' is given the MultiFile option is used. 'mfssm' is both." <<endl;
+  cerr << "or as:    tTiledColumnStManPerf type [mmap]              ";
+  cerr << "      to read back" << endl;
+  cerr << "      type = bl     read in order of baseline" << endl;
+  cerr << "             else   read sequentially" << endl;
+  cerr << "      mmap=1  means use mmap instead of normal reading" << endl;
+}
+
+int main (int argc, char* argv[])
+{
+  if (argc <= 1  ||  (argc > 3  &&  argc <= 8)) {
+    showHelp();
+    exit(0);
+  }
+  try {
+    if (argc > 8) {
+      int  nt4   = atoi(argv[8]);
+      uInt nant  = atoi(argv[3]);
+      uInt ntime = atoi(argv[4]);
+      uInt nbl = nant * (nant+1) / 2;
+      IPosition dataShape(2, atoi(argv[1]), atoi(argv[2]));
+      IPosition rowShape, tileShape;
+      if (nt4 <= 0) {
+        tileShape = IPosition(3, atoi(argv[5]), atoi(argv[6]), atoi(argv[7]));
+      } else {
+        tileShape = IPosition(4, atoi(argv[5]), atoi(argv[6]), atoi(argv[7]), nt4);
+        rowShape  = IPosition(2, nbl, ntime);
+      }
+      Bool useSSM = (argc > 9  &&
+                     (String(argv[9]) == "ssm" || String(argv[9]) == "mfssm"));
+      Bool useMF  = (argc > 9  &&
+                     (String(argv[9]) == "mf"  || String(argv[9]) == "mfssm"));
+      createTable (dataShape, tileShape, rowShape, nant, ntime, useSSM, useMF);
+    } else {
+      Bool useMMap = (argc > 2  &&  argv[2][0] == '1');
+      if (argc > 1  &&  String(argv[1]) == "bl") {
+        readBaseline (useMMap);
+      } else {
+        readSequential (useMMap);
+      }
+    }
+  } catch (const std::exception& x) {
+    cout << "Caught an exception: " << x.what() << endl;
+    return 1;
+  } 
+  return 0;                           // exit with success status
+}

--- a/tables/DataMan/test/tTiledColumnStManPerf.run
+++ b/tables/DataMan/test/tTiledColumnStManPerf.run
@@ -1,0 +1,131 @@
+#!/bin/sh
+#
+# Script to test tTiledColumnStManPerf by running it in various ways.
+# It uses small numbers to ensure automatic tests take very little time.
+#
+# The tests can be run manually with much larger numbers to compare the
+# performance of row tiling.
+# For example:
+#   ./tTiledColumnStManPerf 4 16 40 7200 4 16 4096 0
+
+# First create and read without row tiling
+$casa_checktool ./tTiledColumnStManPerf 4 8 6 4 4 8 6 0
+$casa_checktool ./tTiledColumnStManPerf seq
+$casa_checktool ./tTiledColumnStManPerf seq 1
+$casa_checktool ./tTiledColumnStManPerf bl
+$casa_checktool ./tTiledColumnStManPerf bl 1
+
+# Create with row tiling
+$casa_checktool ./tTiledColumnStManPerf 4 8 6 4 4 8 6 2
+$casa_checktool ./tTiledColumnStManPerf seq
+$casa_checktool ./tTiledColumnStManPerf seq 1
+$casa_checktool ./tTiledColumnStManPerf bl
+$casa_checktool ./tTiledColumnStManPerf bl 1
+
+exit 0
+
+
+cat <<EOF
+
+MacDiepen3.test> ./tTiledColumnStManPerf 4 16 40 7200 4 16 8 512
+Create data table with 5904000 rows
+  npol  = 4
+  nfreq = 16
+  nant  = 40   (nbl = 820)
+  ntime = 7200
+  tileShape = [4, 16, 8, 512]   rowShape = [820, 7200]
+Create table       9.48 real        4.24 user        2.78 system
+>>> TSMCube cache statistics:
+cubeShape: [4, 16, 820, 7200]
+tileShape: [4, 16, 8, 512]
+maxCacheSz:0 MiB
+cacheSize: 103 (*2097152)
+#buckets:  1545
+#inits:    1545
+#writes:   1442
+#accesses: 5904000        hit-rate:  99.9738%
+<<<
+MacDiepen3.test> tTiledColumnStManPerf seq
+Read in sequential order
+>>> TSMCube cache statistics:
+cubeShape: [4, 16, 820, 7200]
+tileShape: [4, 16, 8, 512]
+maxCacheSz:0 MiB
+cacheSize: 103 (*2097152)
+#buckets:  1545
+#reads:    1545
+#accesses: 5904000        hit-rate:  99.9738%
+<<<
+Read sequentially      11.85 real       10.27 user        1.05 system
+MacDiepen3.test> tTiledColumnStManPerf bl
+Read in baseline order
+  nant  = 40   (nbl = 820)
+  ntime = 7200
+Read in bl order       46.02 real       30.66 user       12.95 system
+>>> TSMCube cache statistics:
+cubeShape: [4, 16, 820, 7200]
+tileShape: [4, 16, 8, 512]
+maxCacheSz:0 MiB
+cacheSize: 103 (*2097152)
+#buckets:  1545
+#reads:    1545
+#accesses: 11808000        hit-rate:  99.9869%
+<<<
+MacDiepen3.test> tTiledColumnStManPerf bl 1
+Read in baseline order using memory-mapped files
+  nant  = 40   (nbl = 820)
+  ntime = 7200
+Read in bl order       60.63 real       32.94 user       15.53 system
+>>> No TSMCube cache statistics (uses mmap)
+<<<
+MacDiepen3.test> tTiledColumnStManPerf seq 1
+Read in sequential order using memory-mapped files
+>>> No TSMCube cache statistics (uses mmap)
+<<<
+Read sequentially         14 real       10.59 user        1.12 system
+MacDiepen3.test> ./tTiledColumnStManPerf 4 16 40 7200 4 16 4096 0
+Create data table with 5904000 rows
+  npol  = 4
+  nfreq = 16
+  nant  = 40   (nbl = 820)
+  ntime = 7200
+  tileShape = [4, 16, 4096]   rowShape = []
+Create table       6.54 real        3.66 user        2.42 system
+>>> TSMCube cache statistics:
+cubeShape: [4, 16, 5904000]
+tileShape: [4, 16, 4096]
+maxCacheSz:0 MiB
+cacheSize: 1 (*2097152)
+#buckets:  1442
+#inits:    1442
+#writes:   1441
+#accesses: 5904000        hit-rate:  99.9756%
+<<<
+MacDiepen3.test> tTiledColumnStManPerf seq
+Read in sequential order
+>>> TSMCube cache statistics:
+cubeShape: [4, 16, 5904000]
+tileShape: [4, 16, 4096]
+maxCacheSz:0 MiB
+cacheSize: 1 (*2097152)
+#buckets:  1442
+#reads:    1442
+#accesses: 5904000        hit-rate:  99.9756%
+<<<
+Read sequentially      10.73 real        9.69 user        0.81 system
+MacDiepen3.test> tTiledColumnStManPerf bl
+Read in baseline order
+  nant  = 40   (nbl = 820)
+  ntime = 7200
+Read in bl order     1289.93 real      214.41 user      626.24 system
+>>> TSMCube cache statistics:
+cubeShape: [4, 16, 5904000]
+tileShape: [4, 16, 4096]
+maxCacheSz:0 MiB
+cacheSize: 1 (*2097152)
+#buckets:  1442         (<  #reads + #writes!)
+#reads:    1182440
+#accesses: 11808000        hit-rate:  89.9861%
+<<<
+
+EOF


### PR DESCRIPTION
Support for tiling on row number has been added. It makes it possible for a MeasurementSet to use tiles with a limited number of baselines in it. It makes iteration over baselines much faster.
A test program has been added that can test the performance of various way of storing a DATA column. A test on a 3 GB DATA column (using 820 baselines) with 4 or 8 baselines per 1 MB tile  shows a dramatic performance improvement in iterating over baseline compared to storing the rows linearly.

Close #1140