### PR TITLE
Check open func map before using defaults in ImageOpener

### DIFF
--- a/images/Images/ImageOpener.cc
+++ b/images/Images/ImageOpener.cc
@@ -253,6 +253,10 @@ LatticeBase* ImageOpener::openImage (const String& fileName,
      return 0;
    }
    ImageOpener::ImageTypes type = ImageOpener::imageType(fileName);
+   // override default open functions
+   if (theirOpenFuncMap.find(type) != theirOpenFuncMap.end()) {
+     return theirOpenFuncMap[type] (fileName, spec);
+   }
    // Do not require the registration of a PagedImage or HDF5Image openFunction.
    if (type == AIPSPP) {
      return openPagedImage (fileName, spec);

--- a/images/Images/ImageOpener.cc
+++ b/images/Images/ImageOpener.cc
@@ -252,11 +252,18 @@ LatticeBase* ImageOpener::openImage (const String& fileName,
    if (fileName.empty()) {
      return 0;
    }
+
    ImageOpener::ImageTypes type = ImageOpener::imageType(fileName);
-   // override default open functions
+
+   // Override default openFunction
    if (theirOpenFuncMap.find(type) != theirOpenFuncMap.end()) {
-     return theirOpenFuncMap[type] (fileName, spec);
+     try {
+       return theirOpenFuncMap[type] (fileName, spec);
+     } catch (const AipsError&) {
+       // Try default openFunction if theirOpenFunction fails
+     }
    }
+
    // Do not require the registration of a PagedImage or HDF5Image openFunction.
    if (type == AIPSPP) {
      return openPagedImage (fileName, spec);

--- a/images/Images/ImageOpener.cc
+++ b/images/Images/ImageOpener.cc
@@ -259,7 +259,7 @@ LatticeBase* ImageOpener::openImage (const String& fileName,
    if (theirOpenFuncMap.find(type) != theirOpenFuncMap.end()) {
      try {
        return theirOpenFuncMap[type] (fileName, spec);
-     } catch (const AipsError&) {
+     } catch (...) {
        // Try default openFunction if theirOpenFunction fails
      }
    }


### PR DESCRIPTION
This PR changes ImageOpener::openImage to check the function map before using the default open functions in casacore.

ImageOpener::openImage uses defined open functions for certain image types (including HDF5) before checking the function map, so there is no way to set a custom function for these types.  CARTA HDF5 images fail with casacore::HDF5Image; we have created a custom carta::CartaHdf5Image which we would like to open instead, using registerOpenImageFunction with type HDF5.

