### PR TITLE
Allow offsets to JPL coordinates

### DIFF
--- a/measures/Measures/MCDirection.cc
+++ b/measures/Measures/MCDirection.cc
@@ -527,7 +527,21 @@ void MCDirection::doConvert(MVDirection &in,
 	  log((g2+lengthE+g1)/(g2-lengthE+g1));
 	lengthE /= MeasTable::Planetary(MeasTable::CAU);
       } while (abs(g3-lengthE) > 1e-9*lengthE);
+
+      // MVDirections have default 0,0,1, we do not want to apply
+      // a shift with 90 degrees in latitude (shifts should be
+      // smaller than a few degrees).
+      bool doShift = (in(2)!=1.);
+      Quantity shift_long;
+      Quantity shift_lat;
+      if (doShift) {
+        shift_long = in.getLong();
+        shift_lat = in.getLat();
+      }
       in = *MVPOS1; in.adjust();
+      if (doShift) {
+        in.shift(shift_long, shift_lat);
+      }
       // Correct for light deflection
       // Check if near sun
       if (planID != MeasTable::SUN &&

--- a/measures/Measures/test/tMeasJPL.cc
+++ b/measures/Measures/test/tMeasJPL.cc
@@ -189,6 +189,25 @@ int main()
     cout << "Moon  APP:  " << mc2() << endl;
     cout << "Moon  APP:  " << mc2().getValue().getAngle("deg") << endl;
 
+    MDirection ven_offset(Quantity(1, "deg"), Quantity(0.5, "deg"), venr);
+    MDirection sn_offset(Quantity(1, "deg"), Quantity(0.5, "deg"), sunr);
+    MDirection mon_offset(Quantity(1, "deg"), Quantity(0.5, "deg"),moonr);
+    MDirection::Convert vc1_offset(ven_offset, MDirection::Ref(MDirection::JNAT));
+    MDirection::Convert vc2_offset(ven_offset, MDirection::Ref(MDirection::APP));
+    MDirection::Convert sc1_offset(sn_offset, MDirection::Ref(MDirection::JNAT));
+    MDirection::Convert sc2_offset(sn_offset, MDirection::Ref(MDirection::APP));
+    MDirection::Convert mc1_offset(mon_offset, MDirection::Ref(MDirection::JNAT));
+    MDirection::Convert mc2_offset(mon_offset, MDirection::Ref(MDirection::APP));
+
+    cout << "Venus offset JNAT: " << vc1_offset() << endl;
+    cout << "Venus offset APP:  " << vc2_offset() << endl;
+    cout << "Sun offset   JNAT: " << sc1_offset() << endl;
+    cout << "Sun offset   APP:  " << sc2_offset() << endl;
+    cout << "Sun offset   APP:  " << sc2_offset().getValue().getAngle("deg") << endl;
+    cout << "Moon offset  JNAT: " << mc1_offset() << endl;
+    cout << "Moon offset  APP:  " << mc2_offset() << endl;
+    cout << "Moon offset  APP:  " << mc2_offset().getValue().getAngle("deg") << endl;
+
   } catch (const std::exception& x) {
     cout << x.what() << endl;
   } 

--- a/measures/Measures/test/tMeasJPL.out
+++ b/measures/Measures/test/tMeasJPL.out
@@ -176,3 +176,11 @@ Sun   APP:  [-145.963, -13.639] deg
 Moon  JNAT: Direction: [0.81807, -0.530141, -0.222963]
 Moon  APP:  Direction: [0.817893, -0.53038, -0.223043]
 Moon  APP:  [-32.9623, -12.8878] deg
+Venus offset JNAT: Direction: [-0.79725, -0.565086, -0.212298]
+Venus offset APP:  Direction: [-0.797514, -0.564774, -0.212138]
+Sun offset   JNAT: Direction: [-0.797087, -0.559381, -0.227474]
+Sun offset   APP:  Direction: [-0.797352, -0.559069, -0.227315]
+Sun offset   APP:  [-144.963, -13.139] deg
+Moon offset  JNAT: Direction: [0.828817, -0.516793, -0.214448]
+Moon offset  APP:  Direction: [0.828646, -0.517034, -0.214529]
+Moon offset  APP:  [-31.9621, -12.3879] deg


### PR DESCRIPTION
This adds the possibility to point towards solar system offsets with an offset. For example, the MDirection `sun_offset(Quantity(3, "deg"), Quantity(2, "deg"), MDirection::SUN)` will point away from the sun center 3 degrees in the right ascension direction, 2 degrees in the declination direction.

Previously, the quantities given to any object in a `MDirection::SUN` or other solar system frame were ignored. With this change, we assume that previously for getting solar system coordinates, either the coordinates were omitted or set to zero.