### PR TITLE
Try to get CI to run tests on linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,3 +22,6 @@ jobs:
         
       - name: Build container
         run: docker build . -t ${{ matrix.dist }} -f docker/${{ matrix.dist }}.docker
+
+      - name: Test
+        run: docker run --rm ${{ matrix.dist }} /bin/bash -c 'cd /code/build && make test'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,4 +24,4 @@ jobs:
         run: docker build . -t ${{ matrix.dist }} -f docker/${{ matrix.dist }}.docker
 
       - name: Test
-        run: docker run --rm ${{ matrix.dist }} /bin/bash -c 'cd /code/build && make test'
+        run: docker run --rm ${{ matrix.dist }} /bin/bash -c 'cd /code/build && ctest --output-on-failure'

--- a/docker/ubuntu1804_clang.docker
+++ b/docker/ubuntu1804_clang.docker
@@ -17,6 +17,7 @@ RUN docker-apt-install \
     libhdf5-serial-dev \
     libboost-dev \
     libboost-python-dev \
+    libboost-test-dev \
     libgsl-dev \
     python-numpy \
     python3-numpy

--- a/docker/ubuntu1804_gcc.docker
+++ b/docker/ubuntu1804_gcc.docker
@@ -18,6 +18,7 @@ RUN docker-apt-install \
     libhdf5-serial-dev \
     libboost-dev \
     libboost-python-dev \
+    libboost-test-dev \
     libgsl-dev \
     python-numpy \
     python3-numpy

--- a/docker/ubuntu2004_clang.docker
+++ b/docker/ubuntu2004_clang.docker
@@ -17,6 +17,7 @@ RUN docker-apt-install \
     libhdf5-serial-dev \
     libboost-dev \
     libboost-python-dev \
+    libboost-test-dev \
     libgsl-dev \
     python3-numpy
 ADD . /code

--- a/docker/ubuntu2004_clang.docker
+++ b/docker/ubuntu2004_clang.docker
@@ -19,6 +19,7 @@ RUN docker-apt-install \
     libboost-python-dev \
     libboost-test-dev \
     libgsl-dev \
+    python-is-python3 \
     python3-numpy
 ADD . /code
 RUN useradd -ms /bin/bash casacore

--- a/docker/ubuntu2004_gcc.docker
+++ b/docker/ubuntu2004_gcc.docker
@@ -18,6 +18,7 @@ RUN docker-apt-install \
     libhdf5-serial-dev \
     libboost-dev \
     libboost-python-dev \
+    libboost-test-dev \
     libgsl-dev \
     python3-numpy
 ADD . /code

--- a/docker/ubuntu2004_gcc.docker
+++ b/docker/ubuntu2004_gcc.docker
@@ -20,6 +20,7 @@ RUN docker-apt-install \
     libboost-python-dev \
     libboost-test-dev \
     libgsl-dev \
+    python-is-python3 \
     python3-numpy
 ADD . /code
 RUN useradd -ms /bin/bash casacore


### PR DESCRIPTION
It seems that on the linux-based CI jobs, the tests don't run. The tests do run on OSX. This is an attempt to get the CI-jobs to run `make test`.