### PR TITLE
Fixes #1163

### DIFF
--- a/tables/Tables/PlainTable.cc
+++ b/tables/Tables/PlainTable.cc
@@ -46,9 +46,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# Initialize the static TableCache object.
-TableCache PlainTable::theirTableCache;
-
 PlainTable::PlainTable (SetupNewTable& newtab, rownr_t nrrow, Bool initialize,
                         const TableLock& lockOptions, int endianFormat,
                         const TSMOption& tsmOption)

--- a/tables/Tables/PlainTable.h
+++ b/tables/Tables/PlainTable.h
@@ -258,7 +258,7 @@ public:
 
     // Get access to the TableCache.
     static TableCache& tableCache()
-      { return theirTableCache; }
+      { return TableCache::get_process_instance(); }
 
 private:
     // Copy constructor is forbidden, because copying a table requires
@@ -313,8 +313,6 @@ private:
     Bool           bigEndian_p;        //# True  = big endian canonical
                                        //# False = little endian canonical
     TSMOption      tsmOption_p;
-    //# cache of open (plain) tables
-    static TableCache theirTableCache;
 };
 
 

--- a/tables/Tables/TableCache.h
+++ b/tables/Tables/TableCache.h
@@ -35,6 +35,10 @@
 
 #include <map>
 #include <mutex>
+#include <sys/types.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <string>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -94,11 +98,10 @@ class TableLock;
 class TableCache
 {
 public:
-
-    // Construct an empty cache of open tables.
-    TableCache();
-
-    ~TableCache();
+    // Gets a TableCache that is unique to this process
+    // Due to the file descriptor nature of tables every fork / thread
+    // should get a unique set of table handles.
+    static TableCache& get_process_instance();
 
     // Try to find a table with the given name in the cache.
     // Return a pointer to a table if found (thus if already open).
@@ -146,11 +149,23 @@ public:
     PlainTable* lookCache (const String& name, int tableOption,
                            const TableLock& tableInfo);
 
+    // Multiton pattern - same reference throughout current PID
+    // Only get_process_instance() will initialize a new instance if not existant
+    // for the current PID
+    TableCache& operator= (const TableCache&) { return TableCache::get_process_instance(); }
+protected:
+    // destructor not directly accessable in multiton pattern
+    // TableCache objects should stay alive for the duration of a process
+    ~TableCache() {};
+
 private:
+    // Construct an empty cache of open tables.
+    // Multiton pattern should hide this
+    TableCache() {};
+    TableCache(pid_t creator_pid, pthread_t creator_tid);
+
     // The copy constructor is forbidden.
     TableCache (const TableCache&);
-    // The assignment operator is forbidden.
-    TableCache& operator= (const TableCache&);
 
     // Get the table without doing a mutex lock (for operator()).
     PlainTable* getTable (const String& tableName) const;
@@ -159,8 +174,11 @@ private:
     //# to reduce the number of template instantiations.
     //# The .cc file will use (fully safe) casts.
     std::map<String,void*> tableMap_p;
-    //# A mutex to synchronize access to the cache.
-    mutable std::mutex itsMutex;
+    // Multiton pattern used to ensure no PID shares the same TableCache
+    pid_t creator_pid;
+    pthread_t creator_tid;
+    static std::map<std::string, TableCache*> multitons;
+    static std::mutex instantiator_lock;
 };
 
 

--- a/tables/Tables/TableKeyword.cc
+++ b/tables/Tables/TableKeyword.cc
@@ -173,7 +173,7 @@ void TableKeyword::flush (Bool fsync) const
 	} else {
 	    // The table is not open here, but might be open elsewhere.
 	    // So only flush if open elsewhere, thus in the TableCache.
-            PlainTable::tableCache().flushTable (attr_p.name(), fsync, True);
+        TableCache::get_process_instance().flushTable (attr_p.name(), fsync, True);
 	}
     }
 }


### PR DESCRIPTION
@gervandiepen This fixes the issue we had with tables not being thread safe

I did not fix it as you suggested in the ticket but rather made the tablecache a multiton depending on the pid and tid. This replaces what you had in plaintable by not having a single tablecache static (class) object. Previously the underlying caching and buckets associated with the shared table system induced a segfault.

Rather now the first time a thread executes an open operation the plaintable will create a tablecache for use for the duration of the lifetime of that thread.

Using @JSKenyon and @sjperkins  fixes [python-casacore #209](https://github.com/casacore/python-casacore/pull/209) dropping the gil (which now should not be necessary because the solution makes the casacore table caching system thread safe) I get the following on a small dataset

```
(venvcc) > $ python threaded_tableread.py mk64.Lwide.0.5hr.10s.856mhz.ms 50                                 
Reading MS using a single thread: 61.677s
Again: Reading MS using a single thread: 60.933s
Reading MS using threads and pid multiton TableCache: 42.342s
Reading MS using processes and pid multiton TableCache: 39.944s
```

using the following snippet
```python
import numpy as np
import threading
import pyrap.tables as pt
import os
import concurrent.futures as cf
import multiprocessing
import time
import sys


def threaded_getcolnp(ms_path, colname, startrow, nrow):

    tid = threading.get_ident()

    with pt.table(ms_path, lockoptions="user", ack=False) as ms:

        ref_row = ms.getcol(colname, nrow=1)  # Read an example row.
        ref_dims = ref_row.shape[1:]
        ref_dtype = ref_row.dtype

        out = np.empty((nrow, *ref_dims), dtype=ref_dtype)  # Preallocate output.

        ms.getcolnp(colname, out, startrow=startrow, nrow=nrow)

    return  # We don't want to profile the cost of returning the result.


if __name__ == "__main__":

    ms_path = sys.argv[1]
    no_times = int(sys.argv[2])
    column = "DATA"
    nchunk = 40  # Partition the read into this many chunks.
    nworker = 4  # Number of threads/processes.

    table = pt.table(ms_path, ack=False)
    total_nrow = table.nrows()
    table.close()

    nrow = int(np.ceil(total_nrow / nchunk))  # nrow per chunk.

    starts = np.repeat(np.arange(0, total_nrow, nrow), no_times)
    np.random.shuffle(starts)
    t0 = time.time()
    result = [threaded_getcolnp(ms_path, column, row, nrow) for row in starts]
    print(f"Reading MS using a single thread: {time.time() - t0:.3f}s")


    t0 = time.time()
    result = [threaded_getcolnp(ms_path, column, row, nrow) for row in starts]
    print(f"Again: Reading MS using a single thread: {time.time() - t0:.3f}s")

    t0 = time.time()
    with cf.ThreadPoolExecutor(max_workers=nworker) as tpe:
        futures = [
            tpe.submit(
                threaded_getcolnp,
                ms_path,
                column,
                row,
                nrow
            )
            for row in starts
        ]
    print(f"Reading MS using threads and pid multiton TableCache: {time.time() - t0:.3f}s")

    mp_context = multiprocessing.get_context("spawn")  # Forking breaks things.

    t0 = time.time()
    with cf.ProcessPoolExecutor(max_workers=nworker) as ppe:
        futures = [
            ppe.submit(
                threaded_getcolnp,
                ms_path,
                column,
                row,
                nrow
            )
            for row in starts
        ]
    print(f"Reading MS using processes and pid multiton TableCache: {time.time() - t0:.3f}s")
```

Of course one should use the appropriate locking when trying to do reading and writing between threads or processes as before.