### PR TITLE
Avoid possible TaQLNode memory leaks

### DIFF
--- a/tables/TaQL/TaQLNode.h
+++ b/tables/TaQL/TaQLNode.h
@@ -32,11 +32,11 @@
 #include <casacore/casa/aips.h>
 #include <casacore/tables/TaQL/TaQLNodeRep.h>
 #include <casacore/tables/TaQL/TaQLStyle.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 
 #include <iostream>
 #include <mutex>
 #include <vector>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -89,7 +89,7 @@ public:
 
   // Construct for given letter. It takes over the pointer.
   TaQLNode (TaQLNodeRep* rep)
-    { itsRep = rep; }
+    { itsRep.reset (rep); }
 
   // Copy constructor (reference semantics).
   TaQLNode (const TaQLNode& that)
@@ -113,11 +113,12 @@ public:
 
   // Parse a TaQL command and return the result.
   // An exception is thrown in case of parse errors.
+  // The parse tree is deleted by function clearNodeCreated.
   static TaQLNode parse (const String& command);
 
   // Does the envelope contain a letter?
   Bool isValid() const
-    { return itsRep; }
+    { return Bool(itsRep); }
 
   // Return the type of letter.
   char nodeType() const
@@ -136,14 +137,14 @@ public:
   void show (std::ostream& os) const
     { if (itsRep) itsRep->show (os); }
 
-  // Save and restore the entire tree.
+  // Save and restore the entire parse tree.
   // <group>
   void save (AipsIO& aio) const;
   static TaQLNode restore (AipsIO& aio);
   // </group>
 
 protected:
-  CountedPtr<TaQLNodeRep> itsRep;
+  std::shared_ptr<TaQLNodeRep> itsRep;
 
 private:
   // Delete all nodes that were created by the parser.

--- a/tables/TaQL/TaQLNodeDer.cc
+++ b/tables/TaQL/TaQLNodeDer.cc
@@ -1667,7 +1667,7 @@ void TaQLRecFldNodeRep::show (std::ostream& os) const
     os << itsFromName;
   } else if (itsValues.isValid()) {
     if (itsValues.nodeType() == TaQLNode_Multi  &&
-        dynamic_cast<const TaQLMultiNodeRep*>(itsValues.getRep())->itsNodes.empty()) {
+        dynamic_cast<const TaQLMultiNodeRep&>(*(itsValues.getRep())).itsNodes.empty()) {
       os << "[=]";
     } else {
       itsValues.show (os);

--- a/tables/TaQL/TaQLNodeDer.cc
+++ b/tables/TaQL/TaQLNodeDer.cc
@@ -191,7 +191,7 @@ void TaQLConstNodeRep::save (AipsIO& aio) const
     break;
   }
 }
-TaQLConstNodeRep* TaQLConstNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLConstNodeRep::restore (AipsIO& aio)
 {
   char type;
   Bool isTableName;
@@ -320,7 +320,7 @@ void TaQLRegexNodeRep::save (AipsIO& aio) const
   aio << itsValue << itsCaseInsensitive << itsNegate << itsIgnoreBlanks
       << itsMaxDistance;
 }
-TaQLRegexNodeRep* TaQLRegexNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLRegexNodeRep::restore (AipsIO& aio)
 {
   String value;
   Bool caseInsensitive, negate, ignoreBlanks;
@@ -374,7 +374,7 @@ void TaQLUnaryNodeRep::save (AipsIO& aio) const
   aio << char(itsType);
   itsChild.saveNode (aio);
 }
-TaQLUnaryNodeRep* TaQLUnaryNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLUnaryNodeRep::restore (AipsIO& aio)
 {
   char ctype;
   aio >> ctype;
@@ -492,7 +492,7 @@ void TaQLBinaryNodeRep::save (AipsIO& aio) const
   itsLeft.saveNode (aio);
   itsRight.saveNode (aio);
 }
-TaQLBinaryNodeRep* TaQLBinaryNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLBinaryNodeRep::restore (AipsIO& aio)
 {
   char ctype;
   aio >> ctype;
@@ -542,7 +542,7 @@ void TaQLMultiNodeRep::save (AipsIO& aio) const
     itsNodes[i].saveNode (aio);
   }
 }
-TaQLMultiNodeRep* TaQLMultiNodeRep::restore (AipsIO& aio)
+TaQLMultiNode TaQLMultiNodeRep::restore (AipsIO& aio)
 {
   uInt size, incr;
   Bool isSetOrArray;
@@ -550,13 +550,14 @@ TaQLMultiNodeRep* TaQLMultiNodeRep::restore (AipsIO& aio)
   aio >> isSetOrArray >> prefix >> postfix
       >> sep >> sep2 >> incr;
   aio >> size;
-  TaQLMultiNodeRep* node = new TaQLMultiNodeRep(prefix, postfix, isSetOrArray);
+  std::unique_ptr<TaQLMultiNodeRep> node
+    (new TaQLMultiNodeRep(prefix, postfix, isSetOrArray));
   node->setSeparator (sep);
   node->setSeparator (incr, sep2);
   for (uInt i=0; i<size; ++i) {
     node->add (TaQLNode::restoreNode (aio));
   }
-  return node;
+  return node.release();
 }
 
 TaQLFuncNodeRep::TaQLFuncNodeRep (const String& name)
@@ -585,7 +586,7 @@ void TaQLFuncNodeRep::save (AipsIO& aio) const
   aio << itsName;
   itsArgs.saveNode (aio);
 }
-TaQLFuncNodeRep* TaQLFuncNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLFuncNodeRep::restore (AipsIO& aio)
 {
   String name;
   aio >> name;
@@ -640,7 +641,7 @@ void TaQLRangeNodeRep::save (AipsIO& aio) const
   itsStart.saveNode (aio);
   itsEnd.saveNode (aio);
 }
-TaQLRangeNodeRep* TaQLRangeNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLRangeNodeRep::restore (AipsIO& aio)
 {
   Bool leftClosed, rightClosed;
   aio >> leftClosed >> rightClosed;
@@ -681,7 +682,7 @@ void TaQLIndexNodeRep::save (AipsIO& aio) const
   itsEnd.saveNode (aio);
   itsIncr.saveNode (aio);
 }
-TaQLIndexNodeRep* TaQLIndexNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLIndexNodeRep::restore (AipsIO& aio)
 {
   TaQLNode start = TaQLNode::restoreNode (aio);
   TaQLNode end = TaQLNode::restoreNode (aio);
@@ -714,7 +715,7 @@ void TaQLJoinNodeRep::save (AipsIO& aio) const
   itsTables.saveNode (aio);
   itsCondition.saveNode (aio);
 }
-TaQLJoinNodeRep* TaQLJoinNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLJoinNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
   TaQLNode condition = TaQLNode::restoreNode (aio);
@@ -743,7 +744,7 @@ void TaQLKeyColNodeRep::save (AipsIO& aio) const
 {
   aio << itsName << itsNameMask;
 }
-TaQLKeyColNodeRep* TaQLKeyColNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLKeyColNodeRep::restore (AipsIO& aio)
 {
   String name, nameMask;
   aio >> name >> nameMask;
@@ -772,7 +773,7 @@ void TaQLTableNodeRep::save (AipsIO& aio) const
   aio << itsAlias;
   itsTable.saveNode (aio);
 }
-TaQLTableNodeRep* TaQLTableNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLTableNodeRep::restore (AipsIO& aio)
 {
   String alias;
   aio >> alias;
@@ -811,13 +812,12 @@ void TaQLColNodeRep::save (AipsIO& aio) const
   aio << itsName << itsNameMask << itsDtype;
   itsExpr.saveNode (aio);
 }
-TaQLColNodeRep* TaQLColNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLColNodeRep::restore (AipsIO& aio)
 {
   String name, nameMask, dtype;
   aio >> name >> nameMask >> dtype;
-  TaQLColNodeRep* node = new TaQLColNodeRep (TaQLNode::restoreNode(aio),
-                                             name, nameMask, dtype);
-  return node;
+  return new TaQLColNodeRep (TaQLNode::restoreNode(aio),
+                             name, nameMask, dtype);
 }
 
 TaQLColumnsNodeRep::TaQLColumnsNodeRep (Bool distinct,
@@ -845,7 +845,7 @@ void TaQLColumnsNodeRep::save (AipsIO& aio) const
   aio << itsDistinct;
   itsNodes.saveNode (aio);
 }
-TaQLColumnsNodeRep* TaQLColumnsNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLColumnsNodeRep::restore (AipsIO& aio)
 {
   Bool distinct;
   aio >> distinct;
@@ -875,7 +875,7 @@ void TaQLGroupNodeRep::save (AipsIO& aio) const
   aio << char(itsType);
   itsNodes.saveNode (aio);
 }
-TaQLGroupNodeRep* TaQLGroupNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLGroupNodeRep::restore (AipsIO& aio)
 {
   char ctype;
   aio >> ctype;
@@ -911,7 +911,7 @@ void TaQLSortKeyNodeRep::save (AipsIO& aio) const
   aio << char(itsType);
   itsChild.saveNode (aio);
 }
-TaQLSortKeyNodeRep* TaQLSortKeyNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLSortKeyNodeRep::restore (AipsIO& aio)
 {
   char ctype;
   aio >> ctype;
@@ -947,7 +947,7 @@ void TaQLSortNodeRep::save (AipsIO& aio) const
   aio << itsUnique << char(itsType);
   itsKeys.saveNode (aio);
 }
-TaQLSortNodeRep* TaQLSortNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLSortNodeRep::restore (AipsIO& aio)
 {
   Bool unique;
   char ctype;
@@ -982,7 +982,7 @@ void TaQLLimitOffNodeRep::save (AipsIO& aio) const
   itsLimit.saveNode (aio);
   itsOffset.saveNode (aio);
 }
-TaQLLimitOffNodeRep* TaQLLimitOffNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLLimitOffNodeRep::restore (AipsIO& aio)
 {
   TaQLNode limit = TaQLNode::restoreNode (aio);
   TaQLNode offset = TaQLNode::restoreNode (aio);
@@ -1023,7 +1023,7 @@ void TaQLGivingNodeRep::save (AipsIO& aio) const
     itsType.saveNode (aio);
   }
 }
-TaQLGivingNodeRep* TaQLGivingNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLGivingNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode node = TaQLNode::restoreMultiNode(aio);
   if (node.isValid()) {
@@ -1088,7 +1088,7 @@ void TaQLUpdExprNodeRep::save (AipsIO& aio) const
   itsIndices2.saveNode (aio);
   itsExpr.saveNode (aio);
 }
-TaQLUpdExprNodeRep* TaQLUpdExprNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLUpdExprNodeRep::restore (AipsIO& aio)
 {
   String name, nameMask;
   aio >> name >> nameMask;
@@ -1206,7 +1206,7 @@ void TaQLSelectNodeRep::save (AipsIO& aio) const
   itsDMInfo.saveNode (aio);
   saveSuper (aio);
 }
-TaQLSelectNodeRep* TaQLSelectNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLSelectNodeRep::restore (AipsIO& aio)
 {
   TaQLNode columns = TaQLNode::restoreNode (aio);
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
@@ -1219,13 +1219,12 @@ TaQLSelectNodeRep* TaQLSelectNodeRep::restore (AipsIO& aio)
   TaQLNode limitoff = TaQLNode::restoreNode (aio);
   TaQLNode giving = TaQLNode::restoreNode (aio);
   TaQLMultiNode dminfo = TaQLNode::restoreMultiNode (aio);
-  TaQLSelectNodeRep* node = new TaQLSelectNodeRep (columns, with,
-                                                   tables, join,
-                                                   where, groupby, having,
-                                                   sort, limitoff, giving,
-                                                   dminfo);
+  std::unique_ptr<TaQLSelectNodeRep> node
+    (new TaQLSelectNodeRep (columns, with, tables, join,
+                            where, groupby, having,
+                            sort, limitoff, giving, dminfo));
   node->restoreSuper (aio);
-  return node;
+  return node.release();
 }
 
 TaQLCountNodeRep::TaQLCountNodeRep (const TaQLMultiNode& with,
@@ -1259,15 +1258,16 @@ void TaQLCountNodeRep::save (AipsIO& aio) const
   itsWhere.saveNode (aio);
   saveSuper (aio);
 }
-TaQLCountNodeRep* TaQLCountNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLCountNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLNode columns = TaQLNode::restoreNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
   TaQLNode where = TaQLNode::restoreNode (aio);
-  TaQLCountNodeRep* node = new TaQLCountNodeRep (with, columns, tables, where);
+  std::unique_ptr<TaQLCountNodeRep> node
+    (new TaQLCountNodeRep (with, columns, tables, where));
   node->restoreSuper (aio);
-  return node;
+  return node.release();
 }
 
 TaQLUpdateNodeRep::TaQLUpdateNodeRep (const TaQLMultiNode& with,
@@ -1318,7 +1318,7 @@ void TaQLUpdateNodeRep::save (AipsIO& aio) const
   itsSort.saveNode (aio);
   itsLimitOff.saveNode (aio);
 }
-TaQLUpdateNodeRep* TaQLUpdateNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLUpdateNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
@@ -1404,7 +1404,7 @@ void TaQLInsertNodeRep::save (AipsIO& aio) const
   itsValues.saveNode (aio);
   itsLimit.saveNode (aio);
 }
-TaQLInsertNodeRep* TaQLInsertNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLInsertNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
@@ -1450,7 +1450,7 @@ void TaQLDeleteNodeRep::save (AipsIO& aio) const
   itsSort.saveNode (aio);
   itsLimitOff.saveNode (aio);
 }
-TaQLDeleteNodeRep* TaQLDeleteNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLDeleteNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
@@ -1503,7 +1503,7 @@ void TaQLCalcNodeRep::save (AipsIO& aio) const
   itsSort.saveNode (aio);
   itsLimitOff.saveNode (aio);
 }
-TaQLCalcNodeRep* TaQLCalcNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLCalcNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
@@ -1575,7 +1575,7 @@ void TaQLCreTabNodeRep::save (AipsIO& aio) const
   itsDMInfo.saveNode (aio);
   saveSuper (aio);
 }
-TaQLCreTabNodeRep* TaQLCreTabNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLCreTabNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLNode giving = TaQLNode::restoreNode (aio);
@@ -1623,7 +1623,7 @@ void TaQLColSpecNodeRep::save (AipsIO& aio) const
   aio << itsName << itsLikeCol << itsDtype;
   itsSpec.saveNode (aio);
 }
-TaQLColSpecNodeRep* TaQLColSpecNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLColSpecNodeRep::restore (AipsIO& aio)
 {
   String name, likeCol, dtype;
   aio >> name >> likeCol >> dtype;
@@ -1667,7 +1667,7 @@ void TaQLRecFldNodeRep::show (std::ostream& os) const
     os << itsFromName;
   } else if (itsValues.isValid()) {
     if (itsValues.nodeType() == TaQLNode_Multi  &&
-        ((const TaQLMultiNodeRep*)(itsValues.getRep()))->itsNodes.empty()) {
+        dynamic_cast<const TaQLMultiNodeRep*>(itsValues.getRep())->itsNodes.empty()) {
       os << "[=]";
     } else {
       itsValues.show (os);
@@ -1684,7 +1684,7 @@ void TaQLRecFldNodeRep::save (AipsIO& aio) const
   aio << itsName << itsFromName << itsDtype;
   itsValues.saveNode (aio);
 }
-TaQLRecFldNodeRep* TaQLRecFldNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLRecFldNodeRep::restore (AipsIO& aio)
 {
   String name, fromName, dtype;
   aio >> name >> fromName >> dtype;
@@ -1717,7 +1717,7 @@ void TaQLUnitNodeRep::save (AipsIO& aio) const
   aio << itsUnit;
   itsChild.saveNode (aio);
 }
-TaQLUnitNodeRep* TaQLUnitNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLUnitNodeRep::restore (AipsIO& aio)
 {
   String unit;
   aio >> unit;
@@ -1758,7 +1758,7 @@ void TaQLAltTabNodeRep::save (AipsIO& aio) const
   itsFrom.saveNode (aio);
   itsCommands.saveNode (aio);
 }
-TaQLAltTabNodeRep* TaQLAltTabNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLAltTabNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with     = TaQLNode::restoreMultiNode (aio);
   TaQLNode table         = TaQLNode::restoreNode (aio);
@@ -1791,7 +1791,7 @@ void TaQLAddColNodeRep::save (AipsIO& aio) const
   itsColumns.saveNode(aio);
   itsDMInfo.saveNode(aio);
 }
-TaQLAddColNodeRep* TaQLAddColNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLAddColNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode cols   = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode dminfo = TaQLNode::restoreMultiNode (aio);
@@ -1825,7 +1825,7 @@ void TaQLRenDropNodeRep::save (AipsIO& aio) const
   aio << itsType;
   itsNames.saveNode (aio);
 }
-TaQLRenDropNodeRep* TaQLRenDropNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLRenDropNodeRep::restore (AipsIO& aio)
 {
   Int type;
   aio >> type;
@@ -1850,7 +1850,7 @@ void TaQLSetKeyNodeRep::save (AipsIO& aio) const
 {
   itsKeyVals.saveNode (aio);
 }
-TaQLSetKeyNodeRep* TaQLSetKeyNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLSetKeyNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode keyvals = TaQLNode::restoreMultiNode (aio);
   return new TaQLSetKeyNodeRep (keyvals);
@@ -1873,7 +1873,7 @@ void TaQLAddRowNodeRep::save (AipsIO& aio) const
 {
   itsNRow.saveNode (aio);
 }
-TaQLAddRowNodeRep* TaQLAddRowNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLAddRowNodeRep::restore (AipsIO& aio)
 {
   TaQLNode nrow = TaQLNode::restoreNode (aio);
   return new TaQLAddRowNodeRep (nrow);
@@ -1910,7 +1910,7 @@ void TaQLConcTabNodeRep::save (AipsIO& aio) const
   itsTables.saveNode (aio);
   itsSubTables.saveNode (aio);
 }
-TaQLConcTabNodeRep* TaQLConcTabNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLConcTabNodeRep::restore (AipsIO& aio)
 {
   String tableName;
   aio >> tableName;
@@ -1938,7 +1938,7 @@ void TaQLShowNodeRep::save (AipsIO& aio) const
 {
   itsNames.saveNode (aio);
 }
-TaQLShowNodeRep* TaQLShowNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLShowNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode names = TaQLNode::restoreMultiNode (aio);
   return new TaQLShowNodeRep (names);
@@ -1968,7 +1968,7 @@ void TaQLCopyColNodeRep::save (AipsIO& aio) const
   itsNames.saveNode(aio);
   itsDMInfo.saveNode(aio);
 }
-TaQLCopyColNodeRep* TaQLCopyColNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLCopyColNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode names  = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode dminfo = TaQLNode::restoreMultiNode (aio);
@@ -1996,7 +1996,7 @@ void TaQLDropTabNodeRep::save (AipsIO& aio) const
   itsWith.saveNode(aio);
   itsTables.saveNode(aio);
 }
-TaQLDropTabNodeRep* TaQLDropTabNodeRep::restore (AipsIO& aio)
+TaQLNode TaQLDropTabNodeRep::restore (AipsIO& aio)
 {
   TaQLMultiNode with   = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);

--- a/tables/TaQL/TaQLNodeDer.h
+++ b/tables/TaQL/TaQLNodeDer.h
@@ -81,10 +81,10 @@ public:
   const String& getString() const;
   const String& getUnit() const
     { return itsUnit; }
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLConstNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Type     itsType;
   Bool     itsIsTableName;
@@ -121,10 +121,10 @@ public:
   explicit TaQLRegexNodeRep (const String& value);
   TaQLRegexNodeRep (const String& value, Bool caseInsensitive, Bool negate,
                     Bool ignoreBlanks, Int maxDistance);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLRegexNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String itsValue;
   Bool   itsCaseInsensitive;
@@ -161,10 +161,10 @@ public:
              U_NOTEXISTS=3,
              U_BITNOT   =4};
   TaQLUnaryNodeRep (Type type, const TaQLNode& child);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLUnaryNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Type     itsType;
   TaQLNode itsChild;
@@ -215,10 +215,10 @@ public:
              B_BITXOR     =20,
              B_BITOR      =21};
   TaQLBinaryNodeRep (Type type, const TaQLNode& left, const TaQLNode& right);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLBinaryNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
   // Handle a comparison wih a regex. The operator (~ or !~) is extracted
   // from the regex.
   static TaQLBinaryNodeRep* handleRegex (const TaQLNode& left,
@@ -262,10 +262,10 @@ public:
     { itsNodes.push_back (node); }
   const std::vector<TaQLNode>& getNodes() const
     { return itsNodes; }
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLMultiNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLMultiNode restore (AipsIO& aio);
 
   std::vector<TaQLNode> itsNodes;
   Bool   itsIsSetOrArray;
@@ -296,10 +296,10 @@ class TaQLFuncNodeRep: public TaQLNodeRep
 public:
   TaQLFuncNodeRep (const String& name);
   TaQLFuncNodeRep (const String& name, const TaQLMultiNode& args);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLFuncNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String        itsName;
   TaQLMultiNode itsArgs;
@@ -328,10 +328,10 @@ public:
                     const TaQLNode& end, Bool rightClosed);
   TaQLRangeNodeRep (Bool leftClosed, const TaQLNode& start);
   TaQLRangeNodeRep (const TaQLNode& end, Bool rightClosed);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLRangeNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Bool     itsLeftClosed;
   TaQLNode itsStart;
@@ -360,10 +360,10 @@ class TaQLIndexNodeRep: public TaQLNodeRep
 public:
   TaQLIndexNodeRep (const TaQLNode& start, const TaQLNode& end,
                     const TaQLNode& incr);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLIndexNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLNode itsStart;
   TaQLNode itsEnd;
@@ -390,10 +390,10 @@ class TaQLJoinNodeRep: public TaQLNodeRep
 {
 public:
   TaQLJoinNodeRep (const TaQLMultiNode& tables, const TaQLNode& condition);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLJoinNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsTables;
   TaQLNode      itsCondition;
@@ -419,10 +419,10 @@ class TaQLKeyColNodeRep: public TaQLNodeRep
 {
 public:
   TaQLKeyColNodeRep (const String& name, const String& nameMask = String());
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLKeyColNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String itsName;
   String itsNameMask;
@@ -449,10 +449,10 @@ class TaQLTableNodeRep: public TaQLNodeRep
 {
 public:
   TaQLTableNodeRep (const TaQLNode& table, const String& alias);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLTableNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLNode itsTable;
   String   itsAlias;
@@ -482,10 +482,10 @@ class TaQLColNodeRep: public TaQLNodeRep
 public:
   TaQLColNodeRep (const TaQLNode& expr, const String& name,
                   const String& nameMask, const String& dtype);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLColNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLNode itsExpr;
   String   itsName;
@@ -513,10 +513,10 @@ class TaQLColumnsNodeRep: public TaQLNodeRep
 {
 public:
   TaQLColumnsNodeRep (Bool distinct, const TaQLMultiNode& nodes);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLColumnsNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Bool          itsDistinct;
   TaQLMultiNode itsNodes;
@@ -545,10 +545,10 @@ public:
   enum Type {Normal=0,
              Rollup=1};  //# in the future type Cube could be added
   TaQLGroupNodeRep (Type type, const TaQLMultiNode& nodes);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLGroupNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Type          itsType;
   TaQLMultiNode itsNodes;
@@ -578,10 +578,10 @@ public:
              Descending=1,
              None      =2};
   TaQLSortKeyNodeRep (Type type, const TaQLNode& child);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLSortKeyNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Type     itsType;
   TaQLNode itsChild;
@@ -610,10 +610,10 @@ public:
   enum Type {Ascending =0,
              Descending=1};
   TaQLSortNodeRep (Bool unique, Type type, const TaQLMultiNode& keys);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLSortNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Bool          itsUnique;
   Type          itsType;
@@ -640,10 +640,10 @@ class TaQLLimitOffNodeRep: public TaQLNodeRep
 {
 public:
   TaQLLimitOffNodeRep (const TaQLNode& limit, const TaQLNode& offset);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLLimitOffNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLNode itsLimit;
   TaQLNode itsOffset;
@@ -670,10 +670,10 @@ class TaQLGivingNodeRep: public TaQLNodeRep
 public:
   explicit TaQLGivingNodeRep (const String& name, const TaQLMultiNode& type);
   explicit TaQLGivingNodeRep (const TaQLMultiNode& exprlist);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLGivingNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String        itsName;
   TaQLMultiNode itsType;
@@ -710,10 +710,10 @@ public:
                       const TaQLMultiNode& indices1,
                       const TaQLMultiNode& indices2,
                       const TaQLNode& expr);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLUpdExprNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String        itsName;
   String        itsNameMask;
@@ -756,7 +756,7 @@ public:
     { return itsNoExecute; }
   Bool getFromExecute() const
     { return itsFromExecute; }
-  virtual void show (std::ostream& os) const;
+  virtual void show (std::ostream& os) const override;
 protected:
   void saveSuper (AipsIO& aio) const;
   void restoreSuper (AipsIO& aio);
@@ -799,10 +799,10 @@ public:
                      const TaQLNode& groupby, const TaQLNode& having,
                      const TaQLNode& sort, const TaQLNode& limitoff,
                      const TaQLNode& giving, const TaQLMultiNode& dminfo);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void showDerived (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLSelectNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void showDerived (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLNode      itsColumns;
   TaQLMultiNode itsWith;
@@ -837,10 +837,10 @@ class TaQLCountNodeRep: public TaQLQueryNodeRep
 public:
   TaQLCountNodeRep (const TaQLMultiNode& with, const TaQLNode& columns,
                     const TaQLMultiNode& tables, const TaQLNode& where);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void showDerived (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLCountNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void showDerived (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLNode      itsColumns;
@@ -872,10 +872,10 @@ public:
                      const TaQLMultiNode& tables, const TaQLMultiNode& update,
                      const TaQLMultiNode& from, const TaQLNode& where,
                      const TaQLNode& sort, const TaQLNode& limitoff);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLUpdateNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLMultiNode itsTables;
@@ -910,10 +910,10 @@ public:
                      const TaQLNode& values, const TaQLNode& limit);
   TaQLInsertNodeRep (const TaQLMultiNode& with, const TaQLMultiNode& tables,
                      const TaQLMultiNode& insert);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLInsertNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLMultiNode itsTables;
@@ -943,10 +943,10 @@ public:
   TaQLDeleteNodeRep (const TaQLMultiNode& with, const TaQLMultiNode& tables,
                      const TaQLNode& where,
                      const TaQLNode& sort, const TaQLNode& limitoff);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLDeleteNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLMultiNode itsTables;
@@ -976,10 +976,10 @@ public:
   TaQLCalcNodeRep (const TaQLMultiNode& withTables, const TaQLMultiNode& fromTables,
                    const TaQLNode& expr, const TaQLNode& where,
                    const TaQLNode& sort, const TaQLNode& limitoff);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLCalcNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLMultiNode itsTables;
@@ -1011,10 +1011,10 @@ public:
                      const TaQLNode& giving, const TaQLMultiNode& likeDrop,
                      const TaQLMultiNode& cols,
                      const TaQLNode& limit, const TaQLMultiNode& dminfo);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void showDerived (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLCreTabNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void showDerived (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLNode      itsGiving;
@@ -1045,10 +1045,10 @@ class TaQLColSpecNodeRep: public TaQLNodeRep
 public:
   TaQLColSpecNodeRep (const String& name, const String& likeCol,
                       const String& dtype, const TaQLMultiNode& spec);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLColSpecNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String        itsName;
   String        itsLikeCol;
@@ -1079,10 +1079,10 @@ public:
   TaQLRecFldNodeRep (const String& name, const TaQLRecFldNodeRep&);
   TaQLRecFldNodeRep (const String& name, const String& fromName,
                      const String& dtype);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLRecFldNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String   itsName;
   String   itsFromName;
@@ -1109,10 +1109,10 @@ class TaQLUnitNodeRep: public TaQLNodeRep
 {
 public:
   TaQLUnitNodeRep (const String& unit, const TaQLNode& child);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLUnitNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String   itsUnit;
   TaQLNode itsChild;
@@ -1138,10 +1138,10 @@ class TaQLAltTabNodeRep: public TaQLQueryNodeRep
 public:
   TaQLAltTabNodeRep (const TaQLMultiNode& with, const TaQLNode& table,
                      const TaQLMultiNode& from, const TaQLMultiNode& commands);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void showDerived (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLAltTabNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void showDerived (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLNode      itsTable;
@@ -1168,10 +1168,10 @@ class TaQLAddColNodeRep: public TaQLNodeRep
 {
 public:
   TaQLAddColNodeRep (const TaQLMultiNode& cols, const TaQLMultiNode& dminfo);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLAddColNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsColumns;
   TaQLMultiNode itsDMInfo;
@@ -1196,10 +1196,10 @@ class TaQLRenDropNodeRep: public TaQLNodeRep
 {
 public:
   TaQLRenDropNodeRep (Int type, const TaQLMultiNode& cols);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLRenDropNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   Int           itsType;
   TaQLMultiNode itsNames;
@@ -1224,10 +1224,10 @@ class TaQLSetKeyNodeRep: public TaQLNodeRep
 {
 public:
   TaQLSetKeyNodeRep (const TaQLMultiNode& keyvals);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLSetKeyNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsKeyVals;
 };
@@ -1251,10 +1251,10 @@ class TaQLAddRowNodeRep: public TaQLNodeRep
 {
 public:
   TaQLAddRowNodeRep (const TaQLNode& nrow);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLAddRowNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLNode itsNRow;
 };
@@ -1280,10 +1280,10 @@ public:
   TaQLConcTabNodeRep (const String& tableName,
                       const TaQLMultiNode& tables,
                       const TaQLMultiNode& subtableNames);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void showDerived (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLConcTabNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void showDerived (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   String        itsTableName;
   TaQLMultiNode itsTables;
@@ -1309,10 +1309,10 @@ class TaQLShowNodeRep: public TaQLNodeRep
 {
 public:
   TaQLShowNodeRep (const TaQLMultiNode& names);
-  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const;
-  virtual void show (std::ostream& os) const;
-  virtual void save (AipsIO& aio) const;
-  static TaQLShowNodeRep* restore (AipsIO& aio);
+  virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
+  virtual void show (std::ostream& os) const override;
+  virtual void save (AipsIO& aio) const override;
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsNames;
 };
@@ -1339,7 +1339,7 @@ public:
   virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
   virtual void show (std::ostream& os) const override;
   virtual void save (AipsIO& aio) const override;
-  static TaQLCopyColNodeRep* restore (AipsIO& aio);
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsNames;
   TaQLMultiNode itsDMInfo;
@@ -1367,7 +1367,7 @@ public:
   virtual TaQLNodeResult visit (TaQLNodeVisitor&) const override;
   virtual void show (std::ostream& os) const override;
   virtual void save (AipsIO& aio) const override;
-  static TaQLDropTabNodeRep* restore (AipsIO& aio);
+  static TaQLNode restore (AipsIO& aio);
 
   TaQLMultiNode itsWith;
   TaQLMultiNode itsTables;


### PR DESCRIPTION
TaQLNode and associated classes were using raw pointers at a few places. It has been replaced by unique_ptr. Furthermore, restore now returns a TaQLNode object instead of a pointer.
