### PR TITLE
Revert "Add -std=legacy compiler option for scimath_f"

### DIFF
--- a/scimath_f/CMakeLists.txt
+++ b/scimath_f/CMakeLists.txt
@@ -37,7 +37,7 @@ if (BUILD_FFTPACK_DEPRECATED)
 endif ()
 
 add_library (casa_scimath_f ${buildfiles})
-target_compile_options (casa_scimath_f PRIVATE -std=legacy)
+
 target_link_libraries (casa_scimath_f casa_tables ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${CASACORE_ARCH_LIBS})
 
 install (


### PR DESCRIPTION
This reverts commit c32cf89d81e697b64b89d8e9248d63419c1e8da1 as requested by @aroffringa in #1134.