### PR TITLE
Default BaseTable's MPI communicator to SELF

### DIFF
--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -597,10 +597,11 @@ private:
     String makeAbsoluteName (const String& name) const;
 
 #ifdef HAVE_MPI
-    // MPI communicator for parallel I/O
-    // Set the default to MPI_COMM_WORLD to keep the compatibility for
-    // non-MPI apps to work with the MPI-enabled casacore build.
-    MPI_Comm itsMpiComm = MPI_COMM_WORLD;
+    // MPI communicator for parallel I/O.
+    // When using an MPI-disabled casacore, MPI applications have always been
+    // able to create Tables from each rank independently. Defaulting this
+    // communicator to MPI_COMM_SELF preserves that expectation.
+    MPI_Comm itsMpiComm = MPI_COMM_SELF;
 #endif
 };
 


### PR DESCRIPTION
CC: @pelahi who will be interested in this, as well as @JasonRuonanWang

So far most of the applications we had used with MPI (and the
Adios2StMan) were either writing a single Measurement Set or Table
across all MPI ranks, or passed an explicit MPI communicator to the
Table and Adios2StMan constructors. This has worked well, but means that
the default value of BaseTable.itsMpiComm (MPI_COMM_WORLD) hasn't been
relevant.

New tests have revealed that this is not a great default value. In
particular we have tried running Yandasoft (an MPI-enabled application)
against an MPI-enabled casacore. Until now all of the data written by
Yandasoft doesn't happen with the Adios2StMan, and thus it is expected
that each rank writes its own Tables. Without changing each Table
creation invocation in Yandasoft's code this expectation couldn't be met
though: if casacore's BaseTable's default communicator defaults to
MPI_COMM_WORLD then data races occur in all ranks (except rank 0) since
the directory containing a Table's files is created only on rank 0 of
the Table's communicator. Note that this is completely independent of
the storage manager users choose to use.

Instead of relying on applications changing their code, it's far better
to adjust the default MPI communicator used by BaseTable instead and
change it to MPI_COMM_SELF. This maintains the current expected behavior
on MPI applications running against an MPI-enabled casacore without
changing their code, as each rank in the MPI_COMM_WORLD communicator
will be treated separately.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>