### PR TITLE
Create vector of correct size

### DIFF
--- a/images/Regions/RFReaderWriter.cc
+++ b/images/Regions/RFReaderWriter.cc
@@ -104,7 +104,7 @@ String RFReaderWriter::extensionForType(SupportedType type) {
 }
 
 Vector<RFReaderWriter::SupportedType> RFReaderWriter::supportedTypes(){
-    vector<SupportedType> v(2);
+    vector<SupportedType> v(4);
     v[0] = AIPS_BOX; v[1] = DS9; v[2] = CASA_XML; v[3] = AIPS_IO;
 
     return v;


### PR DESCRIPTION
The code clearly assigns 4 values into the vector, but it only requests
space for 2. This was warned by g++ 11.2.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>