### PR TITLE
Fix doc error in ArrayMeasColumn

### DIFF
--- a/measures/TableMeasures/ArrayMeasColumn.h
+++ b/measures/TableMeasures/ArrayMeasColumn.h
@@ -43,7 +43,7 @@ template <class M> class ScalarMeasColumn;
 
 
 // <summary>
-// Read only access to table array Measure columns.
+// Access table array Measure columns.
 // </summary>
 
 // <use visibility=export>


### PR DESCRIPTION
It looks like this doc was originally for an ROArrayMeasColumn, which no longer exists.