### PR TITLE
Make conversion from std::vector to casacore::Vector explicit

### DIFF
--- a/casa/Arrays/Vector.h
+++ b/casa/Arrays/Vector.h
@@ -146,7 +146,7 @@ public:
     // defined in <src>Vector2.cc</src>. </note>
     // It does implicit promotion/demotion of the type U if different from T.
     template <typename U, typename V>
-    Vector(const std::vector<U, V> &other);
+    explicit Vector(const std::vector<U, V> &other);
 
     // Create a Vector from a container iterator and its length.
     // <note> The length is used instead of last, because the distance

--- a/casa/Arrays/test/tVector.cc
+++ b/casa/Arrays/test/tVector.cc
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE( tovector )
   x[2] = -20;
   std::vector<int> tx;
   x.tovector(tx);
-  Vector<int> xx = x.tovector();
+  Vector<int> xx(x.tovector());
   BOOST_CHECK(tx.size() == x.size());
   BOOST_CHECK(tx.size() == xx.size());
 

--- a/images/Regions/RFReaderWriter.cc
+++ b/images/Regions/RFReaderWriter.cc
@@ -104,7 +104,7 @@ String RFReaderWriter::extensionForType(SupportedType type) {
 }
 
 Vector<RFReaderWriter::SupportedType> RFReaderWriter::supportedTypes(){
-    vector<SupportedType> v(4);
+    Vector<SupportedType> v(4);
     v[0] = AIPS_BOX; v[1] = DS9; v[2] = CASA_XML; v[3] = AIPS_IO;
 
     return v;

--- a/ms/MSSel/MSArrayParse.h
+++ b/ms/MSSel/MSArrayParse.h
@@ -99,7 +99,7 @@ public:
   const TableExprNode *selectRangeGTAndLT(const Int& n0, const Int& n1);
   const TableExprNode *selectRangeGEAndLE(const Int& n0, const Int& n1);
   const TableExprNode *selectArrayIds(const Vector<Int>& arrayids);
-  inline const TableExprNode *selectArrayIds() {return selectArrayIds(parsedIDList_p);}
+  inline const TableExprNode *selectArrayIds() {return selectArrayIds(Vector<int>(parsedIDList_p));}
   const TableExprNode *selectArrayIdsGT(const Vector<Int>& arrayids);
   const TableExprNode *selectArrayIdsLT(const Vector<Int>& arrayids);
   const TableExprNode *selectArrayIdsGTEQ(const Vector<Int>& arrayids);

--- a/ms/MSSel/MSArrayParse.h
+++ b/ms/MSSel/MSArrayParse.h
@@ -99,7 +99,7 @@ public:
   const TableExprNode *selectRangeGTAndLT(const Int& n0, const Int& n1);
   const TableExprNode *selectRangeGEAndLE(const Int& n0, const Int& n1);
   const TableExprNode *selectArrayIds(const Vector<Int>& arrayids);
-  inline const TableExprNode *selectArrayIds() {return selectArrayIds(Vector<int>(parsedIDList_p));}
+  inline const TableExprNode *selectArrayIds() {return selectArrayIds(Vector<Int>(parsedIDList_p));}
   const TableExprNode *selectArrayIdsGT(const Vector<Int>& arrayids);
   const TableExprNode *selectArrayIdsLT(const Vector<Int>& arrayids);
   const TableExprNode *selectArrayIdsGTEQ(const Vector<Int>& arrayids);

--- a/ms/MSSel/MSObservationParse.h
+++ b/ms/MSSel/MSObservationParse.h
@@ -99,7 +99,7 @@ public:
   const TableExprNode *selectRangeGTAndLT(const Int& n0, const Int& n1);
   const TableExprNode *selectRangeGEAndLE(const Int& n0, const Int& n1);
   const TableExprNode *selectObservationIds(const Vector<Int>& scanids);
-  inline const TableExprNode *selectObservationIds() {return selectObservationIds(parsedIDList_p);}
+  inline const TableExprNode *selectObservationIds() {return selectObservationIds(Vector<int>(parsedIDList_p));}
   const TableExprNode *selectObservationIdsGT(const Vector<Int>& scanids);
   const TableExprNode *selectObservationIdsLT(const Vector<Int>& scanids);
   const TableExprNode *selectObservationIdsGTEQ(const Vector<Int>& scanids);

--- a/ms/MSSel/MSObservationParse.h
+++ b/ms/MSSel/MSObservationParse.h
@@ -99,7 +99,7 @@ public:
   const TableExprNode *selectRangeGTAndLT(const Int& n0, const Int& n1);
   const TableExprNode *selectRangeGEAndLE(const Int& n0, const Int& n1);
   const TableExprNode *selectObservationIds(const Vector<Int>& scanids);
-  inline const TableExprNode *selectObservationIds() {return selectObservationIds(Vector<int>(parsedIDList_p));}
+  inline const TableExprNode *selectObservationIds() {return selectObservationIds(Vector<Int>(parsedIDList_p));}
   const TableExprNode *selectObservationIdsGT(const Vector<Int>& scanids);
   const TableExprNode *selectObservationIdsLT(const Vector<Int>& scanids);
   const TableExprNode *selectObservationIdsGTEQ(const Vector<Int>& scanids);

--- a/ms/MSSel/MSScanParse.h
+++ b/ms/MSSel/MSScanParse.h
@@ -99,7 +99,7 @@ public:
   const TableExprNode *selectRangeGTAndLT(const Int& n0, const Int& n1);
   const TableExprNode *selectRangeGEAndLE(const Int& n0, const Int& n1);
   const TableExprNode *selectScanIds(const Vector<Int>& scanids);
-  inline const TableExprNode *selectScanIds() {return selectScanIds(Vector<int>(parsedIDList_p));}
+  inline const TableExprNode *selectScanIds() {return selectScanIds(Vector<Int>(parsedIDList_p));}
   const TableExprNode *selectScanIdsGT(const Vector<Int>& scanids);
   const TableExprNode *selectScanIdsLT(const Vector<Int>& scanids);
   const TableExprNode *selectScanIdsGTEQ(const Vector<Int>& scanids);

--- a/ms/MSSel/MSScanParse.h
+++ b/ms/MSSel/MSScanParse.h
@@ -99,7 +99,7 @@ public:
   const TableExprNode *selectRangeGTAndLT(const Int& n0, const Int& n1);
   const TableExprNode *selectRangeGEAndLE(const Int& n0, const Int& n1);
   const TableExprNode *selectScanIds(const Vector<Int>& scanids);
-  inline const TableExprNode *selectScanIds() {return selectScanIds(parsedIDList_p);}
+  inline const TableExprNode *selectScanIds() {return selectScanIds(Vector<int>(parsedIDList_p));}
   const TableExprNode *selectScanIdsGT(const Vector<Int>& scanids);
   const TableExprNode *selectScanIdsLT(const Vector<Int>& scanids);
   const TableExprNode *selectScanIdsGTEQ(const Vector<Int>& scanids);


### PR DESCRIPTION
Before this MR, it is possible to implicitly convert a std::vector to a casacore::Vector, for example:

std::vector<int> foo();

casacore::Vector<int> v = foo();

would be fine. Since this can be expensive, this should not be done implicitly. There are several bugs in DP3 because of this, and I also found one casacore typo-bug (in RFReaderWriter.cc) by making this conversion explicit.

It might require a few fixes in software that uses casacore, particularly casa (but the upside is that it might also highlight some bugs :) ).

The related DP3 MR is here: https://git.astron.nl/RD/DP3/-/merge_requests/661