### PR TITLE
Added assert to detect issue #1171

### DIFF
--- a/lattices/Lattices/ArrayLattice.tcc
+++ b/lattices/Lattices/ArrayLattice.tcc
@@ -137,6 +137,7 @@ void ArrayLattice<T>::doPutSlice (const Array<T>& sourceBuffer,
 	    where + (sourceBuffer.shape()-1)*stride, 
 	    stride) = sourceBuffer;
   } else {
+    AlwaysAssert(ldim > sdim, AipsError);
     Array<T> allAxes(sourceBuffer.addDegenerate(ldim-sdim));
     itsData(where, 
 	    where + (allAxes.shape()-1)*stride, 


### PR DESCRIPTION
A trivial change "fixing" issue #1171 - added assert to ensure the lattice has more dimensions than the source before adding degenerate axes. As discussed on the ticket, it is possible to support ldim < sdim case as well via reform method. However, mismatched dimensions in this particular operation is a sloppy code. So perhaps, it is better to detect this condition with an assertion rather than sweep under the carpet. 

I can easily implement the support of the ldim < sdim case, if others think it is worth doing.