### PR TITLE
Use shared_ptr instead of own reference counting of BaseTable

### DIFF
--- a/tables/Tables/BaseTabIter.cc
+++ b/tables/Tables/BaseTabIter.cc
@@ -97,7 +97,8 @@ BaseTableIterator::BaseTableIterator (const std::shared_ptr<BaseTable>& btp,
         sortIterBoundariesIt_p   = sortIterBoundaries_p->begin();
         sortIterKeyIdxChangeIt_p = sortIterKeyIdxChange_p->begin();
         aBaseTable_p = sortTab_p->makeRefTable (False, 0);
-        aRefTable_p = aBaseTable_p->asRefTable();
+        aRefTable_p = dynamic_cast<RefTable*>(aBaseTable_p.get());
+        DebugAssert (aRefTable_p, AipsError);
     }
 }
 
@@ -134,7 +135,8 @@ BaseTableIterator::BaseTableIterator (const BaseTableIterator& that)
     }
     if (sortIterBoundaries_p && sortIterKeyIdxChange_p) {
         aBaseTable_p = sortTab_p->makeRefTable (False, 0);
-        aRefTable_p = aBaseTable_p->asRefTable();
+        aRefTable_p = dynamic_cast<RefTable*>(aBaseTable_p.get());
+        DebugAssert (aRefTable_p, AipsError);
     }
 }
 
@@ -160,7 +162,7 @@ void BaseTableIterator::reset()
 std::shared_ptr<BaseTable> BaseTableIterator::next()
 {
     // If there are no group boundaries precomputed do an expensive
-    // walk to check where a new boundary happens by calling the comparion
+    // walk to check where a new boundary happens by calling the comparison
     // functions
     if (!sortIterBoundaries_p || !sortIterKeyIdxChange_p) {
         return noCachedIterBoundariesNext();
@@ -209,7 +211,8 @@ std::shared_ptr<BaseTable> BaseTableIterator::noCachedIterBoundariesNext()
 
     // Allocate a RefTable to represent the rows in the iteration group.
     std::shared_ptr<BaseTable> baseTabPtr = sortTab_p->makeRefTable (False, 0);
-    RefTable* itp = baseTabPtr->asRefTable();
+    RefTable* itp = dynamic_cast<RefTable*>(baseTabPtr.get());
+    DebugAssert (itp, AipsError);
     if (lastRow_p >= sortTab_p->nrow()) {
 	return baseTabPtr;                         // the end of the table
     }

--- a/tables/Tables/BaseTabIter.cc
+++ b/tables/Tables/BaseTabIter.cc
@@ -42,22 +42,22 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // numbers of the rows for that iteration step.
 
 
-BaseTableIterator::BaseTableIterator (BaseTable* btp,
-    const Block<String>& keys,
-    const Block<CountedPtr<BaseCompare> >& cmp,
-    const Block<Int>& order,
-    int option,
-    bool cacheIterationBoundaries)
-: lastRow_p (0),
-  nrkeys_p  (keys.nelements()),
-  keyChangeAtLastNext_p(""),
-  colPtr_p  (keys.nelements()),
-  cmpObj_p  (cmp),
-  lastVal_p (keys.nelements()),
-  curVal_p  (keys.nelements()),
-  sortIterBoundaries_p   (nullptr),
-  sortIterKeyIdxChange_p (nullptr),
-  aRefTable_p(nullptr)
+BaseTableIterator::BaseTableIterator (const std::shared_ptr<BaseTable>& btp,
+                                      const Block<String>& keys,
+                                      const Block<CountedPtr<BaseCompare> >& cmp,
+                                      const Block<Int>& order,
+                                      int option,
+                                      bool cacheIterationBoundaries)
+  : lastRow_p (0),
+    nrkeys_p  (keys.nelements()),
+    keyChangeAtLastNext_p(""),
+    colPtr_p  (keys.nelements()),
+    cmpObj_p  (cmp),
+    lastVal_p (keys.nelements()),
+    curVal_p  (keys.nelements()),
+    sortIterBoundaries_p   (nullptr),
+    sortIterKeyIdxChange_p (nullptr),
+    aRefTable_p(nullptr)
 {
     // If needed sort the table in order of the iteration keys.
     // The passed in compare functions are for the iteration.
@@ -78,27 +78,25 @@ BaseTableIterator::BaseTableIterator (BaseTable* btp,
                 ord[i] = Sort::Descending;
             }
         }
-        if(cacheIterationBoundaries)
-        {
+        if (cacheIterationBoundaries) {
             sortIterBoundaries_p   = std::make_shared<Vector<rownr_t>>();
             sortIterKeyIdxChange_p = std::make_shared<Vector<size_t>>();
         }
-        sortTab_p = (RefTable*) (btp->sort (keys, cmpObj_p, ord, sortopt,
-                                            sortIterBoundaries_p,
-                                            sortIterKeyIdxChange_p ));
+        sortTab_p = btp->sort (keys, cmpObj_p, ord, sortopt,
+                               sortIterBoundaries_p,
+                               sortIterKeyIdxChange_p);
     }
-    sortTab_p->link();
     // Get the pointers to the BaseColumn object.
     // Get a buffer to hold the current and last value per column.
     for (uInt i=0; i<nrkeys_p; i++) {
         colPtr_p[i] = sortTab_p->getColumn (keys[i]);
         colPtr_p[i]->allocIterBuf (lastVal_p[i], curVal_p[i], cmpObj_p[i]);
     }
-    if(cacheIterationBoundaries)
-    {
+    if (cacheIterationBoundaries) {
         sortIterBoundariesIt_p   = sortIterBoundaries_p->begin();
         sortIterKeyIdxChangeIt_p = sortIterKeyIdxChange_p->begin();
-        aRefTable_p = sortTab_p->makeRefTable (False, 0);
+        aBaseTable_p = sortTab_p->makeRefTable (False, 0);
+        aRefTable_p = aBaseTable_p->asRefTable();
     }
 }
 
@@ -126,20 +124,16 @@ BaseTableIterator::BaseTableIterator (const BaseTableIterator& that)
     for (uInt i=0; i<nrkeys_p; i++) {
         colPtr_p[i]->allocIterBuf (lastVal_p[i], curVal_p[i], cmpObj_p[i]);
     }
-    // Link against the table (ie. increase its ref.count).
     sortTab_p = that.sortTab_p;
-    sortTab_p->link();
-    if(sortIterBoundaries_p)
-    {
+    if (sortIterBoundaries_p) {
         sortIterBoundariesIt_p = sortIterBoundaries_p->begin();
     }
-    if(sortIterKeyIdxChange_p)
-    {
+    if (sortIterKeyIdxChange_p) {
         sortIterKeyIdxChangeIt_p = sortIterKeyIdxChange_p->begin();
     }
-    if(sortIterBoundaries_p && sortIterKeyIdxChange_p)
-    {
-        aRefTable_p = sortTab_p->makeRefTable (False, 0);
+    if (sortIterBoundaries_p && sortIterKeyIdxChange_p) {
+        aBaseTable_p = sortTab_p->makeRefTable (False, 0);
+        aRefTable_p = aBaseTable_p->asRefTable();
     }
 }
 
@@ -149,49 +143,41 @@ BaseTableIterator::~BaseTableIterator()
     for (uInt i=0; i<nrkeys_p; i++) {
         colPtr_p[i]->freeIterBuf (lastVal_p[i], curVal_p[i]);
     }
-    // Unlink from the table and delete it.
-    BaseTable::unlink (sortTab_p);
 }
 
 void BaseTableIterator::reset()
 {
     lastRow_p = 0;
-    if(sortIterBoundaries_p)
-    {
+    if (sortIterBoundaries_p) {
         sortIterBoundariesIt_p = sortIterBoundaries_p->begin();
     }
-    if(sortIterKeyIdxChange_p)
-    {
+    if (sortIterKeyIdxChange_p) {
         sortIterKeyIdxChangeIt_p = sortIterKeyIdxChange_p->begin();
     }
 }
 
-BaseTable* BaseTableIterator::next()
+std::shared_ptr<BaseTable> BaseTableIterator::next()
 {
     // If there are no group boundaries precomputed do an expensive
     // walk to check where a new boundary happens by calling the comparion
     // functions
-    if(!sortIterBoundaries_p || !sortIterKeyIdxChange_p)
-    {
+    if (!sortIterBoundaries_p || !sortIterKeyIdxChange_p) {
         return noCachedIterBoundariesNext();
     }
 
     // Allocate a RefTable to represent the rows in the iteration group.
     aRefTable_p->removeAllRow();
     if (lastRow_p >= sortTab_p->nrow()) {
-        return aRefTable_p;                              // the end of the table
+        return aBaseTable_p;                              // the end of the table
     }
 
     // Go to the next group boundary (the one after this), which will be
     // one past the end of the current group.
     ++sortIterBoundariesIt_p;
     rownr_t startNextGroup;
-    if(sortIterBoundariesIt_p == sortIterBoundaries_p->end())
-    {
+    if (sortIterBoundariesIt_p == sortIterBoundaries_p->end()) {
         startNextGroup = sortTab_p->nrow();
-    }
-    else
-    {
+    } else {
         startNextGroup = *sortIterBoundariesIt_p;
     }
     // lastRow_p contains the starting point for this group
@@ -201,32 +187,30 @@ BaseTable* BaseTableIterator::next()
     lastRow_p = startNextGroup;
 
     // If we've reached the end of the table, clear the keyCh_p
-    if (lastRow_p==sortTab_p->nrow())
-    {
+    if (lastRow_p==sortTab_p->nrow()) {
         keyChangeAtLastNext_p=String();
-    }
-    // If not, get the name of the column from the sorting column ID
-    else
-    {
+    } else {
+        // If not, get the name of the column from the sorting column ID
         keyChangeAtLastNext_p=colPtr_p[*sortIterKeyIdxChangeIt_p]->columnDesc().name();
     }
     ++sortIterKeyIdxChangeIt_p;
 
     //# Adjust rownrs in case source table is already a RefTable.
-    Vector<rownr_t>& rownrs = *(aRefTable_p->rowStorage());
+    Vector<rownr_t>& rownrs = aRefTable_p->rowStorage();
     sortTab_p->adjustRownrs (aRefTable_p->nrow(), rownrs, False);
-    return aRefTable_p;
+    return aBaseTable_p;
 }
 
-BaseTable* BaseTableIterator::noCachedIterBoundariesNext()
+std::shared_ptr<BaseTable> BaseTableIterator::noCachedIterBoundariesNext()
 {
     // This is an expensive way to find the next group boundary by calling
     // the sorting function for each individual row.
 
     // Allocate a RefTable to represent the rows in the iteration group.
-    RefTable* itp = sortTab_p->makeRefTable (False, 0);
+    std::shared_ptr<BaseTable> baseTabPtr = sortTab_p->makeRefTable (False, 0);
+    RefTable* itp = baseTabPtr->asRefTable();
     if (lastRow_p >= sortTab_p->nrow()) {
-	return itp;                              // the end of the table
+	return baseTabPtr;                         // the end of the table
     }
     // Add the last found rownr to this iteration group.
     itp->addRownr (lastRow_p);
@@ -253,13 +237,13 @@ BaseTable* BaseTableIterator::noCachedIterBoundariesNext()
     }
 
     // If we've reached the end of the table, clear the keyCh_p
-    if (lastRow_p==nr)
+    if (lastRow_p == nr) {
       keyChangeAtLastNext_p=String();
-
+    }
     //# Adjust rownrs in case source table is already a RefTable.
-    Vector<rownr_t>& rownrs = *(itp->rowStorage());
+    Vector<rownr_t>& rownrs = itp->rowStorage();
     sortTab_p->adjustRownrs (itp->nrow(), rownrs, False);
-    return itp;
+    return baseTabPtr;
 }
 
 void
@@ -268,15 +252,13 @@ BaseTableIterator::copyState(const BaseTableIterator &other)
   lastRow_p = other.lastRow_p;
   keyChangeAtLastNext_p = other.keyChangeAtLastNext_p;
 
-  if(sortIterBoundaries_p)
-  {
+  if (sortIterBoundaries_p) {
       sortIterBoundariesIt_p = sortIterBoundaries_p->begin();
       std::advance(sortIterBoundariesIt_p,
                    std::distance(other.sortIterBoundaries_p->begin(),
                                  other.sortIterBoundariesIt_p));
   }
-  if(sortIterKeyIdxChange_p)
-  {
+  if (sortIterKeyIdxChange_p) {
       sortIterKeyIdxChangeIt_p = sortIterKeyIdxChange_p->begin();
       std::advance(sortIterKeyIdxChangeIt_p,
                    std::distance(other.sortIterKeyIdxChange_p->begin(),

--- a/tables/Tables/BaseTabIter.cc
+++ b/tables/Tables/BaseTabIter.cc
@@ -30,6 +30,7 @@
 #include <casacore/tables/Tables/RefTable.h>
 #include <casacore/tables/Tables/TableColumn.h>
 #include <casacore/casa/Utilities/Sort.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/tables/Tables/TableError.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -96,7 +96,8 @@ public:
     // iteration boundary. This improves performance in general but will
     // break existing applications that change the comparison objects
     // (cmpObjs) between iterations.
-    BaseTableIterator (BaseTable*, const Block<String>& columnNames,
+    BaseTableIterator (const std::shared_ptr<BaseTable>&,
+                       const Block<String>& columnNames,
                        const Block<CountedPtr<BaseCompare> >& cmpObjs,
                        const Block<Int>& orders,
                        int option,
@@ -111,7 +112,7 @@ public:
     virtual void reset();
 
     // Return the next group.
-    virtual BaseTable* next();
+    virtual std::shared_ptr<BaseTable> next();
 
     virtual void copyState(const BaseTableIterator &);
 
@@ -119,10 +120,11 @@ public:
     // comparison function) to terminate the most recent call to next()
     // Enables clients to sense iteration boundary properties
     // and organize associated iterations
-    inline const String& keyChangeAtLastNext() const { return keyChangeAtLastNext_p; };
+    inline const String& keyChangeAtLastNext() const
+      { return keyChangeAtLastNext_p; }
 
 protected:
-    BaseTable*             sortTab_p;     //# Table sorted in iteration order
+    std::shared_ptr<BaseTable> sortTab_p; //# Table sorted in iteration order
     rownr_t                lastRow_p;     //# last row used from reftab
     uInt                   nrkeys_p;      //# nr of columns in group
     String                 keyChangeAtLastNext_p;  //# name of column that terminated most recent next()
@@ -132,7 +134,7 @@ protected:
     // Copy constructor (to be used by clone)
     BaseTableIterator (const BaseTableIterator&);
 
-    BaseTable* noCachedIterBoundariesNext();
+    std::shared_ptr<BaseTable> noCachedIterBoundariesNext();
 
 private:
     // Assignment is not needed, because the assignment operator in
@@ -147,7 +149,8 @@ private:
     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange_p;
     Vector<rownr_t>::iterator sortIterBoundariesIt_p;
     Vector<size_t>::iterator  sortIterKeyIdxChangeIt_p;
-    RefTable* aRefTable_p;
+    std::shared_ptr<BaseTable> aBaseTable_p;
+    RefTable* aRefTable_p;      //# Same as aBaseTable_p
 };
 
 

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -149,8 +149,8 @@ private:
     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange_p;
     Vector<rownr_t>::iterator sortIterBoundariesIt_p;
     Vector<size_t>::iterator  sortIterKeyIdxChangeIt_p;
-    std::shared_ptr<BaseTable> aBaseTable_p;
-    RefTable* aRefTable_p;      //# Same as aBaseTable_p
+    RefTable* aRefTable_p;      //# RefTable returned in each iteration
+    std::shared_ptr<BaseTable> aBaseTable_p; //# Same as above for automatic deletion
 };
 
 

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -78,10 +78,8 @@ BaseTable::BaseTable (MPI_Comm mpiComm, const String& name, int option, rownr_t 
 
 void BaseTable::BaseTableCommon (const String& name, int option, rownr_t nrrow)
 {
-    nrlink_p = 0;
     nrrow_p = nrrow;
     nrrowToAdd_p = 0;
-    tdescPtr_p = 0;
     name_p = name;
     option_p = option;
     noWrite_p = False;
@@ -123,34 +121,15 @@ BaseTable::~BaseTable()
     }
 }
 
-void BaseTable::link()
-{
-    nrlink_p++;
-#ifdef AIPS_TRACE
-    cout << "BaseTable::link:   " << nrlink_p << ' ' << name_p
-	 << ' ' << this << endl;
-#endif
-}
-
-void BaseTable::unlink (BaseTable* btp)
-{
-#ifdef AIPS_TRACE
-    cout << "BaseTable::unlink: " << btp->nrlink_p << ' ' << btp->name_p
-	 << ' ' << btp;
-    if (btp->nrlink_p == 1) {
-        cout << " gets destructed";
-    }
-    cout << endl;
-#endif
-    btp->nrlink_p--;
-    if (btp->nrlink_p == 0) {
-	delete btp;
-    }
-}
-
 Bool BaseTable::isNull() const
 {
   return False;
+}
+
+std::shared_ptr<BaseTable> BaseTable::getSharedPtr() const
+{
+  AlwaysAssert (!thisPtr_p.expired(), AipsError);
+  return thisPtr_p.lock();
 }
 
 
@@ -688,7 +667,7 @@ Bool BaseTable::rowOrder() const
     { return True; }
 
 //# By the default the table cannot return the storage of rownrs.
-Vector<rownr_t>* BaseTable::rowStorage()
+Vector<rownr_t>& BaseTable::rowStorage()
 {
     throw (TableInvOper ("rowStorage() not possible; table " + name_p +
                          " is no RefTable"));
@@ -696,11 +675,12 @@ Vector<rownr_t>* BaseTable::rowStorage()
 
 
 //# Sort a table.
-BaseTable* BaseTable::sort (const Block<String>& names,
-                            const Block<CountedPtr<BaseCompare> >& cmpObj,
-                            const Block<Int>& order, int option,
-                            std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
-                            std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange)
+std::shared_ptr<BaseTable> BaseTable::sort
+(const Block<String>& names,
+ const Block<CountedPtr<BaseCompare> >& cmpObj,
+ const Block<Int>& order, int option,
+ std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
+ std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange)
 
 {
     AlwaysAssert (!isNull(), AipsError);
@@ -727,11 +707,12 @@ BaseTable* BaseTable::sort (const Block<String>& names,
 }
 
 //# Do the actual sort.
-BaseTable* BaseTable::doSort (PtrBlock<BaseColumn*>& sortCol,
-                              const Block<CountedPtr<BaseCompare> >& cmpObj,
-                              const Block<Int>& order, int option,
-                              std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
-                              std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange)
+std::shared_ptr<BaseTable> BaseTable::doSort
+(PtrBlock<BaseColumn*>& sortCol,
+ const Block<CountedPtr<BaseCompare> >& cmpObj,
+ const Block<Int>& order, int option,
+ std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
+ std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange)
 {
     uInt nrkey = sortCol.nelements();
     //# Create a sort object.
@@ -745,32 +726,42 @@ BaseTable* BaseTable::doSort (PtrBlock<BaseColumn*>& sortCol,
     //# Create a reference table.
     //# This table will NOT be in row order.
     rownr_t nrrow = nrow();
-    RefTable* resultTable = makeRefTable (False, nrrow);
+    std::shared_ptr<BaseTable> resultBaseTab = makeRefTable (False, nrrow);
+    RefTable* resultTable = resultBaseTab->asRefTable();
     //# Now sort the table storing the row-numbers in the RefTable.
     //# Adjust rownrs in case source table is already a RefTable.
     //# Then delete possible allocated data blocks.
-    Vector<rownr_t>& rows = *(resultTable->rowStorage());
+    Vector<rownr_t>& rows = resultTable->rowStorage();
     //# Note that nrrow can change in case Sort::NoDuplicates was given.
     nrrow = sortobj.sort (rows, nrrow, option);
-    if(sortIterBoundaries && sortIterKeyIdxChange)
+    if(sortIterBoundaries && sortIterKeyIdxChange) {
         sortobj.unique(*sortIterBoundaries, *sortIterKeyIdxChange, rows);
+    }
     adjustRownrs (nrrow, rows, False);
     resultTable->setNrrow (nrrow);
-    return resultTable;
+    return resultBaseTab;
 }
 
-RefTable* BaseTable::makeRefTable (Bool rowOrder, rownr_t initialNrrow)
+std::shared_ptr<BaseTable> BaseTable::makeRefTable (Bool rowOrder,
+                                                    rownr_t initialNrrow)
 {
-    RefTable* rtp = new RefTable(this, rowOrder, initialNrrow);
-    return rtp;
+  std::shared_ptr<BaseTable> rtp (new RefTable(this, rowOrder, initialNrrow));
+  rtp->setWeakPtr (rtp);
+  return rtp;
 }
 
+RefTable* BaseTable::asRefTable()
+{
+  RefTable* rtp = dynamic_cast<RefTable*>(this);
+  AlwaysAssert (rtp, AipsError);
+  return rtp;
+}
 
 //# No rownrs have to be adjusted and they are by default in ascending order.
 Bool BaseTable::adjustRownrs (rownr_t, Vector<rownr_t>&, Bool) const
     { return True; }
 
-BaseTable* BaseTable::select (rownr_t maxRow, rownr_t offset)
+std::shared_ptr<BaseTable> BaseTable::select (rownr_t maxRow, rownr_t offset)
 {
     if (offset > nrow()) {
         offset = nrow();
@@ -779,7 +770,7 @@ BaseTable* BaseTable::select (rownr_t maxRow, rownr_t offset)
         maxRow = nrow() - offset;
     }
     if (offset == 0  &&  maxRow == nrow()) {
-        return this;
+      return getSharedPtr();    // pointer to itself
     }
     Vector<rownr_t> rownrs(maxRow);
     indgen(rownrs, rownr_t(offset));
@@ -787,8 +778,8 @@ BaseTable* BaseTable::select (rownr_t maxRow, rownr_t offset)
 }
 
 // Do the row selection.
-BaseTable* BaseTable::select (const TableExprNode& node,
-                              rownr_t maxRow, rownr_t offset)
+std::shared_ptr<BaseTable> BaseTable::select (const TableExprNode& node,
+                                              rownr_t maxRow, rownr_t offset)
 {
     // Check we don't deal with a null table.
     AlwaysAssert (!isNull(), AipsError);
@@ -822,7 +813,8 @@ BaseTable* BaseTable::select (const TableExprNode& node,
     //# Loop through all rows and add to reference table if true.
     //# Add the rownr of the root table (one may search a reference table).
     //# Adjust the row numbers to reflect row numbers in the root table.
-    SPtrHolder<RefTable> resultTable (makeRefTable (True, 0));
+    std::shared_ptr<BaseTable> resultBaseTab = makeRefTable (True, 0);
+    RefTable* resultTable = resultBaseTab->asRefTable();
     Bool val;
     rownr_t nrrow = nrow();
     TableExprId id;
@@ -842,67 +834,59 @@ BaseTable* BaseTable::select (const TableExprNode& node,
         }
       }
     }
-    adjustRownrs (resultTable->nrow(), *(resultTable->rowStorage()), False);
-    return resultTable.transfer();
+    adjustRownrs (resultTable->nrow(), resultTable->rowStorage(), False);
+    return resultBaseTab;
 }
 
-BaseTable* BaseTable::select (const Vector<rownr_t>& rownrs)
+std::shared_ptr<BaseTable> BaseTable::select (const Vector<rownr_t>& rownrs)
 {
     AlwaysAssert (!isNull(), AipsError);
     RefTable* rtp = new RefTable(this, rownrs);
-    return rtp;
+    return std::shared_ptr<BaseTable> (rtp);
 }
 
-BaseTable* BaseTable::select (const Block<Bool>& mask)
+std::shared_ptr<BaseTable> BaseTable::select (const Block<Bool>& mask)
 {
     AlwaysAssert (!isNull(), AipsError);
     RefTable* rtp = new RefTable(this, Vector<Bool>(mask.begin(), mask.end()));
-    return rtp;
+    return std::shared_ptr<BaseTable> (rtp);
 }
 
-BaseTable* BaseTable::project (const Block<String>& names)
+std::shared_ptr<BaseTable> BaseTable::project (const Block<String>& names)
 {
     AlwaysAssert (!isNull(), AipsError);
     RefTable* rtp = new RefTable(this, Vector<String>(names.begin(), names.end()));
-    return rtp;
+    return std::shared_ptr<BaseTable> (rtp);
 }
 
 
 //# And (intersect) 2 tables and return a new table.
-BaseTable* BaseTable::tabAnd (BaseTable* that)
+std::shared_ptr<BaseTable> BaseTable::tabAnd (BaseTable* that)
 {
     AlwaysAssert (!isNull(), AipsError);
     //# Check if both table have the same root.
     logicCheck (that);
     //# Anding a table with the (possibly sorted) root table gives the table.
     if (this->nrow() == this->root()->nrow()) {
-	return that;                                  // this is root
+      return that->getSharedPtr();                    // this is root
     }
     if (that->nrow() == that->root()->nrow()) {
-	return this;                                  // that is root
+      return this->getSharedPtr();                    // that is root
     }
     //# There is no root table involved, so we have to deal with RefTables.
-    //# Get both rownr arrays and sort them if not in row order.
-    //# Sorting means that the array is allocated on the heap, which has
-    //# to be deleted afterwards.
-    Bool allsw1, allsw2;
-    rownr_t* inx1;
-    rownr_t* inx2;
-    rownr_t nr1 = this->logicRows (inx1, allsw1);
-    rownr_t nr2 = that->logicRows (inx2, allsw2);
-    RefTable* rtp = makeRefTable (True, 0);           // will be in row order
-    rtp->refAnd (nr1, inx1, nr2, inx2);       // store rownrs in new RefTable
-    if (allsw1) {
-	delete [] inx1;
-    }
-    if (allsw2) {
-	delete [] inx2;
-    }
-    return rtp;
+    //# Get both rownr arrays which are sorted if not in row order.
+    Vector<rownr_t> r1 = this->logicRows();
+    Vector<rownr_t> r2 = that->logicRows();
+    // Create RefTable which will be in row order.
+    std::shared_ptr<BaseTable> baseTabPtr = makeRefTable (True, 0);
+    RefTable* rtp = baseTabPtr->asRefTable();
+    // Store rownrs in new RefTable.
+    rtp->refAnd (r1.size(), r1.data(), r2.size(), r2.data());
+    return baseTabPtr;
 }
 
 //# Or (union) 2 tables and return a new table.
-BaseTable* BaseTable::tabOr (BaseTable* that)
+std::shared_ptr<BaseTable> BaseTable::tabOr (BaseTable* that)
 {
     AlwaysAssert (!isNull(), AipsError);
     //# Check if both table have the same root.
@@ -910,30 +894,22 @@ BaseTable* BaseTable::tabOr (BaseTable* that)
     //# Oring a table with the (possibly sorted) root table gives the root.
     if (this->nrow() == this->root()->nrow()
     ||  that->nrow() == that->root()->nrow()) {
-	return root();
+        return root()->getSharedPtr();
     }
     //# There is no root table involved, so we have to deal with RefTables.
-    //# Get both rownr arrays and sort them if not in row order.
-    //# Sorting means that the array is allocated on the heap, which has
-    //# to be deleted afterwards.
-    Bool allsw1, allsw2;
-    rownr_t* inx1;
-    rownr_t* inx2;
-    rownr_t nr1 = this->logicRows (inx1, allsw1);
-    rownr_t nr2 = that->logicRows (inx2, allsw2);
-    RefTable* rtp = makeRefTable (True, 0);           // will be in row order
-    rtp->refOr (nr1, inx1, nr2, inx2);       // store rownrs in new RefTable
-    if (allsw1) {
-	delete [] inx1;
-    }
-    if (allsw2) {
-	delete [] inx2;
-    }
-    return rtp;
+    //# Get both rownr arrays which are sorted if not in row order.
+    Vector<rownr_t> r1 = this->logicRows();
+    Vector<rownr_t> r2 = that->logicRows();
+    // Create RefTable which will be in row order.
+    std::shared_ptr<BaseTable> baseTabPtr = makeRefTable (True, 0);
+    RefTable* rtp = baseTabPtr->asRefTable();
+    // Store rownrs in new RefTable.
+    rtp->refOr (r1.size(), r1.data(), r2.size(), r2.data());
+    return baseTabPtr;
 }
 
 //# Subtract (difference) 2 tables and return a new table.
-BaseTable* BaseTable::tabSub (BaseTable* that)
+std::shared_ptr<BaseTable> BaseTable::tabSub (BaseTable* that)
 {
     AlwaysAssert (!isNull(), AipsError);
     //# Check if both table have the same root.
@@ -947,27 +923,19 @@ BaseTable* BaseTable::tabSub (BaseTable* that)
 	return that->tabNot();
     }
     //# There is no root table involved, so we have to deal with RefTables.
-    //# Get both rownr arrays and sort them if not in row order.
-    //# Sorting means that the array is allocated on the heap, which has
-    //# to be deleted afterwards.
-    Bool allsw1, allsw2;
-    rownr_t* inx1;
-    rownr_t* inx2;
-    rownr_t nr1 = this->logicRows (inx1, allsw1);
-    rownr_t nr2 = that->logicRows (inx2, allsw2);
-    RefTable* rtp = makeRefTable (True, 0);           // will be in row order
-    rtp->refSub (nr1, inx1, nr2, inx2);       // store rownrs in new RefTable
-    if (allsw1) {
-	delete [] inx1;
-    }
-    if (allsw2) {
-	delete [] inx2;
-    }
-    return rtp;
+    //# Get both rownr arrays which are sorted if not in row order.
+    Vector<rownr_t> r1 = this->logicRows();
+    Vector<rownr_t> r2 = that->logicRows();
+    // Create RefTable which will be in row order.
+    std::shared_ptr<BaseTable> baseTabPtr = makeRefTable (True, 0);
+    RefTable* rtp = baseTabPtr->asRefTable();
+    // Store rownrs in new RefTable.
+    rtp->refSub (r1.size(), r1.data(), r2.size(), r2.data());
+    return baseTabPtr;
 }
 
 //# Xor 2 tables and return a new table.
-BaseTable* BaseTable::tabXor (BaseTable* that)
+std::shared_ptr<BaseTable> BaseTable::tabXor (BaseTable* that)
 {
     AlwaysAssert (!isNull(), AipsError);
     //# Check if both table have the same root.
@@ -980,27 +948,19 @@ BaseTable* BaseTable::tabXor (BaseTable* that)
 	return tabNot();
     }
     //# There is no root table involved, so we have to deal with RefTables.
-    //# Get both rownr arrays and sort them if not in row order.
-    //# Sorting means that the array is allocated on the heap, which has
-    //# to be deleted afterwards.
-    Bool allsw1, allsw2;
-    rownr_t* inx1;
-    rownr_t* inx2;
-    rownr_t nr1 = this->logicRows (inx1, allsw1);
-    rownr_t nr2 = that->logicRows (inx2, allsw2);
-    RefTable* rtp = makeRefTable (True, 0);           // will be in row order
-    rtp->refXor (nr1, inx1, nr2, inx2);       // store rownrs in new RefTable
-    if (allsw1) {
-	delete [] inx1;
-    }
-    if (allsw2) {
-	delete [] inx2;
-    }
-    return rtp;
+    //# Get both rownr arrays which are sorted if not in row order.
+    Vector<rownr_t> r1 = this->logicRows();
+    Vector<rownr_t> r2 = that->logicRows();
+    // Create RefTable which will be in row order.
+    std::shared_ptr<BaseTable> baseTabPtr = makeRefTable (True, 0);
+    RefTable* rtp = baseTabPtr->asRefTable();
+    // Store rownrs in new RefTable.
+    rtp->refXor (r1.size(), r1.data(), r2.size(), r2.data());
+    return baseTabPtr;
 }
 
 //# Negate a table (i.e. take all rows from the root not in table).
-BaseTable* BaseTable::tabNot()
+std::shared_ptr<BaseTable> BaseTable::tabNot()
 {
     AlwaysAssert (!isNull(), AipsError);
     //# Negating the (possibly sorted) root results in an empty table,
@@ -1008,18 +968,14 @@ BaseTable* BaseTable::tabNot()
 	return makeRefTable (True, 0);
     }
     //# There is no root table involved, so we have to deal with RefTables.
-    //# Get both rownr arrays and sort them if not in row order.
-    //# Sorting means that the array is allocated on the heap, which has
-    //# to be deleted.
-    Bool allsw1;
-    rownr_t* inx1;
-    rownr_t nr1 = this->logicRows (inx1, allsw1);
-    RefTable* rtp = makeRefTable (True, 0);           // will be in row order
-    rtp->refNot (nr1, inx1, root()->nrow());    // store rownrs in new RefTable
-    if (allsw1) {
-	delete [] inx1;
-    }
-    return rtp;
+    //# Get rownr array which is sorted if not in row order.
+    Vector<rownr_t> r1 = this->logicRows();
+    // Create RefTable which will be in row order.
+    std::shared_ptr<BaseTable> baseTabPtr = makeRefTable (True, 0);
+    RefTable* rtp = baseTabPtr->asRefTable();
+    // Store rownrs in new RefTable.
+    rtp->refNot (r1.size(), r1.data(), root()->nrow());
+    return baseTabPtr;
 }
 
 //# Check if both tables have the same root.
@@ -1033,22 +989,18 @@ void BaseTable::logicCheck (BaseTable* that)
 //# Get the rownrs from the reference table.
 //# Note that rowStorage() throws an exception if it is not a RefTable.
 //# Sort them if not in row order.
-rownr_t BaseTable::logicRows (rownr_t*& inx, Bool& allsw)
+Vector<rownr_t> BaseTable::logicRows()
 {
     AlwaysAssert (!isNull(), AipsError);
-    allsw = False;
-    inx = RefTable::getStorage (*rowStorage());
-    rownr_t nr = nrow();
-    if (!rowOrder()) {
-	//# rows are not in order, so sort them.
-	//# They have to be copied, because the original should not be changed.
-	rownr_t* inxcp = new rownr_t[nr];
-	objcopy (inxcp, inx, nr);
-	GenSort<rownr_t>::sort (inxcp, nr);
-	inx = inxcp;
-	allsw = True;
+    Vector<rownr_t> rows (rowStorage());
+    if (rowOrder()) {
+      return rows;
     }
-    return nr;
+    //# rows are not in order, so sort them.
+    //# They have to be copied, because the original should not be changed.
+    Vector<rownr_t> rowscp (rows.copy());
+    GenSort<rownr_t>::sort (rowscp);
+    return rowscp;
 }
 
 
@@ -1063,7 +1015,7 @@ BaseTableIterator* BaseTable::makeIterator
     ||  names.nelements() != cmpObj.nelements()) {
 	throw (TableInvOper ("TableIterator: Unequal block lengths"));
     }
-    BaseTableIterator* bti = new BaseTableIterator (this, names,
+    BaseTableIterator* bti = new BaseTableIterator (getSharedPtr(), names,
                                                    cmpObj, order, option,
                                                    cacheIterationBoundaries);
     return bti;

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -889,7 +889,7 @@ std::shared_ptr<BaseTable> BaseTable::tabAnd (BaseTable* that)
 std::shared_ptr<BaseTable> BaseTable::tabOr (BaseTable* that)
 {
     AlwaysAssert (!isNull(), AipsError);
-    //# Check if both table have the same root.
+    //# Check if both tables have the same root.
     logicCheck (that);
     //# Oring a table with the (possibly sorted) root table gives the root.
     if (this->nrow() == this->root()->nrow()
@@ -1170,7 +1170,7 @@ void BaseTable::showStructure (ostream& os, Bool showDataMans, Bool showColumns,
         // Do not show if the subtable has the same root as this table.
         // This is needed to avoid endless recursion in case of SORTED_TABLE
         // in a MeasurementSet.
-        if (tab.isSameRoot (Table(this, False))) {
+        if (tab.isSameRoot (Table(this))) {
           os << endl << "Subtable " << keywords.name(i)
              << " references the parent table!!" << endl;
         } else {

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -101,7 +101,7 @@ class AipsIO;
 // </todo>
 
 
-class BaseTable
+class BaseTable: public std::enable_shared_from_this<BaseTable>
 {
 public:
 
@@ -116,14 +116,6 @@ public:
     // Common code shared by the MPI constructor and non-MPI constructor
     void BaseTableCommon (const String& tableName, int tableOption, rownr_t nrrow);
 
-    // Set the weak_ptr to the object itself, so a shared_ptr can be made from it.
-    void setWeakPtr (const std::shared_ptr<BaseTable>& ptr)
-        { thisPtr_p = ptr; }
-
-    // Get a shared_ptr from the weak_ptr, so this BaseTable object can be shared.
-    // It can only be done if the weak_ptr is not expired.
-    std::shared_ptr<BaseTable> getSharedPtr() const;
-  
     virtual ~BaseTable();
 
     // Is the table a null table?
@@ -486,9 +478,6 @@ public:
     std::shared_ptr<BaseTable> makeRefTable (Bool rowOrder,
                                              rownr_t initialNrrow);
 
-    // Cast this BaseTable to a RefTable as checks it is fine.
-    RefTable* asRefTable();
-  
     // Check if the row number is valid.
     // It throws an exception if out of range.
     void checkRowNumber (rownr_t rownr) const

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -39,6 +39,7 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/IO/FileLocker.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
+#include <memory>
 
 #ifdef HAVE_MPI
 #include <mpi.h>
@@ -115,14 +116,15 @@ public:
     // Common code shared by the MPI constructor and non-MPI constructor
     void BaseTableCommon (const String& tableName, int tableOption, rownr_t nrrow);
 
+    // Set the weak_ptr to the object itself, so a shared_ptr can be made from it.
+    void setWeakPtr (const std::shared_ptr<BaseTable>& ptr)
+        { thisPtr_p = ptr; }
+
+    // Get a shared_ptr from the weak_ptr, so this BaseTable object can be shared.
+    // It can only be done if the weak_ptr is not expired.
+    std::shared_ptr<BaseTable> getSharedPtr() const;
+  
     virtual ~BaseTable();
-
-    // Link to this BaseTable object (i.e. increase reference count).
-    void link();
-
-    // Unlink from a BaseTable.
-    // Delete it if no more references.
-    static void unlink (BaseTable*);
 
     // Is the table a null table?
     // By default it is not.
@@ -354,46 +356,44 @@ public:
     // Select rows using the given expression (which can be null).
     // Skip first <src>offset</src> matching rows.
     // Return at most <src>maxRow</src> matching rows.
-    BaseTable* select (const TableExprNode&, rownr_t maxRow, rownr_t offset);
+    std::shared_ptr<BaseTable> select (const TableExprNode&,
+                                       rownr_t maxRow, rownr_t offset);
 
     // Select maxRow rows and skip first offset rows. maxRow=0 means all.
-    BaseTable* select (rownr_t maxRow, rownr_t offset);
+    std::shared_ptr<BaseTable> select (rownr_t maxRow, rownr_t offset);
 
     // Select rows using a vector of row numbers.
-    BaseTable* select (const Vector<rownr_t>& rownrs);
+    std::shared_ptr<BaseTable> select (const Vector<rownr_t>& rownrs);
 
     // Select rows using a mask block.
     // The length of the block must match the number of rows in the table.
     // If True, the corresponding row will be selected.
-    BaseTable* select (const Block<Bool>& mask);
+    std::shared_ptr<BaseTable> select (const Block<Bool>& mask);
 
     // Project the given columns (i.e. select the columns).
-    BaseTable* project (const Block<String>& columnNames);
-
-    //# Virtually concatenate all tables in this column.
-    //# The column cells must contain tables with the same description.
-//#//    BaseTable* concatenate (const String& columnName);
+    std::shared_ptr<BaseTable> project (const Block<String>& columnNames);
 
     // Do logical operations on a table.
     // <group>
     // intersection with another table
-    BaseTable* tabAnd (BaseTable*);
+    std::shared_ptr<BaseTable> tabAnd (BaseTable*);
     // union with another table
-    BaseTable* tabOr  (BaseTable*);
+    std::shared_ptr<BaseTable> tabOr  (BaseTable*);
     // subtract another table
-    BaseTable* tabSub (BaseTable*);
+    std::shared_ptr<BaseTable> tabSub (BaseTable*);
     // xor with another table
-    BaseTable* tabXor (BaseTable*);
+    std::shared_ptr<BaseTable> tabXor (BaseTable*);
     // take complement
-    BaseTable* tabNot ();
+    std::shared_ptr<BaseTable> tabNot ();
     // </group>
 
     // Sort a table on one or more columns of scalars.
-    BaseTable* sort (const Block<String>& columnNames,
-                     const Block<CountedPtr<BaseCompare> >& compareObjects,
-                     const Block<Int>& sortOrder, int sortOption,
-                     std::shared_ptr<Vector<rownr_t>> sortIterBoundaries = nullptr,
-                     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange = nullptr);
+    std::shared_ptr<BaseTable> sort
+    (const Block<String>& columnNames,
+     const Block<CountedPtr<BaseCompare> >& compareObjects,
+     const Block<Int>& sortOrder, int sortOption,
+     std::shared_ptr<Vector<rownr_t>> sortIterBoundaries = nullptr,
+     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange = nullptr);
 
     // Create an iterator.
     BaseTableIterator* makeIterator (const Block<String>& columnNames,
@@ -462,7 +462,7 @@ public:
 
     // By the default the table cannot return the storage of rownrs.
     // That can only be done by a RefTable, where it is implemented.
-    virtual Vector<rownr_t>* rowStorage();
+    virtual Vector<rownr_t>& rowStorage();
 
     // Adjust the row numbers to be the actual row numbers in the
     // root table. This is, for instance, used when a RefTable is sorted.
@@ -473,16 +473,22 @@ public:
     // Do the actual sort.
     // The default implementation is suitable for almost all cases.
     // Only in RefTable a smarter implementation is provided.
-    virtual BaseTable* doSort (PtrBlock<BaseColumn*>&,
-                               const Block<CountedPtr<BaseCompare> >&,
-                               const Block<Int>& sortOrder,
-                               int sortOption,
-                               std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
-                               std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange);
+    virtual std::shared_ptr<BaseTable> doSort
+    (PtrBlock<BaseColumn*>&,
+     const Block<CountedPtr<BaseCompare> >&,
+     const Block<Int>& sortOrder,
+     int sortOption,
+     std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
+     std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange);
 
     // Create a RefTable object.
-    RefTable* makeRefTable (Bool rowOrder, rownr_t initialNrrow);
+    // The returned object can be casted to RefTable using asRefTable() below.
+    std::shared_ptr<BaseTable> makeRefTable (Bool rowOrder,
+                                             rownr_t initialNrrow);
 
+    // Cast this BaseTable to a RefTable as checks it is fine.
+    RefTable* asRefTable();
+  
     // Check if the row number is valid.
     // It throws an exception if out of range.
     void checkRowNumber (rownr_t rownr) const
@@ -492,9 +498,8 @@ public:
     int traceId() const
         { return itsTraceId; }
 
-
 protected:
-    uInt           nrlink_p;            //# #references to this table
+    std::weak_ptr<BaseTable> thisPtr_p; //# pointer to itself (to make shared_ptr)
     rownr_t        nrrow_p;             //# #rows in this table
     rownr_t        nrrowToAdd_p;        //# #rows to be added
     CountedPtr<TableDesc> tdescPtr_p;   //# Pointer to table description
@@ -584,7 +589,7 @@ private:
 
     // Get the rownrs of the table in ascending order to be
     // used in the logical operation on the table.
-    rownr_t logicRows (rownr_t*& rownrs, Bool& allocated);
+    Vector<rownr_t> logicRows();
 
     // Make an empty table description.
     // This is used if one asks for the description of a NullTable.

--- a/tables/Tables/ConcatTable.h
+++ b/tables/Tables/ConcatTable.h
@@ -303,8 +303,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Block<BaseColumn*> getRefColumns (const String& columnName);
 
     // Create a (temporary) Table object from it.
-    Table asTable()
-      { return Table (this, False); }
+    //Table asTable()
+    ///  { return Table (this, False); }
 
   private:
     // Copy constructor is forbidden, because copying a table requires

--- a/tables/Tables/ConcatTable.h
+++ b/tables/Tables/ConcatTable.h
@@ -302,10 +302,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Get the column objects in the referenced tables.
     Block<BaseColumn*> getRefColumns (const String& columnName);
 
-    // Create a (temporary) Table object from it.
-    //Table asTable()
-    ///  { return Table (this, False); }
-
   private:
     // Copy constructor is forbidden, because copying a table requires
     // some more knowledge (like table name of result).

--- a/tables/Tables/MemoryTable.cc
+++ b/tables/Tables/MemoryTable.cc
@@ -271,7 +271,7 @@ void MemoryTable::addColumn (const ColumnDesc& columnDesc,
 void MemoryTable::addColumn (const ColumnDesc& columnDesc,
 			     const DataManager& dataManager, Bool)
 {
-  Table tab(this, False);
+  Table tab(this, False);   // a temporary Table object
   // Make sure the MemoryStMan is used if no virtual engine is used.
   if (dataManager.isStorageManager()) {
     addColumn (columnDesc, False);

--- a/tables/Tables/MemoryTable.cc
+++ b/tables/Tables/MemoryTable.cc
@@ -74,7 +74,7 @@ MemoryTable::MemoryTable (SetupNewTable& newtab, rownr_t nrrow, Bool initialize)
 				 0, this);
   colSetPtr_p->linkToLockObject (lockPtr_p);
   //# Initialize the data managers.
-  Table tab(this, False);
+  Table tab(this);
   nrrowToAdd_p = nrrow;
   colSetPtr_p->initDataManagers (nrrow, False,
                                  TSMOption(TSMOption::Cache,0,0), tab);
@@ -245,7 +245,7 @@ void MemoryTable::removeRow (rownr_t rownr)
 
 void MemoryTable::addColumn (const ColumnDesc& columnDesc, Bool)
 {
-  Table tab(this, False);
+  Table tab(this);
   ColumnDesc cold(columnDesc);
   // Make sure the MemoryStMan is used.
   cold.dataManagerType() = "MemoryStMan";
@@ -256,7 +256,7 @@ void MemoryTable::addColumn (const ColumnDesc& columnDesc, Bool)
 void MemoryTable::addColumn (const ColumnDesc& columnDesc,
 			     const String& dataManager, Bool byName, Bool)
 {
-  Table tab(this, False);
+  Table tab(this);
   if (byName) {
     colSetPtr_p->addColumn (columnDesc, dataManager, byName, False,
                             TSMOption(TSMOption::Cache,0,0), tab);
@@ -271,7 +271,7 @@ void MemoryTable::addColumn (const ColumnDesc& columnDesc,
 void MemoryTable::addColumn (const ColumnDesc& columnDesc,
 			     const DataManager& dataManager, Bool)
 {
-  Table tab(this, False);   // a temporary Table object
+  Table tab(this);   // a temporary Table object
   // Make sure the MemoryStMan is used if no virtual engine is used.
   if (dataManager.isStorageManager()) {
     addColumn (columnDesc, False);
@@ -283,7 +283,7 @@ void MemoryTable::addColumn (const ColumnDesc& columnDesc,
 void MemoryTable::addColumn (const TableDesc& tableDesc,
 			     const DataManager& dataManager, Bool)
 {
-  Table tab(this, False);
+  Table tab(this);
   // Make sure the MemoryStMan is used if no virtual engine is used.
   if (dataManager.isStorageManager()) {
     MemoryStMan stman(dataManager.dataManagerName());

--- a/tables/Tables/NullTable.cc
+++ b/tables/Tables/NullTable.cc
@@ -240,7 +240,7 @@ Bool NullTable::rowOrder() const
   throw makeError ("rowOrder");
 }
 
-Vector<rownr_t>* NullTable::rowStorage()
+Vector<rownr_t>& NullTable::rowStorage()
 {
   throw makeError ("rowStorage");
 }
@@ -251,12 +251,12 @@ Bool NullTable::adjustRownrs (rownr_t, Vector<rownr_t>&,
   throw makeError ("adjustRownrs");
 }
 
-BaseTable* NullTable::doSort (PtrBlock<BaseColumn*>&,
-                             const Block<CountedPtr<BaseCompare> >&,
-                             const Block<Int>&,
-                             int,
-                             std::shared_ptr<Vector<rownr_t>>,
-                             std::shared_ptr<Vector<size_t>>)
+  std::shared_ptr<BaseTable> NullTable::doSort (PtrBlock<BaseColumn*>&,
+                                                const Block<CountedPtr<BaseCompare> >&,
+                                                const Block<Int>&,
+                                                int,
+                                                std::shared_ptr<Vector<rownr_t>>,
+                                                std::shared_ptr<Vector<size_t>>)
 {
   throw makeError ("doSort");
 }

--- a/tables/Tables/NullTable.h
+++ b/tables/Tables/NullTable.h
@@ -127,15 +127,15 @@ public:
   virtual Vector<rownr_t> rowNumbers() const override;
   virtual BaseTable* root() override;
   virtual Bool rowOrder() const override;
-  virtual Vector<rownr_t>* rowStorage() override;
+  virtual Vector<rownr_t>& rowStorage() override;
   virtual Bool adjustRownrs (rownr_t nrrow, Vector<rownr_t>& rownrs,
 			     Bool determineOrder) const override;
-  virtual BaseTable* doSort (PtrBlock<BaseColumn*>&,
-                             const Block<CountedPtr<BaseCompare> >&,
-                             const Block<Int>& sortOrder,
-                             int sortOption,
-                             std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,
-                             std::shared_ptr<Vector<size_t>> sortIterKeyIdxChange) override;
+  virtual std::shared_ptr<BaseTable> doSort (PtrBlock<BaseColumn*>&,
+                                             const Block<CountedPtr<BaseCompare> >&,
+                                             const Block<Int>&,
+                                             int,
+                                             std::shared_ptr<Vector<rownr_t>>,
+                                             std::shared_ptr<Vector<size_t>>) override;
   virtual void renameSubTables (const String& newName,
 				const String& oldName) override;
   // </group>

--- a/tables/Tables/PlainTable.cc
+++ b/tables/Tables/PlainTable.cc
@@ -465,11 +465,12 @@ void PlainTable::syncTable()
     // Something changed in the table file itself.
     // Reread it into a PlainTable object (don't add it to the cache).
     // Use a different locknr for it to preserve possible existing locks.
-    BaseTable* btab = Table::makeBaseTable
-                         (tableName(), "", Table::Old,
-			  TableLock(TableLock::PermanentLocking),
-			  TSMOption(TSMOption::Buffer,0,0), False, 1);
-    PlainTable* tab = (PlainTable*)btab;
+    std::shared_ptr<BaseTable> btab = Table::makeBaseTable
+      (tableName(), "", Table::Old,
+       TableLock(TableLock::PermanentLocking),
+       TSMOption(TSMOption::Buffer,0,0), False, 1);
+    PlainTable* tab = dynamic_cast<PlainTable*>(btab.get());
+    AlwaysAssert (tab, AipsError);
     TableAttr defaultAttr (tableName(), isWritable(), lockOptions());
     // Now check if all columns are the same.
     // Update the column keywords.
@@ -789,7 +790,6 @@ void PlainTable::setEndian (int endianFormat)
     if (endOpt == Table::AipsrcEndian) {
         String opt;
 	// Default "big" was used until version 10.1203.00.
-	////AipsrcValue<String>::find (opt, "table.endianformat", "big");
 	AipsrcValue<String>::find (opt, "table.endianformat", "local");
 	opt.downcase();
 	if (opt == "big") {

--- a/tables/Tables/PlainTable.cc
+++ b/tables/Tables/PlainTable.cc
@@ -133,7 +133,7 @@ void PlainTable::PlainTableCommon (SetupNewTable& newtab, rownr_t nrrow,
     lockPtr_p->acquire (0, FileLocker::Write, 1);
     colSetPtr_p->linkToLockObject (lockPtr_p);
     //# Initialize the data managers.
-    Table tab(this, False);
+    Table tab(this);
     nrrowToAdd_p = nrrow;
     colSetPtr_p->initDataManagers (nrrow, bigEndian_p, tsmOption_p, tab);
     //# Initialize the columns if needed.
@@ -263,7 +263,7 @@ PlainTable::PlainTable (AipsIO&, uInt version, const String& tabname,
     }
     //# Create a Table object to be used internally by the data managers.
     //# Do not count it, otherwise a mutual dependency exists.
-    Table tab(this, False);
+    Table tab(this);
     nrrow_p = colSetPtr_p->getFile (ios, tab, nrrow_p, bigEndian_p,
                                     tsmOption_p);
     //# Read the TableInfo object.
@@ -703,7 +703,7 @@ void PlainTable::removeRow (rownr_t rownr)
 void PlainTable::addColumn (const ColumnDesc& columnDesc, Bool)
 {
     checkWritable("addColumn");
-    Table tab(this, False);
+    Table tab(this);
     colSetPtr_p->addColumn (columnDesc, bigEndian_p, tsmOption_p, tab);
     tableChanged_p = True;
 }
@@ -711,7 +711,7 @@ void PlainTable::addColumn (const ColumnDesc& columnDesc,
 			    const String& dataManager, Bool byName, Bool)
 {
     checkWritable("addColumn");
-    Table tab(this, False);
+    Table tab(this);
     colSetPtr_p->addColumn (columnDesc, dataManager, byName, bigEndian_p,
                             tsmOption_p, tab);
     tableChanged_p = True;
@@ -720,7 +720,7 @@ void PlainTable::addColumn (const ColumnDesc& columnDesc,
 			    const DataManager& dataManager, Bool)
 {
     checkWritable("addColumn");
-    Table tab(this, False);
+    Table tab(this);
     colSetPtr_p->addColumn (columnDesc, dataManager, bigEndian_p,
                             tsmOption_p, tab);
     tableChanged_p = True;
@@ -729,7 +729,7 @@ void PlainTable::addColumn (const TableDesc& tableDesc,
 			    const DataManager& dataManager, Bool)
 {
     checkWritable("addColumn");
-    Table tab(this, False);
+    Table tab(this);
     colSetPtr_p->addColumn (tableDesc, dataManager, bigEndian_p,
                             tsmOption_p, tab);
     tableChanged_p = True;

--- a/tables/Tables/RefTable.cc
+++ b/tables/Tables/RefTable.cc
@@ -64,7 +64,7 @@ RefTable::RefTable (AipsIO& ios, const String& name, rownr_t nrrow, int opt,
 
 RefTable::RefTable (BaseTable* btp, Bool order, rownr_t nrall)
 : BaseTable    ("", Table::Scratch, nrall),
-  baseTabPtr_p (btp->root()->getSharedPtr()),
+  baseTabPtr_p (btp->root()->shared_from_this()),
   rowOrd_p     (order),
   rowStorage_p (nrall),       // allocate vector of rownrs
   changed_p    (True)
@@ -79,7 +79,7 @@ RefTable::RefTable (BaseTable* btp, Bool order, rownr_t nrall)
 
 RefTable::RefTable (BaseTable* btp, const Vector<rownr_t>& rownrs)
 : BaseTable    ("", Table::Scratch, rownrs.nelements()),
-  baseTabPtr_p (btp->root()->getSharedPtr()),
+  baseTabPtr_p (btp->root()->shared_from_this()),
   rowOrd_p     (True),
   rowStorage_p (0),
   changed_p    (True)
@@ -104,7 +104,7 @@ RefTable::RefTable (BaseTable* btp, const Vector<rownr_t>& rownrs)
 
 RefTable::RefTable (BaseTable* btp, const Vector<Bool>& mask)
 : BaseTable    ("", Table::Scratch, 0),
-  baseTabPtr_p (btp->root()->getSharedPtr()),
+  baseTabPtr_p (btp->root()->shared_from_this()),
   rowOrd_p     (btp->rowOrder()),
   rowStorage_p (0),              // initially empty vector of rownrs
   changed_p    (True)
@@ -126,7 +126,7 @@ RefTable::RefTable (BaseTable* btp, const Vector<Bool>& mask)
 
 RefTable::RefTable (BaseTable* btp, const Vector<String>& columnNames)
 : BaseTable    ("", Table::Scratch, btp->nrow()),
-  baseTabPtr_p (btp->root()->getSharedPtr()),
+  baseTabPtr_p (btp->root()->shared_from_this()),
   rowOrd_p     (btp->rowOrder()),
   rowStorage_p (0),
   changed_p    (True)
@@ -387,7 +387,7 @@ void RefTable::getRef (AipsIO& ios, int opt, const TableLock& lockOptions,
     }else{
         tab = Table(rootName, lockOptions, Table::Update, tsmOption);
     }
-    baseTabPtr_p = tab.baseTablePtr()->getSharedPtr();
+    baseTabPtr_p = tab.baseTablePtr()->shared_from_this();
     if (rootNrow > baseTabPtr_p->nrow()) {
 	throw (TableInvOper
 	           ("RefTable::getRef, #rows in referenced table decreased"));

--- a/tables/Tables/RefTable.h
+++ b/tables/Tables/RefTable.h
@@ -333,7 +333,6 @@ private:
     std::shared_ptr<BaseTable> baseTabPtr_p;//# pointer to parent table
     Bool            rowOrd_p;               //# True = table is in row order
     Vector<rownr_t> rowStorage_p;           //# row numbers in parent table
-    rownr_t*        rows_p;                 //# Pointer to data in rowStorage_p
     std::map<String,String> nameMap_p;      //# map to column name in parent
     std::map<String,RefColumn*> colMap_p;   //# map name to column
     Bool            changed_p;              //# True = changed since last write
@@ -391,7 +390,7 @@ private:
 
 
 inline rownr_t RefTable::rootRownr (rownr_t rnr) const
-    { return rows_p[rnr]; }
+    { return rowStorage_p[rnr]; }
 
 
 

--- a/tables/Tables/RefTable.h
+++ b/tables/Tables/RefTable.h
@@ -305,7 +305,7 @@ public:
 
     // Get row number vector.
     // This is used by the BaseTable logic and sort routines.
-    virtual Vector<rownr_t>* rowStorage();
+    virtual Vector<rownr_t>& rowStorage();
 
     // Add a rownr to reference table.
     void addRownr (rownr_t rownr);
@@ -329,15 +329,11 @@ void addRownrRange (rownr_t startRownr, rownr_t endRownr);
     void refXor (rownr_t nr1, const rownr_t* rows1, rownr_t nr2, const rownr_t* rows2);
     void refNot (rownr_t nr1, const rownr_t* rows1, rownr_t nrmain);
 
-    // Get the internal pointer in a rowStorage vector.
-    // It checks whether no copy is made of the data.
-    static rownr_t* getStorage (Vector<rownr_t>& rownrs);
-
 private:
-    BaseTable*      baseTabPtr_p;           //# pointer to parent table
+    std::shared_ptr<BaseTable> baseTabPtr_p;//# pointer to parent table
     Bool            rowOrd_p;               //# True = table is in row order
     Vector<rownr_t> rowStorage_p;           //# row numbers in parent table
-    rownr_t*        rows_p;                 //# Pointer to rowStorage_p
+    rownr_t*        rows_p;                 //# Pointer to data in rowStorage_p
     std::map<String,String> nameMap_p;      //# map to column name in parent
     std::map<String,RefColumn*> colMap_p;   //# map name to column
     Bool            changed_p;              //# True = changed since last write

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -68,16 +68,15 @@ Table::ScratchCallback* Table::setScratchCallback
 
 Table::Table()
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new NullTable();
-    baseTabPtr_p->link();
+  countedTabPtr_p.reset (new NullTable());
+  baseTabPtr_p = countedTabPtr_p.get();
+  baseTabPtr_p->setWeakPtr (countedTabPtr_p);
 }
 
   Table::Table (const String& name, TableOption option, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
   open (name, "", option, TableLock(), tsmOpt);
@@ -86,7 +85,6 @@ Table::Table()
 Table::Table (const String& name, const TableLock& lockOptions,
 	      TableOption option, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
   open (name, "", option, lockOptions, tsmOpt);
@@ -95,7 +93,6 @@ Table::Table (const String& name, const TableLock& lockOptions,
   Table::Table (const String& name, const String& type, TableOption option,
                 const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
   open (name, type, option, TableLock(), tsmOpt);
@@ -105,7 +102,6 @@ Table::Table (const String& name, const String& type,
 	      const TableLock& lockOptions, TableOption option,
               const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
   open (name, type, option, lockOptions, tsmOpt);
@@ -114,82 +110,76 @@ Table::Table (const String& name, const String& type,
   Table::Table (Table::TableType type, Table::EndianFormat endianFormat,
                 const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
     SetupNewTable newtab("", TableDesc(), Table::Scratch);
+    BaseTable* ptr;
     if (type == Table::Memory) {
-        baseTabPtr_p = new MemoryTable (newtab, 0, False);
+      ptr = new MemoryTable (newtab, 0, False);
     } else {
-        baseTabPtr_p = new PlainTable (newtab, 0, False,
-				       TableLock(), endianFormat, tsmOpt);
+      ptr = new PlainTable (newtab, 0, False,
+                            TableLock(), endianFormat, tsmOpt);
     }
-    baseTabPtr_p->link();
+    initBasePtr (ptr);
 }
 
 Table::Table (SetupNewTable& newtab, rownr_t nrrow, Bool initialize,
 	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new PlainTable (newtab, nrrow, initialize,
-				   TableLock(), endianFormat, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new PlainTable (newtab, nrrow, initialize,
+                                 TableLock(), endianFormat, tsmOpt));
 }
 Table::Table (SetupNewTable& newtab, Table::TableType type,
 	      rownr_t nrrow, Bool initialize,
 	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
+    BaseTable* ptr;
     if (type == Table::Memory) {
-        baseTabPtr_p = new MemoryTable (newtab, nrrow, initialize);
+        ptr = new MemoryTable (newtab, nrrow, initialize);
     } else {
-        baseTabPtr_p = new PlainTable (newtab, nrrow, initialize,
-				       TableLock(), endianFormat, tsmOpt);
+        ptr = new PlainTable (newtab, nrrow, initialize,
+                              TableLock(), endianFormat, tsmOpt);
     }
-    baseTabPtr_p->link();
+    initBasePtr (ptr);
 }
 Table::Table (SetupNewTable& newtab, Table::TableType type,
 	      const TableLock& lockOptions,
 	      rownr_t nrrow, Bool initialize,
 	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
+    BaseTable* ptr;
     if (type == Table::Memory) {
-        baseTabPtr_p = new MemoryTable (newtab, nrrow, initialize);
+        ptr = new MemoryTable (newtab, nrrow, initialize);
     } else {
-        baseTabPtr_p = new PlainTable (newtab, nrrow, initialize,
-				       lockOptions, endianFormat, tsmOpt);
+        ptr = new PlainTable (newtab, nrrow, initialize,
+                              lockOptions, endianFormat, tsmOpt);
     }
-    baseTabPtr_p->link();
+    initBasePtr (ptr);
 }
 Table::Table (SetupNewTable& newtab, TableLock::LockOption lockOption,
 	      rownr_t nrrow, Bool initialize, Table::EndianFormat endianFormat,
               const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new PlainTable (newtab, nrrow, initialize,
-				   TableLock(lockOption),
-				   endianFormat, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new PlainTable (newtab, nrrow, initialize,
+                                 TableLock(lockOption),
+                                 endianFormat, tsmOpt));
 }
 Table::Table (SetupNewTable& newtab, const TableLock& lockOptions,
 	      rownr_t nrrow, Bool initialize, Table::EndianFormat endianFormat,
               const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new PlainTable (newtab, nrrow, initialize, lockOptions,
-				   endianFormat, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new PlainTable (newtab, nrrow, initialize, lockOptions,
+                                 endianFormat, tsmOpt));
 }
 
 #ifdef HAVE_MPI
@@ -197,44 +187,42 @@ Table::Table (SetupNewTable& newtab, const TableLock& lockOptions,
 Table::Table (MPI_Comm mpiComm, Table::TableType type, Table::EndianFormat endianFormat,
                 const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
     SetupNewTable newtab("", TableDesc(), Table::Scratch);
+    BaseTable* ptr;
     if (type == Table::Memory) {
-        baseTabPtr_p = new MemoryTable (newtab, 0, False);
+        ptr = new MemoryTable (newtab, 0, False);
     } else {
-        baseTabPtr_p = new PlainTable (mpiComm, newtab, 0, False,
-				       TableLock(), endianFormat, tsmOpt);
+        ptr = new PlainTable (mpiComm, newtab, 0, False,
+                              TableLock(), endianFormat, tsmOpt);
     }
-    baseTabPtr_p->link();
+    initBasePtr (ptr);
 }
 
 Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, rownr_t nrrow, Bool initialize,
 	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
-				   TableLock(), endianFormat, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new PlainTable (mpiComm, newtab, nrrow, initialize,
+                                 TableLock(), endianFormat, tsmOpt));
 }
 
 Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, Table::TableType type,
 	      rownr_t nrrow, Bool initialize,
 	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
+    BaseTable* ptr;
     if (type == Table::Memory) {
-        baseTabPtr_p = new MemoryTable (newtab, nrrow, initialize);
+        ptr = new MemoryTable (newtab, nrrow, initialize);
     } else {
-        baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
-				       TableLock(), endianFormat, tsmOpt);
+        ptr  = new PlainTable (mpiComm, newtab, nrrow, initialize,
+                               TableLock(), endianFormat, tsmOpt);
     }
-    baseTabPtr_p->link();
+    initBasePtr (ptr);
 }
 
 Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, Table::TableType type,
@@ -242,41 +230,37 @@ Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, Table::TableType type,
 	      rownr_t nrrow, Bool initialize,
 	      Table::EndianFormat endianFormat, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
+    BaseTable* ptr;
     if (type == Table::Memory) {
-        baseTabPtr_p = new MemoryTable (newtab, nrrow, initialize);
+        ptr = new MemoryTable (newtab, nrrow, initialize);
     } else {
-        baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
-				       lockOptions, endianFormat, tsmOpt);
+        ptr = new PlainTable (mpiComm, newtab, nrrow, initialize,
+                              lockOptions, endianFormat, tsmOpt);
     }
-    baseTabPtr_p->link();
+    initBasePtr (ptr);
 }
 
 Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, TableLock::LockOption lockOption,
 	      rownr_t nrrow, Bool initialize, Table::EndianFormat endianFormat,
               const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize,
-				   TableLock(lockOption),
-				   endianFormat, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new PlainTable (mpiComm, newtab, nrrow, initialize,
+                                 TableLock(lockOption),
+                                 endianFormat, tsmOpt));
 }
 
 Table::Table (MPI_Comm mpiComm, SetupNewTable& newtab, const TableLock& lockOptions,
 	      rownr_t nrrow, Bool initialize, Table::EndianFormat endianFormat,
               const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new PlainTable (mpiComm, newtab, nrrow, initialize, lockOptions,
-				   endianFormat, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new PlainTable (mpiComm, newtab, nrrow, initialize, lockOptions,
+                                 endianFormat, tsmOpt));
 }
 
 #endif
@@ -285,11 +269,9 @@ Table::Table (const Block<Table>& tables,
 	      const Block<String>& subTables,
               const String& subDirName)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new ConcatTable (tables, subTables, subDirName);
-    baseTabPtr_p->link();
+    initBasePtr (new ConcatTable (tables, subTables, subDirName));
 }
 
 Table::Table (const Block<String>& tableNames,
@@ -297,12 +279,10 @@ Table::Table (const Block<String>& tableNames,
 	      TableOption option, const TSMOption& tsmOpt,
               const String& subDirName)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-    baseTabPtr_p = new ConcatTable (tableNames, subTables, subDirName,
-				    option, TableLock(), tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new ConcatTable (tableNames, subTables, subDirName,
+                                  option, TableLock(), tsmOpt));
 }
 
 Table::Table (const Block<String>& tableNames,
@@ -310,57 +290,64 @@ Table::Table (const Block<String>& tableNames,
 	      const TableLock& lockOptions,
 	      TableOption option, const TSMOption& tsmOpt)
 : baseTabPtr_p     (0),
-  isCounted_p      (True),
   lastModCounter_p (0)
 {
-  baseTabPtr_p = new ConcatTable (tableNames, subTables, String(),
-				    option, lockOptions, tsmOpt);
-    baseTabPtr_p->link();
+    initBasePtr (new ConcatTable (tableNames, subTables, String(),
+                                  option, lockOptions, tsmOpt));
 }
 
 Table::Table (BaseTable* btp, Bool countIt)
-: baseTabPtr_p     (btp),
-  isCounted_p      (countIt),
+: baseTabPtr_p     (0),
   lastModCounter_p (0)
 {
-    if (isCounted_p  &&  baseTabPtr_p != 0) {
-	baseTabPtr_p->link();
-    }
+  std::shared_ptr<BaseTable> shptr = btp->getSharedPtr();
+  baseTabPtr_p = shptr.get();
+  if (countIt) {
+    countedTabPtr_p = shptr;
+  }
+}
+
+Table::Table (const std::shared_ptr<BaseTable>& shptr, Bool countIt)
+: baseTabPtr_p     (0),
+  lastModCounter_p (0)
+{
+  baseTabPtr_p = shptr.get();
+  baseTabPtr_p->setWeakPtr (shptr);
+  if (countIt) {
+    countedTabPtr_p = shptr;
+  }
 }
 
 Table::Table (const Table& that)
-: baseTabPtr_p     (that.baseTabPtr_p),
-  isCounted_p      (that.isCounted_p),
+: countedTabPtr_p  (that.countedTabPtr_p),
+  baseTabPtr_p     (that.baseTabPtr_p),
   lastModCounter_p (that.lastModCounter_p)
-{
-    if (isCounted_p  &&  baseTabPtr_p != 0) {
-	baseTabPtr_p->link();
-    }
-}
+{}
 
 
 Table::~Table()
 {
-    if (isCounted_p  &&  baseTabPtr_p != 0) {
+    if (countedTabPtr_p) {
 #ifdef CASACORE_UNLOCK_TABLE_ON_DESTRUCT
         unlock();
 #endif
-	BaseTable::unlink (baseTabPtr_p);
     }
 }
 
 Table& Table::operator= (const Table& that)
 {
-    if (isCounted_p  &&  baseTabPtr_p != 0) {
-	BaseTable::unlink (baseTabPtr_p);
-    }
+    countedTabPtr_p  = that.countedTabPtr_p;
     baseTabPtr_p     = that.baseTabPtr_p;
-    isCounted_p      = that.isCounted_p;
     lastModCounter_p = that.lastModCounter_p;
-    if (isCounted_p  &&  baseTabPtr_p != 0) {
-	baseTabPtr_p->link();
-    }
     return *this;
+}
+
+void Table::initBasePtr (BaseTable* ptr)
+{
+  AlwaysAssert (!baseTabPtr_p, AipsError);
+  baseTabPtr_p = ptr;
+  countedTabPtr_p.reset (baseTabPtr_p);
+  baseTabPtr_p->setWeakPtr (countedTabPtr_p);
 }
 
 Block<String> Table::getPartNames (Bool recursive) const
@@ -458,7 +445,7 @@ void Table::open (const String& name, const String& type, int tableOption,
     //# If so, link to it.
     BaseTable* btp = lookCache (absName, tableOption, lockOptions);
     if (btp != 0) {
-	baseTabPtr_p = btp;
+        countedTabPtr_p = btp->getSharedPtr();
     }else{
         //# Check if the table directory exists.
         File dir(absName);
@@ -485,10 +472,10 @@ void Table::open (const String& name, const String& type, int tableOption,
 	    throw (TableNoFile (absName));
 	}
 	// Create the BaseTable object and add a PlainTable to the cache.
-	baseTabPtr_p = makeBaseTable (absName, type, tableOption,
-				      lockOptions, tsmOpt, True, 0);
+	countedTabPtr_p = makeBaseTable (absName, type, tableOption,
+                                         lockOptions, tsmOpt, True, 0);
     }
-    baseTabPtr_p->link();
+    baseTabPtr_p = countedTabPtr_p.get();
     if (deleteOpt) {
 	markForDelete();
     }
@@ -496,12 +483,13 @@ void Table::open (const String& name, const String& type, int tableOption,
 
 // NOTE: When changing this function because of new Table versions, also change
 // TableUtil::getLayout !!!!!
-BaseTable* Table::makeBaseTable (const String& name, const String& type,
-				 int tableOption, const TableLock& lockOptions,
-				 const TSMOption& tsmOpt,
-                                 Bool addToCache, uInt locknr)
+std::shared_ptr<BaseTable> Table::makeBaseTable
+(const String& name, const String& type,
+ int tableOption, const TableLock& lockOptions,
+ const TSMOption& tsmOpt,
+ Bool addToCache, uInt locknr)
 {
-    BaseTable* baseTabPtr = 0;
+    std::shared_ptr<BaseTable> baseTabPtr;
     //# Determine the file option for the table.
     //# Only existing tables can be opened.
     //# This is guaranteed by the calling functions.
@@ -527,19 +515,19 @@ BaseTable* Table::makeBaseTable (const String& name, const String& type,
     ios >> format;
     ios >> tp;
     if (tp == "PlainTable") {
-	baseTabPtr = new PlainTable (ios, version, name, type, nrrow,
-				     tableOption, lockOptions, tsmOpt,
-                                     addToCache, locknr);
+      baseTabPtr.reset (new PlainTable (ios, version, name, type, nrrow,
+                                        tableOption, lockOptions, tsmOpt,
+                                        addToCache, locknr));
     } else if (tp == "RefTable") {
-	baseTabPtr = new RefTable (ios, name, nrrow, tableOption,
-                                   lockOptions, tsmOpt);
+      baseTabPtr.reset (new RefTable (ios, name, nrrow, tableOption,
+                                      lockOptions, tsmOpt));
     } else if (tp == "ConcatTable") {
-	baseTabPtr = new ConcatTable (ios, name, nrrow, tableOption,
-				      lockOptions, tsmOpt);
+      baseTabPtr.reset (new ConcatTable (ios, name, nrrow, tableOption,
+                                         lockOptions, tsmOpt));
     } else {
-	throw (TableInternalError
-	       ("Table::open: unknown table kind " + tp));
+      throw (TableInternalError("Table::open: unknown table kind " + tp));
     }
+    baseTabPtr->setWeakPtr (baseTabPtr);
     return baseTabPtr;
 }
 

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -296,26 +296,19 @@ Table::Table (const Block<String>& tableNames,
                                   option, lockOptions, tsmOpt));
 }
 
-Table::Table (BaseTable* btp, Bool countIt)
-: baseTabPtr_p     (0),
+Table::Table (BaseTable* btp)
+: baseTabPtr_p     (btp),
   lastModCounter_p (0)
-{
-  std::shared_ptr<BaseTable> shptr = btp->getSharedPtr();
-  baseTabPtr_p = shptr.get();
-  if (countIt) {
-    countedTabPtr_p = shptr;
-  }
-}
+{}
 
-Table::Table (const std::shared_ptr<BaseTable>& shptr, Bool countIt)
+Table::Table (const std::shared_ptr<BaseTable>& shptr)
 : baseTabPtr_p     (0),
   lastModCounter_p (0)
 {
   baseTabPtr_p = shptr.get();
+  AlwaysAssert (baseTabPtr_p, AipsError);
   baseTabPtr_p->setWeakPtr (shptr);
-  if (countIt) {
-    countedTabPtr_p = shptr;
-  }
+  countedTabPtr_p = shptr;
 }
 
 Table::Table (const Table& that)

--- a/tables/Tables/Table.cc
+++ b/tables/Tables/Table.cc
@@ -72,7 +72,6 @@ Table::Table()
 {
   countedTabPtr_p.reset (new NullTable());
   baseTabPtr_p = countedTabPtr_p.get();
-  baseTabPtr_p->setWeakPtr (countedTabPtr_p);
 }
 
   Table::Table (const String& name, TableOption option, const TSMOption& tsmOpt)
@@ -307,7 +306,6 @@ Table::Table (const std::shared_ptr<BaseTable>& shptr)
 {
   baseTabPtr_p = shptr.get();
   AlwaysAssert (baseTabPtr_p, AipsError);
-  baseTabPtr_p->setWeakPtr (shptr);
   countedTabPtr_p = shptr;
 }
 
@@ -340,7 +338,6 @@ void Table::initBasePtr (BaseTable* ptr)
   AlwaysAssert (!baseTabPtr_p, AipsError);
   baseTabPtr_p = ptr;
   countedTabPtr_p.reset (baseTabPtr_p);
-  baseTabPtr_p->setWeakPtr (countedTabPtr_p);
 }
 
 Block<String> Table::getPartNames (Bool recursive) const
@@ -438,7 +435,7 @@ void Table::open (const String& name, const String& type, int tableOption,
     //# If so, link to it.
     BaseTable* btp = lookCache (absName, tableOption, lockOptions);
     if (btp != 0) {
-        countedTabPtr_p = btp->getSharedPtr();
+        countedTabPtr_p = btp->shared_from_this();
     }else{
         //# Check if the table directory exists.
         File dir(absName);
@@ -520,7 +517,6 @@ std::shared_ptr<BaseTable> Table::makeBaseTable
     } else {
       throw (TableInternalError("Table::open: unknown table kind " + tp));
     }
-    baseTabPtr->setWeakPtr (baseTabPtr);
     return baseTabPtr;
 }
 

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -1069,12 +1069,11 @@ private:
      const TableLock& lockOptions, const TSMOption& tsmOpt,
      Bool addToCache, uInt locknr);
 
-
     // Get the pointer to the underlying BaseTable.
     // This is needed for some friend classes.
     BaseTable* baseTablePtr() const;
 
-    // Initialize the shared_ptr in the Table and BaseTable object.
+    // Initialize the BaseTable pointers in this Table object.
     void initBasePtr (BaseTable* ptr);
 
     // Look in the cache if the table is already open.

--- a/tables/Tables/Table.h
+++ b/tables/Tables/Table.h
@@ -1040,8 +1040,10 @@ protected:
     // the Table object in the DataManager. Otherwise mutual referencing would occur.
     // Note that the BaseTable object contains a weak_ptr to itself which is the
     // basis for all shared pointer counting.
-    std::shared_ptr<BaseTable> countedTabPtr_p;   
-    BaseTable* baseTabPtr_p;            //# ptr to table representation
+    std::shared_ptr<BaseTable> countedTabPtr_p;
+    // Pointer to BaseTable object which is always filled and always used.
+    // The shared_ptr above is only for reference counting.
+    BaseTable* baseTabPtr_p;
     // Counter of last call to hasDataChanged.
     uInt        lastModCounter_p;
     // Pointer to the ScratchCallback function.
@@ -1049,10 +1051,12 @@ protected:
 
 
     // Construct a Table object from a pointer to BaseTable.
-    // By default the object gets counted.
-    // It uses BaseTable's weak_ptr object to create a shared_ptr to it.
-    Table (BaseTable*, Bool countIt = True);
-    Table (const std::shared_ptr<BaseTable>&, Bool countIt = True);
+    // It is meant for internal Table objects, so the BaseTable is not counted.
+    // Thus the internal shared_ptr is null.
+    Table (BaseTable*);
+
+    // Construct a Table object from a shared pointer to BaseTable.
+    Table (const std::shared_ptr<BaseTable>&);
 
     // Open an existing table.
     void open (const String& name, const String& type, int tableOption,

--- a/tables/Tables/TableColumn.cc
+++ b/tables/Tables/TableColumn.cc
@@ -124,7 +124,7 @@ const ColumnDesc& TableColumn::columnDesc() const
     { return baseColPtr_p->columnDesc(); }
 
 Table TableColumn::table() const
-    { return Table (baseTabPtr_p, False); }
+    { return Table (baseTabPtr_p); }
 
 
 Bool TableColumn::asBool (rownr_t rownr) const


### PR DESCRIPTION
The Table object used its own (old) way of counting BaseTable references. It has been replaced by shared_ptr<BaseTable>.
However, it is somewhat tricky because not all BaseTable references in DataManager objects can be counted (otherwise mutual referencing occurs). Therefore the actual pointer in a Table object is still a raw pointer to BaseTable. A weak_ptr (in the BaseTable object itself) it used to created shared_ptr as needed.

The code has been run through valgrind without any error or leak.
