### PR TITLE
Speedup frame conversion

### DIFF
--- a/coordinates/Coordinates/Coordinate.cc
+++ b/coordinates/Coordinates/Coordinate.cc
@@ -45,7 +45,7 @@
 
 #include <casacore/casa/OS/Timer.h>
 
-#include <casacore/casa/iomanip.h>  
+#include <casacore/casa/iomanip.h>
 #include <casacore/casa/sstream.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -76,7 +76,7 @@ Coordinate& Coordinate::operator=(const Coordinate& other)
    }
    return *this;
 }
- 
+
 
 Coordinate::~Coordinate()
 {}
@@ -90,13 +90,13 @@ Bool Coordinate::toWorldMany(Matrix<Double>& world,
     const uInt nTransforms = pixel.ncolumn();
     world.resize(nWorldAxes(), nTransforms);
     failures.resize(nTransforms);
-//   
+//
     Vector<Double> pixTmp(nPixelAxes());
     Vector<Double> worldTmp(nWorldAxes());
 //
     ArrayAccessor<Double, Axis<1> > jPixel(pixel);
     ArrayAccessor<Double, Axis<1> > jWorld(world);
-// 
+//
     String errorMsg;
     uInt nError = 0;
     uInt k,l;
@@ -105,7 +105,7 @@ Bool Coordinate::toWorldMany(Matrix<Double>& world,
     for (jPixel.reset(),jWorld.reset(),l=0; jPixel!=jPixel.end(); ++jPixel,++jWorld,l++) {
        iPixel = jPixel;            // Partial assignment
        for (iPixel.reset(),k=0; iPixel!=iPixel.end(); ++iPixel,k++) {
-          pixTmp[k] = *iPixel;   
+          pixTmp[k] = *iPixel;
        }
 //
        failures[l] = !toWorld (worldTmp, pixTmp);
@@ -122,8 +122,8 @@ Bool Coordinate::toWorldMany(Matrix<Double>& world,
 //
     if (nError != 0) set_error(errorMsg); // put back the first error
     return (nError==0);
-        
-} 
+
+}
 
 
 Bool Coordinate::toPixelMany(Matrix<Double>& pixel,
@@ -134,24 +134,24 @@ Bool Coordinate::toPixelMany(Matrix<Double>& pixel,
     const uInt nTransforms = world.ncolumn();
     pixel.resize(nPixelAxes(), nTransforms);
     failures.resize(nTransforms);
-//   
+//
     Vector<Double> pixTmp(nPixelAxes());
     Vector<Double> worldTmp(nWorldAxes());
 //
     ArrayAccessor<Double, Axis<1> > jPixel(pixel);
     ArrayAccessor<Double, Axis<1> > jWorld(world);
-//          
+//
     String errorMsg;
     uInt nError = 0;
     uInt k,l;
-    ArrayAccessor<Double, Axis<0> > iPixel, iWorld;  
+    ArrayAccessor<Double, Axis<0> > iPixel, iWorld;
 //
     for (jWorld.reset(),jPixel.reset(),l=0; jWorld!=jWorld.end(); ++jWorld,++jPixel,l++) {
        iWorld = jWorld;           // Partial assigment
        for (iWorld.reset(),k=0; iWorld!=iWorld.end(); ++iWorld,k++) {
           worldTmp[k] = *iWorld;
        }
-// 
+//
        failures[l] = !toPixel(pixTmp, worldTmp);
        if (failures[l]) {
           nError++;
@@ -166,7 +166,7 @@ Bool Coordinate::toPixelMany(Matrix<Double>& pixel,
 //
     if (nError != 0) set_error(errorMsg); // put back the first error
     return (nError==0);
-} 
+}
 
 
 
@@ -174,7 +174,7 @@ Bool Coordinate::toMix(Vector<Double>& worldOut,
                        Vector<Double>& pixelOut,
                        const Vector<Double>& worldIn,
                        const Vector<Double>& pixelIn,
-                       const Vector<Bool>& worldAxes,   
+                       const Vector<Bool>& worldAxes,
                        const Vector<Bool>& pixelAxes,
                        const Vector<Double>&,
                        const Vector<Double>&) const
@@ -192,8 +192,8 @@ Bool Coordinate::toMix(Vector<Double>& worldOut,
 //
    DebugAssert(nWorld == nWorldAxes(), AipsError);
    DebugAssert(worldIn.nelements()==nWorld, AipsError);
-   DebugAssert(nPixel == nPixelAxes(), AipsError);   
-   DebugAssert(pixelIn.nelements()==nPixel, AipsError);   
+   DebugAssert(nPixel == nPixelAxes(), AipsError);
+   DebugAssert(pixelIn.nelements()==nPixel, AipsError);
 //
    for (uInt i=0; i<nPixel; i++) {
       if (pixelAxes(i) && worldAxes(i)) {
@@ -212,7 +212,7 @@ Bool Coordinate::toMix(Vector<Double>& worldOut,
    if (pixel_tmp.nelements()!=nPixel) pixel_tmp.resize(nPixel);
 //
 // Convert world to pixel.  Use  reference value unless
-// world value given. Copy output pixels to output vector 
+// world value given. Copy output pixels to output vector
 // and overwrite with any input pixel values that were given
 //
    world_tmp = referenceValue();
@@ -228,7 +228,7 @@ Bool Coordinate::toMix(Vector<Double>& worldOut,
    }
 //
 // Convert pixel to world.  Use reference pixel unless
-// pixel value given. Copy output worlds to output vector 
+// pixel value given. Copy output worlds to output vector
 // and overwrite with any input world values that were given
 //
    pixel_tmp = referencePixel();
@@ -278,9 +278,9 @@ Bool Coordinate::setWorldAxisUnits(const Vector<String> &units)
     return ok;
 }
 
-void Coordinate::checkFormat(Coordinate::formatType& format, 
+void Coordinate::checkFormat(Coordinate::formatType& format,
                              const Bool ) const
-{  
+{
 // Scientific or fixed formats only are allowed.
 // Absolute or offset is irrelevant
 
@@ -301,7 +301,7 @@ void Coordinate::getPrecision(Int &precision,
 {
 
 // Absolute or offset is irrelevant
-  
+
    checkFormat (format, absolute);
 
    if (format == Coordinate::SCIENTIFIC) {
@@ -314,19 +314,19 @@ void Coordinate::getPrecision(Int &precision,
       if (defPrecFixed >= 0) {
          precision = defPrecFixed;
       } else {
-         precision = 6; 
+         precision = 6;
       }
 
       //   } else if (format == Coordinate::MIXED) {
       // Auto format by STL formatter so precision not relevant
 
-   } else {   
+   } else {
 // RI 20091213 but we should still set it so its not later accessed uninitalized:
-// (also make this branch catch Coordinate::DEFAULT 
+// (also make this branch catch Coordinate::DEFAULT
      precision = 6;
    }
 }
-   
+
 
 String Coordinate::format(
 	String& units, Coordinate::formatType format,
@@ -338,27 +338,27 @@ String Coordinate::format(
 // isAbsolute
 //    T means the worldValue is given as absolute
 //    F means the worldValue is given as relative
-// 
+//
 // showAsAbsolute
 //    T means the worldValue should be formatted as absolute
 //    F means the worldValue should be formatted as relative
 //
 {
    DebugAssert(worldAxis < nWorldAxes(), AipsError);
- 
+
 // Check format
 
    Coordinate::formatType form = format;
    checkFormat (form, showAsAbsolute);
-   
+
 // Set default precision
- 
+
    Int prec = precision;
    if (prec < 0) getPrecision(prec, form, showAsAbsolute, -1, -1, -1);
 
 // Convert given world value to absolute or relative as needed
 
-   static Vector<Double> world;   
+   static Vector<Double> world;
    if (world.nelements()!=nWorldAxes()) world.resize(nWorldAxes());
 //
    if (showAsAbsolute) {
@@ -366,16 +366,16 @@ String Coordinate::format(
          world = 0.0;
          world(worldAxis) = worldValue;
          makeWorldAbsolute(world);
-         worldValue = world(worldAxis); 
+         worldValue = world(worldAxis);
       }
    } else {
       if (isAbsolute) {
          world = referenceValue();
          world(worldAxis) = worldValue;
          makeWorldRelative(world);
-         worldValue = world(worldAxis); 
+         worldValue = world(worldAxis);
       }
-   } 
+   }
 
 // If units are empty, use native unit.
 // Convert to specified unit if possible
@@ -396,7 +396,7 @@ String Coordinate::format(
       q.setUnit(nativeUnitU);
       worldValue = q.getValue(currentUnitU);
    }
-       
+
    ostringstream oss;
    bool precision_set = false;
 
@@ -423,7 +423,7 @@ String Coordinate::format(
    }
 
 // Format and get units.
-  
+
    if (form == Coordinate::MIXED) {
 	   if (usePrecForMixed) {
 		   oss << setprecision(prec);
@@ -438,15 +438,15 @@ String Coordinate::format(
       if ( precision_set == false ) oss.precision(prec);
       oss << worldValue;
    }
-// 
+//
    return String(oss);
 }
 
 
 String Coordinate::formatQuantity (String& units,
-                                   Coordinate::formatType format2, 
-                                   const Quantum<Double>& worldValue, 
-                                   uInt worldAxis, 
+                                   Coordinate::formatType format2,
+                                   const Quantum<Double>& worldValue,
+                                   uInt worldAxis,
                                    Bool isAbsolute,
                                    Bool showAsAbsolute,
                                    Int precision)
@@ -455,15 +455,15 @@ String Coordinate::formatQuantity (String& units,
 
 // Use derived class formatter
 
-   return format(units, format2, 
+   return format(units, format2,
                  worldValue.getValue(Unit(worldAxisUnits()(worldAxis))),
                  worldAxis, isAbsolute, showAsAbsolute, precision);
 }
 
 
 // after = factor * before
-Bool Coordinate::find_scale_factor(String &error, Vector<Double> &factor, 
-				   const Vector<String> &units, 
+Bool Coordinate::find_scale_factor(String &error, Vector<Double> &factor,
+				   const Vector<String> &units,
 				   const Vector<String> &oldUnits)
 {
     factor.resize(units.nelements());
@@ -483,7 +483,7 @@ Bool Coordinate::find_scale_factor(String &error, Vector<Double> &factor,
 		if (!ok) {
 		    error = "Units are not compatible dimensionally";
 		} else {
-		    factor(i) = before.getValue().getFac() / 
+		    factor(i) = before.getValue().getFac() /
 			after.getValue().getFac();
 		}
 	    } else {
@@ -498,7 +498,7 @@ Bool Coordinate::find_scale_factor(String &error, Vector<Double> &factor,
 
 String Coordinate::typeToString (Coordinate::Type type)
 {
-// 
+//
 // I would prefer to call the virtual function
 // Coordinate::showType() but then I need an object
 //
@@ -514,7 +514,7 @@ String Coordinate::typeToString (Coordinate::Type type)
       return String("Quality");
    } else if (type==Coordinate::TABULAR) {
       return String("Tabular");
-   } else if (type==Coordinate::COORDSYS) {      
+   } else if (type==Coordinate::COORDSYS) {
       return String("System");
    } else {
       return String("Unknown - function Coordinate::typeToString needs development");
@@ -539,7 +539,7 @@ Coordinate* Coordinate::makeFourierCoordinate (const Vector<Bool>&,
 
 
 void Coordinate::fourierUnits (String& nameOut, String& unitOut, String& unitInCanon,
-                               Coordinate::Type type, Int axis,   
+                               Coordinate::Type type, Int axis,
                                const String& unitIn,
                                const String& nameIn) const
 
@@ -623,7 +623,7 @@ void Coordinate::makePixelRelativeMany (Matrix<Double>& value) const
 void Coordinate::makeWorldAbsRelMany (Matrix<Double>& value, Bool toAbs) const
 {
     Vector<Double> col(nWorldAxes());
-    Vector<Double> lastInCol(nWorldAxes());    
+    Vector<Double> lastInCol(nWorldAxes());
     Vector<Double> lastOutCol(nWorldAxes());
     uInt k,l;
     Bool same;
@@ -662,7 +662,7 @@ void Coordinate::makeWorldAbsRelMany (Matrix<Double>& value, Bool toAbs) const
 void Coordinate::makePixelAbsRelMany (Matrix<Double>& value, Bool abs) const
 {
     Vector<Double> col(nPixelAxes());
-    Vector<Double> lastInCol(nPixelAxes());    
+    Vector<Double> lastInCol(nPixelAxes());
     Vector<Double> lastOutCol(nPixelAxes());
     uInt k,l;
     Bool same;
@@ -705,7 +705,7 @@ void Coordinate::makeWorldAbsolute (Vector<Double>& world) const
    world += referenceValue();
 }
 
- 
+
 void Coordinate::makeWorldAbsoluteRef (Vector<Double>& world,
                                     const Vector<Double>& refVal) const
 {
@@ -718,9 +718,9 @@ void Coordinate::makeWorldRelative (Vector<Double>& world) const
 {
    DebugAssert(world.nelements()==nWorldAxes(),AipsError);
    world -= referenceValue();
-}  
+}
 
- 
+
 void Coordinate::makePixelAbsolute (Vector<Double>& pixel) const
 {
    DebugAssert(pixel.nelements()==nPixelAxes(),AipsError);
@@ -732,7 +732,7 @@ void Coordinate::makePixelRelative (Vector<Double>& pixel) const
    DebugAssert(pixel.nelements()==nPixelAxes(),AipsError);
    pixel -= referencePixel();
 }
- 
+
 
 
 Bool Coordinate::setWorldMixRanges (const IPosition& shape)
@@ -888,12 +888,12 @@ Bool Coordinate::doNearPixel (const Coordinate& other,
          }
 
 // Ref pix
- 
+
          if (!casacore::near(thisRefPix(i), otherRefPix(i), tol)) {
             oss << "The Coordinates have differing reference pixels for axis "
                  << i;
             set_error(String(oss));
-            return False;        
+            return False;
          }
 
 // pc matrix. Compare row by row.  An axis will turn up in the PC
@@ -902,9 +902,9 @@ Bool Coordinate::doNearPixel (const Coordinate& other,
 // entries of row "i" and all entries of column "i"
 // So just get the ith row and ith column and compare
 // PC is always SQUARE
-    
+
          AlwaysAssert(thisPC.nrow()==thisPC.ncolumn(), AipsError);
-//   
+//
          Vector<Double> r1 = thisPC.row(i);
          Vector<Double> r2 = otherPC.row(i);
          for (uInt j=0; j<r1.nelements(); j++) {
@@ -969,14 +969,24 @@ Bool Coordinate::toWorldWCS (Vector<Double>& world, const Vector<Double>& pixel,
     const double* pixelStore = pixel.getStorage(delPixel);
     double* worldStore = world.getStorage(delWorld);
 //
-    Block<double> imgCrd(nAxes);
     double phi;
     double theta=0;   // initialize, because wcslib not always sets theta
 // Convert from pixel to world with wcs units
 
     int stat;
-    int iret = wcsp2s (&wcs, 1, nAxes, pixelStore, imgCrd.storage(),
-		       &phi, &theta, worldStore, &stat);
+    int iret;
+    constexpr uInt NAXES_THRESHOLD = 10;
+    // avoid dynamic memory allocation for modest number of coordinate axes
+    // note that output stored in imgCrd is not used
+    if (nAxes <= NAXES_THRESHOLD) {
+      thread_local static double imgCrd[NAXES_THRESHOLD];
+      iret = wcsp2s (&wcs, 1, nAxes, pixelStore, imgCrd,
+		         &phi, &theta, worldStore, &stat);
+    } else {
+      Block<double> imgCrd(nAxes);
+      iret = wcsp2s (&wcs, 1, nAxes, pixelStore, imgCrd.storage(),
+		         &phi, &theta, worldStore, &stat);
+    }
     pixel.freeStorage(pixelStore, delPixel);
     world.putStorage(worldStore, delWorld);
 //
@@ -994,7 +1004,7 @@ Bool Coordinate::toWorldWCS (Vector<Double>& world, const Vector<Double>& pixel,
 Bool Coordinate::toPixelWCS(Vector<Double> &pixel, const Vector<Double> &world,
                             ::wcsprm& wcs) const
 {
-   pixel.resize(world.nelements());    
+   pixel.resize(world.nelements());
    const uInt nAxes = nWorldAxes();
    DebugAssert(world.nelements() == nAxes, AipsError);
 
@@ -1003,16 +1013,26 @@ Bool Coordinate::toPixelWCS(Vector<Double> &pixel, const Vector<Double> &world,
    Bool delPixel, delWorld;
    double* pixelStore = pixel.getStorage(delPixel);
    const double* worldStore = world.getStorage(delWorld);
-// 
-   Block<double> imgCrd(nAxes);
+//
    double phi;
    double theta;
-    
+
 // Convert with world with wcs units to pixel
-    
+
    int stat;
-   int iret = wcss2p (&wcs, 1, nAxes, worldStore, &phi, &theta,
-		      imgCrd.storage(), pixelStore, &stat);
+   int iret;
+   constexpr uInt NAXES_THRESHOLD = 10;
+   // avoid dynamic memory allocation for modest number of coordinate axes
+   // note that output stored in imgCrd is not used
+   if (nAxes <= NAXES_THRESHOLD) {
+     thread_local static double imgCrd[NAXES_THRESHOLD];
+     iret = wcss2p (&wcs, 1, nAxes, worldStore, &phi, &theta,
+		        imgCrd, pixelStore, &stat);
+   } else {
+     Block<double> imgCrd(nAxes);
+     iret = wcss2p (&wcs, 1, nAxes, worldStore, &phi, &theta,
+		        imgCrd.storage(), pixelStore, &stat);
+   }
    pixel.putStorage(pixelStore, delPixel);
    world.freeStorage(worldStore, delWorld);
 //
@@ -1029,7 +1049,7 @@ Bool Coordinate::toPixelWCS(Vector<Double> &pixel, const Vector<Double> &world,
 
 Bool Coordinate::toWorldManyWCS (Matrix<Double>& world, const Matrix<Double>& pixel,
                                  Vector<Bool>& failures, ::wcsprm& wcs) const
-{ 
+{
     uInt nTransforms = pixel.ncolumn();
     uInt nAxes = nPixelAxes();
     AlwaysAssert(pixel.nrow()==nAxes, AipsError);
@@ -1041,7 +1061,7 @@ Bool Coordinate::toWorldManyWCS (Matrix<Double>& world, const Matrix<Double>& pi
     Bool deleteWorld, deletePixel;
     Double* pWorld = world.getStorage(deleteWorld);
     const Double* pPixel = pixel.getStorage(deletePixel);
-// 
+//
     Bool deleteImgCrd, deletePhi, deleteTheta, deleteStat;
     Matrix<Double> imgCrd(nAxes,nTransforms);
     Vector<Double> phi(nTransforms);
@@ -1050,10 +1070,10 @@ Bool Coordinate::toWorldManyWCS (Matrix<Double>& world, const Matrix<Double>& pi
 
 // Convert from pixel to world with wcs units
 
-    Double* pImgCrd = imgCrd.getStorage(deleteImgCrd);    
-    Double* pPhi = phi.getStorage(deletePhi);    
-    Double* pTheta = theta.getStorage(deleteTheta);    
-    Int* pStat = stat.getStorage(deleteStat);    
+    Double* pImgCrd = imgCrd.getStorage(deleteImgCrd);
+    Double* pPhi = phi.getStorage(deletePhi);
+    Double* pTheta = theta.getStorage(deleteTheta);
+    Int* pStat = stat.getStorage(deleteStat);
 //
     int iret = wcsp2s (&wcs, nTransforms, nAxes, pPixel, pImgCrd, pPhi, pTheta, pWorld, pStat);
     for (uInt i=0; i<nTransforms; i++) {
@@ -1075,7 +1095,7 @@ Bool Coordinate::toWorldManyWCS (Matrix<Double>& world, const Matrix<Double>& pi
     }
 //
     return True;
-}     
+}
 
 
 Bool Coordinate::toPixelManyWCS (Matrix<Double>& pixel, const Matrix<Double>& world,
@@ -1099,10 +1119,10 @@ Bool Coordinate::toPixelManyWCS (Matrix<Double>& pixel, const Matrix<Double>& wo
     Vector<Double> theta(nTransforms);
     Vector<Int> stat(nTransforms);
 //
-    Double* pImgCrd = imgCrd.getStorage(deleteImgCrd);    
-    Double* pPhi = phi.getStorage(deletePhi);    
-    Double* pTheta = theta.getStorage(deleteTheta);    
-    Int* pStat = stat.getStorage(deleteStat);    
+    Double* pImgCrd = imgCrd.getStorage(deleteImgCrd);
+    Double* pPhi = phi.getStorage(deletePhi);
+    Double* pTheta = theta.getStorage(deleteTheta);
+    Int* pStat = stat.getStorage(deleteStat);
 
 // Convert from wcs units to pixel
 
@@ -1111,7 +1131,7 @@ Bool Coordinate::toPixelManyWCS (Matrix<Double>& pixel, const Matrix<Double>& wo
     for (uInt i=0; i<nTransforms; i++) {
        failures[i] = pStat[i]!=0;
     }
-//  
+//
     world.freeStorage(pWorld, deleteWorld);
     pixel.putStorage(pPixel, deletePixel);
     imgCrd.putStorage(pImgCrd, deleteImgCrd);
@@ -1127,7 +1147,7 @@ Bool Coordinate::toPixelManyWCS (Matrix<Double>& pixel, const Matrix<Double>& wo
     }
     return True;
 }
-  
+
 
 void Coordinate::toCurrentMany(Matrix<Double>& world, const Vector<Double>& toCurrentFactors) const
 {
@@ -1215,8 +1235,8 @@ void Coordinate::pcToXform (Matrix<Double>& xform, const ::wcsprm& wcs) const
         count++;
      }
    }
-}   
-        
+}
+
 void Coordinate::xFormToPC (::wcsprm& wcs, const Matrix<Double>& xform) const
 {
    uInt n = wcs.naxis;

--- a/measures/Measures/MCFrequency.cc
+++ b/measures/Measures/MCFrequency.cc
@@ -1,4 +1,4 @@
-//# MCFrequency.cc: MFrequency conversion routines 
+//# MCFrequency.cc: MFrequency conversion routines
 //# Copyright (C) 1995-1998,2000-2003,2007,2009
 //# Associated Universities, Inc. Washington DC, USA.
 //#
@@ -32,6 +32,22 @@
 #include <casacore/casa/Quanta/MVDirection.h>
 #include <casacore/measures/Measures/Aberration.h>
 #include <casacore/measures/Measures/MeasTable.h>
+
+namespace {
+  inline void updatePosition(casacore::Double const angle0, casacore::Double const angle1,
+                             casacore::MVPosition &pos) {
+      if (angle1 == 0) {
+        pos(0) = std::cos(angle0);
+        pos(1) = std::sin(angle0);
+        pos(2) = 0;
+      } else {
+        auto const loc = std::cos(angle1);
+        pos(0) = std::cos(angle0) * loc;
+        pos(1) = std::sin(angle0) * loc;
+        pos(2) = std::sin(angle1);
+      }
+  }
+}
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -73,7 +89,7 @@ MCFrequency::~MCFrequency() {
 //# Member functions
 
 void MCFrequency::getConvert(MConvertBase &mc,
-			     const MRBase &inref, 
+			     const MRBase &inref,
 			     const MRBase &outref) {
 
   Int iin  = inref.getType();
@@ -106,14 +122,14 @@ void MCFrequency::initConvert(uInt which, MConvertBase &mc) {
   if (!MVDIR1) MVDIR1 = new MVDirection();
 
   switch (which) {
-      
+
   case BARY_GEO:
     if (ABERFROM) delete ABERFROM;
     ABERFROM = new Aberration(Aberration::STANDARD);
     mc.addFrameType(MeasFrame::EPOCH);
     mc.addFrameType(MeasFrame::DIRECTION);
     break;
-      
+
   case GEO_BARY:
     if (ABERTO) delete ABERTO;
     ABERTO = new Aberration(Aberration::STANDARD);
@@ -142,7 +158,7 @@ void MCFrequency::initConvert(uInt which, MConvertBase &mc) {
     break;
 
   case REST_LSRK:
-  case LSRK_REST:      
+  case LSRK_REST:
     mc.addFrameType(MeasFrame::DIRECTION);
     mc.addFrameType(MeasFrame::VELOCITY);
     break;
@@ -171,7 +187,12 @@ void MCFrequency::doConvert(MVFrequency &in,
     switch (mc.getMethod(i)) {
 
     case LSRD_BARY: {
-      *MVPOS1 = MVPosition(MeasTable::velocityLSR(0));
+      auto const vel = MeasTable::velocityLSR(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(outref, inref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
@@ -181,7 +202,12 @@ void MCFrequency::doConvert(MVFrequency &in,
     break;
 
     case BARY_LSRD: {
-      *MVPOS1 = MVPosition(MeasTable::velocityLSR(0));
+      auto const vel = MeasTable::velocityLSR(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(inref, outref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
@@ -199,7 +225,7 @@ void MCFrequency::doConvert(MVFrequency &in,
       g1 = *MVPOS1 * *MVDIR1;
       g2 = in.getValue();
       in = g2*sqrt((1+g1)/(1-g1));
-    }	
+    }
     break;
 
     case GEO_TOPO: {
@@ -212,7 +238,8 @@ void MCFrequency::doConvert(MVFrequency &in,
       MFrequency::Ref::framePosition(outref, inref).
 	getLat(g3);
       g2 = MeasTable::diurnalAber(lengthE, tdbTime);
-      *MVPOS1 = MVDirection(C::pi_2 + g1, 0.0);
+      // *MVPOS1 = MVDirection(C::pi_2 + g1, 0.0);
+      updatePosition(C::pi_2 + g1, 0.0, *MVPOS1);
       MVPOS1->readjust(g2 * cos(g3));
       MFrequency::Ref::frameDirection(outref, inref).
 	getApp(*MVDIR1);
@@ -231,7 +258,7 @@ void MCFrequency::doConvert(MVFrequency &in,
       g1 = *MVPOS1 * *MVDIR1;
       g2 = in.getValue();
       in = g2*sqrt((1-g1)/(1+g1));
-    }	
+    }
     break;
 
     case TOPO_GEO: {
@@ -244,7 +271,8 @@ void MCFrequency::doConvert(MVFrequency &in,
       MFrequency::Ref::framePosition(inref, outref).
 	getLat(g3);
       g2 = MeasTable::diurnalAber(lengthE, tdbTime);
-      *MVPOS1 = MVDirection(C::pi_2 + g1, 0.0);
+      // *MVPOS1 = MVDirection(C::pi_2 + g1, 0.0);
+      updatePosition(C::pi_2 + g1, 0.0, *MVPOS1);
       MVPOS1->readjust(g2*cos(g3));
       MFrequency::Ref::frameDirection(outref, inref).
 	getApp(*MVDIR1);
@@ -254,77 +282,125 @@ void MCFrequency::doConvert(MVFrequency &in,
     }
     break;
 
-    case LSRD_GALACTO:
-      *MVPOS1 = MVPosition(MeasTable::velocityLSRGal(0));
+    case LSRD_GALACTO: {
+      auto const &vel = MeasTable::velocityLSRGal(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(inref, outref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1-g1)/(1+g1));
-      break;
-      
-    case GALACTO_LSRD:
-      *MVPOS1 = MVPosition(MeasTable::velocityLSRGal(0));
+    }
+    break;
+
+    case GALACTO_LSRD: {
+      auto const &vel = MeasTable::velocityLSRGal(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(outref, inref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1+g1)/(1-g1));
-      break;
+    }
+    break;
 
-    case LSRK_BARY:
-      *MVPOS1 = MVPosition(MeasTable::velocityLSRK(0));
+    case LSRK_BARY: {
+      auto const &vel = MeasTable::velocityLSRK(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(outref, inref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1+g1)/(1-g1));
-      break;
+    }
+    break;
 
-    case BARY_LSRK:
-      *MVPOS1 = MVPosition(MeasTable::velocityLSRK(0));
+    case BARY_LSRK: {
+      auto const &vel = MeasTable::velocityLSRK(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(inref, outref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1-g1)/(1+g1));
-      break;
+    }
+    break;
 
-    case LGROUP_BARY:
-      *MVPOS1 = MVPosition(MeasTable::velocityLGROUP(0));
+    case LGROUP_BARY: {
+      auto const &vel = MeasTable::velocityLGROUP(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(outref, inref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1+g1)/(1-g1));
-      break;
+    }
+    break;
 
-    case BARY_LGROUP:
-      *MVPOS1 = MVPosition(MeasTable::velocityLGROUP(0));
+    case BARY_LGROUP: {
+      auto const &vel = MeasTable::velocityLGROUP(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(inref, outref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1-g1)/(1+g1));
-      break;
+    }
+    break;
 
-    case CMB_BARY:
-      *MVPOS1 = MVPosition(MeasTable::velocityCMB(0));
+    case CMB_BARY: {
+      auto const &vel = MeasTable::velocityCMB(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(outref, inref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1+g1)/(1-g1));
-      break;
+    }
+    break;
 
-    case BARY_CMB:
-      *MVPOS1 = MVPosition(MeasTable::velocityCMB(0));
+    case BARY_CMB: {
+      auto const &vel = MeasTable::velocityCMB(0);
+      if (vel.nelements() == 3) {
+        MVPOS1->putVector(vel);
+      } else {
+        *MVPOS1 = MVPosition(vel);
+      }
       MFrequency::Ref::frameDirection(inref, outref).
 	getJ2000(*MVDIR1);
       g1 = (*MVPOS1 * *MVDIR1) / C::c;
       g2 = in.getValue();
       in = g2*sqrt((1-g1)/(1+g1));
-      break;
+    }
+    break;
 
     case REST_LSRK:
       MFrequency::Ref::frameRadialVelocity(inref, outref).

--- a/measures/Measures/MeasMath.cc
+++ b/measures/Measures/MeasMath.cc
@@ -38,6 +38,22 @@
 #include <casacore/measures/Measures/Precession.h>
 #include <casacore/measures/Measures/SolarPos.h>
 
+namespace {
+  inline void updatePosition(casacore::Double const angle0, casacore::Double const angle1,
+                             casacore::MVPosition &pos) {
+      if (angle1 == 0) {
+        pos(0) = std::cos(angle0);
+        pos(1) = std::sin(angle0);
+        pos(2) = 0;
+      } else {
+        auto const loc = std::cos(angle1);
+        pos(0) = std::cos(angle0) * loc;
+        pos(1) = std::sin(angle0) * loc;
+        pos(2) = std::sin(angle1);
+      }
+  }
+}
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Static data
@@ -101,7 +117,7 @@ void MeasMath::getFrame(FrameType i) {
     &MeasFrame::position,
     &MeasFrame::direction,
     &MeasFrame::radialVelocity };
-  
+
   // Get correct frame
   if (!frameOK_p[i]) {
     frameOK_p[i] = True;
@@ -310,12 +326,12 @@ void MeasMath::deapplyAberration(MVPosition &in, Bool doin) {
   // Solve for aberration solution
   do {
     g2 = MVPOS2 * MVPOS1;
-    MVPOS3 = ((g1 * MVPOS2 + 
+    MVPOS3 = ((g1 * MVPOS2 +
 		(1+g2/(1+g1)) * MVPOS1)*(1.0/(1.0+g2)));
     MVPOS3.adjust();
     for (Int j=0; j<3; j++) {
       g3 = MVPOS1(j);
-      MVPOS2(j) -= 
+      MVPOS2(j) -=
 	(MVPOS3(j) - MVPOS4(j))/
 	(((g1+g3*g3/(1+g1))-
 	  g3 * MVPOS3(j))/(1+g2));
@@ -362,7 +378,7 @@ void MeasMath::applySolarPos(MVPosition &in, Bool doin) {
   else {
     getInfo(J2000DIR);
     MVPOS2 = infomvd_p[J2000DIR-N_FrameDInfo];
-  } 
+  }
   g2 = MVPOS2 * MVPOS1;
   // Check if near sun
   if (!nearAbs(g2, 1.0,
@@ -396,8 +412,8 @@ void MeasMath::deapplySolarPos(MVPosition &in, Bool doin) {
       MVPOS3.adjust();
       for (Int j=0; j<3; j++) {
 	g3 = MVPOS1(j);
-	MVPOS2(j) -= 
-	  (MVPOS3(j) + 
+	MVPOS2(j) -=
+	  (MVPOS3(j) +
 	   MVPOS2(j) - MVPOS4(j))/
 	  (1 + (g3 * MVPOS3(j) -
 		g1 * (g2 + g3 *
@@ -437,18 +453,18 @@ void MeasMath::deapplyHADECtoAZEL(MVPosition &in) {
 }
 
 void MeasMath::applyHADECtoAZELGEO(MVPosition &in) {
-  getInfo(LATGEO);   
+  getInfo(LATGEO);
   in *= RotMatrix(Euler(C::pi_2 - info_p[LATGEO] , 2u, C::pi, 3u));
 }
 
 void MeasMath::deapplyHADECtoAZELGEO(MVPosition &in) {
-  getInfo(LATGEO); 
+  getInfo(LATGEO);
   in = RotMatrix(Euler(C::pi_2 - info_p[LATGEO] , 2u, C::pi, 3u)) * in;
 }
 
 void MeasMath::applyJ2000toB1950(MVPosition &in, Bool doin) {
   if (!MeasMath::b1950_reg_p) {
-    b1950_reg_p = 
+    b1950_reg_p =
       AipsrcValue<Double>::registerRC(String("measures.b1950.d_epoch"),
 				      Unit("a"), Unit("a"), 2000.0);
   }
@@ -483,7 +499,7 @@ void MeasMath::applyJ2000toB1950(MVPosition &in, Double epo, Bool doin) {
 
 void MeasMath::deapplyJ2000toB1950(MVPosition &in, Bool doin) {
   if (!MeasMath::b1950_reg_p) {
-    b1950_reg_p = 
+    b1950_reg_p =
       AipsrcValue<Double>::registerRC(String("measures.b1950.d_epoch"),
 				      Unit("a"), Unit("a"), 2000.0);
   }
@@ -517,7 +533,7 @@ void MeasMath::applyETerms(MVPosition &in, Bool doin, Double epo) {
   else {
     getInfo(B1950DIR);
     MVPOS2 = infomvd_p[B1950DIR-N_FrameDInfo];
-  } 
+  }
   g1 = MVPOS2 * MVPOS1;
   MVPOS1 = g1 * MVPOS2 - MVPOS1;
   rotateShift(in, MVPOS1, B1950LONG, B1950LAT, doin);
@@ -584,7 +600,8 @@ void MeasMath::applyTOPOtoHADEC(MVPosition &in, Bool doin) {
   getInfo(RADIUS);
   getInfo(LAT);
   g2 = MeasTable::diurnalAber(info_p[RADIUS], info_p[TDB]);
-  MVPOS1 = MVDirection(info_p[LASTR], info_p[LAT]);
+  // MVPOS1 = MVDirection(info_p[LASTR], info_p[LAT]);
+  updatePosition(info_p[LASTR], info_p[LAT], MVPOS1);
   MVPOS1.readjust(g2);
   /// Really should use topo for planets
   rotateShift(in, MVPOS1, APPLONG, APPLAT, doin);
@@ -597,9 +614,10 @@ void MeasMath::deapplyTOPOtoHADEC(MVPosition &in, Bool doin) {
   getInfo(RADIUS);
   getInfo(LAT);
   g2 = MeasTable::diurnalAber(info_p[RADIUS], info_p[TDB]);
-  MVPOS1 = MVDirection(info_p[LASTR], info_p[LAT]);
+  // MVPOS1 = MVDirection(info_p[LASTR], info_p[LAT]);
+  updatePosition(info_p[LASTR], info_p[LAT], MVPOS1);
   MVPOS1.readjust(g2);
-  applyPolarMotion(in);  
+  applyPolarMotion(in);
   /// Really use topo for planets
   rotateShift(in, -MVPOS1, APPLONG, APPLAT, doin);
 }
@@ -637,14 +655,14 @@ void MeasMath::deapplyECLIPtoJ2000(MVPosition &in) {
 
 void MeasMath::applyMECLIPtoJMEAN(MVPosition &in) {
   getInfo(TDB);
-  in = RotMatrix(Euler(MeasTable::fundArg(0)((info_p[TDB] - 
+  in = RotMatrix(Euler(MeasTable::fundArg(0)((info_p[TDB] -
 					      MeasData::MJD2000)/
 					     MeasData::JDCEN), 1, 0, 0)) * in;
 }
 
 void MeasMath::deapplyMECLIPtoJMEAN(MVPosition &in) {
   getInfo(TDB);
-  in *= RotMatrix(Euler(MeasTable::fundArg(0)((info_p[TDB] - 
+  in *= RotMatrix(Euler(MeasTable::fundArg(0)((info_p[TDB] -
 					       MeasData::MJD2000)/
 					      MeasData::JDCEN), 1, 0, 0));
 }


### PR DESCRIPTION
Changes aim to speedup frequency frame conversion by reducing memory allocation and deallocation. I'm sorry that many whitespace changes are included, especially in Coordinate.cc. Major changes of Coordinate.cc is L977-1036.

I carried out hot spot analysis on the imaging (convolutional gridding) of single dish data using CASA's tsdimaging task. Test data contains about 70000 rows with 2048 channels and 2 polarizations. Roughly 10^8 frequency conversions are required. The screenshots below are the result of hot spot analysis of original code. You can see that significant fraction of CPU time was spent for `operator new` (please see Summary figure), which is very likely to accompany extra CPU time to execute constructor code. Indeed, constructor was one of the bottleneck of frequency conversion. The Breakdown figure for the original code shows that about 23% of CPU time was spent for frequency conversion (`MCFrequency::doConvert`), which competes to the CPU time for gridding (`ggridsd_`), and **about half of frequency conversion was construction/destruction or copy of `MVPosition` and `MVDirection` objects**. This is really inefficient. 

In the improved code, I tried to reduce using `operator new` (Coordinate.cc) and to avoid using constructor/destructor to update another object (MCFrequency.cc and MeasMath.cc). You can see in the figures for branch code that CPU time for `operator new` was less than half of the original analysis, and fraction of the CPU time for frequency conversion was reduced to 15%, which means performance of frequency conversion was significantly improved although it didn't reached to double-speed. In terms of total CPU time, improvement was about 10% (actually performance was improved about 20% including the changes in casa6 repo).

The change is currently a trade-off between performance and the "beauty" of the object oriented programming because the change somehow breaks encapsulation of the object by exposing implementation detail of `MVDirection` and `MVPosition` outside these classes. But 10% improvement in terms of total execution time is quite beneficial.

## Hot spot analysis of original code
### Summary
![conversion-benchmark-summary-original](https://user-images.githubusercontent.com/17893104/173474752-f26239be-bda6-4edd-aa93-db534c09e5d5.png)
### Breakdown
![conversion-benchmark-breakdown-original](https://user-images.githubusercontent.com/17893104/173474741-a069e983-dd15-4bdb-b31a-13cd988f2d0a.png)

## How spot analysis of branch code
### Summary
![conversion-benchmark-summary-tuned](https://user-images.githubusercontent.com/17893104/173474755-e1464726-12dc-4454-9564-8ddeea7098e2.png)
### Breakdown
![conversion-benchmark-breakdown-tuned](https://user-images.githubusercontent.com/17893104/173474748-833a3379-c3e3-4ab2-aac3-24995f8fee2e.png)



