### PR TITLE
Add support for installation of pkg-config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,7 +551,13 @@ foreach (module ${_modules})
             set_target_properties(casa_${module} PROPERTIES LINK_FLAGS -single_module)
         endif (${module} STREQUAL scimath_f OR ${module} STREQUAL fits OR ${module} STREQUAL mirlib OR ${module} STREQUAL coordinates)
     endif (APPLE)
+    set(PRIVATE_LIBS "${PRIVATE_LIBS} -lcasa_${module}")
 endforeach (module)
+
+# Install pkg-config support file
+CONFIGURE_FILE("casacore.pc.in" "casacore.pc" @ONLY)
+set(CASA_PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/casacore.pc" DESTINATION "${CASA_PKGCONFIG_INSTALL_PREFIX}")
 
 # Show summary.
 message (STATUS "CMAKE_SYSTEM .......... = ${CMAKE_SYSTEM}")

--- a/casacore.pc.in
+++ b/casacore.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Casacore
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Libs: -L${libdir} @PRIVATE_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
Using pkg-config files (https://en.wikipedia.org/wiki/Pkg-config) is a convenient way for clients of casacore to get the compiler and linker flags needed to develop an application that uses casa. This pull request adds support for the creation and installation of a casacore.pc file that can be used for such purpose.

The need for this comes from casa, which traditionally has been keeping internal knowledge and how to compile against casacore. The idea here is to remove such knowledge from casa itself and leave it to the casacore installation to provide such information in a standard way.