### PR TITLE
Build python3 by default, not python2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Astronomical data processing library")
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # By default build only Python2 bindings
-option (BUILD_PYTHON "Build the python bindings" YES)
-option (BUILD_PYTHON3 "Build the python3 bindings" NO)
+option (BUILD_PYTHON "Build the python2 bindings" NO)
+option (BUILD_PYTHON3 "Build the python3 bindings" YES)
 
 option (BUILD_DEPRECATED "build and install deprecated classes (such as Map)" NO)
 option (BUILD_FFTPACK_DEPRECATED "build FFTPack" NO)

--- a/docker/py36_wheel.docker
+++ b/docker/py36_wheel.docker
@@ -76,8 +76,6 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
-    -DBUILD_PYTHON3=ON \
-    -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 RUN make install

--- a/docker/py37_wheel.docker
+++ b/docker/py37_wheel.docker
@@ -76,8 +76,6 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
-    -DBUILD_PYTHON3=ON \
-    -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 RUN make install

--- a/docker/py38_wheel.docker
+++ b/docker/py38_wheel.docker
@@ -75,8 +75,6 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
-    -DBUILD_PYTHON3=ON \
-    -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 RUN make install

--- a/docker/py39_wheel.docker
+++ b/docker/py39_wheel.docker
@@ -75,8 +75,6 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
-    -DBUILD_PYTHON3=ON \
-    -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 RUN make install

--- a/docker/ubuntu2004_clang.docker
+++ b/docker/ubuntu2004_clang.docker
@@ -41,8 +41,6 @@ RUN cmake .. \
     -DBUILD_TESTING=ON \
     -DUSE_OPENMP=OFF \
     -DUSE_HDF5=ON \
-    -DBUILD_PYTHON=OFF \
-    -DBUILD_PYTHON3=ON \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
     -DDATA_DIR=/usr/local/share/casacore/data \
     -DCMAKE_C_COMPILER=/usr/bin/clang \

--- a/docker/ubuntu2004_gcc.docker
+++ b/docker/ubuntu2004_gcc.docker
@@ -42,8 +42,6 @@ RUN cmake .. \
     -DBUILD_TESTING=ON \
     -DUSE_OPENMP=OFF \
     -DUSE_HDF5=ON \
-    -DBUILD_PYTHON=OFF \
-    -DBUILD_PYTHON3=ON \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
     -DDATA_DIR=/usr/local/share/casacore/data \
     && make -j`nproc`

--- a/docker/ubuntu2204_clang.docker
+++ b/docker/ubuntu2204_clang.docker
@@ -41,8 +41,6 @@ RUN cmake .. \
     -DBUILD_TESTING=ON \
     -DUSE_OPENMP=OFF \
     -DUSE_HDF5=ON \
-    -DBUILD_PYTHON=OFF \
-    -DBUILD_PYTHON3=ON \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
     -DDATA_DIR=/usr/local/share/casacore/data \
     -DCMAKE_C_COMPILER=/usr/bin/clang \

--- a/docker/ubuntu2204_gcc.docker
+++ b/docker/ubuntu2204_gcc.docker
@@ -42,8 +42,6 @@ RUN cmake .. \
     -DBUILD_TESTING=ON \
     -DUSE_OPENMP=OFF \
     -DUSE_HDF5=ON \
-    -DBUILD_PYTHON=OFF \
-    -DBUILD_PYTHON3=ON \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
     -DDATA_DIR=/usr/local/share/casacore/data \
     -DBUILD_FFTPACK_DEPRECATED=ON \


### PR DESCRIPTION
This is about 2,5 years overdue... We could also remove all magic for working with multiple python versions, but I think for now just setting the right default is quickest and best. We may even need the logic again for python4.