### PR TITLE
Update python docker images

### DIFF
--- a/docker/make_images.sh
+++ b/docker/make_images.sh
@@ -3,6 +3,6 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 36 37 38 39; do
+for i in 36 37 38 39 310; do
     docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:master_wheel${i}
 done

--- a/docker/py310_wheel.docker
+++ b/docker/py310_wheel.docker
@@ -44,8 +44,6 @@ RUN make -j${THREADS}
 WORKDIR /build
 RUN tar jxvf /tmp/boost.tar.bz2
 WORKDIR /build/boost_${BOOST_}
-# patch for python 3.10 (multiple digits)
-#sed -i 's/(\[0-9\])/([0-9][0-9]?)/' tools/boost_install/BoostConfig.cmake
 RUN ./bootstrap.sh --prefix=/opt/boost \
     --with-libraries=python \
     --with-python=/opt/python/${TARGET}/bin/python \
@@ -62,6 +60,7 @@ RUN /opt/python/${TARGET}/bin/pip install numpy==1.22.4
 ADD . /code
 RUN useradd -ms /bin/bash casacore
 RUN chown casacore.casacore /code
+USER casacore
 RUN mkdir /code/build
 WORKDIR /code/build
 RUN cmake .. \

--- a/docker/py310_wheel.docker
+++ b/docker/py310_wheel.docker
@@ -2,12 +2,11 @@ FROM quay.io/pypa/manylinux2014_x86_64
 
 # set python version
 ENV PYMAJOR 3
-ENV PYMINOR 7
-ENV PYUNICODE m
+ENV PYMINOR 10
 ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}${PYUNICODE}
 
 # boost version
-ENV BOOSTMAJOR 75
+ENV BOOSTMAJOR 79
 ENV BOOSTMINOR 0
 ENV BOOST 1.${BOOSTMAJOR}.${BOOSTMINOR}
 ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
@@ -49,6 +48,8 @@ RUN make -j${THREADS}
 WORKDIR /build
 RUN tar jxvf /tmp/boost.tar.bz2
 WORKDIR /build/boost_${BOOST_}
+# patch for python 3.10 (multiple digits)
+#sed -i 's/(\[0-9\])/([0-9][0-9]?)/' tools/boost_install/BoostConfig.cmake
 RUN ./bootstrap.sh --prefix=/opt/boost \
     --with-libraries=python \
     --with-python=/opt/python/${TARGET}/bin/python \
@@ -59,13 +60,12 @@ RUN ./b2 -j${THREADS} \
     link=static,shared install
 
 # casacore wants numpy
-RUN /opt/python/${TARGET}/bin/pip install numpy==1.19.5
+RUN /opt/python/${TARGET}/bin/pip install numpy
 
 # set up casacore
 ADD . /code
 RUN useradd -ms /bin/bash casacore
 RUN chown casacore.casacore /code
-USER casacore
 RUN mkdir /code/build
 WORKDIR /code/build
 RUN cmake .. \

--- a/docker/py310_wheel.docker
+++ b/docker/py310_wheel.docker
@@ -60,7 +60,7 @@ RUN ./b2 -j${THREADS} \
     link=static,shared install
 
 # casacore wants numpy
-RUN /opt/python/${TARGET}/bin/pip install numpy
+RUN /opt/python/${TARGET}/bin/pip install numpy==1.22.4
 
 # set up casacore
 ADD . /code
@@ -76,6 +76,7 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
+    -DPORTABLE=TRUE \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 USER root

--- a/docker/py310_wheel.docker
+++ b/docker/py310_wheel.docker
@@ -14,10 +14,6 @@ ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
 # where do we epect casacore data build time and runtime
 ENV CASACORE_DATA /usr/share/casacore/data
 
-# which casacore version to use
-
-ENV CASACORE_VERSION 3.4.0
-
 # how many threads to use for compiling
 ENV THREADS 4
 

--- a/docker/py36_wheel.docker
+++ b/docker/py36_wheel.docker
@@ -15,10 +15,6 @@ ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
 # where do we epect casacore data build time and runtime
 ENV CASACORE_DATA /usr/share/casacore/data
 
-# which casacore version to use
-
-ENV CASACORE_VERSION 3.4.0
-
 # how many threads to use for compiling
 ENV THREADS 4
 

--- a/docker/py36_wheel.docker
+++ b/docker/py36_wheel.docker
@@ -23,7 +23,7 @@ ENV CASACORE_VERSION 3.4.0
 ENV THREADS 4
 
 # install rpms
-RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel
+RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel gsl-devel
 
 # download other source code
 WORKDIR /tmp
@@ -78,4 +78,5 @@ RUN cmake .. \
     -DDATA_DIR=${CASACORE_DATA} \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
+USER root
 RUN make install

--- a/docker/py36_wheel.docker
+++ b/docker/py36_wheel.docker
@@ -76,6 +76,7 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
+    -DPORTABLE=TRUE \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 USER root

--- a/docker/py37_wheel.docker
+++ b/docker/py37_wheel.docker
@@ -15,10 +15,6 @@ ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
 # where do we epect casacore data build time and runtime
 ENV CASACORE_DATA /usr/share/casacore/data
 
-# which casacore version to use
-
-ENV CASACORE_VERSION 3.4.0
-
 # how many threads to use for compiling
 ENV THREADS 4
 

--- a/docker/py37_wheel.docker
+++ b/docker/py37_wheel.docker
@@ -76,6 +76,7 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
+    -DPORTABLE=TRUE \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 USER root

--- a/docker/py38_wheel.docker
+++ b/docker/py38_wheel.docker
@@ -22,7 +22,7 @@ ENV CASACORE_VERSION 3.4.0
 ENV THREADS 4
 
 # install rpms
-RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel
+RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel gsl-devel
 
 # download other source code
 WORKDIR /tmp
@@ -77,4 +77,5 @@ RUN cmake .. \
     -DDATA_DIR=${CASACORE_DATA} \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
+USER root
 RUN make install

--- a/docker/py38_wheel.docker
+++ b/docker/py38_wheel.docker
@@ -14,10 +14,6 @@ ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
 # where do we epect casacore data build time and runtime
 ENV CASACORE_DATA /usr/share/casacore/data
 
-# which casacore version to use
-
-ENV CASACORE_VERSION 3.4.0
-
 # how many threads to use for compiling
 ENV THREADS 4
 

--- a/docker/py38_wheel.docker
+++ b/docker/py38_wheel.docker
@@ -75,6 +75,7 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
+    -DPORTABLE=TRUE \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 USER root

--- a/docker/py39_wheel.docker
+++ b/docker/py39_wheel.docker
@@ -22,7 +22,7 @@ ENV CASACORE_VERSION 3.4.0
 ENV THREADS 4
 
 # install rpms
-RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel
+RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel gsl-devel
 
 # download other source code
 WORKDIR /tmp
@@ -77,4 +77,5 @@ RUN cmake .. \
     -DDATA_DIR=${CASACORE_DATA} \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
+USER root
 RUN make install

--- a/docker/py39_wheel.docker
+++ b/docker/py39_wheel.docker
@@ -14,10 +14,6 @@ ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
 # where do we epect casacore data build time and runtime
 ENV CASACORE_DATA /usr/share/casacore/data
 
-# which casacore version to use
-
-ENV CASACORE_VERSION 3.4.0
-
 # how many threads to use for compiling
 ENV THREADS 4
 

--- a/docker/py39_wheel.docker
+++ b/docker/py39_wheel.docker
@@ -75,6 +75,7 @@ RUN cmake .. \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \
+    -DPORTABLE=TRUE \
     -DCMAKE_INSTALL_PREFIX=/usr/local
 RUN make -j${THREADS}
 USER root


### PR DESCRIPTION
These are the docker images that I just used for deploying python-casacore 3.5.