### PR TITLE
Add wcslib includes to the clients of casacore.

### DIFF
--- a/casacore.pc.in
+++ b/casacore.pc.in
@@ -9,4 +9,4 @@ Version: @PROJECT_VERSION@
 Requires: @pc_req_public@
 Requires.private: @pc_req_private@
 Libs: -L${libdir} @PRIVATE_LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I@WCSLIB_INCLUDE_DIR@


### PR DESCRIPTION
The WCSLIB headers are included in public casacore headers, hence the flags to discover the WCSLIB library must also be propagated.

This is a small correction patch on previous PR #1202 .