### PR TITLE
Remove Notice leftovers

### DIFF
--- a/casa/Utilities.h
+++ b/casa/Utilities.h
@@ -41,7 +41,6 @@
 #include <casacore/casa/Utilities/DynBuffer.h>
 #include <casacore/casa/Utilities/Fallible.h>
 #include <casacore/casa/Utilities/GenSort.h>
-#include <casacore/casa/Utilities/Notice.h>
 #include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/Regex.h>
 #include <casacore/casa/Utilities/Sequence.h>

--- a/tables/Tables/TableRecord.h
+++ b/tables/Tables/TableRecord.h
@@ -85,7 +85,7 @@ class TableLock;
 // The structure of the TableRecord can be defined at
 // construction time. It can thereafter be restructured. This has the
 // effect, however, that any existing RecordFieldPtr objects become
-// invalid (using the <linkto file="Notice.h">Notice</linkto> classes).
+// invalid.
 // <br>
 // It is possible to add or remove fields once a TableRecord is constructed.
 // However, this is not possible when the TableRecord is constructed with a


### PR DESCRIPTION
When trying to compile CASA with an updated casacore, we noticed that there is a leftover include of Notice.h after the removal done in #1185, in a Utilities.h that is presumably only used from CASA.
This PR removes that include and fixes CASA compilation. It also removes a comment that refers to Notice.