### PR TITLE
Skip van Vleck corrections based on new FITS-IDI keyword

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -169,7 +169,9 @@ Vector<Double> FITSIDItoMS1::effChBw;
 //	
 // Constructor
 //	
-FITSIDItoMS1::FITSIDItoMS1(FitsInput& fitsin, const String& correlat, const Int& obsType, const Bool& initFirstMain)
+FITSIDItoMS1::FITSIDItoMS1(FitsInput& fitsin, const String& correlat,
+			   const Int& obsType, const Bool& initFirstMain,
+			   const Float& vanVleck)
   : BinaryTableExtension(fitsin),
     itsNrMSKs(10),
     itsMSKC(itsNrMSKs," "),
@@ -179,6 +181,7 @@ FITSIDItoMS1::FITSIDItoMS1(FitsInput& fitsin, const String& correlat, const Int&
     ///infile_p(fitsin),
     itsObsType(obsType),
     itsCorrelat(correlat),
+    itsVanVleck(vanVleck),
     msc_p(0)
 {
 
@@ -2247,6 +2250,11 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
 	  Rm = 1.0 / (A * H);
 	  alfa = 1.0;
 	  gamma = 1.0;
+	}
+
+	if (itsVanVleck != 0.0) {
+	  alfa = 1.0;
+	  rho = NULL;
 	}
 
 	bfactc = (gamma*gamma) / (A * Rm * alfa * H);

--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -129,7 +129,9 @@ public:
   // software correlator used by the EVN).
   //
 
-  FITSIDItoMS1(FitsInput& in, const String& correlat, const Int& obsType=0, const Bool& initFirstMain=True);
+  FITSIDItoMS1(FitsInput& in, const String& correlat,
+	       const Int& obsType=0, const Bool& initFirstMain=True,
+	       const Float& vanVleck=0.0);
 
   ~FITSIDItoMS1();
   
@@ -300,6 +302,7 @@ protected:
   Double lastTime_p;
   Int itsObsType;
   String itsCorrelat;
+  Float itsVanVleck;
   MeasurementSet ms_p;
   MSColumns* msc_p;
   static Bool firstMain;

--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -292,18 +292,23 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 
   // Correlator
   String correlat;
+  Float vanVleck = 0.0;
 
   // Loop over all HDU in the FITS-IDI file
   Bool initFirstMain = True;
   while (infits.err() == FitsIO::OK && !infits.eof()) {
 
-    // Fetch correlator name from the primary HDU
+    // Fetch correlator info from the primary HDU
     if (infits.hdutype() == FITS::PrimaryArrayHDU) {
       BytePrimaryArray tab(infits);
       if (tab.kw("CORRELAT")) {
 	correlat = tab.kw("CORRELAT")->asString();
 	correlat.trim();
 	os << LogIO::NORMAL << "Correlator: " << correlat << LogIO::POST;
+      }
+      if (tab.kw("VANVLECK")) {
+	vanVleck = tab.kw("VANVLECK")->asFloat();
+	os << LogIO::NORMAL << "VanVleck: " << vanVleck << LogIO::POST;
       }
     }
 
@@ -318,7 +323,7 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 
     } else {
       // Process the FITS-IDI input from the position of this binary table
-      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain);
+      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain, vanVleck);
       initFirstMain = False;
       String hduName = bintab.extname();
       hduName = hduName.before(trailing);


### PR DESCRIPTION
As described in the VLBA Sensitivity Upgrade Memo 52, new versions of the DiFX correlator will apply the van Vleck when requested to do so.  This will be signalled by a new keyword in the FITS header of FITS-IDI output.  See

  https://library.nrao.edu/public/memos/vlba/up/VLBASU_52.pdf

for more details.

Recognize this new keyword and skip the van Vleck correction if it is set to a non-zero value.