### PR TITLE
Add hash function to String

### DIFF
--- a/casa/BasicSL/String.h
+++ b/casa/BasicSL/String.h
@@ -1035,4 +1035,14 @@ inline ostream &operator<<(ostream &s, const String &x) {
 
 } //# NAMESPACE CASACORE - END
 
+
+// Define the hash function for String, so unordered_set<String> can be used.
+template<>
+struct std::hash<casacore::String>
+{
+  std::size_t operator()(casacore::String const& k) const noexcept
+    { return std::hash<std::string>()(k); }
+};
+
+
 #endif

--- a/casa/BasicSL/test/tString.cc
+++ b/casa/BasicSL/test/tString.cc
@@ -34,6 +34,7 @@
 #include <casacore/casa/stdlib.h>
 #include <casacore/casa/iostream.h>
 #include <casacore/casa/sstream.h>
+#include <unordered_set>
 
 #include <casacore/casa/namespace.h>
 // Generally used variables
@@ -480,6 +481,14 @@ int main() {
   toInt();
   trim();
   startsWith();
+  {
+    // Test to see if String hash works.
+    std::unordered_set<String> sset;
+    sset.insert ("abc");
+    AlwaysAssertExit (sset.size() == 1);
+    AlwaysAssertExit (sset.find("abc") != sset.end());
+    AlwaysAssertExit (sset.find("abd") == sset.end());
+  }
   cout << "\nEnd of test\n";
   return(0);
 }


### PR DESCRIPTION
Having a hash function for String makes it possible to use std::unordered_set<String> (or unordered_map).