### PR TITLE
Fix data race in SpectralCoordinate's toWorld/toPixel

### DIFF
--- a/coordinates/Coordinates/SpectralCoordinate.cc
+++ b/coordinates/Coordinates/SpectralCoordinate.cc
@@ -466,8 +466,8 @@ Bool SpectralCoordinate::toWorld (Vector<Double> &world,
 
 Bool SpectralCoordinate::toWorld(Double& world, const Double& pixel) const
 {
-    static Vector<Double> pixel_tmp1(1);
-    static Vector<Double> world_tmp1(1);
+    thread_local static Vector<Double> pixel_tmp1(1);
+    thread_local static Vector<Double> world_tmp1(1);
 //
     pixel_tmp1[0] = pixel;
     if (toWorld(world_tmp1, pixel_tmp1)) {
@@ -483,7 +483,7 @@ Bool SpectralCoordinate::toWorld(Double& world, const Double& pixel) const
 Bool SpectralCoordinate::toPixel (Vector<Double> &pixel,
                                   const Vector<Double> &world) const
 {
-    static Vector<Double> world_tmp1(1);
+    thread_local static Vector<Double> world_tmp1(1);
     DebugAssert(world.nelements()==1, AipsError);
     Bool ok = True;
 


### PR DESCRIPTION
These two functions use a static 1-element Vector to avoid allocations on each invocation; however these static vectors are shared across multiple threads, leading to race conditions on unlocked data access and therefore unexpected results.

This commit adds the thread_local specifier on these static variables such that in multi-threaded scenarios each thread ends up with its own static copy of the variable, thus avoiding unlocked data shared across threads.

This issue was originally reported in #1200, and then more specifically in #1217.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>