### PR TITLE
First stage of join clause in TaQL

### DIFF
--- a/tables/TaQL/TaQLNodeDer.cc
+++ b/tables/TaQL/TaQLNodeDer.cc
@@ -727,7 +727,7 @@ void TaQLJoinNodeRep::show (std::ostream& os) const
     itsTables.show (os);
     os << ' ';
   }
-  os << "ON CONDITION ";
+  os << "ON ";
   itsCondition.show (os);
 }
 void TaQLJoinNodeRep::save (AipsIO& aio) const
@@ -1161,7 +1161,7 @@ TaQLSelectNodeRep::TaQLSelectNodeRep (const TaQLNode& columns,
 TaQLSelectNodeRep::TaQLSelectNodeRep (const TaQLNode& columns,
                                       const TaQLMultiNode& with,
                                       const TaQLMultiNode& tables,
-                                      const TaQLNode& join,
+                                      const TaQLMultiNode& joins,
                                       const TaQLNode& where,
                                       const TaQLNode& groupby,
                                       const TaQLNode& having,
@@ -1171,7 +1171,7 @@ TaQLSelectNodeRep::TaQLSelectNodeRep (const TaQLNode& columns,
                                       const TaQLMultiNode& dminfo)
   : TaQLQueryNodeRep (TaQLNode_Select),
     itsColumns(columns), itsWith(with), itsTables(tables),
-    itsJoin(join), itsWhere(where), itsGroupby(groupby), itsHaving(having),
+    itsJoins(joins), itsWhere(where), itsGroupby(groupby), itsHaving(having),
     itsSort(sort), itsLimitOff(limitoff), itsGiving(giving),
     itsDMInfo(dminfo)
 {}
@@ -1188,7 +1188,7 @@ void TaQLSelectNodeRep::showDerived (std::ostream& os) const
     os << " FROM ";
     itsTables.show (os);
   }
-  itsJoin.show (os);
+  itsJoins.show (os);
   if (itsWhere.isValid()) {
     os << " WHERE ";
     itsWhere.show (os);
@@ -1216,7 +1216,7 @@ void TaQLSelectNodeRep::save (AipsIO& aio) const
   itsColumns.saveNode (aio);
   itsWith.saveNode (aio);
   itsTables.saveNode (aio);
-  itsJoin.saveNode (aio);
+  itsJoins.saveNode (aio);
   itsWhere.saveNode (aio);
   itsGroupby.saveNode (aio);
   itsHaving.saveNode (aio);
@@ -1231,7 +1231,7 @@ TaQLNode TaQLSelectNodeRep::restore (AipsIO& aio)
   TaQLNode columns = TaQLNode::restoreNode (aio);
   TaQLMultiNode with = TaQLNode::restoreMultiNode (aio);
   TaQLMultiNode tables = TaQLNode::restoreMultiNode (aio);
-  TaQLNode join = TaQLNode::restoreMultiNode (aio);
+  TaQLMultiNode joins = TaQLNode::restoreMultiNode (aio);
   TaQLNode where = TaQLNode::restoreNode (aio);
   TaQLNode groupby = TaQLNode::restoreNode (aio);
   TaQLNode having = TaQLNode::restoreNode (aio);
@@ -1240,7 +1240,7 @@ TaQLNode TaQLSelectNodeRep::restore (AipsIO& aio)
   TaQLNode giving = TaQLNode::restoreNode (aio);
   TaQLMultiNode dminfo = TaQLNode::restoreMultiNode (aio);
   std::unique_ptr<TaQLSelectNodeRep> node
-    (new TaQLSelectNodeRep (columns, with, tables, join,
+    (new TaQLSelectNodeRep (columns, with, tables, joins,
                             where, groupby, having,
                             sort, limitoff, giving, dminfo));
   node->restoreSuper (aio);

--- a/tables/TaQL/TaQLNodeDer.h
+++ b/tables/TaQL/TaQLNodeDer.h
@@ -798,7 +798,7 @@ public:
                      const TaQLNode& giving, const TaQLMultiNode& dminfo);
   TaQLSelectNodeRep (const TaQLNode& columns,
                      const TaQLMultiNode& withTables, const TaQLMultiNode& fromTables,
-                     const TaQLNode& join, const TaQLNode& where,
+                     const TaQLMultiNode& joins, const TaQLNode& where,
                      const TaQLNode& groupby, const TaQLNode& having,
                      const TaQLNode& sort, const TaQLNode& limitoff,
                      const TaQLNode& giving, const TaQLMultiNode& dminfo);
@@ -810,7 +810,7 @@ public:
   TaQLNode      itsColumns;
   TaQLMultiNode itsWith;
   TaQLMultiNode itsTables;
-  TaQLNode      itsJoin;
+  TaQLMultiNode itsJoins;
   TaQLNode      itsWhere;
   TaQLNode      itsGroupby;
   TaQLNode      itsHaving;

--- a/tables/TaQL/TaQLNodeHandler.cc
+++ b/tables/TaQL/TaQLNodeHandler.cc
@@ -388,8 +388,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   TaQLNodeResult TaQLNodeHandler::visitJoinNode (const TaQLJoinNodeRep&)
   {
-    throw TableInvExpr ("join is not supported yet");
-    return TaQLNodeResult();
+    throw TableInvExpr("Joins are not implemented yet");
   }
 
   TaQLNodeResult TaQLNodeHandler::visitGroupNode (const TaQLGroupNodeRep& node)
@@ -529,7 +528,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Furthermore, handle GIVING first, because projection needs to know
     // the resulting table name.
     visitNode     (node.itsGiving);
-    visitNode     (node.itsJoin);
+    handleJoins   (node.itsJoins);
     handleWhere   (node.itsWhere);
     visitNode     (node.itsGroupby);
     visitNode     (node.itsColumns);
@@ -940,6 +939,17 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       topStack()->tableList().addTable (res.getInt(), res.getString(),
                                         res.getTable(), res.getAlias(),
                                         addToFromList, itsTempTables, itsStack);
+    }
+  }
+
+  void TaQLNodeHandler::handleJoins (const TaQLMultiNode& node)
+  {
+    if (! node.isValid()) {
+      return;     // no joins
+    }
+    const std::vector<TaQLNode>& nodes = node.getMultiRep()->itsNodes;
+    for (uInt i=0; i<nodes.size(); ++i) {
+      visitNode (nodes[i]);
     }
   }
 

--- a/tables/TaQL/TaQLNodeHandler.h
+++ b/tables/TaQL/TaQLNodeHandler.h
@@ -171,6 +171,9 @@ private:
   // Handle a MultiNode containing table info.
   void handleTables (const TaQLMultiNode&, Bool addToFromList=True);
 
+  // Handle a MultiNoide containing joins.
+  void handleJoins (const TaQLMultiNode& node);
+
   // Make a ConcatTable from a nested set of tables.
   Table makeConcatTable (const TaQLMultiNodeRep& node);
 

--- a/tables/TaQL/TableGram.ll
+++ b/tables/TaQL/TableGram.ll
@@ -469,13 +469,15 @@ PATTREX   {OPERREX}{WHITE}({PATTEX}|{DISTEX})
             BEGIN(EXPRstate);
             return HAVING;
           }
-{JOIN} {
+{JOIN}    {
             tableGramPosition() += yyleng;
-            throw (TableInvExpr ("JOIN ON is not supported yet"));
+	    BEGIN(TABLENAMEstate);
+	    return JOIN;
           }
-{ON}  {
+{ON}      {
             tableGramPosition() += yyleng;
-            throw (TableInvExpr ("JOIN ON is not supported yet"));
+	    BEGIN(EXPRstate);
+	    return ON;
           }
 
 {AS}      {

--- a/tables/TaQL/TableGram.yy
+++ b/tables/TaQL/TableGram.yy
@@ -60,6 +60,8 @@ Expect them, so bison does not generate an error message.
 %token DROPTAB
 %token WITH
 %token FROM
+%token JOIN
+%token ON
 %token WHERE
 %token GROUPBY
 %token GROUPROLL
@@ -154,6 +156,9 @@ Expect them, so bison does not generate an error message.
 %type <nodelist> concsub
 %type <nodelist> concslist
 %type <nodename> concinto
+%type <nodelist> joins
+%type <nodelist> joinlist
+%type <node> join
 %type <node> whexpr
 %type <node> groupby
 %type <nodelist> exprlist
@@ -408,17 +413,17 @@ withpart:  {   /* no WITH part */
 
 /* The SELECT command; note that many parts are optional which is handled
    in the rule of that part. The FROM part being optional is handled here
-   because later a join might be added. */
-selcomm:   withpart SELECT selcol FROM tables whexpr groupby having order limitoff given dminfo {
+   because a join might be used. */
+selcomm:   withpart SELECT selcol FROM tables joins whexpr groupby having order limitoff given dminfo {
                $$ = new TaQLQueryNode(
-                    new TaQLSelectNodeRep (*$3, *$1, *$5, 0, *$6, *$7, *$8,
-					   *$9, *$10, *$11, *$12));
+                    new TaQLSelectNodeRep (*$3, *$1, *$5, *$6, *$7, *$8, *$9,
+					   *$10, *$11, *$12, *$13));
 	       TaQLNode::theirNodesCreated.push_back ($$);
            }
-         | withpart SELECT selcol into FROM tables whexpr groupby having order limitoff dminfo {
+         | withpart SELECT selcol into FROM tables joins whexpr groupby having order limitoff dminfo {
                $$ = new TaQLQueryNode(
-		    new TaQLSelectNodeRep (*$3, *$1, *$6, 0, *$7, *$8, *$9,
-					   *$10, *$11, *$4, *$12));
+		    new TaQLSelectNodeRep (*$3, *$1, *$6, *$7, *$8, *$9, *$10,
+					   *$11, *$12, *$4, *$13));
 	       TaQLNode::theirNodesCreated.push_back ($$);
            }
          | withpart SELECT selcol whexpr groupby having order limitoff given dminfo {
@@ -1459,6 +1464,34 @@ tabname:   NAME {
            }
          | stabname {
                $$ = $1;
+           }
+         ;
+
+/* JOIN ON is optional */
+joins:     {   /* no joins */
+	       $$ = new TaQLMultiNode();
+	       TaQLNode::theirNodesCreated.push_back ($$);
+           }
+         | joinlist {
+               $$ = $1;
+           }
+         ;
+
+joinlist:  joinlist join {
+               $$ = $1;
+               $$->add (*$2);
+           }
+         | join {
+	       $$ = new TaQLMultiNode(False);
+               $$->setSeparator (String());
+	       TaQLNode::theirNodesCreated.push_back ($$);
+               $$->add (*$1);
+           }
+         ;
+
+join:      JOIN tablist ON orexpr {
+               $$ = new TaQLNode (new TaQLJoinNodeRep (*$2, *$4));
+	       TaQLNode::theirNodesCreated.push_back ($$);
            }
          ;
 

--- a/tables/TaQL/test/tTaQLNode.out
+++ b/tables/TaQL/test/tTaQLNode.out
@@ -419,3 +419,12 @@ WITH [SELECT abs((phase(t1.DATA))-(phase(t2.DATA))) AS D FROM a.ms AS t1,/home/g
 with ~a select 1+2 from [~b,[select 3+4 from [[select 5+6],~c]], ~d giving ~e] where 3+4 giving ~f
 WITH ~a SELECT (1)+(2) FROM [~b,[SELECT (3)+(4) FROM [[SELECT (5)+(6)],~c]],~d GIVING ~e] WHERE (3)+(4) GIVING ~f
 
+select from a join b on a.b == b.b join c on a.c BETWEEN c.m AND c.w
+SELECT FROM a AS a JOIN b AS b ON (a.b)=(b.b) JOIN c AS c ON (a.c) IN {c.m,c.w}
+
+SELECT t1.rowid() as r1, t2.pol, t3.ci FROM tTableGramJoin_tmp.tab t1 JOIN ::DD t2 ON t1.cdd=t2.rowid() JOIN ::SC t3 ON t2.spw=t3.spw AND t1.ct AROUND t3.tod IN t3.w
+SELECT t1.rowid() AS r1,t2.pol,t3.ci FROM tTableGramJoin_tmp.tab AS t1 JOIN ::DD AS t2 ON (t1.cdd)=(t2.rowid()) JOIN ::SC AS t3 ON ((t2.spw)=(t3.spw))&&((t1.ct) IN (t3.tod)<:>(t3.w))
+
+SELECT t1.rowid() as r1, t2.pol, t3.ci FROM tTableGramJoin_tmp.tab t1 JOIN ::DD t2 ON t1.cdd=t2.rowid() JOIN ::SC t3 ON t2.spw=t3.spw AND t1.ct AROUND t3.tod IN t3.w WHERE t3.ci%3!=0
+SELECT t1.rowid() AS r1,t2.pol,t3.ci FROM tTableGramJoin_tmp.tab AS t1 JOIN ::DD AS t2 ON (t1.cdd)=(t2.rowid()) JOIN ::SC AS t3 ON ((t2.spw)=(t3.spw))&&((t1.ct) IN (t3.tod)<:>(t3.w)) WHERE ((t3.ci)%(3))<>(0)
+

--- a/tables/TaQL/test/tTaQLNode.run
+++ b/tables/TaQL/test/tTaQLNode.run
@@ -69,11 +69,13 @@ $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab IN (se
 
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab BETWEEN 2 AND 4'
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab NOT BETWEEN 2 AND 4'
+
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab AROUND 2 IN 4'
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab NOT AROUND 2 IN 4'
 
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab IN [BETWEEN 2 AND 4]'
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab IN AROUND 2 IN 4'
+
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab IN [:=2,4=:<6,7<:]'
 
 $casa_checktool ./tTaQLNode 'select ab,ac from tTaQLNode_tmp.tab where ab IN [2,(3)]'
@@ -212,3 +214,7 @@ $casa_checktool ./tTaQLNode 'show a b c d e'
 $casa_checktool ./tTaQLNode 'with [select abs(phase(t1.DATA) - phase(t2.DATA)) as D from a.ms t1, /home/ger/WSRTA190521040_B001_original.MS t2] t select gmax(iif(D>pi(),D-3.14,D)) from t'
 
 $casa_checktool ./tTaQLNode "with ~a select 1+2 from [~b,[select 3+4 from [[select 5+6],~c]], ~d giving ~e] where 3+4 giving ~f"
+
+$casa_checktool ./tTaQLNode "select from a join b on a.b == b.b join c on a.c BETWEEN c.m AND c.w"
+$casa_checktool ./tTaQLNode "SELECT t1.rowid() as r1, t2.pol, t3.ci FROM tTableGramJoin_tmp.tab t1 JOIN ::DD t2 ON t1.cdd=t2.rowid() JOIN ::SC t3 ON t2.spw=t3.spw AND t1.ct AROUND t3.tod IN t3.w"
+$casa_checktool ./tTaQLNode "SELECT t1.rowid() as r1, t2.pol, t3.ci FROM tTableGramJoin_tmp.tab t1 JOIN ::DD t2 ON t1.cdd=t2.rowid() JOIN ::SC t3 ON t2.spw=t3.spw AND t1.ct AROUND t3.tod IN t3.w WHERE t3.ci%3!=0"


### PR DESCRIPTION
This is the first part of the changes for support of the JOIN clause in TaQL.
This part contains the changes in the scanner/parser and the code to handle the result from the parser and store it in a tree. Handling the result tree is done in a separate PR.

The syntax of the join looks like:

select t1.col1, t2.col2, ... from table table1 t1 JOIN table2 t2 ON condition JOIN table3 t3 ON condition ... WHERE ...

Theta joins (implicit joins in the SELECT clause) are not supported. They are discouraged in SQL.