### PR TITLE
MSLister: prevent undefined behavior from 'log10("negative value") casted to int' that produces crashes in the CASA task listvis with newer GCCs

### DIFF
--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -539,6 +539,12 @@ void MSLister::selectvis(const String& timerange,
   }
 } // end selectvis
 
+/// Calculate the max number of digits needed to print the values in an array
+template <class T> uInt maxDigitsToPrint(const Array<T> &values)
+{
+    return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))+0.5))));
+}
+
 void MSLister::listData(const int pageRows,
                         const String listfile)
 {
@@ -892,21 +898,21 @@ void MSLister::listData(const int pageRows,
       if ( precTime_p < 0 ) precTime_p = 7; // hh:mm:ss.s
       if ( precTime_p > 0 ) oTime_p++; // add space for decimal
 
-      oUVDist_p = (uInt)max(1,(Int)rint(log10(max(uvdist))+0.5)); // order
+      oUVDist_p = maxDigitsToPrint(uvdist); // order
       if ( precUVDist_p < 0 ) precUVDist_p = 0;
       if ( precUVDist_p > 0 ) oUVDist_p++;  // add space for decimal
 
-      oUVW_p = (uInt)max(1,(Int)rint(log10(max(uvw))+0.5)); // order
+      oUVW_p = maxDigitsToPrint(uvw); // order
       if ( precUVW_p < 0 ) precUVW_p = 2;
       if ( precUVW_p > 0 ) oUVW_p++;  // add space for decimal
       oUVW_p++;  // add space for sign
 
-      oAmpl_p = (uInt)max(1,(Int)rint(log10(max(ampl))+0.5));
+      oAmpl_p = maxDigitsToPrint(ampl);
       if ( precAmpl_p < 0 ) precAmpl_p = 3;  // mJy
       if ( precAmpl_p > 0 ) oAmpl_p++;  // add space for decimal
 
       if (!is_float){
-		  oPhase_p = (uInt)max(1,(Int)rint(abs(log10(max(phase)+0.5))));
+		  oPhase_p = maxDigitsToPrint(phase);
 		  if(min(phase) < 0) { oPhase_p+=3; } // add space for sign and column border
 		  else { oPhase_p++; } // add space for column border
 		  //oPhase_p = 3;  // 100s of degs
@@ -914,7 +920,7 @@ void MSLister::listData(const int pageRows,
 		  if ( precPhase_p > 0 ) oPhase_p+=2; // add space for decimal
       }
 
-      oWeight_p = (uInt)max(1,(Int)rint(log10(max(weight))+0.5));  // order
+      oWeight_p = maxDigitsToPrint(weight);  // order
       if ( precWeight_p < 0 ) precWeight_p = 0;
       if ( precWeight_p > 0 ) oWeight_p++;  // add space for decimal
 
@@ -925,8 +931,8 @@ void MSLister::listData(const int pageRows,
       wAnt2_p = columnWidth(antNames2);
 
       wFlag_p = 2; // the flag is always 1 character
-      if (doFld_p) wFld_p    = (uInt)rint(log10((float)max(fieldid))+0.5);
-      if (doSpW_p) wSpW_p    = (uInt)rint(log10((float)max(spwinid))+0.5);
+      if (doFld_p) wFld_p    = maxDigitsToPrint(fieldid);
+      if (doSpW_p) wSpW_p    = maxDigitsToPrint(spwinid);
       if (doChn_p) wChn_p    = 3;
 
 

--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -542,7 +542,7 @@ void MSLister::selectvis(const String& timerange,
 /// Calculate the max number of digits needed to print the values in an array
 template <class T> uInt maxDigitsToPrint(const Array<T> &values)
 {
-    return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))+0.5))));
+    return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))))+0.5));
 }
 
 void MSLister::listData(const int pageRows,


### PR DESCRIPTION
The cast of the result from rint() to (Int) in this line: https://github.com/casacore/casacore/blob/990a7e0e4108d1b39534aa918f675fff27baf4d3/ms/MSOper/MSLister.cc#L909 produces an undefined behavior that with more modern GCCs and the optimization flag `-ftree-vrp` enabled (it is included in `-O2`) makes the MSLister crash in a CASA task test. 

Besides the potential crash that happens when (max(phase)+0.5 < 0), dependent on how the undefined cast behaves in practice, the code is miscalculating that "order" of the phase array, as it assumes that the largest values in (absolute value) are positive.

This patch prevents that `log10("negative value")` by adding an `abs()` around the `max()`, and also uses the same function in all the lines that make a similar calculation for other MS columns / arrays derived from MS columns.



---
**Explanation of the crash:**

When working on an updated build system for CASA we noticed crashes in one of the tests of the CASA task 'listvis', listvis_test1.test2. So far we hadn't seen crashes for this in official CASA builds, but with more modern GCCs (jumping from 5.3 to 8.5 or later) and having `-ftree-vrp` optimizaton flag enabled, the crash happens as follows, in this line:
https://github.com/casacore/casacore/blob/990a7e0e4108d1b39534aa918f675fff27baf4d3/ms/MSOper/MSLister.cc#L909
for the selection of phase values in that test, max(phase) = -89.3596, which produces a "nan" log10 result that then propagates to the max().
Then the undefined behavior (+ `-ftree-vrp` = "enable Value Range Propagation on trees") turns into the following: in the version of max being used for the max(1, (Int)...),  from casa/BasicMath/Math.h https://github.com/casacore/casacore/blob/990a7e0e4108d1b39534aa918f675fff27baf4d3/casa/BasicMath/Math.h#L158
That "a > b" comparison (1 > "nan casted to int = ~2147483648"), when inlined yields false, then max returns "b", which is then casted to uInt 2147483648. This finally produces an out-of-bound access segfault further down in MSLister::listData((), here: https://github.com/casacore/casacore/blob/990a7e0e4108d1b39534aa918f675fff27baf4d3/ms/MSOper/MSLister.cc#L980-L981 (where wVis_p includes oPhase_p).

With older GCCs or with optimization level < `O2` (or using `-fno-tree-vrp` to disable this particular optimization option) the (a>b) comparison is true and that max returns 1, which is a wrong result (as estimate of the number of digits needed to format the output) but doesn't lead to a crash. The latter behavior is what we had so far with older GCCs.

To circumvent this issue temporarily, CASA compiles casacore with `-fno-tree-vrp`. Once the patch included here is applied to MSLister, the `-fno-tree-vrp` can be removed and all tests of task listvis pass without issues.
This funny interaction between the undefined (Int) cast and `-ftree-vrp` can be reproduced with the attached small example: 
[min_max_nan.cc.gz](https://github.com/casacore/casacore/files/10042734/min_max_nan.cc.gz)