### PR TITLE
Add pow function of std::complex<T> and T

### DIFF
--- a/casa/Arrays/ArrayMath.h
+++ b/casa/Arrays/ArrayMath.h
@@ -502,7 +502,8 @@ template<typename T, typename Alloc> Array<T, Alloc> fmod(const Array<T, Alloc> 
 template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, Alloc> &a, const Array<T, Alloc> &b);
 template<typename T, typename Alloc> Array<T, Alloc> floormod(const T &a, const Array<T, Alloc> &b);
 template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, Alloc> &a, const T &b);
-template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const double &b);
+template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const T &b);
+template<typename T, typename Alloc> Array<std::complex<T>, Alloc> pow(const Array<std::complex<T>, Alloc> &a, const T &b);
 template<typename T, typename Alloc> Array<T, Alloc> tan(const Array<T, Alloc> &a);
 template<typename T, typename Alloc> Array<T, Alloc> tanh(const Array<T, Alloc> &a);
 // N.B. fabs is deprecated. Use abs.

--- a/casa/Arrays/ArrayMath.tcc
+++ b/casa/Arrays/ArrayMath.tcc
@@ -841,10 +841,15 @@ template<typename T, typename Alloc> Array<T, Alloc> pow(const T &a, const Array
     return arrayTransformResult (a, b, [](T l, T r) { return std::pow(l, r); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const double &b)
+template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const T &b)
 {
-    Array<T, Alloc> result(a.shape());
-    arrayContTransform (a, b, result, [](T l, T r) { return std::pow(l, r); });
+    return arrayTransformResult (a, b, [](T l, T r) { return std::pow(l, r); });
+}
+
+template<typename T, typename Alloc> Array<std::complex<T>, Alloc> pow(const Array<std::complex<T>, Alloc> &a, const T &b)
+{
+    Array<std::complex<T>, Alloc> result(a.shape());
+    arrayContTransform (a, b, result, [](std::complex<T> l, T r) { return std::pow(l, r); });
     return result;
 }
 

--- a/lattices/LEL/LELFunction2.cc
+++ b/lattices/LEL/LELFunction2.cc
@@ -287,7 +287,7 @@ void LELFunctionFloat::eval(LELArray<Float>& result,
 	    if (scalarTemp == 2) {
 	       result.value() *= result.value();
 	    } else {
-	       Array<Float> temp (pow (result.value(), Double(scalarTemp)));
+	       Array<Float> temp (pow (result.value(), scalarTemp));
 	       result.value().reference (temp);
 	    }
 	    break;
@@ -1241,7 +1241,7 @@ void LELFunctionComplex::eval(LELArray<Complex>& result,
 	    arg_p[1].eval(scalarTemp);
 	    arg_p[0].eval(result, section);
 	    if (scalarTemp.imag() == 0) {
-	       Double exponent = scalarTemp.real();
+	       Float exponent = scalarTemp.real();
 	       if (exponent == 2) {
 		  result.value() *= result.value();
 	       } else {

--- a/tables/TaQL/ExprFuncNodeArray.cc
+++ b/tables/TaQL/ExprFuncNodeArray.cc
@@ -2002,11 +2002,13 @@ MArray<DComplex> TableExprFuncNodeArray::getArrayDComplex
             return casacore::pow (operands()[0]->getDComplex(id),
                                   operands()[1]->getArrayDComplex(id));
         } else if (operands()[1]->valueType() == VTScalar) {
-            MArray<DComplex> arr1 (operands()[0]->getArrayDComplex(id));
-            Array<DComplex> arr2 (arr1.shape());
-            arr2 = operands()[1]->getDComplex(id);
-            /// Make pow of array,scalar possible
-            return MArray<DComplex> (pow(arr1.array(), arr2), arr1);
+          if (operands()[1]->dataType() == NTDouble) {
+            return casacore::pow (operands()[0]->getArrayDComplex(id),
+                                  operands()[1]->getDouble(id));
+          } else {
+            return casacore::pow (operands()[0]->getArrayDComplex(id),
+                                  operands()[1]->getDComplex(id));
+          }
         } else {
             return pow (operands()[0]->getArrayDComplex(id),
                         operands()[1]->getArrayDComplex(id));

--- a/tables/TaQL/MArrayMath.h
+++ b/tables/TaQL/MArrayMath.h
@@ -589,8 +589,12 @@ namespace casacore {
     { return MArray<T> (pow(a, exp.array()), exp); }
 
   template<typename T>
-  MArray<T> pow(const MArray<T>& a, const Double& exp)
+  MArray<T> pow(const MArray<T>& a, const T& exp)
     { return MArray<T> (pow(a.array(), exp), a); }
+
+  template<typename T>
+  MArray<std::complex<T>> pow(const MArray<std::complex<T>>& a, const T& exp)
+  { return MArray<std::complex<T>> (pow(a.array(), exp), a); }
 
   template<typename T>
   MArray<T> min(const MArray<T>& left, const MArray<T>& right)

--- a/tables/TaQL/test/tExprNode.cc
+++ b/tables/TaQL/test/tExprNode.cc
@@ -795,7 +795,7 @@ void doIt()
   checkScaDouble ("norm sd", exprid, norm(esd1), sd1*sd1);
   checkArrDouble ("norm ad", exprid, norm(earrd1), arrd1*arrd1);
   checkScaDouble ("norm sz", exprid, norm(esz1), norm(sz1));
-  checkArrDouble ("norm az", exprid, norm(earrz1), pow(amplitude(arrz1),2));
+  checkArrDouble ("norm az", exprid, norm(earrz1), pow(amplitude(arrz1),2.));
   checkScaInt ("abs si", exprid, abs(esi1), abs(si1));
   checkArrInt ("abs ai", exprid, abs(earri1), abs(arri1));
   checkScaDouble ("abs sd", exprid, abs(esd1), abs(sd1));

--- a/tables/TaQL/test/tMArrayMath.cc
+++ b/tables/TaQL/test/tMArrayMath.cc
@@ -200,6 +200,18 @@ template <typename T> void doTestComplex()
   }
 }
 
+template<typename T> void doTestComplexReal()
+{
+  // Test pow function for mix of complex array and real scalar.
+  T val(1.7);
+  std::complex<T> valc(1,2);
+  MArray<std::complex<T>> m1 (Vector<std::complex<T>>(2, valc));
+  for (int i=0; i<2; ++i) {
+    checkNear (pow(m1,val), std::pow(valc,val), False, i==0);
+    m1.setMask (Vector<Bool>(2,False));
+  }
+}
+
 void doTestMixed()
 {
   // Test masking more thoroughly.
@@ -718,6 +730,10 @@ int main()
     doTestComplex<Complex>();
     cout << "doTestComplex<DComplex>" << endl;
     doTestComplex<DComplex>();
+    cout << "doTestComplexReal<Float>" << endl;
+    doTestComplexReal<Float>();
+    cout << "doTestComplexReal<Double>" << endl;
+    doTestComplexReal<Double>();
     cout << "doTestMixed" << endl;
     doTestMixed();
     cout << "doTestReduce" << endl;


### PR DESCRIPTION
The pow function in ArrayMath only supported a mix of scalar and array, but a scalar exponent could only be of type double. This has been changed to T. An extra pow function has been added to make it possible to have a real exponent for a complex array.
LatticeMath and MArrayMath have been changed accordingly.

Close #1241