### PR TITLE
Handle VLBA/DiFX data without zero-padding correctly 

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -171,7 +171,7 @@ Vector<Double> FITSIDItoMS1::effChBw;
 //	
 FITSIDItoMS1::FITSIDItoMS1(FitsInput& fitsin, const String& correlat,
 			   const Int& obsType, const Bool& initFirstMain,
-			   const Float& vanVleck)
+			   const Float& vanVleck, const Int& zeroPad)
   : BinaryTableExtension(fitsin),
     itsNrMSKs(10),
     itsMSKC(itsNrMSKs," "),
@@ -182,6 +182,7 @@ FITSIDItoMS1::FITSIDItoMS1(FitsInput& fitsin, const String& correlat,
     itsObsType(obsType),
     itsCorrelat(correlat),
     itsVanVleck(vanVleck),
+    itsZeroPad(zeroPad),
     msc_p(0)
 {
 
@@ -2208,8 +2209,8 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
       // Apply digital corrections to data correlated with the DiFX
       // correlator as these have not been applied at the correlator.
       // Various constants have been taken from VLBA Scientific Memo
-      // 12 as the DiFX tries to emulate the original VLBA FX
-      // correlator as closely as possible.  Note that DiFX doesn't
+      // 12 as the DiFX correlator tries to emulate the original VLBA
+      // FX correlator as closely as possible.  Note that DiFX doesn't
       // suffer from saturation so the saturation correction is
       // omitted here.  DiFX currently doesn't support Hanning
       // weighting.
@@ -2263,8 +2264,11 @@ void FITSIDItoMS1::fillMSMainTable(const String& MSFileName, Int& nField, Int& n
 	if (ant1 != ant2 || rho == NULL) {
 	  // Cross-correlations
 	  vis *= Complex(bfactc);
+	} else if (itsZeroPad == 0) {
+	  // Auto-correlations, without zero-padding
+	  vis *= Complex(bfacta);
 	} else {
-	  // Auto-correlations
+	  // Auto-correlations, with zero-padding
 	  for (Int p=0; p<nCorr; p++) {
 	    if (corrProduct_p(0, p) == corrProduct_p(1, p)) {
 

--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -131,7 +131,7 @@ public:
 
   FITSIDItoMS1(FitsInput& in, const String& correlat,
 	       const Int& obsType=0, const Bool& initFirstMain=True,
-	       const Float& vanVleck=0.0);
+	       const Float& vanVleck=0.0, const Int& zeroPad=0);
 
   ~FITSIDItoMS1();
   
@@ -303,6 +303,7 @@ protected:
   Int itsObsType;
   String itsCorrelat;
   Float itsVanVleck;
+  Int itsZeroPad;
   MeasurementSet ms_p;
   MSColumns* msc_p;
   static Bool firstMain;

--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -293,6 +293,7 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
   // Correlator
   String correlat;
   Float vanVleck = 0.0;
+  Int zeroPad = 0;
 
   // Loop over all HDU in the FITS-IDI file
   Bool initFirstMain = True;
@@ -323,12 +324,19 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 
     } else {
       // Process the FITS-IDI input from the position of this binary table
-      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain, vanVleck);
+      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain, vanVleck, zeroPad);
       initFirstMain = False;
       String hduName = bintab.extname();
       hduName = hduName.before(trailing);
       String tableName = itsMSOut;
       if (hduName != "") {
+	if (hduName == "MODEL_COMPS") {
+	  // Zero padding "factor"; a value of 0 implies no zero padding
+	  if (bintab.kw("ZERO_PAD")) {
+	    zeroPad = bintab.kw("ZERO_PAD")->asInt();
+	    os << LogIO::NORMAL << "ZeroPad: " << zeroPad << LogIO::POST;
+	  }
+	}
 	if (hduName != "UV_DATA") {
 	  tableName = tableName + "_tmp/" + hduName;
 	}


### PR DESCRIPTION
Correction of the autocorrelations in the lag domain can only be
done properly if the correlator has zero-padded the data.  Handle
the case where data has not been zero-padded and assume this is
the default as DiFX doesn't zero-pad.

The VLBA correlator indicates whether data has been zero-padded by
setting the ZERO_PAD keyword in the MODEL_COMPS table to a non-zero
value.  Use this to override the default of assuming no zero-padding
has been done.