### PR TITLE
Add Python 3.11 support

### DIFF
--- a/docker/make_images.sh
+++ b/docker/make_images.sh
@@ -3,6 +3,6 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 36 37 38 39 310; do
+for i in 37 38 39 310 311; do
     docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:master_wheel${i}
 done

--- a/docker/py311_wheel.docker
+++ b/docker/py311_wheel.docker
@@ -2,12 +2,11 @@ FROM quay.io/pypa/manylinux2014_x86_64
 
 # set python version
 ENV PYMAJOR 3
-ENV PYMINOR 6
-ENV PYUNICODE m
+ENV PYMINOR 11
 ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}${PYUNICODE}
 
 # boost version
-ENV BOOSTMAJOR 75
+ENV BOOSTMAJOR 79
 ENV BOOSTMINOR 0
 ENV BOOST 1.${BOOSTMAJOR}.${BOOSTMINOR}
 ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
@@ -55,7 +54,7 @@ RUN ./b2 -j${THREADS} \
     link=static,shared install
 
 # casacore wants numpy
-RUN /opt/python/${TARGET}/bin/pip install numpy==1.19.5
+RUN /opt/python/${TARGET}/bin/pip install numpy==1.23.5
 
 # set up casacore
 ADD . /code


### PR DESCRIPTION
Added support for building Python 3.11 docker image. Dropped support for Python 3.6, which is EOL.