### PR TITLE
Add new unit prefixes

### DIFF
--- a/casa/BasicSL/Constants.cc
+++ b/casa/BasicSL/Constants.cc
@@ -105,6 +105,8 @@ const Double C::c		= 2.99792458e+08;
 //----------------------------------------------------------------------------
 
 // Metric prefixes (unity):
+const Double C::quetta 		= 1.0e+30;
+const Double C::ronna 		= 1.0e+27;
 const Double C::yotta 		= 1.0e+24;
 const Double C::zetta 		= 1.0e+21;
 const Double C::exa 		= 1.0e+18;
@@ -125,6 +127,8 @@ const Double C::femto 		= 1.0e-15;
 const Double C::atto 		= 1.0e-18;
 const Double C::zepto 		= 1.0e-21;
 const Double C::yocto 		= 1.0e-24;
+const Double C::ronto 		= 1.0e-27;
+const Double C::quecto 		= 1.0e-30;
 
 // Angular measure:
 const Double C::radian         	= 1.0;

--- a/casa/BasicSL/Constants.h
+++ b/casa/BasicSL/Constants.h
@@ -132,6 +132,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 // <h3>Numerical conversion factors</h3>
 // <srcblock>
+// quetta               e+30 (Q)
+// ronna                e+27 (R)
 // yotta                e+24 (Y)
 // zetta                e+21 (Z)
 // exa                  e+18 (E)
@@ -152,6 +154,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // atto                 e-18 (a)
 // zepto                e-21 (z)
 // yocto                e-24 (y)
+// ronto                e-27 (r)
+// quecto               e-30 (q)
 // </srcblock>
 
 // <h3>Angular measure</h3>
@@ -485,6 +489,10 @@ namespace C {
   
   //  Numerical conversion factors
   // <group>
+  // e+30 (Q)
+  extern const Double quetta;
+  // e+27 (R)
+  extern const Double ronna;
   // e+24 (Y)
   extern const Double yotta;
   // e+21 (Z)
@@ -525,6 +533,10 @@ namespace C {
   extern const Double zepto;
   // e-24 (y)
   extern const Double yocto;
+  // e-27 (r)
+  extern const Double ronto;
+  // e-30 (q)
+  extern const Double quecto;
   // </group>
   
   // Angular measure:

--- a/casa/BasicSL/test/tConstants.cc
+++ b/casa/BasicSL/test/tConstants.cc
@@ -152,6 +152,8 @@ int main()
 
    cout << endl
         << "Metric prefixes:"                               << endl
+        << "C::quetta.............  " << C::quetta          << endl
+        << "C::ronna..............  " << C::ronna           << endl
         << "C::yotta..............  " << C::yotta           << endl
         << "C::zetta..............  " << C::zetta           << endl
         << "C::exa................  " << C::exa             << endl
@@ -171,7 +173,9 @@ int main()
         << "C::femto..............  " << C::femto           << endl
         << "C::atto...............  " << C::atto            << endl
         << "C::zepto..............  " << C::zepto           << endl
-        << "C::yocto..............  " << C::yocto           << endl;
+        << "C::yocto..............  " << C::yocto           << endl
+        << "C::ronto..............  " << C::ronto           << endl
+        << "C::quecto.............  " << C::quecto          << endl;
 
    cout << endl
         << "Angular measure:"                               << endl

--- a/casa/BasicSL/test/tConstants.out
+++ b/casa/BasicSL/test/tConstants.out
@@ -94,6 +94,8 @@ Fundamental physical constants (SI units):
 C::c..................  2.99792e+08
 
 Metric prefixes:
+C::quetta.............  1e+30
+C::ronna..............  1e+27
 C::yotta..............  1e+24
 C::zetta..............  1e+21
 C::exa................  1e+18
@@ -114,6 +116,8 @@ C::femto..............  1e-15
 C::atto...............  1e-18
 C::zepto..............  1e-21
 C::yocto..............  1e-24
+C::ronto..............  1e-27
+C::quecto.............  1e-30
 
 Angular measure:
 C::radian.............  1

--- a/casa/Quanta/UnitMap2.cc
+++ b/casa/Quanta/UnitMap2.cc
@@ -33,6 +33,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 void UnitMap::initUMPrefix (UMaps& maps) {
   map<String, UnitName>& mapPref = maps.mapPref;
   mapPref.insert(map<String, UnitName>::value_type
+			   ("Q", UnitName("Q", C::quetta,"quetta")));
+  mapPref.insert(map<String, UnitName>::value_type
+			   ("R", UnitName("R", C::ronna, "ronna")));
+  mapPref.insert(map<String, UnitName>::value_type
 			   ("Y", UnitName("Y", C::yotta, "yotta")));
   mapPref.insert(map<String, UnitName>::value_type
 			   ("Z", UnitName("Z", C::zetta, "zetta")));
@@ -72,6 +76,10 @@ void UnitMap::initUMPrefix (UMaps& maps) {
 			   ("z", UnitName("z", C::zepto, "zepto")));
   mapPref.insert(map<String, UnitName>::value_type
 			   ("y", UnitName("y", C::yocto, "yocto")));
+  mapPref.insert(map<String, UnitName>::value_type
+			   ("r", UnitName("r", C::ronto, "ronto")));
+  mapPref.insert(map<String, UnitName>::value_type
+			   ("q", UnitName("q", C::quecto,"quecto")));
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/Quanta/test/tUnit.out
+++ b/casa/Quanta/test/tUnit.out
@@ -6,11 +6,13 @@ Define user unit symbols:
 --------------------------
 List all defined symbols
 
-Prefix table (20):
+Prefix table (24):
     E         (exa)                        1e+18
     G         (giga)                       1000000000
     M         (mega)                       1000000
     P         (peta)                       1e+15
+    Q         (quetta)                     1e+30
+    R         (ronna)                      1e+27
     T         (tera)                       1e+12
     Y         (yotta)                      1e+24
     Z         (zetta)                      1e+21
@@ -24,6 +26,8 @@ Prefix table (20):
     m         (milli)                      0.001
     n         (nano)                       1e-09
     p         (pico)                       1e-12
+    q         (quecto)                     1e-30
+    r         (ronto)                      1e-27
     u         (micro)                      1e-06
     y         (yocto)                      1e-24
     z         (zepto)                      1e-21


### PR DESCRIPTION
The new SI prefixes quetta, ronna, ronto and quecto have been added.

Close #1256