### PR TITLE
Fix a few small TaQL issues

### DIFF
--- a/derivedmscal/DerivedMC/Register.cc
+++ b/derivedmscal/DerivedMC/Register.cc
@@ -111,11 +111,11 @@ namespace casacore {
       " hourangle of ANTENNA1" << endl;
     os << "  double MSCAL.HA2()            "
       " hourangle of ANTENNA2" << endl;
-    os << "  doublearray MSCAL.HADEC()          "
+    os << "  doublearray MSCAL.HADEC()     "
       " hourangle/declination of array center" << endl;
-    os << "  doublearray MSCAL.HADEC1()         "
+    os << "  doublearray MSCAL.HADEC1()    "
       " hourangle/declination of ANTENNA1" << endl;
-    os << "  doublearray MSCAL.HADEC2()         "
+    os << "  doublearray MSCAL.HADEC2()    "
       " hourangle/declination of ANTENNA2" << endl;
     os << "  doublearray MSCAL.AZEL()      "
       " azimuth/elevation of array center" << endl;
@@ -151,11 +151,11 @@ namespace casacore {
       " calc Apparent UVW coordinates in wvl for reffreq" << endl;
     os << "  doublearray MSCAL.UVWAPPWVLS()"
       " calc Apparent UVW coordinates in wvl per channel" << endl;
-    os << "  double MSCAL.DELAY1()"
+    os << "  double MSCAL.DELAY1()  "
       " calc delay (seconds) of ANTENNA1 w.r.t. array center" << endl;
-    os << "  double MSCAL.DELAY2()"
+    os << "  double MSCAL.DELAY2()  "
       " calc delay (seconds) of ANTENNA2 w.r.t. array center" << endl;
-    os << "  double MSCAL.DELAY1()"
+    os << "  double MSCAL.DELAY1()  "
       " calc delay (seconds) of ANTENNA1 w.r.t. ANTENNA2" << endl;
   }
 

--- a/tables/TaQL/ExprNode.cc
+++ b/tables/TaQL/ExprNode.cc
@@ -1361,8 +1361,27 @@ TableExprNode TableExprNode::newFunctionNode
       resDT = TableExprFuncNode::checkOperands (dtypeOper, resVT, vtypeOper,
                                                 ftype, par);
       if (resVT == TableExprNodeRep::VTScalar) {
-        fnode = new TableExprFuncNode (ftype, resDT, resVT, set,
-                                       par, dtypeOper, tabInfo);
+        TableExprFuncNode* node = new TableExprFuncNode (ftype, resDT, resVT, set,
+                                                         par, dtypeOper, tabInfo);
+        fnode.reset (node);
+        // If the condition of IIF is a constant scalar, evaluate and replace.
+        // Do it only if the data type matches.
+        // Take the operands from the function node created,
+        // because the units might be adapted.
+        if (ftype == TableExprFuncNode::iifFUNC) {
+          const std::vector<TENShPtr>& oper = node->operands();
+          if (oper[0]->isConstant()) {
+            if (oper[0]->getBool(TableExprId(0))) {
+              if (resDT == oper[1]->dataType()) {
+                fnode = oper[1];
+              }
+            } else {
+              if (resDT == oper[2]->dataType()) {
+                fnode = oper[2];
+              }
+            }
+          }
+        }
       } else {
         fnode = new TableExprFuncNodeArray (ftype, resDT, resVT, set,
                                             par, dtypeOper, style);

--- a/tables/TaQL/ExprNodeSet.h
+++ b/tables/TaQL/ExprNodeSet.h
@@ -205,6 +205,9 @@ public:
     // Let a set node convert itself to the given unit.
     void adaptSetUnits (const Unit&) override;
 
+    // Try to set the set's shape for a bounded set with single elements.
+    void setShape();
+
 private:
     // A copy of a TableExprNodeSet cannot be made.
     TableExprNodeSet& operator= (const TableExprNodeSet&);

--- a/tables/TaQL/ExprNodeSetElem.cc
+++ b/tables/TaQL/ExprNodeSetElem.cc
@@ -221,6 +221,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     dtype_p = itsStart->dataType();
     setUnit (itsStart->unit());
     setExprType();
+    ndim_p  = value.getNodeRep()->ndim();
+    shape_p = value.getNodeRep()->shape();
   }
 
   TableExprNodeSetElemSingle::TableExprNodeSetElemSingle

--- a/tables/apps/taql.cc
+++ b/tables/apps/taql.cc
@@ -1084,6 +1084,7 @@ void execFileCommands (TableMap& tableMap, const Options& options)
 {
   // Reads all commands from the file and split them at ;.
   // A command can be continued on the next line.
+  // An error in a command file is severe, so it exits on error.
   vector<String> commands;
   Bool appendLast = False;
   std::ifstream ifs(options.fname.c_str());
@@ -1132,12 +1133,17 @@ void askCommands (TableMap& tableMap, Options& options)
   }
 #endif
   while (True) {
-    String str;
-    // Read and execute until ^D or quit is given.
-    if (! (readLineSkip (str, "TaQL> ")  &&
-           executeArgs (splitWS(str), False, tableMap, options))) {
-      cerr << endl;
-      break;
+    // Catch errors, so the user can retry.
+    try {
+      String str;
+      // Read and execute until ^D or quit is given.
+      if (! (readLineSkip (str, "TaQL> ")  &&
+             executeArgs (splitWS(str), False, tableMap, options))) {
+        cerr << endl;
+        break;
+      }
+    } catch (const std::exception& x) {
+      cout << x.what() << endl;
     }
   }
 #ifdef HAVE_READLINE


### PR DESCRIPTION
- Fix indentation of derivedmscal help info
- Fix problem that shape([DATA]) returned an empty shape because ExprNodeSet did not set ndim and shape
- Catch exception in interactive mode in taql program, so it continues in case of errors
- Optimize IIF in case the condition is a constant scalar
