### PR TITLE
Avoid referencing a temporary Table

### DIFF
--- a/tables/TaQL/ExprNode.h
+++ b/tables/TaQL/ExprNode.h
@@ -285,7 +285,7 @@ public:
 
     // Get the table to which the expression node belongs.
     //# [[deprecated ("Use getTableInfo().table() instead")]]
-    const Table& table() const
+    Table table() const
       __attribute__ ((deprecated ("Use getTableInfo().table() instead")))
       { return getTableInfo().table(); }
 


### PR DESCRIPTION
Avoid referencing the Table in a temporary TableExprInfo object. Copy the Table instead.
