### PR TITLE
Fix reading FITS files with extra bytes after last HDU

### DIFF
--- a/fits/FITS/fitsio.cc
+++ b/fits/FITS/fitsio.cc
@@ -502,6 +502,9 @@ void FitsInput::read_header_rec() {
             m_rec_type = FITS::UnrecognizableRecord;
             return;
         }
+        //cout << "[FitsInput::read_header_rec()] Extra bytes after the end of the FITS file" << endl;
+	m_rec_type = FITS::EndOfFile;
+	return;
     }
     // since ffmrhd() reads the header, we need to move the file pointer back
     // to the beginning of the hdu before calling m_fin.read()


### PR DESCRIPTION
Older FITS-IDI from the VLBA archive have an extra record filled with zeroes after the last HDU of the file.  This causes the FITS code in casacore to read the last HDU over and over again.  Fix this by signalling the end of file even if there are remaining bytes after the last HDU.