### PR TITLE
Fixes for importing FITS-IDI files with multiple frequency setups

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -2915,7 +2915,7 @@ void FITSIDItoMS1::fillSpectralWindowTable()
   //cout << "nRow=" << nRow << endl;
 
 
-  Int nSpW = nIF_p;
+  Int nSpW = nIF_p * nRow;
   effChBw.resize(nSpW);
 
   // The type of the column changes according to the number of entries

--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -318,6 +318,7 @@ protected:
   static std::map<Int,Int> antIdFromNo;
   static std::map<Int,Int> digiLevels;
   static Vector<Double> effChBw;
+  Int nFreqid_p;
 
   //
   //# Member Functions


### PR DESCRIPTION
A CASA user dug out some that from the VLBA archive that uses multiple frequency setups in a single FITS-IDI. This appeared to work (after working around the issue address in #1267) but the CASA listobs complained about DATA_DESC_IDs in that are not found in the DATA_DESCRIPTION table. The first commit in this series addresses this
issue. The second commit then adds support for recognizing specific frequency setups in flagging information in the FITS-IDI FLAG table.