### PR TITLE
Remove allocator Template parameter from Arrays

### DIFF
--- a/casa/Arrays/Array.h
+++ b/casa/Arrays/Array.h
@@ -44,7 +44,7 @@ namespace casacore { //#Begin casa namespace
 
 // <summary> A templated N-D %Array class with zero origin. </summary>
 
-// Array<T, Alloc> is a templated, N-dimensional, %Array class. The origin is zero,
+// Array<T> is a templated, N-dimensional, %Array class. The origin is zero,
 // but by default indices are zero-based. This Array class is the
 // base class for the Vector, Matrix, and Cube subclasses.
 //
@@ -131,7 +131,7 @@ namespace casacore { //#Begin casa namespace
 // Element by element mathematical and logical operations are available
 // for arrays (defined in aips/ArrayMath.h and aips/ArrayLogical.h).
 // Because arithmetic and logical functions are split out, it is possible
-// to create an Array<T, Alloc> (and hence Vector<T> etc) for any type T that has
+// to create an Array<T> (and hence Vector<T> etc) for any type T that has
 // a default constructor, assignment operator, and copy constructor. In
 // particular, Array<String> works.
 //
@@ -151,11 +151,11 @@ namespace casacore { //#Begin casa namespace
 //        base class.
 // </todo>
 
-template<typename T, typename Alloc> class Array : public ArrayBase
+template<typename T> class Array : public ArrayBase
 {
 public:
     // Result has dimensionality of zero, and  nelements is zero.
-    Array(const Alloc& allocator = Alloc());
+    Array();
 
     // Create an array of the given shape, i.e. after construction
     // array.ndim() == shape.nelements() and array.shape() == shape.
@@ -168,12 +168,12 @@ public:
     // Especially when <src>T</src> is of type <src>Complex</src> or <src>DComplex</src> and it is unnecessary to initialize,
     // provide initPolicy with value <src>NO_INIT</src> to skip the initialization.
     // Therefore, it is strongly recommended to explicitly provide initPolicy parameter,
-    explicit Array(const IPosition &shape, const Alloc& allocator = Alloc());
+    explicit Array(const IPosition &shape);
 
     // Create an array of the given shape and initialize it with the
     // initial value.
     // Storage is allocated by <src>DefaultAllocator<T></src>.
-    Array(const IPosition &shape, const T &initialValue, const Alloc& allocator = Alloc());
+    Array(const IPosition &shape, const T &initialValue);
     
     // This is a tag for the constructor that may be used to construct an uninitialized Array.
     static struct uninitializedType{} uninitialized;
@@ -183,20 +183,20 @@ public:
     // <srcblock>
     //   Array<int> a(shape, Array<int>::uninitialized);
     // </srcblock>
-    Array(const IPosition& shape, uninitializedType, const Alloc& allocator = Alloc());
+    Array(const IPosition& shape, uninitializedType);
     
     // Construct a one-dimensional array from an initializer list.
     // Example:
     // <srcblock>
     //   Array<int> a({5, 6, 7, 8});
     // </srcblock>
-    Array(std::initializer_list<T> list, const Alloc& allocator = Alloc());
+    Array(std::initializer_list<T> list);
 
     // After construction, this and other reference the same storage.
-    Array(const Array<T, Alloc> &other);
+    Array(const Array<T> &other);
 
     // Source will be empty after this call.
-    Array(Array<T, Alloc>&& source) noexcept;
+    Array(Array<T>&& source) noexcept;
 
     // Create an Array of a given shape from a pointer.
     // If <src>policy</src> is <src>COPY</src>, storage of a new copy is allocated by <src>DefaultAllocator<T></src>.
@@ -208,9 +208,9 @@ public:
     //   IPosition shape(1, 10);
     //   int *ptr = alloc.allocate(shape.product());
     //   size_t nread = fread(ptr, sizeof(int), shape.product(), fp);
-    //   Array<int> ai(shape, ptr, TAKE_OVER, Alloc::value);
+    //   Array<int> ai(shape, ptr, TAKE_OVER);
     // </srcblock>
-    Array(const IPosition &shape, T *storage, StorageInitPolicy policy = COPY, const Alloc& allocator = Alloc());
+    Array(const IPosition &shape, T *storage, StorageInitPolicy policy = COPY);
 
     // Create an Array of a given shape from a pointer. Because the pointer
     // is const, a copy is always made.
@@ -219,7 +219,7 @@ public:
 
     // Construct an array from an iterator and a shape.
     template<typename InputIterator>
-    Array(const IPosition &shape, InputIterator startIter, const Alloc& allocator = Alloc());
+    Array(const IPosition &shape, InputIterator startIter);
     
     // Frees up storage only if this array was the last reference to it.
     virtual ~Array() noexcept;
@@ -227,16 +227,10 @@ public:
     // Make an empty array of the same template type.
     virtual std::unique_ptr<ArrayBase> makeArray() const override;
 
-    // Retrieve the allocator associated with this array.
-    // @{
-    Alloc& allocator() { return *data_p; }
-    const Alloc& allocator() const { return *data_p; }
-    // @}
-    
     // Assign the other array to this array.
     // If the shapes mismatch, this array is resized.
     // <group>
-    void assign (const Array<T, Alloc>& other);
+    void assign (const Array<T>& other);
     
     void assignBase (const ArrayBase& other, bool checkType=true) override;
     // </group>
@@ -261,7 +255,7 @@ public:
     // Array slices. Otherwise one first needs to use the copy constructor.
     //# The const has been introduced on 2005-Mar-31 because of the hassle
     //# involved in calling the copy ctor before reference.
-    virtual void reference(const Array<T, Alloc> &other);
+    virtual void reference(const Array<T> &other);
 
     // Copy the values in other to this. If the array on the left hand
     // side has no elements, then it is resized to be the same size as
@@ -280,7 +274,7 @@ public:
     // </srcblock>
     // Note that the assign function can be used to assign a
     // non-conforming array.
-    Array<T, Alloc>& assign_conforming(const Array<T, Alloc>& other)
+    Array<T>& assign_conforming(const Array<T>& other)
     {
       return assign_conforming_implementation(other, std::is_copy_assignable<T>());
     }
@@ -291,25 +285,23 @@ public:
     //    <li> ArrayConformanceError
     // </thrown>
     //
-    template<typename MaskAlloc>
-    Array<T, Alloc>& assign_conforming (const MaskedArray<T, Alloc, MaskAlloc>& marray);
+    Array<T>& assign_conforming (const MaskedArray<T>& marray);
 
     // TODO we should change the semantics
-    Array<T, Alloc>& operator=(const Array<T, Alloc>& other)
+    Array<T>& operator=(const Array<T>& other)
     { return assign_conforming(other); }
  
     // Calls assign_conforming().
-    template<typename MaskAlloc>
-    Array<T, Alloc>& operator=(const MaskedArray<T, Alloc, MaskAlloc>& marray)
+    Array<T>& operator=(const MaskedArray<T>& marray)
     { return assign_conforming(marray); }
     
     // The move operator takes the storage from the given array. After moving an
     // Array, the source Array will be left empty.
-    Array<T, Alloc>& operator=(Array<T, Alloc>&& other);
+    Array<T>& operator=(Array<T>&& other);
 
     // Set every element of this array to "value". In other words, a scalar
     // behaves as if it were a constant conformant array.
-    Array<T, Alloc>& operator=(const T& value);
+    Array<T>& operator=(const T& value);
 
     // This makes a copy of the array and returns it. This can be
     // useful for, e.g. making working copies of function arguments
@@ -336,9 +328,7 @@ public:
     // be deprecated and removed?)
     //
     // TODO deprecate
-    Array<T, Alloc> copy() const {                         // Make a copy of this
-      return copy(Alloc());
-    }
+    Array<T> copy() const;
     
     // This function copies the matching part of from array to this array.
     // The matching part is the part with the minimum size for each axis.
@@ -346,7 +336,7 @@ public:
     // the matching part has shape [4,3].
     // <br>Note it is used by the resize function if
     // <src>copyValues==true</src>.
-    void copyMatchingPart (const Array<T, Alloc>& from);
+    void copyMatchingPart (const Array<T>& from);
 
     // This ensures that this array does not reference any other storage.
     // <note role=tip>
@@ -394,7 +384,7 @@ public:
     // Vector<float> line(square.reform(lineShape));
     // // "square"'s storage may now be accessed through Vector "line"
     // </srcblock>
-    Array<T, Alloc> reform(const IPosition& shape) const;
+    Array<T> reform(const IPosition& shape) const;
 
     // Having an array that can be reused without requiring reallocation can
     // be useful for large arrays.  The method reformOrResize permits this
@@ -464,11 +454,11 @@ public:
     // in a correct number of axes.
     // </note>
     // <group>
-    Array<T, Alloc> nonDegenerate(size_t startingAxis=0, bool throwIfError=true) const;
-    Array<T, Alloc> nonDegenerate(const IPosition& ignoreAxes) const;
-    void nonDegenerate(const Array<T, Alloc> &other, size_t startingAxis=0,
+    Array<T> nonDegenerate(size_t startingAxis=0, bool throwIfError=true) const;
+    Array<T> nonDegenerate(const IPosition& ignoreAxes) const;
+    void nonDegenerate(const Array<T> &other, size_t startingAxis=0,
 		       bool throwIfError=true);
-    void nonDegenerate(const Array<T, Alloc> &other, const IPosition &ignoreAxes)
+    void nonDegenerate(const Array<T> &other, const IPosition &ignoreAxes)
         { doNonDegenerate (other, ignoreAxes); }
     // </group> 
 
@@ -486,8 +476,8 @@ public:
     // Array. Note that the <src>reform</src> function can also be
     // used to add extra axes.
     // <group>
-    const Array<T, Alloc> addDegenerate(size_t numAxes) const;
-    Array<T, Alloc> addDegenerate(size_t numAxes);
+    const Array<T> addDegenerate(size_t numAxes) const;
+    Array<T> addDegenerate(size_t numAxes);
     // </group>
 
     // Make this array a different shape. If <src>copyValues==true</src>
@@ -521,23 +511,23 @@ public:
     // Get a reference to an array section extending
     // from start to end (inclusive).
     // <group>
-    Array<T, Alloc> operator()(const IPosition &start,
+    Array<T> operator()(const IPosition &start,
                         const IPosition &end);
-    const Array<T, Alloc> operator()(const IPosition &start,
+    const Array<T> operator()(const IPosition &start,
                               const IPosition &end) const;
     // Along the ith axis, every inc[i]'th element is chosen.
-    Array<T, Alloc> operator()(const IPosition &start,
+    Array<T> operator()(const IPosition &start,
                         const IPosition &end,
 			const IPosition &inc);
-    const Array<T, Alloc> operator()(const IPosition &start,
+    const Array<T> operator()(const IPosition &start,
                               const IPosition &end,
                               const IPosition &inc) const;
     // </group>
 
     // Get a reference to an array section using a Slicer.
     // <group>
-    Array<T, Alloc> operator()(const Slicer&);
-    const Array<T, Alloc> operator()(const Slicer&) const;
+    Array<T> operator()(const Slicer&);
+    const Array<T> operator()(const Slicer&) const;
     // </group>
 
     // Get a reference to a section of an array.
@@ -551,12 +541,12 @@ public:
     // <note>This function should not be used in tight loops as it is (much)
     // slower than iterating using begin() and end(), ArrayIter, or
     // ArrayAccessor.</note>
-    Array<T, Alloc> operator[] (size_t i) const;
+    Array<T> operator[] (size_t i) const;
 
     // Get the diagonal of each matrix part in the full array.
     // The matrices are taken using axes firstAxes and firstAxis+1.
     // diag==0 is main diagonal; diag>0 above the main diagonal; diag<0 below.
-    Array<T, Alloc> diagonals (size_t firstAxis=0, long long diag=0) const;
+    Array<T> diagonals (size_t firstAxis=0, long long diag=0) const;
 
     // The array is masked by the input LogicalArray.
     // This mask must conform to the array.
@@ -591,7 +581,7 @@ public:
 
     // Are the shapes identical?
     // <group>
-    bool conform (const Array<T, Alloc> &other) const
+    bool conform (const Array<T> &other) const
       { return conform2(other); }
     bool conform (const MaskedArray<T> &other) const;
     // </group>
@@ -630,7 +620,7 @@ public:
     const T *getStorage(bool& deleteIt) const
     {
       // The cast is OK because the return pointer will be cast to const
-      return const_cast<Array<T, Alloc>*>(this)->getStorage(deleteIt);
+      return const_cast<Array<T>*>(this)->getStorage(deleteIt);
     }
     void *getVStorage(bool &deleteIt) override;
     const void *getVStorage(bool &deleteIt) const override;
@@ -657,18 +647,17 @@ public:
     // If <src>policy</src> is <src>COPY</src>, storage of a new copy is allocated by <src>allocator</src>.
     // If <src>policy</src> is <src>TAKE_OVER</src>, <src>storage</src> will be destructed and released by <src>allocator</src>.
     virtual void takeStorage(const IPosition &shape, T *storage,
-        StorageInitPolicy policy = COPY, const Alloc& allocator = Alloc());
+        StorageInitPolicy policy = COPY);
 
     // Since the pointer is const, a copy is always taken.
     // Storage of a new copy is allocated by the specified allocator.
-    virtual void takeStorage(const IPosition &shape, const T *storage,
-        const Alloc& allocator = Alloc());
+    virtual void takeStorage(const IPosition &shape, const T *storage);
     // </group>
 
 
     // Used to iterate through Arrays. Derived classes VectorIterator and
     // MatrixIterator are probably more useful.
-    friend class ArrayIterator<T, Alloc>;
+    friend class ArrayIterator<T>;
 
     // Create an ArrayIterator object of the correct type.
     std::unique_ptr<ArrayPositionIterator> makeIterator(size_t byDim) const override;
@@ -680,7 +669,7 @@ public:
     {
     public:
       // Create the begin const_iterator object for an Array.
-      explicit BaseIteratorSTL (const Array<T, Alloc>&);
+      explicit BaseIteratorSTL (const Array<T>&);
       // Create the end const_iterator object for an Array.
       // It also acts as the default constructor.
       explicit BaseIteratorSTL (const T* end = 0)
@@ -723,7 +712,7 @@ public:
       size_t      itsLineAxis;
       IPosition itsCurPos;
       IPosition itsLastPos;
-      const Array<T, Alloc>* itsArray; 
+      const Array<T>* itsArray;
       bool      itsContig;
     };
 
@@ -740,7 +729,7 @@ public:
       // </group>
 
       // Create the begin iterator object for an Array.
-      explicit IteratorSTL (Array<T, Alloc>& arr)
+      explicit IteratorSTL (Array<T>& arr)
 	: BaseIteratorSTL (arr) {}
       // Create the end iterator object for an Array.
       // It also acts as the default constructor.
@@ -778,7 +767,7 @@ public:
       // </group>
 
       // Create the begin const_iterator object for an Array.
-      explicit ConstIteratorSTL (const Array<T, Alloc>& arr)
+      explicit ConstIteratorSTL (const Array<T>& arr)
 	: BaseIteratorSTL (arr) {}
       // Create the end const_iterator object for an Array.
       // It also acts as the default constructor.
@@ -835,8 +824,6 @@ public:
     // STL-style typedefs.
     // <group>
     
-    // Type of allocator used to allocate and deallocate space
-    typedef Alloc allocator_type;
     // Element type
     typedef T value_type;
     // TODO This is how std containers define a reference type, but
@@ -884,26 +871,23 @@ private:
   // This method implements it for when T is integral, in which case the templated parameter
   // is the initial value.
   template<typename Integral>
-  Array(const IPosition &shape, Integral startIter, const Alloc& allocator, std::true_type /*is_integral*/ );
+  Array(const IPosition &shape, Integral startIter, std::true_type /*is_integral*/ );
   
   // Implementation of constructor taking a Shape, a Templated parameter and an allocator.
   // This method implements it for when T is NOT integral, in which case the templated parameter
   // is an iterator.
   template<typename InputIterator>
-  Array(const IPosition &shape, InputIterator startIter, const Alloc& allocator, std::false_type /*is_integral*/ );
+  Array(const IPosition &shape, InputIterator startIter, std::false_type /*is_integral*/ );
   
-  // Makes a copy using the allocator.
-  Array<T, Alloc> copy(const Alloc& allocator) const;
-
   // Implementation for assign for copyable types
-  Array<T, Alloc>& assign_conforming_implementation (const Array<T, Alloc>& other, std::true_type);
+  Array<T>& assign_conforming_implementation (const Array<T>& other, std::true_type);
   // Implementation for assign for non-copyable types: can not be assigned
-  Array<T, Alloc>& assign_conforming_implementation (const Array<T, Alloc>&, std::false_type)
+  Array<T>& assign_conforming_implementation (const Array<T>&, std::false_type)
   {
     throw ArrayError("Can not assign from non-copyable object");
   }
-  static void copyToContiguousStorage(T *dst, Array<T, Alloc> const& src, std::true_type);
-  static void copyToContiguousStorage(T*, Array<T, Alloc> const&, std::false_type)
+  static void copyToContiguousStorage(T *dst, Array<T> const& src, std::true_type);
+  static void copyToContiguousStorage(T*, Array<T> const&, std::false_type)
   {
     throw ArrayError("Can not coy from non-copyable object");      
   }
@@ -916,14 +900,14 @@ private:
     
 protected:
      // Source will be empty with given shape after this call.
-    Array(Array<T, Alloc>&& source, const IPosition& shapeForSource) noexcept;
+    Array(Array<T>&& source, const IPosition& shapeForSource) noexcept;
     
-    template<typename ST, typename SAlloc>
-    friend void swap(Array<ST, SAlloc>& left, Array<ST, SAlloc>& right);
+    template<typename ST>
+    friend void swap(Array<ST>& left, Array<ST>& right);
     
     // Swap this array with another array.
     // Normally, casacore::swap() should be used instead.
-    void swap(Array<T, Alloc>& other);
+    void swap(Array<T>& other);
 
     // pre/post processing hook of takeStorage() for subclasses.
     virtual void preTakeStorage(const IPosition &) {}
@@ -955,13 +939,13 @@ protected:
     
     virtual void checkAssignableType(ArrayBase& arrayBase) const
     {
-      const Array<T, Alloc>* pa = dynamic_cast<const Array<T, Alloc>*>(&arrayBase);
+      const Array<T>* pa = dynamic_cast<const Array<T>*>(&arrayBase);
       if (pa == nullptr) {
         throw ArrayError("ArrayBase& has incorrect template type");
       }
     }
     
-    static void copyToContiguousStorage(T *dst, Array<T, Alloc> const& src)
+    static void copyToContiguousStorage(T *dst, Array<T> const& src)
     {
       copyToContiguousStorage(dst, src, std::is_copy_assignable<T>());
     }
@@ -970,12 +954,12 @@ protected:
     // This is the implementation of the nonDegenerate functions.
     // It has a different name to be able to make it virtual without having
     // the "hide virtual function" message when compiling derived classes.
-    virtual void doNonDegenerate(const Array<T, Alloc> &other,
+    virtual void doNonDegenerate(const Array<T> &other,
                                  const IPosition &ignoreAxes);
 
 
     // Shared pointer to a Storage that contains the data.
-    std::shared_ptr<arrays_internal::Storage<T, Alloc>> data_p;
+    std::shared_ptr<arrays_internal::Storage<T>> data_p;
 
     // This pointer is adjusted to point to the first element of the array.
     // It is not necessarily the same thing as data->storage() since
@@ -999,22 +983,22 @@ protected:
 
 // Swap the first array with the second.
 // This is more efficient than std::swap()
-template<typename T, typename Alloc>
-void swap(Array<T, Alloc>& first, Array<T, Alloc>& second)
+template<typename T>
+void swap(Array<T>& first, Array<T>& second)
 {
   first.swap(second);
 }
 
 //# Declare extern templates for often used types.
-extern template class Array<bool, std::allocator<bool>>;
-extern template class Array<char, std::allocator<char>>;
-extern template class Array<unsigned char, std::allocator<unsigned char>>;
-extern template class Array<short, std::allocator<short>>;
-extern template class Array<unsigned short, std::allocator<unsigned short>>;
-extern template class Array<int, std::allocator<int>>;
-extern template class Array<long long, std::allocator<long long>>;
-extern template class Array<float, std::allocator<float>>;
-extern template class Array<double, std::allocator<double>>;
+extern template class Array<bool>;
+extern template class Array<char>;
+extern template class Array<unsigned char>;
+extern template class Array<short>;
+extern template class Array<unsigned short>;
+extern template class Array<int>;
+extern template class Array<long long>;
+extern template class Array<float>;
+extern template class Array<double>;
 
 }//#End casa namespace
 

--- a/casa/Arrays/Array.tcc
+++ b/casa/Arrays/Array.tcc
@@ -41,8 +41,8 @@
 
 namespace casacore {//#Begin casa namespace
 
-template<typename T, typename Alloc> Array<T, Alloc>::Array(const Alloc& allocator)
-: data_p(new arrays_internal::Storage<T, Alloc>(0, allocator)),
+template<typename T> Array<T>::Array()
+: data_p(new arrays_internal::Storage<T>(0)),
   begin_p(nullptr),
   end_p(nullptr)
 {
@@ -52,11 +52,10 @@ template<typename T, typename Alloc> Array<T, Alloc>::Array(const Alloc& allocat
 // <thrown>
 //   <item> ArrayShapeError
 // </thrown>
-template<class T, typename Alloc>
-Array<T, Alloc>::Array(const IPosition &shape,
-        const Alloc& allocator)
+template<class T>
+Array<T>::Array(const IPosition &shape)
 : ArrayBase(shape),
-  data_p(new arrays_internal::Storage<T, Alloc>(nelements(), allocator)),
+  data_p(new arrays_internal::Storage<T>(nelements())),
   begin_p(data_p->data())
 {
   setEndIter();
@@ -66,36 +65,36 @@ Array<T, Alloc>::Array(const IPosition &shape,
 // <thrown>
 //   <item> ArrayShapeError
 // </thrown>
-template<typename T, typename Alloc> Array<T, Alloc>::Array(const IPosition &shape,
-  const T &initialValue, const Alloc& allocator)
+template<typename T> Array<T>::Array(const IPosition &shape,
+  const T &initialValue)
 : ArrayBase(shape),
-  data_p(new arrays_internal::Storage<T, Alloc>(nelements(), initialValue, allocator)),
+  data_p(new arrays_internal::Storage<T>(nelements(), initialValue)),
   begin_p(data_p->data())
 {
   setEndIter();
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-Array<T, Alloc>::Array(const IPosition& shape, uninitializedType, const Alloc& allocator)
+template<typename T>
+Array<T>::Array(const IPosition& shape, uninitializedType)
 : ArrayBase(shape),
-  data_p(arrays_internal::Storage<T, Alloc>::MakeUninitialized(nelements(), allocator)),
+  data_p(arrays_internal::Storage<T>::MakeUninitialized(nelements())),
   begin_p(data_p->data())
 {
   setEndIter();
   assert(ok());
 }
 
-template<typename T, typename Alloc> Array<T, Alloc>::Array(std::initializer_list<T> list, const Alloc& allocator)
+template<typename T> Array<T>::Array(std::initializer_list<T> list)
 : ArrayBase (IPosition(1, list.size())),
-  data_p(new arrays_internal::Storage<T, Alloc>(list.begin(), list.end(), allocator)),
+  data_p(new arrays_internal::Storage<T>(list.begin(), list.end())),
   begin_p(data_p->data())
 {
   setEndIter();
   assert(ok());
 }
 
-template<typename T, typename Alloc> Array<T, Alloc>::Array(const Array<T, Alloc> &other)
+template<typename T> Array<T>::Array(const Array<T> &other)
 : ArrayBase (other),
   data_p(other.data_p),
   begin_p   (other.begin_p),
@@ -104,7 +103,7 @@ template<typename T, typename Alloc> Array<T, Alloc>::Array(const Array<T, Alloc
   assert(ok());
 }
 
-template<typename T, typename Alloc> Array<T, Alloc>::Array(Array<T, Alloc>&& source) noexcept
+template<typename T> Array<T>::Array(Array<T>&& source) noexcept
 : ArrayBase (std::move(source)),
   data_p(source.data_p),
   begin_p(source.begin_p),
@@ -121,7 +120,7 @@ template<typename T, typename Alloc> Array<T, Alloc>::Array(Array<T, Alloc>&& so
   assert(ok());
 }
 
-template<typename T, typename Alloc> Array<T, Alloc>::Array(Array<T, Alloc>&& source, const IPosition& shapeForSource) noexcept
+template<typename T> Array<T>::Array(Array<T>&& source, const IPosition& shapeForSource) noexcept
 : ArrayBase (std::move(source), shapeForSource),
   data_p(source.data_p),
   begin_p(source.begin_p),
@@ -132,51 +131,51 @@ template<typename T, typename Alloc> Array<T, Alloc>::Array(Array<T, Alloc>&& so
   assert(ok());
 }
 
-template<class T, typename Alloc>
-Array<T, Alloc>::Array(const IPosition &shape, T *storage,
-                StorageInitPolicy policy, const Alloc& allocator)
+template<class T>
+Array<T>::Array(const IPosition &shape, T *storage,
+                StorageInitPolicy policy)
 : ArrayBase(shape),
   data_p(),
   begin_p(nullptr),
   end_p(nullptr)
 {
-  takeStorage(shape, storage, policy, allocator);
+  takeStorage(shape, storage, policy);
   assert(ok());
 }
 
-template<class T, typename Alloc>
-Array<T, Alloc>::Array(const IPosition &shape, const T *storage)
+template<class T>
+Array<T>::Array(const IPosition &shape, const T *storage)
 : ArrayBase(shape),
   data_p(),
   begin_p(nullptr),
   end_p(nullptr)
 {
-  takeStorage(shape, storage, static_cast<Alloc&>(*data_p));
+  takeStorage(shape, storage);
   assert(ok());
 }
 
-template<typename T, typename Alloc>
+template<typename T>
 template<typename InputIterator>
-Array<T, Alloc>::Array(const IPosition &shape, InputIterator startIter, const Alloc& allocator)
-: Array<T, Alloc>(shape, startIter, allocator, std::is_integral<InputIterator>())
+Array<T>::Array(const IPosition &shape, InputIterator startIter)
+: Array<T>(shape, startIter, std::is_integral<InputIterator>())
 { }
 
-template<typename T, typename Alloc>
+template<typename T>
 template<typename InputIterator>
-Array<T, Alloc>::Array(const IPosition &shape, InputIterator startIter, const Alloc& allocator, std::false_type)
+Array<T>::Array(const IPosition &shape, InputIterator startIter, std::false_type)
 : ArrayBase(shape),
-  data_p(new arrays_internal::Storage<T, Alloc>(startIter, std::next(startIter, nelements()), allocator)),
+  data_p(new arrays_internal::Storage<T>(startIter, std::next(startIter, nelements()))),
   begin_p(data_p->data())
 {
   setEndIter();
   assert(ok());
 }
 
-template<typename T, typename Alloc>
+template<typename T>
 template<typename Integral>
-Array<T, Alloc>::Array(const IPosition &shape, Integral initialValue, const Alloc& allocator, std::true_type)
+Array<T>::Array(const IPosition &shape, Integral initialValue, std::true_type)
 : ArrayBase(shape),
-  data_p(new arrays_internal::Storage<T, Alloc>(nelements(), initialValue, allocator)),
+  data_p(new arrays_internal::Storage<T>(nelements(), initialValue)),
   begin_p(data_p->data())
 {
   setEndIter();
@@ -184,20 +183,20 @@ Array<T, Alloc>::Array(const IPosition &shape, Integral initialValue, const Allo
 }
 
 
-template<typename T, typename Alloc> Array<T, Alloc>::~Array() noexcept
+template<typename T> Array<T>::~Array() noexcept
 { }
 
-template<class T, typename Alloc>
-std::unique_ptr<ArrayBase> Array<T, Alloc>::makeArray() const
+template<class T>
+std::unique_ptr<ArrayBase> Array<T>::makeArray() const
 {
-  return std::unique_ptr<ArrayBase>(new Array<T, Alloc>(static_cast<const Alloc&>(*data_p)));
+  return std::unique_ptr<ArrayBase>(new Array<T>());
 }
 
 // It is better for a move assignment to be noexcept, but that would allow
 // assigning Matrix to Vector (etc) without being able to throw. Hence, I
 // think it is not possible to do this without changing such semantics.
-template<class T, typename Alloc>
-Array<T, Alloc>& Array<T, Alloc>::operator= (Array<T, Alloc>&& source)
+template<class T>
+Array<T>& Array<T>::operator= (Array<T>&& source)
 {
   bool swapWouldClashRequirements =
     source.fixedDimensionality() != 0 && fixedDimensionality() != 0 &&
@@ -227,8 +226,8 @@ Array<T, Alloc>& Array<T, Alloc>::operator= (Array<T, Alloc>&& source)
   return *this;
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::swap(Array<T, Alloc>& other)
+template<class T>
+void Array<T>::swap(Array<T>& other)
 {
   checkBeforeResize(other.shape());
   other.checkBeforeResize(shape());
@@ -241,8 +240,8 @@ void Array<T, Alloc>::swap(Array<T, Alloc>& other)
   std::swap(data_p, other.data_p);
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::assign (const Array<T, Alloc>& other)
+template<class T>
+void Array<T>::assign (const Array<T>& other)
 {
   assert(ok());
   if (! shape().isEqual (other.shape())) {
@@ -252,20 +251,20 @@ void Array<T, Alloc>::assign (const Array<T, Alloc>& other)
   assign_conforming (other);
 }
 
-template<class T, typename Alloc> void Array<T, Alloc>::assignBase (const ArrayBase& other, bool checkType)
+template<class T> void Array<T>::assignBase (const ArrayBase& other, bool checkType)
 {
   assert(ok());
   // Checking the type can be expensive, so only do if needed or in debug mode.
   if (checkType  /*||  aips_debug*/) {
-    const Array<T, Alloc>* pa = dynamic_cast<const Array<T, Alloc>*>(&other);
+    const Array<T>* pa = dynamic_cast<const Array<T>*>(&other);
     if (pa == nullptr) {
       throw ArrayError("assign(ArrayBase&) has incorrect template type");
     }
   }
-  assign (static_cast<const Array<T, Alloc>&>(other));
+  assign (static_cast<const Array<T>&>(other));
 }
 
-template<class T, typename Alloc> void Array<T, Alloc>::reference(const Array<T, Alloc> &other)
+template<class T> void Array<T>::reference(const Array<T> &other)
 {
   assert(ok());
   
@@ -279,7 +278,7 @@ template<class T, typename Alloc> void Array<T, Alloc>::reference(const Array<T,
     const int newValue = (other.nelements() == 0) ? 0 : 1;
     for(size_t i=other.ndim(); i!=fixedDimensionality(); ++i)
       newShape[i] = newValue;
-    Array<T, Alloc> tmp(*other.data_p);
+    Array<T> tmp;
     tmp.reference(other);
     other.baseReform(tmp, newShape);
     reference( tmp );
@@ -296,7 +295,7 @@ template<class T, typename Alloc> void Array<T, Alloc>::reference(const Array<T,
   }
 }
 
-template<class T, typename Alloc> void Array<T, Alloc>::copyToContiguousStorage(T *storage, Array<T, Alloc> const& src, std::true_type)
+template<class T> void Array<T>::copyToContiguousStorage(T *storage, Array<T> const& src, std::true_type)
 {
   if (src.contiguousStorage()) {
     std::copy_n(src.begin_p, src.nels_p, storage);
@@ -333,20 +332,20 @@ template<class T, typename Alloc> void Array<T, Alloc>::copyToContiguousStorage(
   }
 }
 
-template<typename T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::copy(const Alloc& allocator) const
+template<typename T>
+Array<T> Array<T>::copy() const
 {
     assert(ok());
 
-    Array<T, Alloc> vp(shape(), allocator);
+    Array<T> vp(shape());
     if (ndim() != 0)
         copyToContiguousStorage(vp.begin_p, *this);
     
     return vp;
 }
 
-template<typename T, typename Alloc>
-Array<T, Alloc>& Array<T, Alloc>::assign_conforming_implementation(const Array<T, Alloc>& other, std::true_type)
+template<typename T>
+Array<T>& Array<T>::assign_conforming_implementation(const Array<T>& other, std::true_type)
 {
   assert(ok());
 
@@ -398,14 +397,14 @@ Array<T, Alloc>& Array<T, Alloc>::assign_conforming_implementation(const Array<T
     }
   } else {
     // Array was empty; make a new copy and reference it.
-    Array<T, Alloc> tmp (other.copy(static_cast<Alloc>(*data_p)));
+    Array<T> tmp (other.copy());
     reference (tmp);
   }
   return *this;
 }
 
-template<typename T, typename Alloc>
-Array<T, Alloc> &Array<T, Alloc>::operator=(const T &val)
+template<typename T>
+Array<T> &Array<T>::operator=(const T &val)
 {
     assert(ok());
 
@@ -413,15 +412,14 @@ Array<T, Alloc> &Array<T, Alloc>::operator=(const T &val)
     return *this;
 }
 
-template<typename T, typename Alloc>
-template<typename MaskAlloc>
-Array<T, Alloc>& Array<T, Alloc>::assign_conforming(const MaskedArray<T, Alloc, MaskAlloc>& marray)
+template<typename T>
+Array<T>& Array<T>::assign_conforming(const MaskedArray<T>& marray)
 {
     assert(ok());
 
     if (!conform(marray)) {
         throw(ArrayConformanceError(
-            "Array<T> & Array<T, Alloc>::assign_conforming (const MaskedArray<T, Alloc, MaskAlloc>& marray)"
+            "Array<T> & Array<T>::assign_conforming (const MaskedArray<T>& marray)"
             "- Conformance error."));
     }
 
@@ -456,7 +454,7 @@ Array<T, Alloc>& Array<T, Alloc>::assign_conforming(const MaskedArray<T, Alloc, 
 }
 
 
-template<class T, typename Alloc> void Array<T, Alloc>::set(const T &Value)
+template<class T> void Array<T>::set(const T &Value)
 {
   assert(ok());
 
@@ -495,9 +493,9 @@ template<class T, typename Alloc> void Array<T, Alloc>::set(const T &Value)
   }
 }
 
-template<class T, typename Alloc>
+template<class T>
 template<typename Callable>
-void Array<T, Alloc>::apply(Callable function)
+void Array<T>::apply(Callable function)
 {
     assert(ok());
 
@@ -530,14 +528,14 @@ void Array<T, Alloc>::apply(Callable function)
     }
 }
 
-template<class T, typename Alloc> void Array<T, Alloc>::unique()
+template<class T> void Array<T>::unique()
 {
   assert(ok());
 
   if (!contiguousStorage() || !isUnique())
   {
     // OK, we know we are going to need to copy.
-    Array<T, Alloc> tmp(copy(static_cast<Alloc&>(*data_p)));
+    Array<T> tmp(copy());
     reference (tmp);
   }
 }
@@ -545,20 +543,20 @@ template<class T, typename Alloc> void Array<T, Alloc>::unique()
 // <thrown>
 //   <item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::reform(const IPosition& len) const
+template<typename T>
+Array<T> Array<T>::reform(const IPosition& len) const
 {
   assert(ok());
   // Check if reform is possible and needed.
   // If not needed, simply return a copy.
-  Array<T, Alloc> tmp(*this);
+  Array<T> tmp(*this);
   baseReform (tmp, len);
   tmp.setEndIter();
   return tmp;
 }
 
-template <typename T, typename Alloc>
-bool Array<T, Alloc>::adjustLastAxis (const IPosition& newShape,
+template <typename T>
+bool Array<T>::adjustLastAxis (const IPosition& newShape,
   size_t resizePercentage, bool resizeIfNeeded)
 {
     assert(ok());
@@ -567,7 +565,7 @@ bool Array<T, Alloc>::adjustLastAxis (const IPosition& newShape,
     if (newShape.size() == currentShape.size()){ // Let base method handle attempt dimensionality changes
 	for (size_t i = 0; i < newShape.size() - 1; i++){
 	    if (currentShape (i) != newShape (i)){
-        std::string message = "Array<T, Alloc>::extend - New shape can only change last dimension:"
+        std::string message = "Array<T>::extend - New shape can only change last dimension:"
           " current=" + currentShape.toString() + ", new=" + newShape.toString();
         throw ArrayConformanceError (message);
 	    }
@@ -587,9 +585,9 @@ bool Array<T, Alloc>::adjustLastAxis (const IPosition& newShape,
 }
 
 
-template<class T, typename Alloc>
+template<class T>
 bool
-Array<T, Alloc>::reformOrResize (const IPosition & newShape,
+Array<T>::reformOrResize (const IPosition & newShape,
                           size_t resizePercentage,
                           bool resizeIfNeeded)
 {
@@ -608,24 +606,24 @@ Array<T, Alloc>::reformOrResize (const IPosition & newShape,
     return originalElements != (long long) data_p->size();
 }
 
-template<class T, typename Alloc>
+template<class T>
 inline size_t
-Array<T, Alloc>::capacity () const
+Array<T>::capacity () const
 {
     return data_p->size(); // returns the number of elements allocated.
 }
 
-template<class T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::nonDegenerate (size_t startingAxis, bool throwIfError) const
+template<class T>
+Array<T> Array<T>::nonDegenerate (size_t startingAxis, bool throwIfError) const
 {
-    Array<T, Alloc> tmp(static_cast<Alloc&>(*data_p));
+    Array<T> tmp;
     assert(ok());
     tmp.nonDegenerate (*this, startingAxis, throwIfError);
     return tmp;
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::nonDegenerate (const Array<T, Alloc> &other, size_t startingAxis,
+template<class T>
+void Array<T>::nonDegenerate (const Array<T> &other, size_t startingAxis,
 			      bool throwIfError)
 {
   if (startingAxis < other.ndim()) {
@@ -640,35 +638,35 @@ void Array<T, Alloc>::nonDegenerate (const Array<T, Alloc> &other, size_t starti
   }
 }
 
-template<class T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::nonDegenerate (const IPosition &ignoreAxes) const
+template<class T>
+Array<T> Array<T>::nonDegenerate (const IPosition &ignoreAxes) const
 {
-    Array<T, Alloc> tmp(static_cast<Alloc&>(*data_p));
+    Array<T> tmp;
     assert(ok());
     tmp.nonDegenerate(*this, ignoreAxes);
     return tmp;
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::removeDegenerate (size_t startingAxis, bool throwIfError)
+template<class T>
+void Array<T>::removeDegenerate (size_t startingAxis, bool throwIfError)
 {
-    Array<T, Alloc> tmp(static_cast<Alloc&>(*data_p));
+    Array<T> tmp;
     assert(ok());
     tmp.nonDegenerate (*this, startingAxis, throwIfError);
     reference (tmp);
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::removeDegenerate (const IPosition &ignoreAxes)
+template<class T>
+void Array<T>::removeDegenerate (const IPosition &ignoreAxes)
 {
-    Array<T, Alloc> tmp(static_cast<Alloc&>(*data_p));
+    Array<T> tmp;
     assert(ok());
     tmp.nonDegenerate(*this, ignoreAxes);
     reference (tmp);
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::doNonDegenerate (const Array<T, Alloc> &other,
+template<class T>
+void Array<T>::doNonDegenerate (const Array<T> &other,
                                 const IPosition &ignoreAxes)
 {
     assert(ok());
@@ -678,19 +676,19 @@ void Array<T, Alloc>::doNonDegenerate (const Array<T, Alloc> &other,
     setEndIter();
 }
 
-template<class T, typename Alloc>
-const Array<T, Alloc> Array<T, Alloc>::addDegenerate(size_t numAxes) const
+template<class T>
+const Array<T> Array<T>::addDegenerate(size_t numAxes) const
 {
-    Array<T, Alloc> * This = const_cast<Array<T, Alloc>*>(this);
-    const Array<T, Alloc> tmp(This->addDegenerate(numAxes));
+    Array<T> * This = const_cast<Array<T>*>(this);
+    const Array<T> tmp(This->addDegenerate(numAxes));
     return tmp;
 }
 
-template<class T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::addDegenerate(size_t numAxes)
+template<class T>
+Array<T> Array<T>::addDegenerate(size_t numAxes)
 {
     assert(ok());
-    Array<T, Alloc> tmp(*this);
+    Array<T> tmp(*this);
     if (numAxes > 0) {
         baseAddDegenerate (tmp, numAxes);
 	tmp.setEndIter();
@@ -699,7 +697,7 @@ Array<T, Alloc> Array<T, Alloc>::addDegenerate(size_t numAxes)
 }
 
 
-template<class T, typename Alloc> bool Array<T, Alloc>::conform(const MaskedArray<T> &other) const
+template<class T> bool Array<T>::conform(const MaskedArray<T> &other) const
 {
     return conform (other.getArray());
 }
@@ -707,13 +705,13 @@ template<class T, typename Alloc> bool Array<T, Alloc>::conform(const MaskedArra
 // <thrown>
 //   <item> ArrayConformanceError
 // </thrown>
-template<class T, typename Alloc> void Array<T, Alloc>::resize()
+template<class T> void Array<T>::resize()
 {
   IPosition emptyShape(fixedDimensionality(), 0);
   resize (emptyShape);
 }
 
-template<class T, typename Alloc> void Array<T, Alloc>::resize(const IPosition& len, bool copyValues)
+template<class T> void Array<T>::resize(const IPosition& len, bool copyValues)
 {
   assert(ok());
   // Maybe we don't need to resize; let's see if we can short circuit
@@ -721,7 +719,7 @@ template<class T, typename Alloc> void Array<T, Alloc>::resize(const IPosition& 
     return;
   }
   // OK we differ, so we really have to resize ourselves.
-  Array<T, Alloc> tmp(len, static_cast<Alloc&>(*data_p));
+  Array<T> tmp;
   // Copy the contents if needed.
   if (copyValues) {
     tmp.copyMatchingPart (*this);
@@ -729,8 +727,8 @@ template<class T, typename Alloc> void Array<T, Alloc>::resize(const IPosition& 
   this->reference(tmp);
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::copyMatchingPart (const Array<T, Alloc>& from)
+template<class T>
+void Array<T>::copyMatchingPart (const Array<T>& from)
 {
   if (nelements() > 0  &&  from.nelements() > 0) {
     // Create IPositions of the correct length.
@@ -749,20 +747,20 @@ void Array<T, Alloc>::copyMatchingPart (const Array<T, Alloc>& from)
       endfr[i] = sz-1;
     }
     // Get the subsection of to and from array.
-    Array<T, Alloc> subto = (*this)(IPosition(ndim(), 0), endto);
-    Array<T, Alloc> fromc(from);    // make non-const
-    Array<T, Alloc> subfr = fromc(IPosition(from.ndim(), 0), endfr);
+    Array<T> subto = (*this)(IPosition(ndim(), 0), endto);
+    Array<T> fromc(from);    // make non-const
+    Array<T> subfr = fromc(IPosition(from.ndim(), 0), endfr);
     // Reform to if the dimensionalities differ.
     if (subto.ndim() != subfr.ndim()) {
-      Array<T, Alloc> tmp = subto.reform (endfr+1);
+      Array<T> tmp = subto.reform (endfr+1);
       subto.reference (tmp);
     }
     subto.assign_conforming(subfr);
   }    
 }
 
-template<class T, typename Alloc>
-T &Array<T, Alloc>::operator()(const IPosition &index)
+template<class T>
+T &Array<T>::operator()(const IPosition &index)
 {
   assert(ok());
 
@@ -776,8 +774,8 @@ T &Array<T, Alloc>::operator()(const IPosition &index)
   return begin_p[offs];
 }
 
-template<class T, typename Alloc>
-const T &Array<T, Alloc>::operator()(const IPosition &index) const
+template<class T>
+const T &Array<T>::operator()(const IPosition &index) const
 {
   assert(ok());
   size_t offs=0;
@@ -790,13 +788,13 @@ const T &Array<T, Alloc>::operator()(const IPosition &index) const
 // <thrown>
 //     <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::operator()(const IPosition& b,
+template<typename T>
+Array<T> Array<T>::operator()(const IPosition& b,
   const IPosition& e,
   const IPosition& i)
 {
     assert(ok());
-    Array<T, Alloc> tmp(*this);
+    Array<T> tmp(*this);
     size_t offs = makeSubset (tmp, b, e, i);
     tmp.begin_p += offs;
     tmp.setEndIter();
@@ -804,27 +802,27 @@ Array<T, Alloc> Array<T, Alloc>::operator()(const IPosition& b,
     return tmp;
 }
 
-template<class T, typename Alloc>
-const Array<T, Alloc> Array<T, Alloc>::operator()(
+template<class T>
+const Array<T> Array<T>::operator()(
   const IPosition &b, const IPosition &e, const IPosition &i) const
 {
-    return const_cast<Array<T, Alloc>*>(this)->operator() (b,e,i);
+    return const_cast<Array<T>*>(this)->operator() (b,e,i);
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> Array<T, Alloc>::operator()(const IPosition &b,
+template<typename T> Array<T> Array<T>::operator()(const IPosition &b,
 						const IPosition &e)
 {
     IPosition i(e.nelements());
     i = 1;
     return (*this)(b,e,i);
 }
-template<class T, typename Alloc> const Array<T, Alloc> Array<T, Alloc>::operator()(const IPosition &b,
+template<class T> const Array<T> Array<T>::operator()(const IPosition &b,
                                                       const IPosition &e) const
 {
-    return const_cast<Array<T, Alloc>*>(this)->operator() (b,e);
+    return const_cast<Array<T>*>(this)->operator() (b,e);
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> Array<T, Alloc>::operator()(const Slicer& slicer)
+template<typename T> Array<T> Array<T>::operator()(const Slicer& slicer)
 {
     if (slicer.isFixed()) {
         return operator() (slicer.start(), slicer.end(), slicer.stride());
@@ -833,19 +831,19 @@ template<typename T, typename Alloc> Array<T, Alloc> Array<T, Alloc>::operator()
     slicer.inferShapeFromSource (shape(), blc, trc, inc);
     return operator() (blc, trc, inc);
 }
-template<class T, typename Alloc>
-const Array<T, Alloc> Array<T, Alloc>::operator()(const Slicer& slicer) const
+template<class T>
+const Array<T> Array<T>::operator()(const Slicer& slicer) const
 {
-    return const_cast<Array<T, Alloc>*>(this)->operator() (slicer);
+    return const_cast<Array<T>*>(this)->operator() (slicer);
 }
 
-template<class T, typename Alloc>
-std::unique_ptr<ArrayBase> Array<T, Alloc>::getSection(const Slicer& slicer) const
+template<class T>
+std::unique_ptr<ArrayBase> Array<T>::getSection(const Slicer& slicer) const
 {
-    return std::unique_ptr<ArrayBase>(new Array<T, Alloc>(operator()(slicer)));
+    return std::unique_ptr<ArrayBase>(new Array<T>(operator()(slicer)));
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> Array<T, Alloc>::operator[](size_t i) const
+template<typename T> Array<T> Array<T>::operator[](size_t i) const
 {
     assert(ok());
     size_t nd = ndim();
@@ -862,53 +860,53 @@ template<typename T, typename Alloc> Array<T, Alloc> Array<T, Alloc>::operator[]
 }
 
 
-template<class T, typename Alloc>
-const MaskedArray<T> Array<T, Alloc>::operator() (const LogicalArray &mask) const
+template<class T>
+const MaskedArray<T> Array<T>::operator() (const LogicalArray &mask) const
 {
     MaskedArray<T> ret (*this, mask, true);
     return ret;
 }
 
-template<class T, typename Alloc>
-MaskedArray<T> Array<T, Alloc>::operator() (const LogicalArray &mask)
+template<class T>
+MaskedArray<T> Array<T>::operator() (const LogicalArray &mask)
 {
     MaskedArray<T> ret (*this, mask);
     return ret;
 }
 
-template<class T, typename Alloc>
-const MaskedArray<T> Array<T, Alloc>::operator() (const MaskedLogicalArray &mask) const
+template<class T>
+const MaskedArray<T> Array<T>::operator() (const MaskedLogicalArray &mask) const
 {
     MaskedArray<T> ret (*this, mask, true);
     return ret;
 }
 
-template<class T, typename Alloc>
-MaskedArray<T> Array<T, Alloc>::operator() (const MaskedLogicalArray &mask)
+template<class T>
+MaskedArray<T> Array<T>::operator() (const MaskedLogicalArray &mask)
 {
     MaskedArray<T> ret (*this, mask);
     return ret;
 }
 
-template<class T, typename Alloc>
-Array<T, Alloc> Array<T, Alloc>::diagonals (size_t firstAxis, long long diag) const
+template<class T>
+Array<T> Array<T>::diagonals (size_t firstAxis, long long diag) const
 {
   assert(ok());
-  Array<T, Alloc> tmp(*this);
+  Array<T> tmp(*this);
   tmp.begin_p += tmp.makeDiagonal (firstAxis, diag);
   tmp.makeSteps();
   return tmp;
 }
 
 
-template<class T, typename Alloc> size_t Array<T, Alloc>::nrefs() const
+template<class T> size_t Array<T>::nrefs() const
 {
   assert(ok());
   return data_p.use_count();
 }
 
 // This is relatively expensive
-template<class T, typename Alloc> bool Array<T, Alloc>::ok() const
+template<class T> bool Array<T>::ok() const
 {
   assert(ArrayBase::ok());
   assert(data_p != nullptr);
@@ -937,8 +935,8 @@ template<class T, typename Alloc> bool Array<T, Alloc>::ok() const
 // <thrown>
 //    <item> ArrayError
 // </thrown>
-template<class T, typename Alloc>
-T* Array<T, Alloc>::getStorage(bool& deleteIt)
+template<class T>
+T* Array<T>::getStorage(bool& deleteIt)
 {
   assert(ok());
   deleteIt = false;
@@ -953,7 +951,7 @@ T* Array<T, Alloc>::getStorage(bool& deleteIt)
 
   // We need to do a copy
   size_t n = nelements();
-  T* storage = data_p->allocate(n);
+  T* storage = std::allocator<T>().allocate(n);
   try {
     for(size_t i=0; i!=n; ++i)
       new (&storage[i]) T();
@@ -962,14 +960,14 @@ T* Array<T, Alloc>::getStorage(bool& deleteIt)
     // TODO To be correct, the destructors of the already
     // constructed object should be called, but this is
     // a border case so ignored for now.
-    data_p->deallocate(storage, nelements());
+    std::allocator<T>().deallocate(storage, nelements());
     throw;
   }
   deleteIt = true;
   return storage;
 }
 
-template<class T, typename Alloc> void Array<T, Alloc>::putStorage(T *&storage, bool deleteAndCopy)
+template<class T> void Array<T>::putStorage(T *&storage, bool deleteAndCopy)
 {
   assert(ok());
 
@@ -1010,8 +1008,8 @@ template<class T, typename Alloc> void Array<T, Alloc>::putStorage(T *&storage, 
   freeStorage(fakeStorage, deleteAndCopy);
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::freeStorage(const T*&storage, bool deleteIt) const
+template<class T>
+void Array<T>::freeStorage(const T*&storage, bool deleteIt) const
 {
   assert(ok());
 
@@ -1025,37 +1023,37 @@ void Array<T, Alloc>::freeStorage(const T*&storage, bool deleteIt) const
     // TODO this is only allowed when allocator is always equal, but is done for
     // now to keep the method const.
     // see e.g. std::allocator_traits<allocator_type>::is_always_equal
-    data_p->deallocate(ptr, n);
+    std::allocator<T>().deallocate(ptr, n);
   }
   storage = nullptr;
 }
 
-template<class T, typename Alloc>
-void *Array<T, Alloc>::getVStorage(bool &deleteIt)
+template<class T>
+void *Array<T>::getVStorage(bool &deleteIt)
 {
     return getStorage (deleteIt);
 }
-template<class T, typename Alloc>
-const void *Array<T, Alloc>::getVStorage(bool &deleteIt) const
+template<class T>
+const void *Array<T>::getVStorage(bool &deleteIt) const
 {
     return getStorage (deleteIt);
 }
-template<class T, typename Alloc>
-void Array<T, Alloc>::putVStorage(void *&storage, bool deleteAndCopy)
+template<class T>
+void Array<T>::putVStorage(void *&storage, bool deleteAndCopy)
 {
   T* &ptr = reinterpret_cast<T*&>(storage);
   putStorage (ptr, deleteAndCopy);
 }
-template<class T, typename Alloc>
-void Array<T, Alloc>::freeVStorage(const void *&storage, bool deleteAndCopy) const
+template<class T>
+void Array<T>::freeVStorage(const void *&storage, bool deleteAndCopy) const
 {
   const T* &ptr = reinterpret_cast<const T*&>(storage);
   freeStorage (ptr, deleteAndCopy);
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::takeStorage(const IPosition &shape, T *storage,
-                           StorageInitPolicy policy, const Alloc& allocator)
+template<class T>
+void Array<T>::takeStorage(const IPosition &shape, T *storage,
+                           StorageInitPolicy policy)
 {
   preTakeStorage(shape);
 
@@ -1063,11 +1061,11 @@ void Array<T, Alloc>::takeStorage(const IPosition &shape, T *storage,
   
   if(policy == SHARE)
   {
-    data_p = arrays_internal::Storage<T, Alloc>::MakeFromSharedData(storage, new_nels, allocator);
+    data_p = arrays_internal::Storage<T>::MakeFromSharedData(storage, new_nels);
   }
   else {
     if (data_p==nullptr || !isUnique() || data_p->size() != new_nels) {
-      data_p = arrays_internal::Storage<T, Alloc>::MakeFromMove(storage, storage+new_nels, allocator);
+      data_p = arrays_internal::Storage<T>::MakeFromMove(storage, storage+new_nels);
     } else {
         std::move(storage, storage+new_nels, data_p->data());
     }
@@ -1082,7 +1080,7 @@ void Array<T, Alloc>::takeStorage(const IPosition &shape, T *storage,
     // TODO this is not consistent with old behaviour
     for(size_t i=0; i!=new_nels; ++i)
       storage[new_nels-i-1].~T();
-    Alloc(allocator).deallocate(storage, new_nels);
+    std::allocator<T>().deallocate(storage, new_nels);
   }
   
   // Call OK at the end rather than the beginning since this might
@@ -1092,26 +1090,25 @@ void Array<T, Alloc>::takeStorage(const IPosition &shape, T *storage,
   postTakeStorage();
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::takeStorage(const IPosition &shape, const T *storage,
-  const Alloc& allocator)
+template<class T>
+void Array<T>::takeStorage(const IPosition &shape, const T *storage)
 {
     // This cast is safe since a copy will be made
     T *storagefake = const_cast<T*>(storage);
-    takeStorage(shape, storagefake, COPY, allocator);
+    takeStorage(shape, storagefake, COPY);
 }
 
 
-template<class T, typename Alloc>
-std::unique_ptr<ArrayPositionIterator> Array<T, Alloc>::makeIterator (size_t byDim) const
+template<class T>
+std::unique_ptr<ArrayPositionIterator> Array<T>::makeIterator (size_t byDim) const
 {
-    return std::unique_ptr<ArrayPositionIterator>( new ArrayIterator<T, Alloc> (*this, byDim) );
+    return std::unique_ptr<ArrayPositionIterator>( new ArrayIterator<T> (*this, byDim) );
 }
 
 
 
-template<class T, typename Alloc>
-Array<T, Alloc>::BaseIteratorSTL::BaseIteratorSTL (const Array<T, Alloc>& arr)
+template<class T>
+Array<T>::BaseIteratorSTL::BaseIteratorSTL (const Array<T>& arr)
 : itsLineIncr (0),
   itsCurPos   (arr.ndim(), 0),
   itsArray    (&arr),
@@ -1145,8 +1142,8 @@ Array<T, Alloc>::BaseIteratorSTL::BaseIteratorSTL (const Array<T, Alloc>& arr)
   }
 }
 
-template<class T, typename Alloc>
-void Array<T, Alloc>::BaseIteratorSTL::increment()
+template<class T>
+void Array<T>::BaseIteratorSTL::increment()
 {
   size_t axis;
   for (axis=itsLineAxis+1; axis<itsCurPos.nelements(); axis++) {
@@ -1166,8 +1163,8 @@ void Array<T, Alloc>::BaseIteratorSTL::increment()
 }
 
 
-template<class T, typename Alloc>
-std::vector<T> Array<T, Alloc>::tovector() const {
+template<class T>
+std::vector<T> Array<T>::tovector() const {
   bool deleteIt;
   const T *stor = getStorage(deleteIt);
   std::vector<T> out;
@@ -1175,23 +1172,23 @@ std::vector<T> Array<T, Alloc>::tovector() const {
   // TODO this is formally not allowed: the allocator is not const, so
   // might cause the object to change. This tovector() method can obviously be implemented
   // in a const manner, so this needs to be rewritten.
-  const_cast<Array<T, Alloc>*>(this)->freeStorage(stor, deleteIt);
+  const_cast<Array<T>*>(this)->freeStorage(stor, deleteIt);
   return out;
 }
 
-template<class T, typename Alloc>
+template<class T>
 template<class U>
-void Array<T, Alloc>::tovector(std::vector<T, U> &out) const {
+void Array<T>::tovector(std::vector<T, U> &out) const {
   bool deleteIt;
   const T *stor = getStorage(deleteIt);
   out.assign(stor, stor+nelements());
   /// See note above for @ref tovector()
-  const_cast<Array<T, Alloc>*>(this)->freeStorage(stor, deleteIt);
+  const_cast<Array<T>*>(this)->freeStorage(stor, deleteIt);
 }
 
 // Define static member
-template<typename T, typename Alloc>
-typename Array<T, Alloc>::uninitializedType Array<T, Alloc>::uninitialized;
+template<typename T>
+typename Array<T>::uninitializedType Array<T>::uninitialized;
 
 } //#End casa namespace
 

--- a/casa/Arrays/Array.tcc
+++ b/casa/Arrays/Array.tcc
@@ -719,7 +719,7 @@ template<class T> void Array<T>::resize(const IPosition& len, bool copyValues)
     return;
   }
   // OK we differ, so we really have to resize ourselves.
-  Array<T> tmp;
+  Array<T> tmp(len);
   // Copy the contents if needed.
   if (copyValues) {
     tmp.copyMatchingPart (*this);

--- a/casa/Arrays/ArrayFwd.h
+++ b/casa/Arrays/ArrayFwd.h
@@ -5,17 +5,17 @@
 
 namespace casacore { //#Begin casa namespace
 
-template<typename T, typename Alloc = std::allocator<T>> class Array;
-template<typename T, typename Alloc = std::allocator<T>> class Vector;
-template<typename T, typename Alloc = std::allocator<T>> class Matrix;
-template<typename T, typename Alloc = std::allocator<T>> class Cube;
+template<typename T> class Array;
+template<typename T> class Vector;
+template<typename T> class Matrix;
+template<typename T> class Cube;
 typedef bool LogicalArrayElem;
 typedef Array<LogicalArrayElem> LogicalArray;
-template<typename T, typename ArrayAlloc, typename MaskAlloc> class MaskedArray;
-typedef MaskedArray<LogicalArrayElem, std::allocator<LogicalArrayElem>, std::allocator<LogicalArrayElem>> MaskedLogicalArray;
+template<typename T> class MaskedArray;
+typedef MaskedArray<LogicalArrayElem> MaskedLogicalArray;
 class Slice;
 class Slicer;
-template<typename T, typename Alloc = std::allocator<T>> class ArrayIterator;
+template<typename T> class ArrayIterator;
 
 }
 

--- a/casa/Arrays/ArrayIter.h
+++ b/casa/Arrays/ArrayIter.h
@@ -66,12 +66,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //    <here>ArrayIterator</here> -- Iterate an Array cursor through another Array.
 // </linkfrom>
 //
-template<typename T, typename Alloc> class ArrayIterator : public ArrayPositionIterator
+template<typename T> class ArrayIterator : public ArrayPositionIterator
 {
 public:
     // Step through array "arr" over the first byDim axes
     // (using a cursor of dimensionality "byDim").
-    explicit ArrayIterator(const Array<T, Alloc> &arr, size_t byDim=1);
+    explicit ArrayIterator(const Array<T> &arr, size_t byDim=1);
 
     // Step through an array using the given axes.
     // The axes can be given in two ways:
@@ -86,7 +86,7 @@ public:
     // iteration step returns a cursor (containing the data of axis 1).
     // During the iteration axis 2 will vary most rapidly (as it was
     // given first).
-    ArrayIterator(const Array<T, Alloc> &arr, const IPosition &axes,
+    ArrayIterator(const Array<T> &arr, const IPosition &axes,
 		  bool axesAreCursor = true);
 
     // Move the cursor to the next position.
@@ -110,29 +110,29 @@ public:
     // Return the cursor. (Perhaps we should have a fn() that returns a
     // reference to the original array as well?)
     // <group>
-    Array<T, Alloc> &array() {return *ap_p;}
+    Array<T> &array() {return *ap_p;}
     virtual ArrayBase& getArray() override;
     // </group>
 
 
 protected:
     // The cursor
-    std::unique_ptr<Array<T, Alloc>> ap_p;
+    std::unique_ptr<Array<T>> ap_p;
 
 private:
     // helper function to centralize construction work
-    void init(const Array<T, Alloc> &);
+    void init(const Array<T> &);
     // helper function to set the pointer to the new data position in ap
     // after a step in the given dimension. -1 resets it to the beginning.
     void apSetPointer(int stepDim);
 
-    Array<T, Alloc> pOriginalArray_p;
+    Array<T> pOriginalArray_p;
     IPosition offset_p;
     T* dataPtr_p;
 
     //# Presently the following are not defined.
-    ArrayIterator(const ArrayIterator<T, Alloc> &);
-    ArrayIterator<T, Alloc> &operator=(const ArrayIterator<T, Alloc> &);
+    ArrayIterator(const ArrayIterator<T> &);
+    ArrayIterator<T> &operator=(const ArrayIterator<T> &);
 };
 
 // 
@@ -166,17 +166,17 @@ private:
 //     a const Array.
 // </linkfrom>
 //
-template<typename T, typename Alloc=std::allocator<T>> class ReadOnlyArrayIterator
+template<typename T> class ReadOnlyArrayIterator
 {
 public:
     // Step through array "arr" using a cursor of dimensionality "byDim".
-    explicit ReadOnlyArrayIterator(const Array<T, Alloc> &arr, size_t byDim=1) 
-	: ai(const_cast<Array<T, Alloc>&>(arr),byDim) {}
+    explicit ReadOnlyArrayIterator(const Array<T> &arr, size_t byDim=1)
+	: ai(const_cast<Array<T>&>(arr),byDim) {}
 
     // Step through an array for the given iteration axes.
-  ReadOnlyArrayIterator(const Array<T, Alloc> &arr, const IPosition &axes,
+  ReadOnlyArrayIterator(const Array<T> &arr, const IPosition &axes,
 			bool axesAreCursor = true)
-	: ai(const_cast<Array<T, Alloc>&>(arr),axes,axesAreCursor) {}
+	: ai(const_cast<Array<T>&>(arr),axes,axesAreCursor) {}
 
     // Move the cursor to the next position.
     void next() {ai.next();}
@@ -199,7 +199,7 @@ public:
     
     // Return the cursor. (Perhaps we should have a fn() that returns a
     // reference to the original array as well?)
-    const Array<T, Alloc> &array() {return ai.array();}
+    const Array<T> &array() {return ai.array();}
 	
     // The same as the functions in ArrayPositionIterator.
     // <group>
@@ -212,11 +212,11 @@ public:
 private:
     // Not implemented.
     // <group>
-    ReadOnlyArrayIterator (const ReadOnlyArrayIterator<T, Alloc> &);
-    ReadOnlyArrayIterator<T, Alloc> &operator=(const ReadOnlyArrayIterator<T, Alloc> &);
+    ReadOnlyArrayIterator (const ReadOnlyArrayIterator<T> &);
+    ReadOnlyArrayIterator<T> &operator=(const ReadOnlyArrayIterator<T> &);
     // </group>
     
-    ArrayIterator<T, Alloc> ai;
+    ArrayIterator<T> ai;
 };
 
 

--- a/casa/Arrays/ArrayIter.tcc
+++ b/casa/Arrays/ArrayIter.tcc
@@ -31,20 +31,20 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<typename T, typename Alloc> ArrayIterator<T, Alloc>::ArrayIterator(const Array<T, Alloc> &a, size_t byDim)
+template<typename T> ArrayIterator<T>::ArrayIterator(const Array<T> &a, size_t byDim)
 : ArrayPositionIterator(a.shape(), byDim),
   ap_p(),
-  pOriginalArray_p(a.allocator())
+  pOriginalArray_p()
 {
     init(a);
 }
 
-template<typename T, typename Alloc> ArrayIterator<T, Alloc>::ArrayIterator(const Array<T, Alloc> &a,
+template<typename T> ArrayIterator<T>::ArrayIterator(const Array<T> &a,
 						  const IPosition &axes,
 						  bool axesAreCursor)
 : ArrayPositionIterator(a.shape(), axes, axesAreCursor),
   ap_p(),
-  pOriginalArray_p(a.allocator())
+  pOriginalArray_p()
 {
     init(a);
 }
@@ -52,13 +52,13 @@ template<typename T, typename Alloc> ArrayIterator<T, Alloc>::ArrayIterator(cons
 // <thrown>
 //     <item> ArrayIteratorError
 // </thrown>
-template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::init(const Array<T, Alloc> &a)
+template<typename T> void ArrayIterator<T>::init(const Array<T> &a)
 {
     pOriginalArray_p.reference (a);
     dataPtr_p = pOriginalArray_p.begin_p;
 
     if (dimIter() < 1)
-	throw(ArrayIteratorError("ArrayIterator<T, Alloc>::ArrayIterator<T, Alloc> - "
+	throw(ArrayIteratorError("ArrayIterator<T>::ArrayIterator<T> - "
 				 " at the moment cannot iterate by scalars"));
     IPosition blc(pOriginalArray_p.ndim(), 0);
     IPosition trc(pOriginalArray_p.endPosition());
@@ -84,20 +84,20 @@ template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::init(const Ar
     // correct shape. We only want to remove the iteration axes, not the
     // possible degenerate axes in the cursor).
     if (dimIter() < pOriginalArray_p.ndim()) {
-        ap_p.reset( new Array<T, Alloc>(pOriginalArray_p(blc,trc).nonDegenerate(cursorAxes())) );
+        ap_p.reset( new Array<T>(pOriginalArray_p(blc,trc).nonDegenerate(cursorAxes())) );
     } else {
         // Same dimensionality, so no degenerate axes
-        ap_p.reset( new Array<T, Alloc>(pOriginalArray_p) );
+        ap_p.reset( new Array<T>(pOriginalArray_p) );
     }
 }
 
 // <thrown>
 //     <item> ArrayIteratorError
 // </thrown>
-template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::apSetPointer(int stepDim)
+template<typename T> void ArrayIterator<T>::apSetPointer(int stepDim)
 {
     if (ap_p == 0)
-	throw(ArrayIteratorError("ArrayIterator<T, Alloc>::apSetPointer()"
+	throw(ArrayIteratorError("ArrayIterator<T>::apSetPointer()"
 				 " - no iteration array!"));
     if (pastEnd()) {
 	ap_p->begin_p = 0;  // Mark it "invalid"
@@ -112,24 +112,24 @@ template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::apSetPointer(
     }
 }
 
-template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::reset()
+template<typename T> void ArrayIterator<T>::reset()
 {
     ArrayPositionIterator::reset();
     apSetPointer(-1);
 }
 
-template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::next()
+template<typename T> void ArrayIterator<T>::next()
 {
     int stepDim = ArrayPositionIterator::nextStep();
     apSetPointer(stepDim);
 }
 
   
-template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::set (const IPosition& cursorPos)
+template<typename T> void ArrayIterator<T>::set (const IPosition& cursorPos)
 {
     ArrayPositionIterator::set (cursorPos);
     if (ap_p == nullptr)
-	throw(ArrayIteratorError("ArrayIterator<T, Alloc>::apSetPointer()"
+	throw(ArrayIteratorError("ArrayIterator<T>::apSetPointer()"
 				 " - no iteration array!"));
     if (pastEnd()) {
 	ap_p->begin_p = 0;  // Mark it "invalid"
@@ -140,7 +140,7 @@ template<typename T, typename Alloc> void ArrayIterator<T, Alloc>::set (const IP
     }  
 }
 
-template<typename T, typename Alloc> ArrayBase& ArrayIterator<T, Alloc>::getArray()
+template<typename T> ArrayBase& ArrayIterator<T>::getArray()
 {
     return array();
 }

--- a/casa/Arrays/ArrayLogical.h
+++ b/casa/Arrays/ArrayLogical.h
@@ -379,13 +379,11 @@ template<class T> bool anyOR (const T &val, const Array<T> &array);
 
 
 // Are all elements true?
-template<typename Alloc>
-inline bool allTrue (const Array<bool, Alloc>& array)
+inline bool allTrue (const Array<bool>& array)
   { return allEQ (array, true); }
 
 // Is any element true?
-template<typename Alloc>
-inline bool anyTrue (const Array<bool, Alloc>& array)
+inline bool anyTrue (const Array<bool>& array)
   { return anyEQ (array, true); }
 
 // The same functions as above, but for selected axes.

--- a/casa/Arrays/ArrayMath.h
+++ b/casa/Arrays/ArrayMath.h
@@ -180,9 +180,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // <group>
 // Transform left and right to a result using the binary operator.
 // Result MUST be a contiguous array.
-template<typename L, typename AllocL, typename R, typename AllocR, typename RES, typename AllocRES, typename BinaryOperator>
-inline void arrayContTransform (const Array<L, AllocL>& left, const Array<R, AllocR>& right,
-                                Array<RES, AllocRES>& result, BinaryOperator op)
+template<typename L, typename R, typename RES, typename BinaryOperator>
+inline void arrayContTransform (const Array<L>& left, const Array<R>& right,
+                                Array<RES>& result, BinaryOperator op)
 {
   assert (result.contiguousStorage());
   if (left.contiguousStorage()  &&  right.contiguousStorage()) {
@@ -196,9 +196,9 @@ inline void arrayContTransform (const Array<L, AllocL>& left, const Array<R, All
 
 // Transform left and right to a result using the binary operator.
 // Result MUST be a contiguous array.
-template<typename L, typename AllocL, typename R, typename RES, typename AllocRES, typename BinaryOperator>
-inline void arrayContTransform (const Array<L, AllocL>& left, R right,
-                                Array<RES, AllocRES>& result, BinaryOperator op)
+template<typename L, typename R, typename RES, typename BinaryOperator>
+inline void arrayContTransform (const Array<L>& left, R right,
+                                Array<RES>& result, BinaryOperator op)
 {
   assert (result.contiguousStorage());
   if (left.contiguousStorage()) {
@@ -216,9 +216,9 @@ inline void arrayContTransform (const Array<L, AllocL>& left, R right,
 
 // Transform left and right to a result using the binary operator.
 // Result MUST be a contiguous array.
-template<typename L, typename R, typename AllocR, typename RES, typename AllocRES, typename BinaryOperator>
-inline void arrayContTransform (L left, const Array<R, AllocR>& right,
-                                Array<RES, AllocRES>& result, BinaryOperator op)
+template<typename L, typename R, typename RES, typename BinaryOperator>
+inline void arrayContTransform (L left, const Array<R>& right,
+                                Array<RES>& result, BinaryOperator op)
 {
   assert (result.contiguousStorage());
   if (right.contiguousStorage()) {
@@ -236,9 +236,9 @@ inline void arrayContTransform (L left, const Array<R, AllocR>& right,
 
 // Transform array to a result using the unary operator.
 // Result MUST be a contiguous array.
-template<typename T, typename Alloc, typename RES, typename AllocRES, typename UnaryOperator>
-inline void arrayContTransform (const Array<T, Alloc>& arr,
-                                Array<RES, AllocRES>& result, UnaryOperator op)
+template<typename T, typename RES, typename UnaryOperator>
+inline void arrayContTransform (const Array<T>& arr,
+                                Array<RES>& result, UnaryOperator op)
 {
   assert (result.contiguousStorage());
   if (arr.contiguousStorage()) {
@@ -250,53 +250,53 @@ inline void arrayContTransform (const Array<T, Alloc>& arr,
 
 // Transform left and right to a result using the binary operator.
 // Result need not be a contiguous array.
-template<typename L, typename R, typename RES, typename BinaryOperator, typename AllocL, typename AllocR, typename AllocRES>
-void arrayTransform (const Array<L, AllocL>& left, const Array<R, AllocR>& right,
-                     Array<RES, AllocRES>& result, BinaryOperator op);
+template<typename L, typename R, typename RES, typename BinaryOperator>
+void arrayTransform (const Array<L>& left, const Array<R>& right,
+                     Array<RES>& result, BinaryOperator op);
 
 // Transform left and right to a result using the binary operator.
 // Result need not be a contiguous array.
-template<typename L, typename R, typename RES, typename BinaryOperator, typename Alloc, typename AllocRES>
-void arrayTransform (const Array<L, Alloc>& left, R right,
-                     Array<RES, AllocRES>& result, BinaryOperator op);
+template<typename L, typename R, typename RES, typename BinaryOperator>
+void arrayTransform (const Array<L>& left, R right,
+                     Array<RES>& result, BinaryOperator op);
 
 // Transform left and right to a result using the binary operator.
 // Result need not be a contiguous array.
-template<typename L, typename R, typename RES, typename BinaryOperator, typename Alloc, typename AllocRES>
-void arrayTransform (L left, const Array<R, Alloc>& right,
-                     Array<RES, AllocRES>& result, BinaryOperator op);
+template<typename L, typename R, typename RES, typename BinaryOperator>
+void arrayTransform (L left, const Array<R>& right,
+                     Array<RES>& result, BinaryOperator op);
 
 // Transform array to a result using the unary operator.
 // Result need not be a contiguous array.
-template<typename T, typename RES, typename UnaryOperator, typename Alloc, typename AllocRES>
-void arrayTransform (const Array<T, Alloc>& arr,
-                     Array<RES, AllocRES>& result, UnaryOperator op);
+template<typename T, typename RES, typename UnaryOperator>
+void arrayTransform (const Array<T>& arr,
+                     Array<RES>& result, UnaryOperator op);
 
 // Transform left and right to a result using the binary operator.
 // The created and returned result array is contiguous.
-template<typename T, typename BinaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& left, const Array<T, Alloc>& right,
+template<typename T, typename BinaryOperator>
+Array<T> arrayTransformResult (const Array<T>& left, const Array<T>& right,
                                BinaryOperator op);
 
 // Transform left and right to a result using the binary operator.
 // The created and returned result array is contiguous.
-template<typename T, typename BinaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& left, T right, BinaryOperator op);
+template<typename T, typename BinaryOperator>
+Array<T> arrayTransformResult (const Array<T>& left, T right, BinaryOperator op);
 
 // Transform left and right to a result using the binary operator.
 // The created and returned result array is contiguous.
-template<typename T, typename BinaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (T left, const Array<T, Alloc>& right, BinaryOperator op);
+template<typename T, typename BinaryOperator>
+Array<T> arrayTransformResult (T left, const Array<T>& right, BinaryOperator op);
 
 // Transform array to a result using the unary operator.
 // The created and returned result array is contiguous.
-template<typename T, typename UnaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& arr, UnaryOperator op);
+template<typename T, typename UnaryOperator>
+Array<T> arrayTransformResult (const Array<T>& arr, UnaryOperator op);
 
 // Transform left and right in place using the binary operator.
 // The result is stored in the left array (useful for e.g. the += operation).
-template<typename L, typename R, typename BinaryOperator, typename AllocL, typename AllocR>
-inline void arrayTransformInPlace (Array<L, AllocL>& left, const Array<R, AllocR>& right,
+template<typename L, typename R, typename BinaryOperator>
+inline void arrayTransformInPlace (Array<L>& left, const Array<R>& right,
                                    BinaryOperator op)
 {
   if (left.contiguousStorage()  &&  right.contiguousStorage()) {
@@ -308,8 +308,8 @@ inline void arrayTransformInPlace (Array<L, AllocL>& left, const Array<R, AllocR
 
 // Transform left and right in place using the binary operator.
 // The result is stored in the left array (useful for e.g. the += operation).
-template<typename L, typename R, typename BinaryOperator, typename Alloc>
-inline void arrayTransformInPlace (Array<L, Alloc>& left, R right, BinaryOperator op)
+template<typename L, typename R, typename BinaryOperator>
+inline void arrayTransformInPlace (Array<L>& left, R right, BinaryOperator op)
 {
   if (left.contiguousStorage()) {
     myiptransform (left.cbegin(), left.cend(), right, op);
@@ -323,8 +323,8 @@ inline void arrayTransformInPlace (Array<L, Alloc>& left, R right, BinaryOperato
 // Transform the array in place using the unary operator.
 // E.g. doing <src>arrayTransformInPlace(array, Sin<T>())</src> is faster than
 // <src>array=sin(array)</src> as it does not need to create a temporary array.
-template<typename T, typename UnaryOperator, typename Alloc>
-inline void arrayTransformInPlace (Array<T, Alloc>& arr, UnaryOperator op)
+template<typename T, typename UnaryOperator>
+inline void arrayTransformInPlace (Array<T>& arr, UnaryOperator op)
 {
   if (arr.contiguousStorage()) {
     std::transform(arr.cbegin(), arr.cend(), arr.cbegin(), op);
@@ -338,143 +338,143 @@ inline void arrayTransformInPlace (Array<T, Alloc>& arr, UnaryOperator op)
 // Element by element arithmetic modifying left in-place. left and other
 // must be conformant.
 // <group>
-template<typename T, typename Alloc> void operator+= (Array<T, Alloc> &left, const Array<T, Alloc> &other);
-template<typename T, typename Alloc> void operator-= (Array<T, Alloc> &left, const Array<T, Alloc> &other);
-template<typename T, typename Alloc> void operator*= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator+= (Array<T> &left, const Array<T> &other);
+template<typename T> void operator-= (Array<T> &left, const Array<T> &other);
+template<typename T> void operator*= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "*=");
     arrayTransformInPlace (left, other, std::multiplies<T>());
 }
 
-template<typename T, typename Alloc> void operator/= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator/= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "/=");
     arrayTransformInPlace (left, other, std::divides<T>());
 }
-template<typename T, typename Alloc> void operator%= (Array<T, Alloc> &left, const Array<T, Alloc> &other);
-template<typename T, typename Alloc> void operator&= (Array<T, Alloc> &left, const Array<T, Alloc> &other);
-template<typename T, typename Alloc> void operator|= (Array<T, Alloc> &left, const Array<T, Alloc> &other);
-template<typename T, typename Alloc> void operator^= (Array<T, Alloc> &left, const Array<T, Alloc> &other);
+template<typename T> void operator%= (Array<T> &left, const Array<T> &other);
+template<typename T> void operator&= (Array<T> &left, const Array<T> &other);
+template<typename T> void operator|= (Array<T> &left, const Array<T> &other);
+template<typename T> void operator^= (Array<T> &left, const Array<T> &other);
 // </group>
 
 // 
 // Element by element arithmetic modifying left in-place. The scalar "other"
 // behaves as if it were a conformant Array to left filled with constant values.
 // <group>
-template<typename T, typename Alloc> void operator+= (Array<T, Alloc> &left, const T &other);
-template<typename T, typename Alloc> void operator-= (Array<T, Alloc> &left, const T &other);
-template<typename T, typename Alloc> void operator*= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator+= (Array<T> &left, const T &other);
+template<typename T> void operator-= (Array<T> &left, const T &other);
+template<typename T> void operator*= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, std::multiplies<T>());
 }
-template<typename T, typename Alloc> void operator/= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator/= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, std::divides<T>());
 }
-template<typename T, typename Alloc> void operator%= (Array<T, Alloc> &left, const T &other);
-template<typename T, typename Alloc> void operator&= (Array<T, Alloc> &left, const T &other);
-template<typename T, typename Alloc> void operator|= (Array<T, Alloc> &left, const T &other);
-template<typename T, typename Alloc> void operator^= (Array<T, Alloc> &left, const T &other);
+template<typename T> void operator%= (Array<T> &left, const T &other);
+template<typename T> void operator&= (Array<T> &left, const T &other);
+template<typename T> void operator|= (Array<T> &left, const T &other);
+template<typename T> void operator^= (Array<T> &left, const T &other);
 // </group>
 
 // Unary arithmetic operation.
 // 
 // <group>
-template<typename T, typename Alloc> Array<T, Alloc> operator+(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> operator-(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> operator~(const Array<T, Alloc> &a);
+template<typename T> Array<T> operator+(const Array<T> &a);
+template<typename T> Array<T> operator-(const Array<T> &a);
+template<typename T> Array<T> operator~(const Array<T> &a);
 // </group>
 
 // 
 // Element by element arithmetic on two arrays, returning an array.
 // <group>
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator+ (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator- (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc>
-  Array<T, Alloc> operator*(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+  Array<T> operator+ (const Array<T> &left, const Array<T> &right);
+template<typename T>
+  Array<T> operator- (const Array<T> &left, const Array<T> &right);
+template<typename T>
+  Array<T> operator*(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "*");
     return arrayTransformResult (left, right, std::multiplies<T>());
 }
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator/ (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator% (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator| (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator& (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc> 
-  Array<T, Alloc> operator^ (const Array<T, Alloc> &left, const Array<T, Alloc> &right);
+template<typename T>
+  Array<T> operator/ (const Array<T> &left, const Array<T> &right);
+template<typename T>
+  Array<T> operator% (const Array<T> &left, const Array<T> &right);
+template<typename T>
+  Array<T> operator| (const Array<T> &left, const Array<T> &right);
+template<typename T>
+  Array<T> operator& (const Array<T> &left, const Array<T> &right);
+template<typename T>
+  Array<T> operator^ (const Array<T> &left, const Array<T> &right);
 // </group>
 
 // 
 // Element by element arithmetic between an array and a scalar, returning
 // an array.
 // <group>
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator+ (const Array<T, Alloc> &left, const T &right);
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator- (const Array<T, Alloc> &left, const T &right);
-template<class T, typename Alloc>
-Array<T, Alloc> operator* (const Array<T, Alloc> &left, const T &right)
+template<typename T>
+    Array<T> operator+ (const Array<T> &left, const T &right);
+template<typename T>
+    Array<T> operator- (const Array<T> &left, const T &right);
+template<class T>
+Array<T> operator* (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, std::multiplies<T>());
 }
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator/ (const Array<T, Alloc> &left, const T &right);
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator% (const Array<T, Alloc> &left, const T &right);
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator| (const Array<T, Alloc> &left, const T &right);
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator& (const Array<T, Alloc> &left, const T &right);
-template<typename T, typename Alloc> 
-    Array<T, Alloc> operator^ (const Array<T, Alloc> &left, const T &right);
+template<typename T>
+    Array<T> operator/ (const Array<T> &left, const T &right);
+template<typename T>
+    Array<T> operator% (const Array<T> &left, const T &right);
+template<typename T>
+    Array<T> operator| (const Array<T> &left, const T &right);
+template<typename T>
+    Array<T> operator& (const Array<T> &left, const T &right);
+template<typename T>
+    Array<T> operator^ (const Array<T> &left, const T &right);
 // </group>
 
 // 
 // Element by element arithmetic between a scalar and an array, returning
 // an array.
 // <group>
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator+ (const T &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator- (const T &left, const Array<T, Alloc> &right);
-template<class T, typename Alloc> 
-Array<T, Alloc> operator* (const T &left, const Array<T, Alloc> &right)
+template<typename T>
+    Array<T> operator+ (const T &left, const Array<T> &right);
+template<typename T>
+    Array<T> operator- (const T &left, const Array<T> &right);
+template<class T>
+Array<T> operator* (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, std::multiplies<T>());
 }
 
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator/ (const T &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator% (const T &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator| (const T &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator& (const T &left, const Array<T, Alloc> &right);
-template<typename T, typename Alloc>  
-    Array<T, Alloc> operator^ (const T &left, const Array<T, Alloc> &right);
+template<typename T>
+    Array<T> operator/ (const T &left, const Array<T> &right);
+template<typename T>
+    Array<T> operator% (const T &left, const Array<T> &right);
+template<typename T>
+    Array<T> operator| (const T &left, const Array<T> &right);
+template<typename T>
+    Array<T> operator& (const T &left, const Array<T> &right);
+template<typename T>
+    Array<T> operator^ (const T &left, const Array<T> &right);
 // </group>
 
 // 
 // Transcendental function that can be applied to essentially all numeric
 // types. Works on an element-by-element basis.
 // <group>
-template<typename T, typename Alloc> Array<T, Alloc> cos(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> cosh(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> exp(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> log(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> log10(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> pow(const T &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> sin(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> sinh(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> sqrt(const Array<T, Alloc> &a);
+template<typename T> Array<T> cos(const Array<T> &a);
+template<typename T> Array<T> cosh(const Array<T> &a);
+template<typename T> Array<T> exp(const Array<T> &a);
+template<typename T> Array<T> log(const Array<T> &a);
+template<typename T> Array<T> log10(const Array<T> &a);
+template<typename T> Array<T> pow(const Array<T> &a, const Array<T> &b);
+template<typename T> Array<T> pow(const T &a, const Array<T> &b);
+template<typename T> Array<T> sin(const Array<T> &a);
+template<typename T> Array<T> sinh(const Array<T> &a);
+template<typename T> Array<T> sqrt(const Array<T> &a);
 // </group>
 
 // 
@@ -482,50 +482,50 @@ template<typename T, typename Alloc> Array<T, Alloc> sqrt(const Array<T, Alloc> 
 // basis. Although a template function, this does not make sense for all
 // numeric types.
 // <group>
-template<typename T, typename Alloc> Array<T, Alloc> acos(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> asin(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> atan(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> atan2(const Array<T, Alloc> &y, const Array<T, Alloc> &x);
-template<typename T, typename Alloc> Array<T, Alloc> atan2(const T &y, const Array<T, Alloc> &x);
-template<typename T, typename Alloc> Array<T, Alloc> atan2(const Array<T, Alloc> &y, const T &x);
-template<typename T, typename Alloc> Array<T, Alloc> ceil(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> fabs(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> abs(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> floor(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> round(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> sign(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> fmod(const Array<T, Alloc> &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> fmod(const T &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> fmod(const Array<T, Alloc> &a, const T &b);
-template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, Alloc> &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> floormod(const T &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, Alloc> &a, const T &b);
-template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const T &b);
-template<typename T, typename Alloc> Array<std::complex<T>, Alloc> pow(const Array<std::complex<T>, Alloc> &a, const T &b);
-template<typename T, typename Alloc> Array<T, Alloc> tan(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> Array<T, Alloc> tanh(const Array<T, Alloc> &a);
+template<typename T> Array<T> acos(const Array<T> &a);
+template<typename T> Array<T> asin(const Array<T> &a);
+template<typename T> Array<T> atan(const Array<T> &a);
+template<typename T> Array<T> atan2(const Array<T> &y, const Array<T> &x);
+template<typename T> Array<T> atan2(const T &y, const Array<T> &x);
+template<typename T> Array<T> atan2(const Array<T> &y, const T &x);
+template<typename T> Array<T> ceil(const Array<T> &a);
+template<typename T> Array<T> fabs(const Array<T> &a);
+template<typename T> Array<T> abs(const Array<T> &a);
+template<typename T> Array<T> floor(const Array<T> &a);
+template<typename T> Array<T> round(const Array<T> &a);
+template<typename T> Array<T> sign(const Array<T> &a);
+template<typename T> Array<T> fmod(const Array<T> &a, const Array<T> &b);
+template<typename T> Array<T> fmod(const T &a, const Array<T> &b);
+template<typename T> Array<T> fmod(const Array<T> &a, const T &b);
+template<typename T> Array<T> floormod(const Array<T> &a, const Array<T> &b);
+template<typename T> Array<T> floormod(const T &a, const Array<T> &b);
+template<typename T> Array<T> floormod(const Array<T> &a, const T &b);
+template<typename T> Array<T> pow(const Array<T> &a, const T &b);
+template<typename T> Array<std::complex<T>> pow(const Array<std::complex<T>> &a, const T &b);
+template<typename T> Array<T> tan(const Array<T> &a);
+template<typename T> Array<T> tanh(const Array<T> &a);
 // N.B. fabs is deprecated. Use abs.
-template<typename T, typename Alloc> Array<T, Alloc> fabs(const Array<T, Alloc> &a);
+template<typename T> Array<T> fabs(const Array<T> &a);
 // </group>
 
 // 
 // <group>
 // Find the minimum and maximum values of an array, including their locations.
-template<typename ScalarType, typename Alloc>
+template<typename ScalarType>
 void minMax(ScalarType &minVal, ScalarType &maxVal, IPosition &minPos, 
-	    IPosition &maxPos, const Array<ScalarType, Alloc> &array);
+	    IPosition &maxPos, const Array<ScalarType> &array);
 // The array is searched at locations where the mask equals <src>valid</src>.
 // (at least one such position must exist or an exception will be thrown).
 // MaskType should be an Array of bool.
-template<typename ScalarType, typename Alloc>
+template<typename ScalarType>
 void minMax(ScalarType &minVal, ScalarType &maxVal, IPosition &minPos,
-	    IPosition &maxPos, const Array<ScalarType, Alloc> &array, 
+	    IPosition &maxPos, const Array<ScalarType> &array,
 	    const Array<bool> &mask, bool valid=true);
 // The array * weight is searched 
-template<typename ScalarType, typename Alloc>
+template<typename ScalarType>
 void minMaxMasked(ScalarType &minVal, ScalarType &maxVal, IPosition &minPos,
-		  IPosition &maxPos, const Array<ScalarType, Alloc> &array, 
-		  const Array<ScalarType, Alloc> &weight);
+		  IPosition &maxPos, const Array<ScalarType> &array,
+		  const Array<ScalarType> &weight);
 // </group>
 
 // 
@@ -535,52 +535,52 @@ void minMaxMasked(ScalarType &minVal, ScalarType &maxVal, IPosition &minPos,
 //
 // This sets min and max to the minimum and maximum of the array to 
 // avoid having to do two passes with max() and min() separately.
-template<typename T, typename Alloc> void minMax(T &min, T &max, const Array<T, Alloc> &a);
+template<typename T> void minMax(T &min, T &max, const Array<T> &a);
 //
 // The minimum element of the array.
 // Requires that the type "T" has comparison operators.
-template<typename T, typename Alloc>  T min(const Array<T, Alloc> &a);
+template<typename T>  T min(const Array<T> &a);
 // The maximum element of the array.
 // Requires that the type "T" has comparison operators.
-template<typename T, typename Alloc>  T max(const Array<T, Alloc> &a);
+template<typename T>  T max(const Array<T> &a);
 
 // "result" contains the maximum of "a" and "b" at each position. "result",
 // "a", and "b" must be conformant.
-template<typename T, typename Alloc> void max(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
-			   const Array<T, Alloc> &b);
+template<typename T> void max(Array<T> &result, const Array<T> &a,
+			   const Array<T> &b);
 // "result" contains the minimum of "a" and "b" at each position. "result",
 // "a", and "b" must be conformant.
-template<typename T, typename Alloc> void min(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
-			   const Array<T, Alloc> &b);
+template<typename T> void min(Array<T> &result, const Array<T> &a,
+			   const Array<T> &b);
 // Return an array that contains the maximum of "a" and "b" at each position.
 // "a" and "b" must be conformant.
-template<typename T, typename Alloc> Array<T, Alloc> max(const Array<T, Alloc> &a, const Array<T, Alloc> &b);
-template<typename T, typename Alloc> Array<T, Alloc> max(const T &a, const Array<T, Alloc> &b);
+template<typename T> Array<T> max(const Array<T> &a, const Array<T> &b);
+template<typename T> Array<T> max(const T &a, const Array<T> &b);
 // Return an array that contains the minimum of "a" and "b" at each position.
 // "a" and "b" must be conformant.
-template<typename T, typename Alloc> Array<T, Alloc> min(const Array<T, Alloc> &a, const Array<T, Alloc> &b);
+template<typename T> Array<T> min(const Array<T> &a, const Array<T> &b);
 
 // "result" contains the maximum of "a" and "b" at each position. "result",
 // and "a" must be conformant.
-template<typename T, typename Alloc> void max(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
+template<typename T> void max(Array<T> &result, const Array<T> &a,
 			   const T &b);
-template<typename T, typename Alloc> inline void max(Array<T, Alloc> &result, const T &a, 
-                                  const Array<T, Alloc> &b)
+template<typename T> inline void max(Array<T> &result, const T &a,
+                                  const Array<T> &b)
   { max (result, b, a); }
 // "result" contains the minimum of "a" and "b" at each position. "result",
 // and "a" must be conformant.
-template<typename T, typename Alloc> void min(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
+template<typename T> void min(Array<T> &result, const Array<T> &a,
 			   const T &b);
-template<typename T, typename Alloc> inline void min(Array<T, Alloc> &result, const T &a, 
-                                  const Array<T, Alloc> &b)
+template<typename T> inline void min(Array<T> &result, const T &a,
+                                  const Array<T> &b)
   { min (result, b, a); }
 // Return an array that contains the maximum of "a" and "b" at each position.
-template<typename T, typename Alloc> Array<T, Alloc> max(const Array<T, Alloc> &a, const T &b);
-template<typename T, typename Alloc> inline Array<T, Alloc> max(const T &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> max(const Array<T> &a, const T &b);
+template<typename T> inline Array<T> max(const T &a, const Array<T> &b)
   { return max(b, a); }
 // Return an array that contains the minimum of "a" and "b" at each position.
-template<typename T, typename Alloc> Array<T, Alloc> min(const Array<T, Alloc> &a, const T &b);
-template<typename T, typename Alloc> inline Array<T, Alloc> min(const T &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> min(const Array<T> &a, const T &b);
+template<typename T> inline Array<T> min(const T &a, const Array<T> &b)
   { return min(b, a); }
 // </group>
 
@@ -588,44 +588,44 @@ template<typename T, typename Alloc> inline Array<T, Alloc> min(const T &a, cons
 // Fills all elements of "array" with a sequence starting with "start"
 // and incrementing by "inc" for each element. The first axis varies
 // most rapidly.
-template<typename T, typename Alloc> void indgen(Array<T, Alloc> &a, T start, T inc);
+template<typename T> void indgen(Array<T> &a, T start, T inc);
 // 
 // Fills all elements of "array" with a sequence starting with 0
 // and ending with nelements() - 1. The first axis varies
 // most rapidly.
-template<typename T, typename Alloc> inline void indgen(Array<T, Alloc> &a)
+template<typename T> inline void indgen(Array<T> &a)
   { indgen(a, T(0), T(1)); }
 // 
 // Fills all elements of "array" with a sequence starting with start
 // incremented by one for each position in the array. The first axis varies
 // most rapidly.
-template<typename T, typename Alloc> inline void indgen(Array<T, Alloc> &a, T start)
+template<typename T> inline void indgen(Array<T> &a, T start)
   { indgen(a, start, T(1)); }
 
 // Create a Vector of the given length and fill it with the start value
 // incremented with <code>inc</code> for each element.
-template<typename T, typename Alloc=std::allocator<T>> inline Vector<T, Alloc> indgen(size_t length, T start, T inc)
+template<typename T> inline Vector<T> indgen(size_t length, T start, T inc)
 {
-  Vector<T, Alloc> x(length);
+  Vector<T> x(length);
   indgen(x, start, inc);
   return x;
 }
 
 
 // Sum of every element of the array.
-template<typename T, typename Alloc> T sum(const Array<T, Alloc> &a);
+template<typename T> T sum(const Array<T> &a);
 // 
 // Sum the square of every element of the array.
-template<typename T, typename Alloc> T sumsqr(const Array<T, Alloc> &a);
+template<typename T> T sumsqr(const Array<T> &a);
 // 
 // Product of every element of the array. This could of course easily
 // overflow.
-template<typename T, typename Alloc> T product(const Array<T, Alloc> &a);
+template<typename T> T product(const Array<T> &a);
 
 // 
 // The mean of "a" is the sum of all elements of "a" divided by the number
 // of elements of "a".
-template<typename T, typename Alloc> T mean(const Array<T, Alloc> &a);
+template<typename T> T mean(const Array<T> &a);
 
 // The variance of "a" is the sum of (a(i) - mean(a))**2/(a.nelements() - ddof).
 // Similar to numpy the argument ddof (delta degrees of freedom) tells if the
@@ -634,31 +634,31 @@ template<typename T, typename Alloc> T mean(const Array<T, Alloc> &a);
 // <br>Note that for a complex valued T the absolute values are used; in that way
 // the variance is equal to the sum of the variances of the real and imaginary parts.
 // Hence the imaginary part in the return value is 0.
-template<typename T, typename Alloc> T variance(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> T pvariance(const Array<T, Alloc> &a, size_t ddof=0);
+template<typename T> T variance(const Array<T> &a);
+template<typename T> T pvariance(const Array<T> &a, size_t ddof=0);
 // Rather than using a computed mean, use the supplied value.
-template<typename T, typename Alloc> T variance(const Array<T, Alloc> &a, T mean);
-template<typename T, typename Alloc> T pvariance(const Array<T, Alloc> &a, T mean, size_t ddof=0);
+template<typename T> T variance(const Array<T> &a, T mean);
+template<typename T> T pvariance(const Array<T> &a, T mean, size_t ddof=0);
 
 // The standard deviation of "a" is the square root of its variance.
-template<typename T, typename Alloc> T stddev(const Array<T, Alloc> &a);
-template<typename T, typename Alloc> T pstddev(const Array<T, Alloc> &a, size_t ddof=0);
-template<typename T, typename Alloc> T stddev(const Array<T, Alloc> &a, T mean);
-template<typename T, typename Alloc> T pstddev(const Array<T, Alloc> &a, T mean, size_t ddof=0);
+template<typename T> T stddev(const Array<T> &a);
+template<typename T> T pstddev(const Array<T> &a, size_t ddof=0);
+template<typename T> T stddev(const Array<T> &a, T mean);
+template<typename T> T pstddev(const Array<T> &a, T mean, size_t ddof=0);
 
 // 
 // The average deviation of "a" is the sum of abs(a(i) - mean(a))/N. (N.B.
 // N, not N-1 in the denominator).
-template<typename T, typename Alloc> T avdev(const Array<T, Alloc> &a);
+template<typename T> T avdev(const Array<T> &a);
 // 
 // The average deviation of "a" is the sum of abs(a(i) - mean(a))/N. (N.B.
 // N, not N-1 in the denominator).
 // Rather than using a computed mean, use the supplied value.
-template<typename T, typename Alloc> T avdev(const Array<T, Alloc> &a,T mean);
+template<typename T> T avdev(const Array<T> &a,T mean);
 
 //
 // The root-mean-square of "a" is the sqrt of sum(a*a)/N.
-template<typename T, typename Alloc> T rms(const Array<T, Alloc> &a);
+template<typename T> T rms(const Array<T> &a);
 
 
 // The median of "a" is a(n/2).
@@ -680,18 +680,18 @@ template<typename T, typename Alloc> T rms(const Array<T, Alloc> &a);
 // obtain the index of the median in an array. </note>
 // <group>
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T median(const Array<T, Alloc> &a, std::vector<T> &scratch, bool sorted,
+template<typename T> T median(const Array<T> &a, std::vector<T> &scratch, bool sorted,
 			   bool takeEvenMean, bool inPlace=false);
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T median(const Array<T, Alloc> &a, bool sorted, bool takeEvenMean,
+template<typename T> T median(const Array<T> &a, bool sorted, bool takeEvenMean,
 			   bool inPlace=false)
     { std::vector<T> scratch; return median (a, scratch, sorted, takeEvenMean, inPlace); }
-template<typename T, typename Alloc> inline T median(const Array<T, Alloc> &a, bool sorted)
+template<typename T> inline T median(const Array<T> &a, bool sorted)
     { return median (a, sorted, (a.nelements() <= 100), false); }
-template<typename T, typename Alloc> inline T median(const Array<T, Alloc> &a)
+template<typename T> inline T median(const Array<T> &a)
     { return median (a, false, (a.nelements() <= 100), false); }
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> inline T medianInPlace(const Array<T, Alloc> &a, bool sorted=false)
+template<typename T> inline T medianInPlace(const Array<T> &a, bool sorted=false)
     { return median (a, sorted, (a.nelements() <= 100), true); }
 // </group>
 
@@ -699,18 +699,18 @@ template<typename T, typename Alloc> inline T medianInPlace(const Array<T, Alloc
 // the median functions
 // <group>
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T madfm(const Array<T, Alloc> &a, std::vector<T> &tmp, bool sorted, 
+template<typename T> T madfm(const Array<T> &a, std::vector<T> &tmp, bool sorted,
                          bool takeEvenMean, bool inPlace = false);
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T madfm(const Array<T, Alloc> &a, bool sorted, bool takeEvenMean,
+template<typename T> T madfm(const Array<T> &a, bool sorted, bool takeEvenMean,
                           bool inPlace=false)
     { std::vector<T> tmp; return madfm(a, tmp, sorted, takeEvenMean, inPlace); }
-template<typename T, typename Alloc> inline T madfm(const Array<T, Alloc> &a, bool sorted)
+template<typename T> inline T madfm(const Array<T> &a, bool sorted)
     { return madfm(a, sorted, (a.nelements() <= 100), false); }
-template<typename T, typename Alloc> inline T madfm(const Array<T, Alloc> &a)
+template<typename T> inline T madfm(const Array<T> &a)
     { return madfm(a, false, (a.nelements() <= 100), false); }
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> inline T madfmInPlace(const Array<T, Alloc> &a, bool sorted=false)
+template<typename T> inline T madfmInPlace(const Array<T> &a, bool sorted=false)
     { return madfm(a, sorted, (a.nelements() <= 100), true); }
 // </group>
 
@@ -722,10 +722,10 @@ template<typename T, typename Alloc> inline T madfmInPlace(const Array<T, Alloc>
 // <note>The function kthLargest in class GenSortIndirect can be used to
 // obtain the index of the fractile in an array. </note>
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T fractile(const Array<T, Alloc> &a, std::vector<T> &tmp, float fraction,
+template<typename T> T fractile(const Array<T> &a, std::vector<T> &tmp, float fraction,
 			     bool sorted=false, bool inPlace=false);
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T fractile(const Array<T, Alloc> &a, float fraction,
+template<typename T> T fractile(const Array<T> &a, float fraction,
 			     bool sorted=false, bool inPlace=false)
   { std::vector<T> tmp; return fractile (a, tmp, fraction, sorted, inPlace); }
 
@@ -733,11 +733,11 @@ template<typename T, typename Alloc> T fractile(const Array<T, Alloc> &a, float 
 // This is the full range between the bottom and the top fraction.
 // <group>
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T interFractileRange(const Array<T, Alloc> &a, std::vector<T> &tmp,
+template<typename T> T interFractileRange(const Array<T> &a, std::vector<T> &tmp,
                                        float fraction,
                                        bool sorted=false, bool inPlace=false);
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T interFractileRange(const Array<T, Alloc> &a, float fraction,
+template<typename T> T interFractileRange(const Array<T> &a, float fraction,
                                        bool sorted=false, bool inPlace=false)
   { std::vector<T> tmp; return interFractileRange(a, tmp, fraction, sorted, inPlace); }
 // </group>
@@ -750,11 +750,11 @@ template<typename T, typename Alloc> T interFractileRange(const Array<T, Alloc> 
 // 1998)
 // <group>
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T interHexileRange(const Array<T, Alloc> &a, std::vector<T> &tmp,
+template<typename T> T interHexileRange(const Array<T> &a, std::vector<T> &tmp,
                                      bool sorted=false, bool inPlace=false)
   { return interFractileRange(a, tmp, 1./6., sorted, inPlace); }
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T interHexileRange(const Array<T, Alloc> &a, bool sorted=false,
+template<typename T> T interHexileRange(const Array<T> &a, bool sorted=false,
                                      bool inPlace=false)
   { return interFractileRange(a, 1./6., sorted, inPlace); }
 // </group>
@@ -764,11 +764,11 @@ template<typename T, typename Alloc> T interHexileRange(const Array<T, Alloc> &a
 // quarter of ordered array values.
 // <group>
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T interQuartileRange(const Array<T, Alloc> &a, std::vector<T> &tmp,
+template<typename T> T interQuartileRange(const Array<T> &a, std::vector<T> &tmp,
                                        bool sorted=false, bool inPlace=false)
   { return interFractileRange(a, tmp, 0.25, sorted, inPlace); }
 // TODO shouldn't take a const Array for in place sorting
-template<typename T, typename Alloc> T interQuartileRange(const Array<T, Alloc> &a, bool sorted=false,
+template<typename T> T interQuartileRange(const Array<T> &a, bool sorted=false,
                                        bool inPlace=false)
   { return interFractileRange(a, 0.25, sorted, inPlace); }
 // </group>
@@ -777,48 +777,48 @@ template<typename T, typename Alloc> T interQuartileRange(const Array<T, Alloc> 
 // Methods for element-by-element scaling of complex and real.
 // Note that std::complex<float> and std::complex<double> are typedefs for std::complex.
 //<group>
-template<typename T, typename AllocC, typename AllocR>
-void operator*= (Array<std::complex<T>, AllocC> &left, const Array<T, AllocR> &other)
+template<typename T>
+void operator*= (Array<std::complex<T>> &left, const Array<T> &other)
 {
   checkArrayShapes (left, other, "*=");
   arrayTransformInPlace (left, other,
                          [](std::complex<T> left, T right) { return left*right; });
 }
 
-template<typename T, typename Alloc>
-void operator*= (Array<std::complex<T>, Alloc> &left, const T &other)
+template<typename T>
+void operator*= (Array<std::complex<T>> &left, const T &other)
 {
   arrayTransformInPlace (left, other,
                          [](std::complex<T> left, T right) { return left*right; });
 }
 
-template<typename T, typename AllocC, typename AllocR>
-void operator/= (Array<std::complex<T>, AllocC> &left, const Array<T, AllocR> &other)
+template<typename T>
+void operator/= (Array<std::complex<T>> &left, const Array<T> &other)
 {
   checkArrayShapes (left, other, "/=");
   arrayTransformInPlace (left, other,
                          [](std::complex<T> left, T right) { return left/right; });
 }
 
-template<typename T, typename Alloc>
-void operator/= (Array<std::complex<T>, Alloc> &left, const T &other)
+template<typename T>
+void operator/= (Array<std::complex<T>> &left, const T &other)
 {
   arrayTransformInPlace (left, other,
                          [](std::complex<T> left, T right) { return left/right; });
 }
 
-template<typename T, typename AllocC, typename AllocR>
-Array<std::complex<T>, AllocC> operator* (const Array<std::complex<T>, AllocC> &left,
-                                   const Array<T, AllocR> &right)
+template<typename T>
+Array<std::complex<T>> operator* (const Array<std::complex<T>> &left,
+                                   const Array<T> &right)
 {
   checkArrayShapes (left, right, "*");
-  Array<std::complex<T>, AllocC> result(left.shape());
+  Array<std::complex<T>> result(left.shape());
   arrayContTransform (left, right, result,
                       [](std::complex<T> left, T right) { return left*right; });
   return result;
 }
-template<typename T, typename Alloc>
-Array<std::complex<T> > operator* (const Array<std::complex<T>, Alloc> &left,
+template<typename T>
+Array<std::complex<T> > operator* (const Array<std::complex<T>> &left,
                                    const T &other)
 {
   Array<std::complex<T> > result(left.shape());
@@ -826,9 +826,9 @@ Array<std::complex<T> > operator* (const Array<std::complex<T>, Alloc> &left,
                       [](std::complex<T> left, T right) { return left*right; });
   return result;
 }
-template<typename T, typename Alloc>
+template<typename T>
 Array<std::complex<T> > operator*(const std::complex<T> &left,
-                                  const Array<T, Alloc> &other)
+                                  const Array<T> &other)
 {
   Array<std::complex<T> > result(other.shape());
   arrayContTransform (left, other, result,
@@ -836,28 +836,28 @@ Array<std::complex<T> > operator*(const std::complex<T> &left,
   return result;
 }
 
-template<typename T, typename AllocC, typename AllocR>
-Array<std::complex<T>, AllocC> operator/ (const Array<std::complex<T>, AllocC> &left,
-                                   const Array<T, AllocR> &right)
+template<typename T>
+Array<std::complex<T>> operator/ (const Array<std::complex<T>> &left,
+                                   const Array<T> &right)
 {
   checkArrayShapes (left, right, "/");
-  Array<std::complex<T>, AllocC> result(left.shape());
+  Array<std::complex<T>> result(left.shape());
   arrayContTransform (left, right, result,
                       [](std::complex<T> l, T r) { return l/r; });
   return result;
 }
-template<typename T, typename Alloc>
-Array<std::complex<T>, Alloc> operator/ (const Array<std::complex<T>, Alloc> &left,
+template<typename T>
+Array<std::complex<T>> operator/ (const Array<std::complex<T>> &left,
                                    const T &other)
 {
-  Array<std::complex<T>, Alloc> result(left.shape());
+  Array<std::complex<T>> result(left.shape());
   arrayContTransform (left, other, result,
                       [](std::complex<T> left, T right) { return left/right; });
   return result;
 }
-template<typename T, typename Alloc>
+template<typename T>
 Array<std::complex<T>> operator/(const std::complex<T> &left,
-                                  const Array<T, Alloc> &other)
+                                  const Array<T> &other)
 {
   Array<std::complex<T>> result(other.shape());
   arrayContTransform (left, other, result,
@@ -883,21 +883,21 @@ Matrix<std::complex<double>> conj(const Matrix<std::complex<double>> &carray);
 // Note that std::complex<float> and std::complex<double> are simply typedefs for std::complex<float>
 // and std::complex<double>, so the result is in fact one of these types.
 // <group>
-template<typename T, typename Alloc>
-Array<std::complex<T> > makeComplex(const Array<T, Alloc> &real, const Array<T, Alloc>& imag);
-template<typename T, typename Alloc>
-Array<std::complex<T> > makeComplex(const T &real, const Array<T, Alloc>& imag);
-template<typename T, typename Alloc>
-Array<std::complex<T> > makeComplex(const Array<T, Alloc> &real, const T& imag);
+template<typename T>
+Array<std::complex<T> > makeComplex(const Array<T> &real, const Array<T>& imag);
+template<typename T>
+Array<std::complex<T> > makeComplex(const T &real, const Array<T>& imag);
+template<typename T>
+Array<std::complex<T> > makeComplex(const Array<T> &real, const T& imag);
 // </group>
 
 // Set the real part of the left complex array to the right real array.
-template<typename C, typename R, typename AllocC, typename AllocR>
-void setReal(Array<C, AllocC> &carray, const Array<R, AllocR> &rarray);
+template<typename C, typename R>
+void setReal(Array<C> &carray, const Array<R> &rarray);
 
 // Set the imaginary part of the left complex array to right real array.
-template<typename C, typename R, typename AllocC, typename AllocR>
-void setImag(Array<C, AllocC> &carray, const Array<R, AllocR> &rarray);
+template<typename C, typename R>
+void setImag(Array<C> &carray, const Array<R> &rarray);
 
 // Extracts the real part of a complex array into an array of floats.
 // <group>
@@ -970,14 +970,14 @@ void  RealToComplex(Array<std::complex<double>> &carray, const Array<double> &ra
 // of doubles from an array of floats. Arrays to and from must be conformant
 // (same shape). Also, it must be possible to convert a scalar of type U 
 // to type T.
-template<typename T, typename U, typename AllocT, typename AllocU>
-void convertArray(Array<T, AllocT> &to, const Array<U, AllocU> &from);
+template<typename T, typename U>
+void convertArray(Array<T> &to, const Array<U> &from);
 
 // Returns an array where every element is squared.
-template<typename T, typename Alloc> Array<T, Alloc> square(const Array<T, Alloc> &val);
+template<typename T> Array<T> square(const Array<T> &val);
 
 // Returns an array where every element is cubed.
-template<typename T, typename Alloc> Array<T, Alloc> cube(const Array<T, Alloc> &val);
+template<typename T> Array<T> cube(const Array<T> &val);
 
 // Helper function for expandArray using recursion for each axis.
 template<typename T>
@@ -1038,14 +1038,14 @@ T* expandRecursive (int axis, const IPosition& shp, const IPosition& mult,
 // This choice can be made for each axis; a value 0 means linearly,
 // another value means alternately. If the length of alternate is less than
 // the dimensionality of the output array, the missing ones default to 0.
-template<typename T, typename Alloc>
-void expandArray (Array<T, Alloc>& out, const Array<T, Alloc>& in,
+template<typename T>
+void expandArray (Array<T>& out, const Array<T>& in,
                   const IPosition& alternate=IPosition())
 {
   IPosition mult, inshp, outshp;
   IPosition alt = checkExpandArray (mult, inshp,
                                     in.shape(), out.shape(), alternate);
-  Array<T, Alloc> incp(in);
+  Array<T> incp(in);
   if (in.ndim() < inshp.size()) {
     incp.reference (in.reform(inshp));
   }

--- a/casa/Arrays/ArrayMath.tcc
+++ b/casa/Arrays/ArrayMath.tcc
@@ -42,9 +42,9 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<typename L, typename R, typename RES, typename BinaryOperator, typename AllocL, typename AllocR, typename AllocRES>
-void arrayTransform (const Array<L, AllocL>& left, const Array<R, AllocR>& right,
-                     Array<RES, AllocRES>& result, BinaryOperator op)
+template<typename L, typename R, typename RES, typename BinaryOperator>
+void arrayTransform (const Array<L>& left, const Array<R>& right,
+                     Array<RES>& result, BinaryOperator op)
 {
   if (result.contiguousStorage()) {
     arrayContTransform (left, right, result, op);
@@ -59,9 +59,9 @@ void arrayTransform (const Array<L, AllocL>& left, const Array<R, AllocR>& right
   }
 }
 
-template<typename L, typename R, typename RES, typename BinaryOperator, typename AllocL, typename AllocRES>
-void arrayTransform (const Array<L, AllocL>& left, R right,
-                     Array<RES, AllocRES>& result, BinaryOperator op)
+template<typename L, typename R, typename RES, typename BinaryOperator>
+void arrayTransform (const Array<L>& left, R right,
+                     Array<RES>& result, BinaryOperator op)
 {
   if (result.contiguousStorage()) {
     arrayContTransform (left, right, result, op);
@@ -74,9 +74,9 @@ void arrayTransform (const Array<L, AllocL>& left, R right,
   }
 }
 
-template<typename L, typename R, typename RES, typename BinaryOperator, typename AllocR, typename AllocRES>
-void arrayTransform (L left, const Array<R, AllocR>& right,
-                     Array<RES, AllocRES>& result, BinaryOperator op)
+template<typename L, typename R, typename RES, typename BinaryOperator>
+void arrayTransform (L left, const Array<R>& right,
+                     Array<RES>& result, BinaryOperator op)
 {
   if (result.contiguousStorage()) {
     arrayContTransform (left, right, result, op);
@@ -89,9 +89,9 @@ void arrayTransform (L left, const Array<R, AllocR>& right,
   }
 }
 
-template<typename T, typename RES, typename UnaryOperator, typename AllocL, typename AllocRES>
-void arrayTransform (const Array<T, AllocL>& arr,
-                     Array<RES, AllocRES>& result, UnaryOperator op)
+template<typename T, typename RES, typename UnaryOperator>
+void arrayTransform (const Array<T>& arr,
+                     Array<RES>& result, UnaryOperator op)
 {
   if (result.contiguousStorage()) {
     arrayContTransform (arr, result, op);
@@ -104,35 +104,35 @@ void arrayTransform (const Array<T, AllocL>& arr,
   }
 }
 
-template<typename T, typename BinaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& left, const Array<T, Alloc>& right,
+template<typename T, typename BinaryOperator>
+Array<T> arrayTransformResult (const Array<T>& left, const Array<T>& right,
                                BinaryOperator op)
 {
-  Array<T, Alloc> res(left.shape());
+  Array<T> res(left.shape());
   arrayContTransform (left, right, res, op);
   return res;
 }
 
-template<typename T, typename BinaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& left, T right, BinaryOperator op)
+template<typename T, typename BinaryOperator>
+Array<T> arrayTransformResult (const Array<T>& left, T right, BinaryOperator op)
 {
-  Array<T, Alloc> res(left.shape());
+  Array<T> res(left.shape());
   arrayContTransform (left, right, res, op);
   return res;
 }
 
-template<typename T, typename BinaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (T left, const Array<T, Alloc>& right, BinaryOperator op)
+template<typename T, typename BinaryOperator>
+Array<T> arrayTransformResult (T left, const Array<T>& right, BinaryOperator op)
 {
-  Array<T, Alloc> res(right.shape());
+  Array<T> res(right.shape());
   arrayContTransform (left, right, res, op);
   return res;
 }
 
-template<typename T, typename UnaryOperator, typename Alloc>
-Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& arr, UnaryOperator op)
+template<typename T, typename UnaryOperator>
+Array<T> arrayTransformResult (const Array<T>& arr, UnaryOperator op)
 {
-  Array<T, Alloc> res(arr.shape());
+  Array<T> res(arr.shape());
   arrayContTransform (arr, res, op);
   return res;
 }
@@ -141,15 +141,15 @@ Array<T, Alloc> arrayTransformResult (const Array<T, Alloc>& arr, UnaryOperator 
 // <thrown>
 //   <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> 
+template<typename T>
 void minMax(T &minVal, T &maxVal, 
 	    IPosition &minPos, IPosition &maxPos,
-	    const Array<T, Alloc> &array) 
+	    const Array<T> &array)
 {
   size_t n = array.nelements();
   if (n == 0) {
     throw(ArrayError("void minMax(T &min, T &max, IPosition &minPos,"
-                     "IPosition &maxPos, const Array<T, Alloc> &array) - "
+                     "IPosition &maxPos, const Array<T> &array) - "
                      "Array has no elements"));	
   }
   size_t minp = 0;
@@ -157,7 +157,7 @@ void minMax(T &minVal, T &maxVal,
   T minv = array.data()[0];
   T maxv = minv;
   if (array.contiguousStorage()) {
-    typename Array<T, Alloc>::const_contiter iter = array.cbegin();
+    typename Array<T>::const_contiter iter = array.cbegin();
     for (size_t i=0; i<n; ++i, ++iter) {
       if (*iter < minv) {
         minv = *iter;
@@ -168,7 +168,7 @@ void minMax(T &minVal, T &maxVal,
       }
     }
   } else {
-    typename Array<T, Alloc>::const_iterator iter = array.begin();
+    typename Array<T>::const_iterator iter = array.begin();
     for (size_t i=0; i<n; ++i, ++iter) {
       if (*iter < minv) {
         minv = *iter;
@@ -192,23 +192,23 @@ void minMax(T &minVal, T &maxVal,
 // <thrown>
 //   <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> 
+template<typename T>
 void minMaxMasked(T &minVal, T &maxVal, 
                   IPosition &minPos, IPosition &maxPos,
-                  const Array<T, Alloc> &array, const Array<T, Alloc> &weight) 
+                  const Array<T> &array, const Array<T> &weight)
 {
   size_t n = array.nelements();
   if (n == 0) {
     throw(ArrayError("void minMax(T &min, T &max, IPosition &minPos,"
-                     "IPosition &maxPos, const Array<T, Alloc> &array) - "
-                     "const Array<T, Alloc> &weight) - " 
+                     "IPosition &maxPos, const Array<T> &array) - "
+                     "const Array<T> &weight) - "
                      "Array has no elements"));	
   }
   if (! array.shape().isEqual (weight.shape())) {
     throw(ArrayConformanceError("void minMaxMasked(T &min, T &max,"
                                 "IPosition &minPos, IPosition &maxPos, "
-                                "const Array<T, Alloc> &array, "
-                                "const Array<T, Alloc> &weight) - array " 
+                                "const Array<T> &array, "
+                                "const Array<T> &weight) - array "
                                 "and weight do not have the same shape()"));
   }
   size_t minp = 0;
@@ -216,8 +216,8 @@ void minMaxMasked(T &minVal, T &maxVal,
   T minv = array.data()[0] * weight.data()[0];
   T maxv = minv;
   if (array.contiguousStorage()  &&  weight.contiguousStorage()) {
-    typename Array<T, Alloc>::const_contiter iter = array.cbegin();
-    typename Array<T, Alloc>::const_contiter witer = weight.cbegin();
+    typename Array<T>::const_contiter iter = array.cbegin();
+    typename Array<T>::const_contiter witer = weight.cbegin();
     for (size_t i=0; i<n; ++i, ++iter, ++witer) {
       T tmp = *iter * *witer;
       if (tmp < minv) {
@@ -229,8 +229,8 @@ void minMaxMasked(T &minVal, T &maxVal,
       }
     }
   } else {
-    typename Array<T, Alloc>::const_iterator iter = array.begin();
-    typename Array<T, Alloc>::const_iterator witer = weight.begin();
+    typename Array<T>::const_iterator iter = array.begin();
+    typename Array<T>::const_iterator witer = weight.begin();
     for (size_t i=0; i<n; ++i, ++iter, ++witer) {
       T tmp = *iter * *witer;
       if (tmp < minv) {
@@ -255,22 +255,22 @@ void minMaxMasked(T &minVal, T &maxVal,
 //   <item> ArrayError
 //   <item> AipsError
 // </thrown>
-template<typename T, typename Alloc> 
+template<typename T>
 void minMax(T &minVal, T &maxVal, 
 	    IPosition &minPos, IPosition &maxPos,
-	    const Array<T, Alloc> &array, const Array<bool> &mask, bool valid)
+	    const Array<T> &array, const Array<bool> &mask, bool valid)
 {
   size_t n = array.nelements();
   if (n == 0) {
     throw(ArrayError("void minMax(T &min, T &max, IPosition &minPos,"
-                     "IPosition &maxPos, const Array<T, Alloc> &array, "
+                     "IPosition &maxPos, const Array<T> &array, "
                      "const Array<bool> &mask) - "
                      "Array has no elements"));	
   }
   if (! array.shape().isEqual (mask.shape())) {
     throw(ArrayConformanceError("void minMax(T &min, T &max,"
                                 "IPosition &minPos, IPosition &maxPos,"
-                                "const Array<T, Alloc> &array, "
+                                "const Array<T> &array, "
                                 "const Array<bool> &mask) - " 
                                 "array and mask do not have the same shape()"));
   }
@@ -279,7 +279,7 @@ void minMax(T &minVal, T &maxVal,
   T minv = T();
   T maxv = T();
   if (array.contiguousStorage()  &&  mask.contiguousStorage()) {
-    typename Array<T, Alloc>::const_contiter iter = array.cbegin();
+    typename Array<T>::const_contiter iter = array.cbegin();
     typename Array<bool>::const_contiter miter = mask.cbegin();
     size_t i=0;
     for (; i<n; ++i, ++iter, ++miter) {
@@ -301,7 +301,7 @@ void minMax(T &minVal, T &maxVal,
       }
     }
   } else {
-    typename Array<T, Alloc>::const_iterator iter = array.begin();
+    typename Array<T>::const_iterator iter = array.begin();
     typename Array<bool>::const_iterator miter = mask.begin();
     size_t i=0;
     for (; i<n; ++i, ++iter, ++miter) {
@@ -326,7 +326,7 @@ void minMax(T &minVal, T &maxVal,
   if (minp ==n) {
     throw(std::runtime_error("void minMax(T &min, T &max,"
                     "IPosition &minPos, IPosition &maxPos,"
-                    "const Array<T, Alloc> &array, "
+                    "const Array<T> &array, "
                     "const Array<bool> &mask) - no valid array elements"));
   }
   minPos.resize (array.ndim());
@@ -340,19 +340,19 @@ void minMax(T &minVal, T &maxVal,
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void operator+= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator+= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "+=");
     arrayTransformInPlace (left, other, std::plus<T>());
 }
 
-template<typename T, typename Alloc>  T min(const Array<T, Alloc> &a)
+template<typename T>  T min(const Array<T> &a)
     { T Min, Max; minMax(Min, Max, a); return Min; }
 
-template<typename T, typename Alloc>  T max(const Array<T, Alloc> &a)
+template<typename T>  T max(const Array<T> &a)
     { T Min, Max; minMax(Min, Max, a); return Max; }
 
-template<typename T, typename Alloc> void operator+= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator+= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, std::plus<T>());
 }
@@ -360,13 +360,13 @@ template<typename T, typename Alloc> void operator+= (Array<T, Alloc> &left, con
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void operator-= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator-= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "-=");
     arrayTransformInPlace (left, other, std::minus<T>());
 }
 
-template<typename T, typename Alloc> void operator-= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator-= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, std::minus<T>());
 }
@@ -374,13 +374,13 @@ template<typename T, typename Alloc> void operator-= (Array<T, Alloc> &left, con
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void operator%= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator%= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "%=");
     arrayTransformInPlace (left, other, std::modulus<T>());
 }
 
-template<typename T, typename Alloc> void operator%= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator%= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, std::modulus<T>());
 }
@@ -388,13 +388,13 @@ template<typename T, typename Alloc> void operator%= (Array<T, Alloc> &left, con
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void operator&= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator&= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "&=");
     arrayTransformInPlace (left, other, [](T a, T b){ return a&b; });
 }
 
-template<typename T, typename Alloc> void operator&= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator&= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, [](T a, T b){ return a&b; });
 }
@@ -402,13 +402,13 @@ template<typename T, typename Alloc> void operator&= (Array<T, Alloc> &left, con
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void operator|= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator|= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "|=");
     arrayTransformInPlace (left, other, [](T a, T b){ return a|b; });
 }
 
-template<typename T, typename Alloc> void operator|= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator|= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, [](T a, T b){ return a|b; });
 }
@@ -416,28 +416,28 @@ template<typename T, typename Alloc> void operator|= (Array<T, Alloc> &left, con
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void operator^= (Array<T, Alloc> &left, const Array<T, Alloc> &other)
+template<typename T> void operator^= (Array<T> &left, const Array<T> &other)
 {
     checkArrayShapes (left, other, "^=");
     arrayTransformInPlace (left, other, [](T a, T b){ return a^b; });
 }
 
-template<typename T, typename Alloc> void operator^= (Array<T, Alloc> &left, const T &other)
+template<typename T> void operator^= (Array<T> &left, const T &other)
 {
     arrayTransformInPlace (left, other, [](T a, T b){ return a^b; });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> operator+(const Array<T, Alloc> &a)
+template<typename T> Array<T> operator+(const Array<T> &a)
 {
     return a.copy();
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> operator-(const Array<T, Alloc> &a)
+template<typename T> Array<T> operator-(const Array<T> &a)
 {
     return arrayTransformResult (a, std::negate<T>());
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> operator~(const Array<T, Alloc> &a)
+template<typename T> Array<T> operator~(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T val) { return ~val; }); // bit_not would be nicer, but is C++14
 }
@@ -445,8 +445,8 @@ template<typename T, typename Alloc> Array<T, Alloc> operator~(const Array<T, Al
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator+(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator+(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "+");
     return arrayTransformResult (left, right, std::plus<T>());
@@ -455,8 +455,8 @@ template<typename T, typename Alloc>
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator-(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator-(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "-");
     return arrayTransformResult (left, right, std::minus<T>());
@@ -466,124 +466,124 @@ template<typename T, typename Alloc>
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator/(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator/(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "/");
     return arrayTransformResult (left, right, std::divides<T>());
 }
 
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator%(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator%(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "%");
     return arrayTransformResult (left, right, std::modulus<T>());
 }
 
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator&(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator&(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "%");
     return arrayTransformResult (left, right, [](T a, T b){ return a&b; });
 }
 
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator|(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator|(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "%");
     return arrayTransformResult (left, right, [](T a, T b){ return a|b; });
 }
 
-template<typename T, typename Alloc>
-   Array<T, Alloc> operator^(const Array<T, Alloc> &left, const Array<T, Alloc> &right)
+template<typename T>
+   Array<T> operator^(const Array<T> &left, const Array<T> &right)
 {
     checkArrayShapes (left, right, "%");
     return arrayTransformResult (left, right, [](T a, T b){ return a^b; });
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator+ (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator+ (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, std::plus<T>());
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator- (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator- (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, std::minus<T>());
 }
 
 
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator/ (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator/ (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, std::divides<T>());
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator% (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator% (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, std::modulus<T>());
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator& (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator& (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, [](T a, T b){ return a&b; });
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator| (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator| (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, [](T a, T b){ return a|b; });
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator^ (const Array<T, Alloc> &left, const T &right)
+template<class T>
+Array<T> operator^ (const Array<T> &left, const T &right)
 {
     return arrayTransformResult (left, right, [](T a, T b){ return a^b; });
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator+ (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator+ (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, std::plus<T>());
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator- (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator- (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, std::minus<T>());
 }
 
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator/ (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator/ (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, std::divides<T>());
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator% (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator% (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, std::modulus<T>());
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator& (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator& (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, [](T a, T b){ return a&b; });
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator| (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator| (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, [](T a, T b){ return a|b; });
 }
 
-template<class T, typename Alloc> 
-Array<T, Alloc> operator^ (const T &left, const Array<T, Alloc> &right)
+template<class T>
+Array<T> operator^ (const T &left, const Array<T> &right)
 {
     return arrayTransformResult (left, right, [](T a, T b){ return a^b; });
 }
@@ -591,18 +591,18 @@ Array<T, Alloc> operator^ (const T &left, const Array<T, Alloc> &right)
 // <thrown>
 //   </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> void minMax(T &minVal, T &maxVal, const Array<T, Alloc> &array)
+template<typename T> void minMax(T &minVal, T &maxVal, const Array<T> &array)
 {
   if (array.nelements() == 0) {
-    throw(ArrayError("void minMax(T &min, T &max, const Array<T, Alloc> &array) - "
+    throw(ArrayError("void minMax(T &min, T &max, const Array<T> &array) - "
                      "Array has no elements"));	
   }
   if (array.contiguousStorage()) {
     // minimal scope as some compilers may spill onto stack otherwise
     T minv = array.data()[0];
     T maxv = minv;
-    typename Array<T, Alloc>::const_contiter iterEnd = array.cend();
-    for (typename Array<T, Alloc>::const_contiter iter = array.cbegin();
+    typename Array<T>::const_contiter iterEnd = array.cend();
+    for (typename Array<T>::const_contiter iter = array.cbegin();
          iter!=iterEnd; ++iter) {
       if (*iter < minv) {
         minv = *iter;
@@ -617,8 +617,8 @@ template<typename T, typename Alloc> void minMax(T &minVal, T &maxVal, const Arr
   } else {
     T minv = array.data()[0];
     T maxv = minv;
-    typename Array<T, Alloc>::const_iterator iterEnd = array.end();
-    for (typename Array<T, Alloc>::const_iterator iter = array.begin();
+    typename Array<T>::const_iterator iterEnd = array.end();
+    for (typename Array<T>::const_iterator iter = array.begin();
          iter!=iterEnd; ++iter) {
       if (*iter < minv) {
         minv = *iter;
@@ -635,8 +635,8 @@ template<typename T, typename Alloc> void minMax(T &minVal, T &maxVal, const Arr
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void max(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
-			   const Array<T, Alloc> &b)
+template<typename T> void max(Array<T> &result, const Array<T> &a,
+			   const Array<T> &b)
 {
     checkArrayShapes (a, b, "max");
     checkArrayShapes (a, result, "max");
@@ -646,24 +646,24 @@ template<typename T, typename Alloc> void max(Array<T, Alloc> &result, const Arr
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void min(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
-			   const Array<T, Alloc> &b)
+template<typename T> void min(Array<T> &result, const Array<T> &a,
+			   const Array<T> &b)
 {
     checkArrayShapes (a, b, "min");
     checkArrayShapes (a, result, "min");
     arrayTransform (a, b, result, [](T l, T r){ return std::min<T>(l, r); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> max(const Array<T, Alloc> &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> max(const Array<T> &a, const Array<T> &b)
 {
-    Array<T, Alloc> result(a.shape());
+    Array<T> result(a.shape());
     max(result, a, b);
     return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> min(const Array<T, Alloc> &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> min(const Array<T> &a, const Array<T> &b)
 {
-    Array<T, Alloc> result(a.shape());
+    Array<T> result(a.shape());
     min(result, a, b);
     return result;
 }
@@ -671,7 +671,7 @@ template<typename T, typename Alloc> Array<T, Alloc> min(const Array<T, Alloc> &
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void max(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
+template<typename T> void max(Array<T> &result, const Array<T> &a,
 			   const T &b)
 {
     checkArrayShapes (a, result, "max");
@@ -681,146 +681,146 @@ template<typename T, typename Alloc> void max(Array<T, Alloc> &result, const Arr
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void min(Array<T, Alloc> &result, const Array<T, Alloc> &a, 
+template<typename T> void min(Array<T> &result, const Array<T> &a,
 			   const T &b)
 {
     checkArrayShapes (a, result, "min");
     arrayTransform (a, b, result, [](T a, T b){ return std::min<T>(a, b); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> max(const Array<T, Alloc> &a, const T &b)
+template<typename T> Array<T> max(const Array<T> &a, const T &b)
 {
-    Array<T, Alloc> result(a.shape());
+    Array<T> result(a.shape());
     max(result, a, b);
     return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> min(const Array<T, Alloc> &a, const T &b)
+template<typename T> Array<T> min(const Array<T> &a, const T &b)
 {
-    Array<T, Alloc> result(a.shape());
+    Array<T> result(a.shape());
     min(result, a, b);
     return result;
 }
 
-template<typename T, typename Alloc>
-void indgen(Array<T, Alloc> &a, T start, T inc)
+template<typename T>
+void indgen(Array<T> &a, T start, T inc)
 {
   if (a.contiguousStorage()) {
-    typename Array<T, Alloc>::contiter aend = a.cend();
-    for (typename Array<T, Alloc>::contiter iter=a.cbegin(); iter!=aend; ++iter) {
+    typename Array<T>::contiter aend = a.cend();
+    for (typename Array<T>::contiter iter=a.cbegin(); iter!=aend; ++iter) {
       *iter = start;
       start += inc;
     }
   } else {
-    typename Array<T, Alloc>::iterator aend = a.end();
-    for (typename Array<T, Alloc>::iterator iter=a.begin(); iter!=aend; ++iter) {
+    typename Array<T>::iterator aend = a.end();
+    for (typename Array<T>::iterator iter=a.begin(); iter!=aend; ++iter) {
       *iter = start;
       start += inc;
     }
   }
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> cos(const Array<T, Alloc> &a)
+template<typename T> Array<T> cos(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::cos(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> cosh(const Array<T, Alloc> &a)
+template<typename T> Array<T> cosh(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::cosh(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> exp(const Array<T, Alloc> &a)
+template<typename T> Array<T> exp(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::exp(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> log(const Array<T, Alloc> &a)
+template<typename T> Array<T> log(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::log(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> log10(const Array<T, Alloc> &a)
+template<typename T> Array<T> log10(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::log10(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> sin(const Array<T, Alloc> &a)
+template<typename T> Array<T> sin(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::sin(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> sinh(const Array<T, Alloc> &a)
+template<typename T> Array<T> sinh(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T v){ return std::sinh(v); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> sqrt(const Array<T, Alloc> &a)
+template<typename T> Array<T> sqrt(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T a){ return std::sqrt(a);});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> square(const Array<T, Alloc> &a)
+template<typename T> Array<T> square(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T a){ return a*a; });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> cube(const Array<T, Alloc> &a)
+template<typename T> Array<T> cube(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T a){ return a*a*a; });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> acos(const Array<T, Alloc> &a)
+template<typename T> Array<T> acos(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T a){ return std::acos(a); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> asin(const Array<T, Alloc> &a)
+template<typename T> Array<T> asin(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T a){ return std::asin(a); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> atan(const Array<T, Alloc> &a)
+template<typename T> Array<T> atan(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T a){ return std::atan(a); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> ceil(const Array<T, Alloc> &a)
+template<typename T> Array<T> ceil(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T val) { return std::ceil(val);});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> fabs(const Array<T, Alloc> &a)
+template<typename T> Array<T> fabs(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T t){ return std::abs(t); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> abs(const Array<T, Alloc> &a)
+template<typename T> Array<T> abs(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T t){ return std::abs(t); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> floor(const Array<T, Alloc> &a)
+template<typename T> Array<T> floor(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T t){ return std::floor(t); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> round(const Array<T, Alloc> &a)
+template<typename T> Array<T> round(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T t){ return std::round(t); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> sign(const Array<T, Alloc> &a)
+template<typename T> Array<T> sign(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T value) { return (value<0 ? -1 : (value>0 ? 1:0));});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> tan(const Array<T, Alloc> &a)
+template<typename T> Array<T> tan(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T t){ return std::tan(t); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> tanh(const Array<T, Alloc> &a)
+template<typename T> Array<T> tanh(const Array<T> &a)
 {
     return arrayTransformResult (a, [](T t){ return std::tanh(t); });
 }
@@ -828,25 +828,25 @@ template<typename T, typename Alloc> Array<T, Alloc> tanh(const Array<T, Alloc> 
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> pow(const Array<T> &a, const Array<T> &b)
 {
     checkArrayShapes (a, b, "pow");
     return arrayTransformResult (a, b, [](T l, T r) { return std::pow(l, r); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> pow(const T &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> pow(const T &a, const Array<T> &b)
 {
     return arrayTransformResult (a, b, [](T l, T r) { return std::pow(l, r); });
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> pow(const Array<T, Alloc> &a, const T &b)
+template<typename T> Array<T> pow(const Array<T> &a, const T &b)
 {
     return arrayTransformResult (a, b, [](T l, T r) { return std::pow(l, r); });
 }
 
-template<typename T, typename Alloc> Array<std::complex<T>, Alloc> pow(const Array<std::complex<T>, Alloc> &a, const T &b)
+template<typename T> Array<std::complex<T>> pow(const Array<std::complex<T>> &a, const T &b)
 {
-    Array<std::complex<T>, Alloc> result(a.shape());
+    Array<std::complex<T>> result(a.shape());
     arrayContTransform (a, b, result, [](std::complex<T> l, T r) { return std::pow(l, r); });
     return result;
 }
@@ -854,18 +854,18 @@ template<typename T, typename Alloc> Array<std::complex<T>, Alloc> pow(const Arr
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Array<T, Alloc> atan2(const Array<T, Alloc> &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> atan2(const Array<T> &a, const Array<T> &b)
 {
     checkArrayShapes (a, b, "atan2");
     return arrayTransformResult (a, b, [](T l, T r) { return std::atan2(l,r);});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> atan2(const T &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> atan2(const T &a, const Array<T> &b)
 {
     return arrayTransformResult (a, b, [](T l, T r) { return std::atan2(l,r);});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> atan2(const Array<T, Alloc> &a, const T &b)
+template<typename T> Array<T> atan2(const Array<T> &a, const T &b)
 {
     return arrayTransformResult (a, b, [](T l, T r) { return std::atan2(l,r);});
 }
@@ -873,18 +873,18 @@ template<typename T, typename Alloc> Array<T, Alloc> atan2(const Array<T, Alloc>
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Array<T, Alloc> fmod(const Array<T, Alloc> &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> fmod(const Array<T> &a, const Array<T> &b)
 {
     checkArrayShapes (a, b, "fmod");
     return arrayTransformResult (a, b, [](T l, T r) { return std::fmod(l,r);});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> fmod(const T &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> fmod(const T &a, const Array<T> &b)
 {
     return arrayTransformResult (a, b, [](T l, T r) { return std::fmod(l,r);});
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> fmod(const Array<T, Alloc> &a, const T &b)
+template<typename T> Array<T> fmod(const Array<T> &a, const T &b)
 {
     return arrayTransformResult (a, b, [](T l, T r) { return std::fmod(l,r);});
 }
@@ -893,18 +893,18 @@ template<typename T, typename Alloc> Array<T, Alloc> fmod(const Array<T, Alloc> 
 // <thrown>
 //   </item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, Alloc> &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> floormod(const Array<T> &a, const Array<T> &b)
 {
     checkArrayShapes (a, b, "floormod");
     return arrayTransformResult (a, b, static_cast<T (*)(T,T)>(arrays_internal::floormod));
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> floormod(const T &a, const Array<T, Alloc> &b)
+template<typename T> Array<T> floormod(const T &a, const Array<T> &b)
 {
     return arrayTransformResult (a, b, static_cast<T (*)(T,T)>(arrays_internal::floormod));
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, Alloc> &a, const T &b)
+template<typename T> Array<T> floormod(const Array<T> &a, const T &b)
 {
     return arrayTransformResult (a, b, static_cast<T (*)(T,T)>(arrays_internal::floormod));
 }
@@ -913,14 +913,14 @@ template<typename T, typename Alloc> Array<T, Alloc> floormod(const Array<T, All
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T sum(const Array<T, Alloc> &a)
+template<typename T> T sum(const Array<T> &a)
 {
   return a.contiguousStorage() ?
     std::accumulate(a.cbegin(), a.cend(), T(), std::plus<T>()) :
     std::accumulate(a.begin(),  a.end(),  T(), std::plus<T>());
 }
 
-template<typename T, typename Alloc> T sumsqr(const Array<T, Alloc> &a)
+template<typename T> T sumsqr(const Array<T> &a)
 {
   auto sumsqr = [](T left, T right) { return left + right*right;};
   return a.contiguousStorage() ?
@@ -931,7 +931,7 @@ template<typename T, typename Alloc> T sumsqr(const Array<T, Alloc> &a)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T product(const Array<T, Alloc> &a)
+template<typename T> T product(const Array<T> &a)
 {
   if (a.empty()) {
     return T();
@@ -939,11 +939,11 @@ template<typename T, typename Alloc> T product(const Array<T, Alloc> &a)
   // Get first element, because T(1) may not work for all types.
   T prod = *a.data();
   if (a.contiguousStorage()) {
-    typename Array<T, Alloc>::const_contiter iter(a.cbegin());
+    typename Array<T>::const_contiter iter(a.cbegin());
     ++iter;
     return std::accumulate(iter, a.cend(), prod, std::multiplies<T>());
   } else {
-    typename Array<T, Alloc>::const_iterator iter(a.begin());
+    typename Array<T>::const_iterator iter(a.begin());
     ++iter;
     return std::accumulate(iter, a.end(),  prod, std::multiplies<T>());
   }
@@ -952,10 +952,10 @@ template<typename T, typename Alloc> T product(const Array<T, Alloc> &a)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T mean(const Array<T, Alloc> &a)
+template<typename T> T mean(const Array<T> &a)
 {
     if (a.empty()) {
-	throw(ArrayError("::mean(const Array<T, Alloc> &) - 0 element array"));
+	throw(ArrayError("::mean(const Array<T> &) - 0 element array"));
     }
     return T(sum(a)/T(1.0*a.nelements()));
 }
@@ -965,10 +965,10 @@ template<typename T, typename Alloc> T mean(const Array<T, Alloc> &a)
 // </thrown>
 // Similar to numpy the ddof argument can be used to get the population
 // variance (ddof=0) or the sample variance (ddof=1).
-template<typename T, typename Alloc> T pvariance(const Array<T, Alloc> &a, T mean, size_t ddof)
+template<typename T> T pvariance(const Array<T> &a, T mean, size_t ddof)
 {
   if (a.nelements() < ddof+1) {
-    throw(ArrayError("::variance(const Array<T, Alloc> &) - Need at least " +
+    throw(ArrayError("::variance(const Array<T> &) - Need at least " +
                      std::to_string(ddof+1) + 
                      " elements"));
   }
@@ -977,15 +977,15 @@ template<typename T, typename Alloc> T pvariance(const Array<T, Alloc> &a, T mea
     std::accumulate(a.begin(),  a.end(),  T(), arrays_internal::SumSqrDiff<T>(mean));
   return T(sum/T(1.0*a.nelements() - ddof));
 }
-template<typename T, typename Alloc> T variance(const Array<T, Alloc> &a, T mean)
+template<typename T> T variance(const Array<T> &a, T mean)
 {
   return pvariance (a, mean, 1);
 }
-template<typename T, typename Alloc> T pvariance(const Array<T, Alloc> &a, size_t ddof)
+template<typename T> T pvariance(const Array<T> &a, size_t ddof)
 {
   return pvariance(a, mean(a), ddof);
 }
-template<typename T, typename Alloc> T variance(const Array<T, Alloc> &a)
+template<typename T> T variance(const Array<T> &a)
 {
   return pvariance(a, mean(a), 1);
 }
@@ -993,24 +993,24 @@ template<typename T, typename Alloc> T variance(const Array<T, Alloc> &a)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T pstddev(const Array<T, Alloc> &a, T mean, size_t ddof)
+template<typename T> T pstddev(const Array<T> &a, T mean, size_t ddof)
 {
   if (a.nelements() < ddof+1) {
-    throw(ArrayError("::stddev(const Array<T, Alloc> &) - Need at least " +
+    throw(ArrayError("::stddev(const Array<T> &) - Need at least " +
                      std::to_string(ddof+1) + 
                      " elements"));
   }
   return std::sqrt(pvariance(a, mean, ddof));
 }
-template<typename T, typename Alloc> T stddev(const Array<T, Alloc> &a, T mean)
+template<typename T> T stddev(const Array<T> &a, T mean)
 {
   return pstddev (a, mean, 1);
 }
-template<typename T, typename Alloc> T pstddev(const Array<T, Alloc> &a, size_t ddof)
+template<typename T> T pstddev(const Array<T> &a, size_t ddof)
 {
   return pstddev (a, mean(a), ddof);
 }
-template<typename T, typename Alloc> T stddev(const Array<T, Alloc> &a)
+template<typename T> T stddev(const Array<T> &a)
 {
   return pstddev (a, mean(a), 1);
 }
@@ -1019,10 +1019,10 @@ template<typename T, typename Alloc> T stddev(const Array<T, Alloc> &a)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T avdev(const Array<T, Alloc> &a)
+template<typename T> T avdev(const Array<T> &a)
 {
     if (a.nelements() < 1) {
-	throw(ArrayError("::avdev(const Array<T, Alloc> &,) - Need at least 1 "
+	throw(ArrayError("::avdev(const Array<T> &,) - Need at least 1 "
 			 "element"));
     }
     return avdev(a, mean(a));
@@ -1031,10 +1031,10 @@ template<typename T, typename Alloc> T avdev(const Array<T, Alloc> &a)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T avdev(const Array<T, Alloc> &a, T mean)
+template<typename T> T avdev(const Array<T> &a, T mean)
 {
     if (a.nelements() < 1) {
-	throw(ArrayError("::avdev(const Array<T, Alloc> &,T) - Need at least 1 "
+	throw(ArrayError("::avdev(const Array<T> &,T) - Need at least 1 "
 			 "element"));
     }
     auto sumabsdiff = [mean](T left, T right) { return left + std::abs(right-mean); };
@@ -1047,10 +1047,10 @@ template<typename T, typename Alloc> T avdev(const Array<T, Alloc> &a, T mean)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T rms(const Array<T, Alloc> &a)
+template<typename T> T rms(const Array<T> &a)
 {
     if (a.nelements() < 1) {
-	throw(ArrayError("::rms(const Array<T, Alloc> &) - Need at least 1 "
+	throw(ArrayError("::rms(const Array<T> &) - Need at least 1 "
 			 "element"));
     }
     auto sumsqr = [](T left, T right) { return left + right*right; };
@@ -1063,7 +1063,7 @@ template<typename T, typename Alloc> T rms(const Array<T, Alloc> &a)
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T median(const Array<T, Alloc> &a, std::vector<T>& scratch, bool sorted,
+template<typename T> T median(const Array<T> &a, std::vector<T>& scratch, bool sorted,
   bool takeEvenMean, bool inPlace)
 {
   T medval=T();
@@ -1110,11 +1110,11 @@ template<typename T, typename Alloc> T median(const Array<T, Alloc> &a, std::vec
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T madfm(const Array<T, Alloc> &a, std::vector<T>& scratch, bool sorted,
+template<typename T> T madfm(const Array<T> &a, std::vector<T>& scratch, bool sorted,
   bool takeEvenMean, bool inPlace)
 {
   T med = median(a, scratch, sorted, takeEvenMean, inPlace);
-  Array<T, Alloc> atmp;
+  Array<T> atmp;
   if (inPlace  &&  a.contiguousStorage()) {
     atmp.reference (a);   // remove constness
   } else {
@@ -1123,7 +1123,7 @@ template<typename T, typename Alloc> T madfm(const Array<T, Alloc> &a, std::vect
     // (this was changed for array2: sharing storage is no longer possible)
     assert(a.size() == scratch.size());
     atmp.resize(a.shape());
-    atmp.assign_conforming (Array<T, Alloc>(a.shape(), scratch.data()));
+    atmp.assign_conforming (Array<T>(a.shape(), scratch.data()));
   }
   T* aptr = atmp.data();
   for (size_t i=0; i<atmp.size(); ++i) {
@@ -1135,15 +1135,15 @@ template<typename T, typename Alloc> T madfm(const Array<T, Alloc> &a, std::vect
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> T fractile(const Array<T, Alloc> &a, std::vector<T>& scratch, float fraction,
+template<typename T> T fractile(const Array<T> &a, std::vector<T>& scratch, float fraction,
 			     bool sorted, bool inPlace)
 {
   if (fraction < 0  ||  fraction > 1) {
-    throw(ArrayError("::fractile(const Array<T, Alloc>&) - fraction <0 or >1 "));
+    throw(ArrayError("::fractile(const Array<T>&) - fraction <0 or >1 "));
   }    
   size_t nelem = a.nelements();
   if (nelem < 1) {
-    throw(ArrayError("::fractile(const Array<T, Alloc>&) - Need at least 1 "
+    throw(ArrayError("::fractile(const Array<T>&) - Need at least 1 "
       "elements"));
   }
   // A copy is needed if not contiguous or if not in place.
@@ -1165,8 +1165,8 @@ template<typename T, typename Alloc> T fractile(const Array<T, Alloc> &a, std::v
 // <thrown>
 //    </item> ArrayError
 // </thrown>
-template<typename T, typename Alloc>
-T interFractileRange(const Array<T, Alloc> &a, std::vector<T>& scratch,
+template<typename T>
+T interFractileRange(const Array<T> &a, std::vector<T>& scratch,
   float fraction, bool sorted, bool inPlace)
 {
   if (!(fraction>0  &&  fraction<0.5))
@@ -1180,14 +1180,14 @@ T interFractileRange(const Array<T, Alloc> &a, std::vector<T>& scratch,
     // Using it saves making another copy.
     if (a.size() != scratch.size())
       throw std::runtime_error("interFractileRange: array sizes don't match");
-    Array<T, Alloc> atmp(a.shape(), scratch.data(), SHARE);
+    Array<T> atmp(a.shape(), scratch.data(), SHARE);
     hex2 = fractile(atmp, scratch, 1-fraction, sorted, inPlace);
   }
   return (hex2 - hex1);
 }
 
-template<typename T, typename Alloc>
-Array<std::complex<T> > makeComplex(const Array<T, Alloc> &left, const Array<T, Alloc>& right)
+template<typename T>
+Array<std::complex<T> > makeComplex(const Array<T> &left, const Array<T>& right)
 {
   checkArrayShapes (left, right, "makeComplex");
   Array<std::complex<T> > res(left.shape());
@@ -1196,8 +1196,8 @@ Array<std::complex<T> > makeComplex(const Array<T, Alloc> &left, const Array<T, 
   return res;
 }
 
-template<typename T, typename Alloc>
-Array<std::complex<T> > makeComplex(const T &left, const Array<T, Alloc>& right)
+template<typename T>
+Array<std::complex<T> > makeComplex(const T &left, const Array<T>& right)
 {
   Array<std::complex<T> > res(right.shape());
   arrayContTransform (left, right, res,
@@ -1205,8 +1205,8 @@ Array<std::complex<T> > makeComplex(const T &left, const Array<T, Alloc>& right)
   return res;
 }
 
-template<typename T, typename Alloc>
-Array<std::complex<T> > makeComplex(const Array<T, Alloc> &left, const T& right)
+template<typename T>
+Array<std::complex<T> > makeComplex(const Array<T> &left, const T& right)
 {
   Array<std::complex<T> > res(left.shape());
   arrayContTransform (left, right, res,
@@ -1214,8 +1214,8 @@ Array<std::complex<T> > makeComplex(const Array<T, Alloc> &left, const T& right)
   return res;
 }
 
-template<typename C, typename R, typename AllocC, typename AllocR>
-void setReal(Array<C, AllocC> &carray, const Array<R, AllocR> &rarray)
+template<typename C, typename R>
+void setReal(Array<C> &carray, const Array<R> &rarray)
 {
   checkArrayShapes (carray, rarray, "setReal");
   // Cannot be done in place, because imag is taken from second operand.
@@ -1223,37 +1223,37 @@ void setReal(Array<C, AllocC> &carray, const Array<R, AllocR> &rarray)
                   [](R l, C r)->C { return C(l, std::imag(r)); });
 }
 
-template<typename C, typename R, typename AllocC, typename AllocR>
-void setImag(Array<C, AllocC> &carray, const Array<R, AllocR> &rarray)
+template<typename C, typename R>
+void setImag(Array<C> &carray, const Array<R> &rarray)
 {
   checkArrayShapes (carray, rarray, "setImag");
   arrayTransformInPlace (carray, rarray,
                   [](C l, R r)->C { return C(std::real(l), r); });
 }
 
-template<typename T, typename U, typename AllocT, typename AllocU>
-void convertArray(Array<T, AllocT> &to, const Array<U, AllocU> &from)
+template<typename T, typename U>
+void convertArray(Array<T> &to, const Array<U> &from)
 {
     if (to.nelements() == 0 && from.nelements() == 0) {
 	return;
     }
     if (to.shape() != from.shape()) {
-	throw(ArrayConformanceError("void ::convertArray(Array<T, Alloc> &to, "
-				    "const Array<U, AllocU> &from)"
+	throw(ArrayConformanceError("void ::convertArray(Array<T> &to, "
+				    "const Array<U> &from)"
 				    " - arrays do not conform"));
     }
     if (to.contiguousStorage()  &&  from.contiguousStorage()) {
-      typename Array<U, AllocU>::const_contiter endFrom = from.cend();
-      typename Array<U, AllocU>::const_contiter iterFrom = from.cbegin();
-      for (typename Array<T, AllocT>::contiter iterTo = to.cbegin();
+      typename Array<U>::const_contiter endFrom = from.cend();
+      typename Array<U>::const_contiter iterFrom = from.cbegin();
+      for (typename Array<T>::contiter iterTo = to.cbegin();
 	   iterFrom != endFrom;
 	   ++iterFrom, ++iterTo) {
 	arrays_internal::convertScalar (*iterTo, *iterFrom);
       }
     } else {
-      typename Array<U, AllocU>::const_iterator endFrom = from.end();
-      typename Array<U, AllocU>::const_iterator iterFrom = from.begin();
-      for (typename Array<T, AllocT>::iterator iterTo = to.begin();
+      typename Array<U>::const_iterator endFrom = from.end();
+      typename Array<U>::const_iterator iterFrom = from.begin();
+      for (typename Array<T>::iterator iterTo = to.begin();
 	   iterFrom != endFrom;
 	   ++iterFrom, ++iterTo) {
 	arrays_internal::convertScalar (*iterTo, *iterFrom);

--- a/casa/Arrays/ArrayOpsDiffShapes.h
+++ b/casa/Arrays/ArrayOpsDiffShapes.h
@@ -81,8 +81,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // Returns a LogicalArray with elements (at pos) set to (data(pos) ==
 // truthvalue).  data is effectively collapsed using anyEQ if necessary to
 // fit desiredform.  Throws an exception if that does not work.
-template<typename T, typename Alloc>
-LogicalArray reformedMask(const Array<T, Alloc>& data, const T truthvalue,
+template<typename T>
+LogicalArray reformedMask(const Array<T>& data, const T truthvalue,
 			  const IPosition& desiredform);
 
 // Can arrays left and right with respective shapes leftShape and rightShape be
@@ -102,8 +102,8 @@ bool rightExpandableToLeft(const IPosition& leftShape, const IPosition& rightSha
 //# 			BinaryOperator op);
 
 // Like binOpExpandR(left, right, res, op), but work on left in place.
-template<typename L, typename AllocL, typename R, typename AllocR, typename BinaryOperator>
-void binOpExpandInPlace(Array<L, AllocL>& left, const Array<R, AllocR>& right, BinaryOperator op);
+template<typename L, typename R, typename BinaryOperator>
+void binOpExpandInPlace(Array<L>& left, const Array<R>& right, BinaryOperator op);
 
 // </group>
 

--- a/casa/Arrays/ArrayOpsDiffShapes.tcc
+++ b/casa/Arrays/ArrayOpsDiffShapes.tcc
@@ -33,8 +33,8 @@
 
 namespace casacore {
 
-template<typename T, typename Alloc>
-LogicalArray reformedMask(const Array<T, Alloc>& data, const T truthvalue,
+template<typename T>
+LogicalArray reformedMask(const Array<T>& data, const T truthvalue,
 			  const IPosition& desiredform)
 {
   if(data.shape().nelements() == desiredform.nelements()
@@ -51,7 +51,7 @@ LogicalArray reformedMask(const Array<T, Alloc>& data, const T truthvalue,
 
       // Create an array with desiredform's shape,
       LogicalArray collapseddata(desiredform);
-      ReadOnlyArrayIterator<T, Alloc> data_cursor(data,
+      ReadOnlyArrayIterator<T> data_cursor(data,
 					   IPosition::otherAxes(n_data_dim,
 					      IPosition::makeAxisPath(n_desired_dim)));
       IPosition collapsedPos;
@@ -85,54 +85,8 @@ LogicalArray reformedMask(const Array<T, Alloc>& data, const T truthvalue,
   }
 }
 
-// template<typename L, typename R, typename BinaryOperator, typename RES>
-// Array<RES> binOpExpandR(const Array<L>& left, const Array<R>& right,
-// 			BinaryOperator op)
-// {
-//   const IPosition leftShape = left.shape();
-//   Array<RES> res(leftShape);
-
-//   if(left.conform(right)){
-//     arrayContTransform(left, right, res, op);
-//   }
-//   else if(left.nelements() == right.nelements()){
-//     arrayContTransform(left, right.reform(leftShape), res, op);
-//   }
-//   else{
-//     const IPosition rightShape = right.shape();
-
-//     if(rightExpandableToLeft(leftShape, rightShape)){
-//       size_t n_right_dim = rightShape.nelements();
-//       ArrayIterator<L>   left_cursor(left, n_right_dim);
-//       ArrayIterator<RES> res_cursor(res, n_right_dim);
-//       IPosition rightPos;
-	
-//       // Go through each position in the new array,
-//       for(ArrayPositionIterator positer(rightShape, 0);
-// 	  !positer.pastEnd(); positer.next()){
-// 	rightPos = positer.pos();
-// 	left_cursor.set(rightPos);
-// 	res_cursor.set(rightPos);
-
-// 	// "resChunk op= rightEntry"
-// 	arrayContTransform(left_cursor.array(), right(rightPos),
-// 			   res_cursor.array(), op);
-//       }
-//     }
-//     else{
-//       ostringstream os;  // String(rightShape) is not supported.
-
-//       os << "binOpExpandR(): right's shape (" << rightShape << ")\n"
-// 	 << " has more dimensions than left's (" << leftShape << ")!";
-      
-//       throw(ArrayConformanceError(os));
-//     }
-//   }
-//   return res;
-// }
-
-template<typename L, typename AllocL, typename R, typename AllocR, typename BinaryOperator>
-void binOpExpandInPlace(Array<L, AllocL>& leftarr, const Array<R, AllocR>& rightarr, BinaryOperator op)
+template<typename L, typename R, typename BinaryOperator>
+void binOpExpandInPlace(Array<L>& leftarr, const Array<R>& rightarr, BinaryOperator op)
 {
   const IPosition leftShape  = leftarr.shape();
   const IPosition rightShape = rightarr.shape();

--- a/casa/Arrays/ArrayPartMath.h
+++ b/casa/Arrays/ArrayPartMath.h
@@ -103,79 +103,79 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // partialNFalse to count the number of true or false elements in an array.
 // </note>
 // <group>
-template<typename T, typename Alloc> Array<T, Alloc> partialSums (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialSums (const Array<T>& array,
 					const IPosition& collapseAxes);
-template<typename T, typename Alloc> Array<T, Alloc> partialSumSqrs (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialSumSqrs (const Array<T>& array,
                                            const IPosition& collapseAxes);
-template<typename T, typename Alloc> Array<T, Alloc> partialProducts (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialProducts (const Array<T>& array,
 					    const IPosition& collapseAxes);
-template<typename T, typename Alloc> Array<T, Alloc> partialMins (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMins (const Array<T>& array,
 					const IPosition& collapseAxes);
-template<typename T, typename Alloc> Array<T, Alloc> partialMaxs (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMaxs (const Array<T>& array,
 					const IPosition& collapseAxes);
-template<typename T, typename Alloc> Array<T, Alloc> partialMeans (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMeans (const Array<T>& array,
 					 const IPosition& collapseAxes);
-template<typename T, typename Alloc>
-inline Array<T, Alloc> partialVariances (const Array<T, Alloc>& array,
+template<typename T>
+inline Array<T> partialVariances (const Array<T>& array,
   const IPosition& collapseAxes, size_t ddof=1)
 {
     return partialVariances (array, collapseAxes,
 			     partialMeans (array, collapseAxes), ddof);
 }
-template<typename T, typename Alloc> Array<T, Alloc> partialVariances (const Array<T, Alloc>& array,
-					     const IPosition& collapseAxes, const Array<T, Alloc>& means);
-template<typename T, typename Alloc> Array<T, Alloc> partialVariances (const Array<T, Alloc>& array,
-					     const IPosition& collapseAxes, const Array<T, Alloc>& means, size_t ddof);
-template<typename T, typename Alloc> Array<std::complex<T>> partialVariances (const Array<std::complex<T>>& array,
+template<typename T> Array<T> partialVariances (const Array<T>& array,
+					     const IPosition& collapseAxes, const Array<T>& means);
+template<typename T> Array<T> partialVariances (const Array<T>& array,
+					     const IPosition& collapseAxes, const Array<T>& means, size_t ddof);
+template<typename T> Array<std::complex<T>> partialVariances (const Array<std::complex<T>>& array,
                                                            const IPosition& collapseAxes,
                                                            const Array<std::complex<T>>& means,
                                                            size_t ddof);
-template<typename T, typename Alloc> inline Array<T, Alloc> partialStddevs (const Array<T, Alloc>& array,
+template<typename T> inline Array<T> partialStddevs (const Array<T>& array,
                                                   const IPosition& collapseAxes,
                                                   size_t ddof=1)
 {
     return sqrt (partialVariances (array, collapseAxes,
 				   partialMeans (array, collapseAxes), ddof));
 }
-template<typename T, typename Alloc> inline Array<T, Alloc> partialStddevs (const Array<T, Alloc>& array,
+template<typename T> inline Array<T> partialStddevs (const Array<T>& array,
                                                   const IPosition& collapseAxes,
-                                                  const Array<T, Alloc>& means,
+                                                  const Array<T>& means,
                                                   size_t ddof=1)
 {
   return sqrt (partialVariances (array, collapseAxes, means, ddof));
 }
-template<typename T, typename Alloc> inline Array<T, Alloc> partialAvdevs (const Array<T, Alloc>& array,
+template<typename T> inline Array<T> partialAvdevs (const Array<T>& array,
                                                  const IPosition& collapseAxes)
 {
     return partialAvdevs (array, collapseAxes,
 			  partialMeans (array, collapseAxes));
 }
-template<typename T, typename Alloc> Array<T, Alloc> partialAvdevs (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialAvdevs (const Array<T>& array,
 					  const IPosition& collapseAxes,
-					  const Array<T, Alloc>& means);
-template<typename T, typename Alloc> Array<T, Alloc> partialRmss (const Array<T, Alloc>& array,
+					  const Array<T>& means);
+template<typename T> Array<T> partialRmss (const Array<T>& array,
 					const IPosition& collapseAxes);
-template<typename T, typename Alloc> Array<T, Alloc> partialMedians (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMedians (const Array<T>& array,
 					   const IPosition& collapseAxes,
 					   bool takeEvenMean=false,
 					   bool inPlace=false);
-template<typename T, typename Alloc> Array<T, Alloc> partialMadfms (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMadfms (const Array<T>& array,
                                           const IPosition& collapseAxes,
                                           bool takeEvenMean=false,
                                           bool inPlace=false);
-template<typename T, typename Alloc> Array<T, Alloc> partialFractiles (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialFractiles (const Array<T>& array,
                                              const IPosition& collapseAxes,
                                              float fraction,
                                              bool inPlace=false);
-template<typename T, typename Alloc> Array<T, Alloc> partialInterFractileRanges (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialInterFractileRanges (const Array<T>& array,
                                                        const IPosition& collapseAxes,
                                                        float fraction,
                                                        bool inPlace=false);
-template<typename T, typename Alloc> Array<T, Alloc> partialInterHexileRanges (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialInterHexileRanges (const Array<T>& array,
                                                      const IPosition& collapseAxes,
                                                      bool inPlace=false)
   { return partialInterFractileRanges (array, collapseAxes, 1./6., inPlace); }
-template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialInterQuartileRanges (const Array<T>& array,
                                                       const IPosition& collapseAxes,
                                                       bool inPlace=false)
   { return partialInterFractileRanges (array, collapseAxes, 0.25, inPlace); }
@@ -186,71 +186,71 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
   // Define functors to perform a reduction function on an Array object.
   // Use virtual functions instead of templates to avoid code bloat
   // in partialArrayMath, etc.
-  template<typename T, typename Alloc=std::allocator<T>> class SumFunc : public ArrayFunctorBase<T> {
+  template<typename T> class SumFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~SumFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return sum(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return sum(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class SumSqrFunc : public ArrayFunctorBase<T> {
+  template<typename T> class SumSqrFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~SumSqrFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return sumsqr(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return sumsqr(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class ProductFunc : public ArrayFunctorBase<T> {
+  template<typename T> class ProductFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~ProductFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return product(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return product(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class MinFunc : public ArrayFunctorBase<T> {
+  template<typename T> class MinFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~MinFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return min(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return min(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class MaxFunc : public ArrayFunctorBase<T> {
+  template<typename T> class MaxFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~MaxFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return max(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return max(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class MeanFunc : public ArrayFunctorBase<T> {
+  template<typename T> class MeanFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~MeanFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return mean(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return mean(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class VarianceFunc : public ArrayFunctorBase<T> {
+  template<typename T> class VarianceFunc : public ArrayFunctorBase<T> {
   public:
     explicit VarianceFunc (size_t ddof)
       : itsDdof(ddof) {}
     virtual ~VarianceFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return pvariance(arr, itsDdof); }
+    virtual T operator() (const Array<T>& arr) const final override { return pvariance(arr, itsDdof); }
   private:
     size_t itsDdof;
   };
-  template<typename T, typename Alloc=std::allocator<T>> class StddevFunc : public ArrayFunctorBase<T> {
+  template<typename T> class StddevFunc : public ArrayFunctorBase<T> {
   public:
     explicit StddevFunc (size_t ddof)
       : itsDdof(ddof) {}
     virtual ~StddevFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return pstddev(arr, itsDdof); }
+    virtual T operator() (const Array<T>& arr) const final override { return pstddev(arr, itsDdof); }
   private:
     size_t itsDdof;
   };
-  template<typename T, typename Alloc=std::allocator<T>> class AvdevFunc : public ArrayFunctorBase<T> {
+  template<typename T> class AvdevFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~AvdevFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return avdev(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return avdev(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class RmsFunc : public ArrayFunctorBase<T> {
+  template<typename T> class RmsFunc : public ArrayFunctorBase<T> {
   public:
     virtual ~RmsFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override { return rms(arr); }
+    virtual T operator() (const Array<T>& arr) const final override { return rms(arr); }
   };
-  template<typename T, typename Alloc=std::allocator<T>> class MedianFunc : public ArrayFunctorBase<T> {
+  template<typename T> class MedianFunc : public ArrayFunctorBase<T> {
   public:
     explicit MedianFunc (bool sorted=false, bool takeEvenMean=true,
                           bool inPlace = false)
       : itsSorted(sorted), itsTakeEvenMean(takeEvenMean), itsInPlace(inPlace) {}
     virtual ~MedianFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override
+    virtual T operator() (const Array<T>& arr) const final override
       { return median(arr, itsTmp, itsSorted, itsTakeEvenMean, itsInPlace); }
   private:
     bool     itsSorted;
@@ -258,13 +258,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
     bool     itsInPlace;
     mutable std::vector<T> itsTmp;
   };
-  template<typename T, typename Alloc=std::allocator<T>> class MadfmFunc : public ArrayFunctorBase<T> {
+  template<typename T> class MadfmFunc : public ArrayFunctorBase<T> {
   public:
     explicit MadfmFunc(bool sorted = false, bool takeEvenMean = true,
                        bool inPlace = false)
       : itsSorted(sorted), itsTakeEvenMean(takeEvenMean), itsInPlace(inPlace) {}
     virtual ~MadfmFunc() {}
-    virtual T operator()(const Array<T, Alloc>& arr) const final override
+    virtual T operator()(const Array<T>& arr) const final override
       { return madfm(arr, itsTmp, itsSorted, itsTakeEvenMean, itsInPlace); }
   private:
     bool     itsSorted;
@@ -272,13 +272,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
     bool     itsInPlace;
     mutable std::vector<T> itsTmp;
   };
-  template<typename T, typename Alloc=std::allocator<T>> class FractileFunc : public ArrayFunctorBase<T> {
+  template<typename T> class FractileFunc : public ArrayFunctorBase<T> {
   public:
     explicit FractileFunc (float fraction,
                             bool sorted = false, bool inPlace = false)
       : itsFraction(fraction), itsSorted(sorted), itsInPlace(inPlace) {}
     virtual ~FractileFunc() {}
-    virtual T operator() (const Array<T, Alloc>& arr) const final override
+    virtual T operator() (const Array<T>& arr) const final override
       { return fractile(arr, itsTmp, itsFraction, itsSorted, itsInPlace); }
   private:
     float    itsFraction;
@@ -286,13 +286,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
     bool     itsInPlace;
     mutable std::vector<T> itsTmp;
   };
-  template<typename T, typename Alloc=std::allocator<T>> class InterFractileRangeFunc {
+  template<typename T> class InterFractileRangeFunc {
   public:
     explicit InterFractileRangeFunc(float fraction,
                                     bool sorted = false, bool inPlace = false)
       : itsFraction(fraction), itsSorted(sorted), itsInPlace(inPlace) {}
     virtual ~InterFractileRangeFunc() {}
-    virtual T operator()(const Array<T, Alloc>& arr) const final override
+    virtual T operator()(const Array<T>& arr) const final override
       { return interFractileRange(arr, itsTmp, itsFraction,
                                   itsSorted, itsInPlace); }
   private:
@@ -301,17 +301,17 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
     bool     itsInPlace;
     mutable std::vector<T> itsTmp;
   };
-  template<typename T, typename Alloc=std::allocator<T>> class InterHexileRangeFunc: public InterFractileRangeFunc<T, Alloc> {
+  template<typename T> class InterHexileRangeFunc: public InterFractileRangeFunc<T> {
   public:
     explicit InterHexileRangeFunc(bool sorted = false, bool inPlace = false)
-      : InterFractileRangeFunc<T, Alloc> (1./6., sorted, inPlace)
+      : InterFractileRangeFunc<T> (1./6., sorted, inPlace)
     {}
     virtual ~InterHexileRangeFunc() {}
   };
-  template<typename T, typename Alloc=std::allocator<T>> class InterQuartileRangeFunc: public InterFractileRangeFunc<T, Alloc> {
+  template<typename T> class InterQuartileRangeFunc: public InterFractileRangeFunc<T> {
   public:
     explicit InterQuartileRangeFunc(bool sorted = false, bool inPlace = false)
-      : InterFractileRangeFunc<T, Alloc> (0.25, sorted, inPlace)
+      : InterFractileRangeFunc<T> (0.25, sorted, inPlace)
     {} 
     virtual ~InterQuartileRangeFunc() {}
   };
@@ -320,18 +320,18 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
 
   // Do partial reduction of an Array object. I.e., perform the operation
   // on a subset of the array axes (the collapse axes).
-  template<typename T, typename Alloc=std::allocator<T>>
-  inline Array<T, Alloc> partialArrayMath (const Array<T, Alloc>& a,
+  template<typename T>
+  inline Array<T> partialArrayMath (const Array<T>& a,
                                     const IPosition& collapseAxes,
                                     const ArrayFunctorBase<T>& funcObj)
   {
-    Array<T, Alloc> res;
+    Array<T> res;
     partialArrayMath (res, a, collapseAxes, funcObj);
     return res;
   }
-  template<typename T, typename Alloc, typename RES, typename RESAlloc>
-  void partialArrayMath (Array<RES, RESAlloc>& res,
-                         const Array<T, Alloc>& a,
+  template<typename T, typename RES>
+  void partialArrayMath (Array<RES>& res,
+                         const Array<T>& a,
                          const IPosition& collapseAxes,
                          const ArrayFunctorBase<T,RES>& funcObj);
 
@@ -348,18 +348,18 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
 // The dimensionality of the array can be larger than the box; in that
 // case the missing axes of the box are assumed to have length 1.
 // A box axis length <= 0 means the full array axis.
-  template<typename T, typename Alloc>
-  inline Array<T, Alloc> boxedArrayMath (const Array<T, Alloc>& a,
+  template<typename T>
+  inline Array<T> boxedArrayMath (const Array<T>& a,
                                   const IPosition& boxSize,
                                   const ArrayFunctorBase<T>& funcObj)
   {
-    Array<T, Alloc> res;
+    Array<T> res;
     boxedArrayMath (res, a, boxSize, funcObj);
     return res;
   }
-  template<typename T, typename Alloc, typename RES, typename RESAlloc>
-  void boxedArrayMath (Array<RES, RESAlloc>&,
-                       const Array<T, Alloc>& array,
+  template<typename T, typename RES>
+  void boxedArrayMath (Array<RES>&,
+                       const Array<T>& array,
                        const IPosition& boxSize,
                        const ArrayFunctorBase<T,RES>& funcObj);
 
@@ -387,19 +387,19 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterQuartileRanges 
 // as casacore class MedianSlider, for a 2D array
 // it is much, much faster.
 // </note>
-  template<typename T, typename Alloc=std::allocator<T>>
-  inline Array<T, Alloc> slidingArrayMath (const Array<T, Alloc>& a,
+  template<typename T>
+  inline Array<T> slidingArrayMath (const Array<T>& a,
                                     const IPosition& halfBoxSize,
                                     const ArrayFunctorBase<T>& funcObj,
                                     bool fillEdge=true)
   {
-    Array<T, Alloc> res;
+    Array<T> res;
     slidingArrayMath (res, a, halfBoxSize, funcObj, fillEdge);
     return res;
   }
-  template<typename T, typename Alloc, typename RES, typename RESAlloc>
-  void slidingArrayMath (Array<RES, RESAlloc>& res,
-                         const Array<T, Alloc>& array,
+  template<typename T, typename RES>
+  void slidingArrayMath (Array<RES>& res,
+                         const Array<T>& array,
                          const IPosition& halfBoxSize,
                          const ArrayFunctorBase<T,RES>& funcObj,
                          bool fillEdge=true);

--- a/casa/Arrays/ArrayPartMath.tcc
+++ b/casa/Arrays/ArrayPartMath.tcc
@@ -32,7 +32,7 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<typename T, typename Alloc> Array<T, Alloc> partialSums (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialSums (const Array<T>& array,
 					const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
@@ -41,13 +41,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialSums (const Array<T,
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
   size_t stax = partialFuncHelper (nelemCont, resShape, incr, shape,
 				 collapseAxes);
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   bool deleteData, deleteRes;
   const T* arrData = array.getStorage (deleteData);
@@ -99,7 +99,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialSums (const Array<T,
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialSumSqrs (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialSumSqrs (const Array<T>& array,
                                            const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
@@ -108,13 +108,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialSumSqrs (const Array
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
   size_t stax = partialFuncHelper (nelemCont, resShape, incr, shape,
 				 collapseAxes);
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   bool deleteData, deleteRes;
   const T* arrData = array.getStorage (deleteData);
@@ -168,7 +168,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialSumSqrs (const Array
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialProducts (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialProducts (const Array<T>& array,
 					    const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
@@ -177,13 +177,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialProducts (const Arra
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
   size_t stax = partialFuncHelper (nelemCont, resShape, incr, shape,
 				 collapseAxes);
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = T(1);
   bool deleteData, deleteRes;
   const T* arrData = array.getStorage (deleteData);
@@ -235,7 +235,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialProducts (const Arra
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialMins (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMins (const Array<T>& array,
 					const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
@@ -244,13 +244,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMins (const Array<T,
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
   size_t stax = partialFuncHelper (nelemCont, resShape, incr, shape,
 				 collapseAxes);
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   bool deleteData, deleteRes;
   const T* arrData = array.getStorage (deleteData);
@@ -263,8 +263,8 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMins (const Array<T,
     size_t axis = collapseAxes(i);
     end(axis) = 0;
   }
-  Array<T, Alloc> tmp(array);           // to get a non-const array for operator()
-  Array<T, Alloc> scratch(result);
+  Array<T> tmp(array);           // to get a non-const array for operator()
+  Array<T> scratch(result);
   result.assign_conforming( tmp(IPosition(ndim,0), end).reform (resShape) );
   // Find out how contiguous the data is, i.e. if some contiguous data
   // end up in the same output element.
@@ -317,7 +317,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMins (const Array<T,
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialMaxs (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMaxs (const Array<T>& array,
 					const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
@@ -326,13 +326,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMaxs (const Array<T,
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
   size_t stax = partialFuncHelper (nelemCont, resShape, incr, shape,
 				 collapseAxes);
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   bool deleteData, deleteRes;
   const T* arrData = array.getStorage (deleteData);
@@ -345,7 +345,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMaxs (const Array<T,
     size_t axis = collapseAxes(i);
     end(axis) = 0;
   }
-  Array<T, Alloc> tmp(array);           // to get a non-const array for operator()
+  Array<T> tmp(array);           // to get a non-const array for operator()
   result.assign_conforming( tmp(IPosition(ndim,0), end).reform (resShape) );
   // Find out how contiguous the data is, i.e. if some contiguous data
   // end up in the same output element.
@@ -398,13 +398,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMaxs (const Array<T,
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialMeans (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMeans (const Array<T>& array,
 					 const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
     return array.copy();
   }
-  Array<T, Alloc> result = partialSums (array, collapseAxes);
+  Array<T> result = partialSums (array, collapseAxes);
   size_t nr = result.nelements();
   if (nr > 0) {
     size_t factor = array.nelements() / nr;
@@ -418,22 +418,22 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMeans (const Array<T
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialVariances (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialVariances (const Array<T>& array,
 					     const IPosition& collapseAxes,
-					     const Array<T, Alloc>& means)
+					     const Array<T>& means)
 {
   return partialVariances (array, collapseAxes, means, 1);
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialVariances (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialVariances (const Array<T>& array,
 					     const IPosition& collapseAxes,
-					     const Array<T, Alloc>& means,
+					     const Array<T>& means,
                                              size_t ddof)
 {
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
@@ -443,7 +443,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialVariances (const Arr
     throw ArrayError ("partialVariances: shape of means array mismatches "
 		     "shape of result array");
   }
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   size_t nr = result.nelements();
   int factor = int(array.nelements() / nr) - ddof;
@@ -512,9 +512,9 @@ template<typename T, typename Alloc> Array<T, Alloc> partialVariances (const Arr
   return result;
 }
 
-template<typename T, typename Alloc>
-Array<std::complex<T>, Alloc> partialVariances (const Array<std::complex<T>, Alloc>& array,
-  const IPosition& collapseAxes, const Array<std::complex<T>, Alloc>& means,
+template<typename T>
+Array<std::complex<T>> partialVariances (const Array<std::complex<T>>& array,
+  const IPosition& collapseAxes, const Array<std::complex<T>>& means,
   size_t ddof)
 {
   const IPosition& shape = array.shape();
@@ -599,14 +599,14 @@ Array<std::complex<T>, Alloc> partialVariances (const Array<std::complex<T>, All
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialAvdevs (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialAvdevs (const Array<T>& array,
 					  const IPosition& collapseAxes,
-					  const Array<T, Alloc>& means)
+					  const Array<T>& means)
 {
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
@@ -616,7 +616,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialAvdevs (const Array<
     throw ArrayError ("partialAvdevs: shape of means array mismatches "
 		     "shape of result array");
   }
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   size_t nr = result.nelements();
   size_t factor = array.nelements() / nr;
@@ -680,7 +680,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialAvdevs (const Array<
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialRmss (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialRmss (const Array<T>& array,
 					const IPosition& collapseAxes)
 {
   if (collapseAxes.nelements() == 0) {
@@ -689,13 +689,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialRmss (const Array<T,
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   IPosition resShape, incr;
   int nelemCont = 0;
   size_t stax = partialFuncHelper (nelemCont, resShape, incr, shape,
 				 collapseAxes);
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   result = 0;
   size_t nr = result.nelements();
   size_t factor = array.nelements() / nr;
@@ -755,13 +755,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialRmss (const Array<T,
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialMedians (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMedians (const Array<T>& array,
 					   const IPosition& collapseAxes,
 					   bool takeEvenMean,
 					   bool inPlace)
 {
   // Need to make shallow copy because operator() is non-const.
-  Array<T, Alloc> arr = array;
+  Array<T> arr = array;
   // Is there anything to collapse?
   if (collapseAxes.nelements() == 0) {
     return (inPlace  ?  array : array.copy());
@@ -769,7 +769,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMedians (const Array
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   // Get the remaining axes.
   // It also checks if axes are specified correctly.
@@ -788,7 +788,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMedians (const Array
     resShape.resize(1);
     resShape[0] = 1;
   }
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   bool deleteRes;
   T* resData = result.getStorage (deleteRes);
   T* res = resData;
@@ -816,13 +816,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMedians (const Array
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialMadfms (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialMadfms (const Array<T>& array,
                                          const IPosition& collapseAxes,
                                          bool takeEvenMean,
                                          bool inPlace)
 {
   // Need to make shallow copy because operator() is non-const.
-  Array<T, Alloc> arr = array;
+  Array<T> arr = array;
   // Is there anything to collapse?
   if (collapseAxes.nelements() == 0) {
     return (inPlace  ?  array : array.copy());
@@ -830,7 +830,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMadfms (const Array<
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   // Get the remaining axes.
   // It also checks if axes are specified correctly.
@@ -849,7 +849,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMadfms (const Array<
     resShape.resize(1);
     resShape[0] = 1;
   }
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   bool deleteRes;
   T* resData = result.getStorage (deleteRes);
   T* res = resData;
@@ -877,16 +877,16 @@ template<typename T, typename Alloc> Array<T, Alloc> partialMadfms (const Array<
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialFractiles (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialFractiles (const Array<T>& array,
 					     const IPosition& collapseAxes,
 					     float fraction,
 					     bool inPlace)
 {
   if (fraction < 0  ||  fraction > 1) {
-    throw(ArrayError("::fractile(const Array<T, Alloc>&) - fraction <0 or >1 "));
+    throw(ArrayError("::fractile(const Array<T>&) - fraction <0 or >1 "));
   }    
   // Need to make shallow copy because operator() is non-const.
-  Array<T, Alloc> arr = array;
+  Array<T> arr = array;
   // Is there anything to collapse?
   if (collapseAxes.nelements() == 0) {
     return (inPlace  ?  array : array.copy());
@@ -894,7 +894,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialFractiles (const Arr
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   // Get the remaining axes.
   // It also checks if axes are specified correctly.
@@ -913,7 +913,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialFractiles (const Arr
     resShape.resize(1);
     resShape[0] = 1;
   }
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   bool deleteRes;
   T* resData = result.getStorage (deleteRes);
   T* res = resData;
@@ -941,13 +941,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialFractiles (const Arr
   return result;
 }
 
-template<typename T, typename Alloc> Array<T, Alloc> partialInterFractileRanges (const Array<T, Alloc>& array,
+template<typename T> Array<T> partialInterFractileRanges (const Array<T>& array,
                                                        const IPosition& collapseAxes,
                                                        float fraction,
                                                        bool inPlace)
 {
   // Need to make shallow copy because operator() is non-const.
-  Array<T, Alloc> arr = array;
+  Array<T> arr = array;
   // Is there anything to collapse?
   if (collapseAxes.nelements() == 0) {
     return (inPlace  ?  array : array.copy());
@@ -955,7 +955,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterFractileRanges 
   const IPosition& shape = array.shape();
   size_t ndim = shape.nelements();
   if (ndim == 0) {
-    return Array<T, Alloc>();
+    return Array<T>();
   }
   // Get the remaining axes.
   // It also checks if axes are specified correctly.
@@ -974,7 +974,7 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterFractileRanges 
     resShape.resize(1);
     resShape[0] = 1;
   }
-  Array<T, Alloc> result (resShape);
+  Array<T> result (resShape);
   bool deleteRes;
   T* resData = result.getStorage (deleteRes);
   T* res = resData;
@@ -1003,13 +1003,13 @@ template<typename T, typename Alloc> Array<T, Alloc> partialInterFractileRanges 
 }
 
 
-template<typename T, typename Alloc, typename RES, typename RESAlloc>
-void partialArrayMath (Array<RES, RESAlloc>& res,
-                       const Array<T, Alloc>& a,
+template<typename T, typename RES>
+void partialArrayMath (Array<RES>& res,
+                       const Array<T>& a,
                        const IPosition& collapseAxes,
                        const ArrayFunctorBase<T,RES>& funcObj)
 {
-  ReadOnlyArrayIterator<T, Alloc> aiter(a, collapseAxes);
+  ReadOnlyArrayIterator<T> aiter(a, collapseAxes);
   IPosition shape(a.shape().removeAxes (collapseAxes));
   res.resize (shape);
   RES* data = res.data();
@@ -1020,9 +1020,9 @@ void partialArrayMath (Array<RES, RESAlloc>& res,
 }
 
 
-template <typename T, typename Alloc, typename RES, typename RESAlloc>
-void boxedArrayMath (Array<RES, RESAlloc>& result,
-                     const Array<T, Alloc>& array,
+template <typename T, typename RES>
+void boxedArrayMath (Array<RES>& result,
+                     const Array<T>& array,
                      const IPosition& boxShape,
                      const ArrayFunctorBase<T,RES>& funcObj)
 {
@@ -1057,9 +1057,9 @@ void boxedArrayMath (Array<RES, RESAlloc>& result,
   }
 }
 
-template <typename T, typename Alloc, typename RES, typename RESAlloc>
-void slidingArrayMath (Array<RES, RESAlloc>& result,
-                       const Array<T, Alloc>& array,
+template <typename T, typename RES>
+void slidingArrayMath (Array<RES>& result,
+                       const Array<T>& array,
                        const IPosition& halfBoxShape,
                        const ArrayFunctorBase<T,RES>& funcObj,
                        bool fillEdge)

--- a/casa/Arrays/ArrayStr.h
+++ b/casa/Arrays/ArrayStr.h
@@ -13,8 +13,8 @@ namespace casacore {
 // preceeded by the position of the start of the vector. If the origin of
 // the array isn't zero it is printed. The shape of the array is always
 // printed.
-template<typename T, typename Alloc>
-std::ostream &operator << (std::ostream &, const Array<T, Alloc> &);
+template<typename T>
+std::ostream &operator << (std::ostream &, const Array<T> &);
 
 // Read an ascii representation of an array. All types with an <src><<</src>
 // operator can be handled. The basic format of the input should be:
@@ -55,11 +55,11 @@ std::ostream &operator << (std::ostream &, const Array<T, Alloc> &);
 // transpose (it) (which can be undone by the user specifying transpose).
 //
 // <group>
-template<typename T, typename Alloc>
-std::istream &operator>> (std::istream &s, Array<T, Alloc> &x);
+template<typename T>
+std::istream &operator>> (std::istream &s, Array<T> &x);
 
-template<typename T, typename Alloc>
-bool read(std::istream &s, Array<T, Alloc> &x,
+template<typename T>
+bool read(std::istream &s, Array<T> &x,
 			    const IPosition *ip=0, bool it=false);
 // </group>
 
@@ -76,9 +76,9 @@ bool read(std::istream &s, Array<T, Alloc> &x,
 // input not equal to ip (if specified); the shape given by user as input
 // does not conform to ip (if given) or the number of elements input.<br>
 // trans will be true if transpose asked by user; or if forced by it.
-template<typename T, typename Alloc> bool readArrayBlock(std::istream &s, bool &trans,
+template<typename T> bool readArrayBlock(std::istream &s, bool &trans,
   IPosition &p,
-  std::vector<T, Alloc> &x,
+  std::vector<T> &x,
   const IPosition *ip=0, bool it=false);
 
 // <summary>
@@ -130,15 +130,15 @@ template<typename T, typename Alloc> bool readArrayBlock(std::istream &s, bool &
 // The matrix should be declared but NOT dimensioned in the calling program.
 
 // <group>
-template <typename T, typename Alloc>
-void readAsciiMatrix (Matrix<T, Alloc>& mat, const char* fileName);
+template <typename T>
+void readAsciiMatrix (Matrix<T>& mat, const char* fileName);
 
-template <typename T, typename Alloc>
-void writeAsciiMatrix (const Matrix<T, Alloc>& mat, const char* fileName);
+template <typename T>
+void writeAsciiMatrix (const Matrix<T>& mat, const char* fileName);
 // </group>
 
-template<typename T, typename Alloc>
-std::string to_string(const Array<T, Alloc> array);
+template<typename T>
+std::string to_string(const Array<T> array);
 
 }
 

--- a/casa/Arrays/ArrayStr.tcc
+++ b/casa/Arrays/ArrayStr.tcc
@@ -12,8 +12,8 @@
 
 namespace casacore {
   
-template<typename T, typename Alloc>
-std::string to_string(const Array<T, Alloc> array)
+template<typename T>
+std::string to_string(const Array<T> array)
 {
   std::ostringstream str;
   str << array;
@@ -27,8 +27,8 @@ template<typename T>
 inline void ArrayIO_printValue (std::ostream& s, const T& v)
   { s << v; }
 
-template<typename T, typename Alloc>
-std::ostream &operator<<(std::ostream &s, const Array<T, Alloc> &a)
+template<typename T>
+std::ostream &operator<<(std::ostream &s, const Array<T> &a)
 {
   // Print any "header" information
   if (a.ndim() > 2) {
@@ -115,8 +115,8 @@ std::ostream &operator<<(std::ostream &s, const Array<T, Alloc> &a)
 //
 // They should eventually be replaced with something more sophisticated.
 
-template <typename T, typename Alloc>
-void write_array (const Array<T, Alloc>& the_array, const std::string& fileName)
+template <typename T>
+void write_array (const Array<T>& the_array, const std::string& fileName)
 {
   size_t nbytes = the_array.nelements() * sizeof(T);
   std::ofstream outfile(fileName, std::ios::out);
@@ -129,8 +129,8 @@ void write_array (const Array<T, Alloc>& the_array, const std::string& fileName)
   outfile.close();
 }
 
-template <typename T, typename Alloc>
-void read_array(Array<T, Alloc>& the_array, const std::string& fileName)
+template <typename T>
+void read_array(Array<T>& the_array, const std::string& fileName)
 {
   size_t nbytes = the_array.nelements() * sizeof(T);
   std::ifstream infile(fileName, std::ios::in);
@@ -145,8 +145,8 @@ void read_array(Array<T, Alloc>& the_array, const std::string& fileName)
   the_array.putStorage (storage, delete_storage);
 }
 
-template <typename T, typename Alloc>
-void readAsciiMatrix (Matrix<T, Alloc>& mat, const char* filein)
+template <typename T>
+void readAsciiMatrix (Matrix<T>& mat, const char* filein)
 {
   const size_t bufSize = 1024;
   char buf[bufSize];
@@ -231,8 +231,8 @@ void readAsciiMatrix (Matrix<T, Alloc>& mat, const char* filein)
 }
 
 
-template <typename T, typename Alloc>
-void writeAsciiMatrix (const Matrix<T, Alloc>& mat, const char* fileout)
+template <typename T>
+void writeAsciiMatrix (const Matrix<T>& mat, const char* fileout)
 {
   std::ofstream oFile;
   oFile.precision(12);
@@ -249,8 +249,8 @@ void writeAsciiMatrix (const Matrix<T, Alloc>& mat, const char* fileout)
 }
 
 
-template <typename T, typename Alloc>
-void readAsciiVector (Vector<T, Alloc>& vect, const char* filein) 
+template <typename T>
+void readAsciiVector (Vector<T>& vect, const char* filein)
 {
   const size_t bufSize = 1024;
   char buf[bufSize];
@@ -321,8 +321,8 @@ void readAsciiVector (Vector<T, Alloc>& vect, const char* filein)
   
 }
 
-template <typename T, typename Alloc>
-void writeAsciiVector (const Vector<T, Alloc>& vect, const char* fileout)
+template <typename T>
+void writeAsciiVector (const Vector<T>& vect, const char* fileout)
 {
   size_t rows = vect.size();
   std::ofstream oFile;
@@ -337,18 +337,18 @@ void writeAsciiVector (const Vector<T, Alloc>& vect, const char* fileout)
   oFile << '\n'; 
 }
 
-template <typename T, typename Alloc>
-std::istream &operator >> (std::istream &s, Array<T, Alloc> &x) {
+template <typename T>
+std::istream &operator >> (std::istream &s, Array<T> &x) {
   if (!read(s, x, 0, false)) {
     s.clear(std::ios::failbit | s.rdstate());
   }
   return s;
 }
 
-template <typename T, typename Alloc>
-bool read(std::istream &s, Array<T, Alloc> &x,
+template <typename T>
+bool read(std::istream &s, Array<T> &x,
 	  const IPosition *ip, bool it) {
-  ///  Array<T, Alloc> *to; PCAST(to, Array<T, Alloc>, &x);
+  ///  Array<T> *to; PCAST(to, Array<T>, &x);
   ///  if (to) {
   // If an empty array, it can get any dimension.
   if (x.ndim() == 0) {
@@ -379,7 +379,7 @@ bool read(std::istream &s, Array<T, Alloc> &x,
     // Otherwise try if we can resize.
     // This will always be possible for an Array,
     // but e.g. not for Vector if the Array is not 1D.
-    Array<T, Alloc> tx;
+    Array<T> tx;
     if (!read(s, tx, ip, it)) return false;
     // TODO this can be done without trial and error:
     // reading a matrix in always throws and catches an exception
@@ -423,10 +423,10 @@ bool read(std::istream &s, Array<T, Alloc> &x,
   return true;
 }
 
-template <typename T, typename Alloc>
+template <typename T>
 bool readArrayBlock(std::istream &s, bool &trans,
                     IPosition &p,
-                    std::vector<T, Alloc> &x, const IPosition *ip, bool it) {
+                    std::vector<T> &x, const IPosition *ip, bool it) {
   if (!s.good()) {
     s.clear(std::ios::failbit|s.rdstate()); // Redundant if using GNU iostreams
     return false;

--- a/casa/Arrays/Array_tmpl.cc
+++ b/casa/Arrays/Array_tmpl.cc
@@ -30,14 +30,14 @@
 
 //# Instantiate extern templates for often used types.
 namespace casacore {
-  template class Array<bool, std::allocator<bool>>;
-  template class Array<char, std::allocator<char>>;
-  template class Array<unsigned char, std::allocator<unsigned char>>;
-  template class Array<short, std::allocator<short>>;
-  template class Array<unsigned short, std::allocator<unsigned short>>;
-  template class Array<int, std::allocator<int>>;
-  template class Array<unsigned int, std::allocator<unsigned int>>;
-  template class Array<long long, std::allocator<long long>>;
-  template class Array<float, std::allocator<float>>;
-  template class Array<double, std::allocator<double>>;
+  template class Array<bool>;
+  template class Array<char>;
+  template class Array<unsigned char>;
+  template class Array<short>;
+  template class Array<unsigned short>;
+  template class Array<int>;
+  template class Array<unsigned int>;
+  template class Array<long long>;
+  template class Array<float>;
+  template class Array<double>;
 }

--- a/casa/Arrays/Cube.h
+++ b/casa/Arrays/Cube.h
@@ -68,41 +68,39 @@ namespace casacore { //#Begin casa namespace
 // index operations will be bounds-checked. Neither of these should
 // be defined for production code.
 
-template<typename T, typename Alloc> class Cube : public Array<T, Alloc>
+template<typename T> class Cube : public Array<T>
 {
 public:
 
     // A Cube of length zero in each dimension; zero origin.
-    Cube(const Alloc& allocator=Alloc());
+    Cube();
 
     // A l1xl2xl3 sized cube.
     // Fill it with the initial value.
-    Cube(size_t l1, size_t l2, size_t l3, const T &initialValue=T(), const Alloc& allocator=Alloc());
+    Cube(size_t l1, size_t l2, size_t l3, const T &initialValue=T());
     
     // An uninitialized l1xl2xl3 sized cube.
-    Cube(size_t l1, size_t l2, size_t l3, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator=Alloc());
+    Cube(size_t l1, size_t l2, size_t l3, typename Array<T>::uninitializedType);
 
     // A Cube where the shape ("len") is defined with IPositions.
     // Fill it with the initial value.
-    Cube(const IPosition &length, const T &initialValue = T(), const Alloc& allocator=Alloc());
+    Cube(const IPosition &length, const T &initialValue = T());
 
     // An uninitialized Cube where the shape ("len") is defined with IPositions.
-    Cube(const IPosition& length, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator=Alloc());
+    Cube(const IPosition& length, typename Array<T>::uninitializedType);
     
     // The copy constructor uses reference semantics.
-    Cube(const Cube<T, Alloc> &);
-    Cube(Cube<T, Alloc> &&);
+    Cube(const Cube<T> &);
+    Cube(Cube<T> &&);
 
     // Construct a cube by reference from "other". "other must have
     // ndim() of 3 or less. The warning which applies to the copy constructor
     // is also valid here.
-    Cube(const Array<T, Alloc> &);
-    Cube(Array<T, Alloc> &&);
+    Cube(const Array<T> &);
+    Cube(Array<T> &&);
 
     // Create an Cube of a given shape from a pointer.
     Cube(const IPosition &shape, T *storage, StorageInitPolicy policy = COPY);
-    // Create an Cube of a given shape from a pointer.
-    Cube(const IPosition &shape, T *storage, StorageInitPolicy policy, const Alloc& allocator);
     // Create an  Cube of a given shape from a pointer. Because the pointer
     // is const, a copy is always made.
     Cube(const IPosition &shape, const T *storage);
@@ -110,7 +108,7 @@ public:
     // Resize to the given shape.
     // Resize without argument is equal to resize(0,0,0).
     // <group>
-    using Array<T, Alloc>::resize;
+    using Array<T>::resize;
     void resize(size_t nx, size_t ny, size_t nz, bool copyValues=false);
     // </group>
 
@@ -120,12 +118,12 @@ public:
     // Note that the assign function can be used to assign a
     // non-conforming cube.
     // <group>
-    Cube<T, Alloc> &operator=(const Cube<T, Alloc>& source)
-    { Array<T, Alloc>::operator=(source); return *this; }
-    Cube<T, Alloc> &operator=(Cube<T, Alloc>&& source)
-    { Array<T, Alloc>::operator=(std::move(source)); return *this; }
+    Cube<T> &operator=(const Cube<T>& source)
+    { Array<T>::operator=(source); return *this; }
+    Cube<T> &operator=(Cube<T>&& source)
+    { Array<T>::operator=(std::move(source)); return *this; }
     
-    Cube<T, Alloc>& operator=(const Array<T, Alloc>& source)
+    Cube<T>& operator=(const Array<T>& source)
     {
       // TODO is it highly confusing that operator= is specialized for Cube, e.g.
       // this is allowed:
@@ -141,20 +139,20 @@ public:
       // same!
       
       if (source.ndim() == 3) {
-        Array<T, Alloc>::operator=(source);
+        Array<T>::operator=(source);
       } else {
         // This might work if a.ndim == 1 or 2
-        (*this) = Cube<T, Alloc>(source);
+        (*this) = Cube<T>(source);
       }
       return *this;
     }
    
-    Cube<T, Alloc>& operator=(Array<T, Alloc>&& source)
+    Cube<T>& operator=(Array<T>&& source)
     {
       if (source.ndim() == 3) {
-        Array<T, Alloc>::operator=(std::move(source));
+        Array<T>::operator=(std::move(source));
       } else {
-        (*this) = Cube<T, Alloc>(std::move(source));
+        (*this) = Cube<T>(std::move(source));
       }
       return *this;
     }
@@ -163,14 +161,14 @@ public:
 
     // Copy val into every element of this cube; i.e. behaves as if
     // val were a constant conformant cube.
-    Array<T, Alloc> &operator=(const T &val)
+    Array<T> &operator=(const T &val)
       { return Array<T>::operator=(val); }
 
     // Copy to this those values in marray whose corresponding elements
     // in marray's mask are true.
     
     // TODO
-    //Cube<T, Alloc> &operator= (const MaskedArray<T> &marray)
+    //Cube<T> &operator= (const MaskedArray<T> &marray)
     //  { Array<T> (*this) = marray; return *this; }
 
 
@@ -202,9 +200,9 @@ public:
     // vd(Slice(0,10),Slice(10,10,Slice(0,10))) = -1.0; // sub-cube set to -1.0
     // </srcblock>
     // <group>
-    Cube<T, Alloc> operator()(const Slice &sliceX, const Slice &sliceY,
+    Cube<T> operator()(const Slice &sliceX, const Slice &sliceY,
 		       const Slice &sliceZ);
-    const Cube<T, Alloc> operator()(const Slice &sliceX, const Slice &sliceY,
+    const Cube<T> operator()(const Slice &sliceX, const Slice &sliceY,
                              const Slice &sliceZ) const;
     // </group>
 
@@ -264,12 +262,12 @@ public:
     // Of course you could also use a Matrix
     // iterator on the cube.
     // <group>
-    Matrix<T, Alloc> xyPlane(size_t zplane); 
-    const  Matrix<T, Alloc> xyPlane(size_t zplane) const; 
-    Matrix<T, Alloc> xzPlane(size_t yplane); 
-    const  Matrix<T, Alloc> xzPlane(size_t yplane) const; 
-    Matrix<T, Alloc> yzPlane(size_t xplane); 
-    const  Matrix<T, Alloc> yzPlane(size_t xplane) const; 
+    Matrix<T> xyPlane(size_t zplane);
+    const  Matrix<T> xyPlane(size_t zplane) const;
+    Matrix<T> xzPlane(size_t yplane);
+    const  Matrix<T> xzPlane(size_t yplane) const;
+    Matrix<T> yzPlane(size_t xplane);
+    const  Matrix<T> yzPlane(size_t xplane) const;
     // </group>
 
     // The length of each axis of the cube.

--- a/casa/Arrays/Cube.tcc
+++ b/casa/Arrays/Cube.tcc
@@ -34,47 +34,47 @@
 
 namespace casacore {
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(const Alloc& allocator)
-: Array<T>(IPosition(3, 0), allocator)
+template<typename T> Cube<T>::Cube()
+: Array<T>(IPosition(3, 0))
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(size_t l1, size_t l2, size_t l3,
-    const T &initialValue, const Alloc& allocator)
-: Array<T>(IPosition(3, l1, l2, l3), initialValue, allocator)
+template<typename T> Cube<T>::Cube(size_t l1, size_t l2, size_t l3,
+    const T &initialValue)
+: Array<T>(IPosition(3, l1, l2, l3), initialValue)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(size_t l1, size_t l2, size_t l3,
-    typename Array<T, Alloc>::uninitializedType, const Alloc& allocator)
-: Array<T>(IPosition(3, l1, l2, l3), Array<T, Alloc>::uninitialized, allocator)
+template<typename T> Cube<T>::Cube(size_t l1, size_t l2, size_t l3,
+    typename Array<T>::uninitializedType)
+: Array<T>(IPosition(3, l1, l2, l3), Array<T>::uninitialized)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(const IPosition &length,
-    const T &initialValue, const Alloc& allocator)
-  : Array<T>(length, initialValue, allocator)
+template<typename T> Cube<T>::Cube(const IPosition &length,
+    const T &initialValue)
+  : Array<T>(length, initialValue)
 {
   this->checkBeforeResize(length);
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(const IPosition &length,
-    typename Array<T, Alloc>::uninitializedType, const Alloc& allocator)
-  : Array<T>(length, Array<T, Alloc>::uninitialized, allocator)
+template<typename T> Cube<T>::Cube(const IPosition &length,
+    typename Array<T>::uninitializedType)
+  : Array<T>(length, Array<T>::uninitialized)
 {
   this->checkBeforeResize(length);
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(const Cube<T, Alloc> &source)
+template<typename T> Cube<T>::Cube(const Cube<T> &source)
   : Array<T>(source)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(Cube<T, Alloc>&& source)
+template<typename T> Cube<T>::Cube(Cube<T>&& source)
   : Array<T>(std::move(source), IPosition(3, 0))
 {
   assert(ok());
@@ -83,33 +83,33 @@ template<typename T, typename Alloc> Cube<T, Alloc>::Cube(Cube<T, Alloc>&& sourc
 // <thrown>
 //   <item> ArrayNDimError
 // </thrown>
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(const Array<T, Alloc> &source)
+template<typename T> Cube<T>::Cube(const Array<T> &source)
 : Array<T>(source)
 {
   this->checkCubeShape();
   assert(ok());
 }
 
-template<typename T, typename Alloc> Cube<T, Alloc>::Cube(Array<T, Alloc>&& source)
+template<typename T> Cube<T>::Cube(Array<T>&& source)
 : Array<T>(std::move(source))
 {
   this->checkCubeShape();
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-void Cube<T, Alloc>::resize(size_t nx, size_t ny, size_t nz, bool copyValues)
+template<typename T>
+void Cube<T>::resize(size_t nx, size_t ny, size_t nz, bool copyValues)
 {
     assert(ok());
     IPosition l(3);
     l(0) = nx; l(1) = ny; l(2) = nz;
-    Cube<T, Alloc>::resize(l, copyValues);
+    Cube<T>::resize(l, copyValues);
 }
 
 // <thrown>
 //    <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> Cube<T, Alloc> Cube<T, Alloc>::operator()(const Slice &sliceX,
+template<typename T> Cube<T> Cube<T>::operator()(const Slice &sliceX,
                                               const Slice &sliceY,
                                               const Slice &sliceZ)
 {
@@ -145,16 +145,16 @@ template<typename T, typename Alloc> Cube<T, Alloc> Cube<T, Alloc>::operator()(c
 
     // Check that the selected slice is valid
     if (s1 < 1 || s2 < 1 || s3 < 1) {
-	throw(ArrayError("Cube<T, Alloc>::operator()(Slice,Slice,Slice) : step < 1"));
+	throw(ArrayError("Cube<T>::operator()(Slice,Slice,Slice) : step < 1"));
     } else if (l1 < 0  || l2 < 0 || l3 < 0) {
-	throw(ArrayError("Cube<T, Alloc>::operator()(Slice,Slice,Slice): length < 0"));
+	throw(ArrayError("Cube<T>::operator()(Slice,Slice,Slice): length < 0"));
     } else if ((b1+(l1-1)*s1 >= this->length_p(0)) || 
 	       (b2+(l2-1)*s2 >= this->length_p(1)) ||
 	       (b3+(l3-1)*s3 >= this->length_p(2))) {
-	throw(ArrayError("Cube<T, Alloc>::operator()(Slice,Slice,Slice) : "
+	throw(ArrayError("Cube<T>::operator()(Slice,Slice,Slice) : "
 			 "Desired slice extends beyond the end of the array"));
     } else if (b1 < 0 || b2 < 0 || b3 < 0) {
-	throw(ArrayError("Cube<T, Alloc>::operator()(Slice,Slice,Slice) : "
+	throw(ArrayError("Cube<T>::operator()(Slice,Slice,Slice) : "
 			 "start of slice before beginning of cube"));
    }
 
@@ -167,14 +167,14 @@ template<typename T, typename Alloc> Cube<T, Alloc> Cube<T, Alloc>::operator()(c
     return this->operator()(blc,trc,incr);
 }
 
-template<typename T, typename Alloc> const Cube<T, Alloc> Cube<T, Alloc>::operator()
+template<typename T> const Cube<T> Cube<T>::operator()
   (const Slice &sliceX, const Slice &sliceY, const Slice &sliceZ) const
 {
-    return const_cast<Cube<T, Alloc>*>(this)->operator() (sliceX, sliceY, sliceZ);
+    return const_cast<Cube<T>*>(this)->operator() (sliceX, sliceY, sliceZ);
 }
 
-template<typename T, typename Alloc>
-void Cube<T, Alloc>::doNonDegenerate (const Array<T> &other,
+template<typename T>
+void Cube<T>::doNonDegenerate (const Array<T> &other,
                                const IPosition &ignoreAxes)
 {
     Array<T> tmp(*this);
@@ -190,81 +190,81 @@ void Cube<T, Alloc>::doNonDegenerate (const Array<T> &other,
 // <thrown>
 //   <item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Matrix<T, Alloc> Cube<T, Alloc>::xyPlane(size_t which)
+template<typename T> Matrix<T> Cube<T>::xyPlane(size_t which)
 {
     assert(ok());
     if ((long long)(which) >= this->length_p(2)) {
-	throw(ArrayConformanceError("Cube<T, Alloc>::xyPlane - plane > end"));
+	throw(ArrayConformanceError("Cube<T>::xyPlane - plane > end"));
     }
-    Cube<T, Alloc> tmp((*this)(Slice(), Slice(), which));
+    Cube<T> tmp((*this)(Slice(), Slice(), which));
     tmp.ndimen_p = 2;
     tmp.length_p.resize (2);
     tmp.inc_p.resize (2);
     tmp.originalLength_p.resize (2);
     tmp.makeSteps();
-    return Matrix<T, Alloc>(tmp); // should match Matrix<T>(const Array<T> &)
+    return Matrix<T>(tmp); // should match Matrix<T>(const Array<T> &)
 }
 
 
-template<typename T, typename Alloc> const Matrix<T, Alloc> Cube<T, Alloc>::xyPlane(size_t which) const
+template<typename T> const Matrix<T> Cube<T>::xyPlane(size_t which) const
 {
-    Cube<T, Alloc> *This = const_cast<Cube<T, Alloc>*>(this);
+    Cube<T> *This = const_cast<Cube<T>*>(this);
     // Cast away constness, but the return type is a const Matrix<T>, so
     // this should still be safe.
     return This->xyPlane(which);
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc> Cube<T, Alloc>::xzPlane(size_t which)
+template<typename T> Matrix<T> Cube<T>::xzPlane(size_t which)
 {
     assert(ok());
     if ((long long)(which) >= this->length_p(1)) {
-	throw(ArrayConformanceError("Cube<T, Alloc>::xzPlane - plane > end"));
+	throw(ArrayConformanceError("Cube<T>::xzPlane - plane > end"));
     }
-    Cube<T, Alloc> tmp((*this)(Slice(), which, Slice()));
+    Cube<T> tmp((*this)(Slice(), which, Slice()));
     // Keep axes 0 and 2, even if they have length 1.
     return tmp.nonDegenerate(IPosition(2,0,2));
 }
 
-template<typename T, typename Alloc> const Matrix<T, Alloc> Cube<T, Alloc>::xzPlane(size_t which) const
+template<typename T> const Matrix<T> Cube<T>::xzPlane(size_t which) const
 {
-    Cube<T, Alloc> *This = const_cast<Cube<T, Alloc>*>(this);
+    Cube<T> *This = const_cast<Cube<T>*>(this);
     // Cast away constness, but the return type is a const Matrix<T>, so
     // this should still be safe.
     return This->xzPlane(which);
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc> Cube<T, Alloc>::yzPlane(size_t which)
+template<typename T> Matrix<T> Cube<T>::yzPlane(size_t which)
 {
     assert(ok());
     if ((long long)(which) >= this->length_p(0)) {
-	throw(ArrayConformanceError("Cube<T, Alloc>::yzPlane - plane > end"));
+	throw(ArrayConformanceError("Cube<T>::yzPlane - plane > end"));
     }
-    Cube<T, Alloc> tmp((*this)(which, Slice(), Slice()));
+    Cube<T> tmp((*this)(which, Slice(), Slice()));
     // Keep axes 1 and 2, even if they have length 1.
     return tmp.nonDegenerate(IPosition(2,1,2));
 }
 
 
-template<typename T, typename Alloc> const Matrix<T, Alloc> Cube<T, Alloc>::yzPlane(size_t which) const
+template<typename T> const Matrix<T> Cube<T>::yzPlane(size_t which) const
 {
-    Cube<T, Alloc> *This = const_cast<Cube<T, Alloc>*>(this);
+    Cube<T> *This = const_cast<Cube<T>*>(this);
     // Cast away constness, but the return type is a const Matrix<T>, so
     // this should still be safe.
     return This->yzPlane(which);
 }
 
 
-template<typename T, typename Alloc> bool Cube<T, Alloc>::ok() const
+template<typename T> bool Cube<T>::ok() const
 {
 #ifndef NDEBUG
   if(this->ndim() != 3)
     throw std::runtime_error("ndim() == " + std::to_string(this->ndim()));
 #endif
-  return this->ndim() == 3 && Array<T, Alloc>::ok();
+  return this->ndim() == 3 && Array<T>::ok();
 }
 
-template<typename T, typename Alloc>
-Cube<T, Alloc>::Cube(const IPosition &shape, T *storage, 
+template<typename T>
+Cube<T>::Cube(const IPosition &shape, T *storage,
 		  StorageInitPolicy policy)
   : Array<T>(shape, storage, policy)
 {
@@ -272,17 +272,8 @@ Cube<T, Alloc>::Cube(const IPosition &shape, T *storage,
     throw ArrayError("len.nelements() != 3");
 }
 
-template<typename T, typename Alloc>
-Cube<T, Alloc>::Cube(const IPosition &shape, T *storage,
-                  StorageInitPolicy policy, const Alloc& allocator)
-  : Array<T>(shape, storage, policy, allocator)
-{
-  if(shape.nelements() != 3)
-    throw ArrayError("len.nelements() != 3");
-}
-
-template<typename T, typename Alloc>
-Cube<T, Alloc>::Cube(const IPosition &shape, const T *storage)
+template<typename T>
+Cube<T>::Cube(const IPosition &shape, const T *storage)
   : Array<T>(shape, storage)
 {
    if(shape.nelements() != 3)
@@ -290,8 +281,8 @@ Cube<T, Alloc>::Cube(const IPosition &shape, const T *storage)
 }
 
 
-template<typename T, typename Alloc>
-void Cube<T, Alloc>::preTakeStorage(const IPosition &shape)
+template<typename T>
+void Cube<T>::preTakeStorage(const IPosition &shape)
 {
   Array<T>::preTakeStorage(shape);
   if(shape.nelements() != 3)

--- a/casa/Arrays/MaskArrIO.h
+++ b/casa/Arrays/MaskArrIO.h
@@ -28,7 +28,7 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
+template<typename T>
 class MaskedArray;
 
 // <summary>
@@ -84,13 +84,13 @@ class MaskedArray;
 // 
 // Write out an ascii representation of a MaskedArray.
 // The component Array and LogicalArray are written out sequentially.
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-std::ostream & operator<< (std::ostream &, const MaskedArray<T, ArrayAlloc, MaskAlloc> &);
+template<typename T>
+std::ostream & operator<< (std::ostream &, const MaskedArray<T> &);
 
 
 // </group>
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-std::string to_string(const MaskedArray<T, ArrayAlloc, MaskAlloc> &);
+template<typename T>
+std::string to_string(const MaskedArray<T> &);
 
 } //# NAMESPACE CASACORE - END
 

--- a/casa/Arrays/MaskLogiArrFwd.h
+++ b/casa/Arrays/MaskLogiArrFwd.h
@@ -83,7 +83,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forwards
 
-template<typename T, typename ArrayAlloc=std::allocator<T>, typename MaskAlloc=std::allocator<LogicalArrayElem>> class MaskedArray;
+template<typename T> class MaskedArray;
 
 
 // Define MaskedLogicalArray. 

--- a/casa/Arrays/MaskedArray.h
+++ b/casa/Arrays/MaskedArray.h
@@ -318,14 +318,14 @@ class Slicer;
 // </todo>
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
+template<typename T>
 class MaskedArray
 {
 
 public:
-  typedef Array<T, ArrayAlloc> array_type;
-  typedef Array<LogicalArrayElem, MaskAlloc> mask_type;
-  typedef MaskedArray<T, ArrayAlloc, MaskAlloc> masked_array_type;
+  typedef Array<T> array_type;
+  typedef Array<LogicalArrayElem> mask_type;
+  typedef MaskedArray<T> masked_array_type;
   
   // Default constructor for a MaskedArray does not allocate any memory
   // for the Data array or Mask. Hence the masked array 
@@ -609,7 +609,7 @@ public:
     // <group>
 
     // The returned Array will have dimension one.
-    Array<T, ArrayAlloc> getCompressedArray () const;
+    Array<T> getCompressedArray () const;
 
     // The returned Array will have the input shape.  This shape must
     // give the returned Array the required number of elements.
@@ -618,7 +618,7 @@ public:
     //    <li> ArrayError
     // </thrown>
     //
-    Array<T, ArrayAlloc> getCompressedArray (const IPosition & shape) const;
+    Array<T> getCompressedArray (const IPosition & shape) const;
 
     // </group>
 
@@ -725,12 +725,12 @@ protected:
 //
 //   <group name=conform2>
 //
-template<typename TL, typename ArrayAllocL, typename MaskAllocL, typename TR, typename ArrayAllocR>
-  bool conform2 (const MaskedArray<TL, ArrayAllocL, MaskAllocL> &left, const Array<TR, ArrayAllocR> &right);
-template<typename TL, typename ArrayAllocL, typename TR, typename ArrayAllocR, typename MaskAllocR>
-  bool conform2 (const Array<TL, ArrayAllocL> &left, const MaskedArray<TR, ArrayAllocR, MaskAllocR> &right);
-template<typename TL, typename ArrayAllocL, typename MaskAllocL, typename TR, typename ArrayAllocR, typename MaskAllocR>
-  bool conform2 (const MaskedArray<TL, ArrayAllocL, MaskAllocL> &left, const MaskedArray<TR, ArrayAllocR, MaskAllocR> &right);
+template<typename TLL, typename TRR>
+  bool conform2 (const MaskedArray<TLL> &left, const Array<TRR> &right);
+template<typename TLL, typename TRR>
+  bool conform2 (const Array<TLL> &left, const MaskedArray<TRR> &right);
+template<typename TLL, typename TRR>
+  bool conform2 (const MaskedArray<TLL> &left, const MaskedArray<TRR> &right);
 //
 //   </group>
 

--- a/casa/Arrays/MaskedArray.tcc
+++ b/casa/Arrays/MaskedArray.tcc
@@ -36,8 +36,8 @@
 
 namespace casacore {                                        //# NAMESPACE CASACORE - BEGIN
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> 
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray () :
+template<typename T>
+MaskedArray<T>::MaskedArray () :
 pArray (),
 pMask (),
 nelemValid (0),
@@ -45,8 +45,8 @@ nelemValidIsOK (false),
 isRO (false)
 {}
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const array_type &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const array_type &inarray,
   const LogicalArray &inmask,
   bool isreadonly)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false),
@@ -55,7 +55,7 @@ isRO (isreadonly)
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(const array_type &,"
+      "MaskedArray<T>::MaskedArray(const array_type &,"
       " const LogicalArray &, bool)"
       " - arrays do not conform"));
    }
@@ -68,15 +68,15 @@ isRO (isreadonly)
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const array_type &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const array_type &inarray,
   const LogicalArray &inmask)
 : pArray(), pMask (), nelemValid (0), nelemValidIsOK (false), isRO (false)
 {
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() !=  inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(const array_type &,"
+      "MaskedArray<T>::MaskedArray(const array_type &,"
       " const LogicalArray &)"
       " - arrays do not conform"));
    }
@@ -89,8 +89,8 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const array_type &inarray,
 
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const MaskedArray<T> &inarray,
   const LogicalArray &inmask,
   bool isreadonly)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false),
@@ -99,7 +99,7 @@ isRO ( (inarray.isRO || isreadonly))
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &,"
+      "MaskedArray<T>::MaskedArray (const MaskedArray<T> &,"
       " const LogicalArray &, bool)"
       " - arrays do not conform"));
    }
@@ -114,8 +114,8 @@ isRO ( (inarray.isRO || isreadonly))
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const MaskedArray<T> &inarray,
 const LogicalArray &inmask)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false),
 isRO (inarray.isRO)
@@ -123,7 +123,7 @@ isRO (inarray.isRO)
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &,"
+      "MaskedArray<T>::MaskedArray (const MaskedArray<T> &,"
       " const LogicalArray &)"
       " - arrays do not conform"));
    }
@@ -138,8 +138,8 @@ isRO (inarray.isRO)
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const array_type &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const array_type &inarray,
 const MaskedLogicalArray &inmask,
 bool isreadonly)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false),
@@ -148,7 +148,7 @@ isRO (isreadonly)
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(const array_type &inarray,"
+      "MaskedArray<T>::MaskedArray(const array_type &inarray,"
       " const MaskedLogicalArray &inmask, bool isreadonly)"
       " - arrays do not conform"));
    }
@@ -162,15 +162,15 @@ isRO (isreadonly)
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const array_type &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const array_type &inarray,
 const MaskedLogicalArray &inmask)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false), isRO (false)
 {
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(const array_type &inarray,"
+      "MaskedArray<T>::MaskedArray(const array_type &inarray,"
       " const MaskedLogicalArray &inmask)"
       " - arrays do not conform"));
    }
@@ -184,8 +184,8 @@ const MaskedLogicalArray &inmask)
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const MaskedArray<T> &inarray,
 const MaskedLogicalArray &inmask)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false),
 isRO (inarray.isRO)
@@ -193,7 +193,7 @@ isRO (inarray.isRO)
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &inarray,"
+      "MaskedArray<T>::MaskedArray (const MaskedArray<T> &inarray,"
       " const MaskedLogicalArray &inmask)"
       " - arrays do not conform"));
    }
@@ -208,8 +208,8 @@ isRO (inarray.isRO)
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &inarray,
+template<typename T>
+MaskedArray<T>::MaskedArray (const MaskedArray<T> &inarray,
 const MaskedLogicalArray &inmask,
 bool isreadonly)
 : pArray (), pMask (), nelemValid (0), nelemValidIsOK (false),
@@ -218,7 +218,7 @@ isRO ( (inarray.isRO || isreadonly))
   //    if (! conform2 (inarray, inmask)) {
   if (inarray.shape() != inmask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray (const MaskedArray<T, ArrayAlloc, MaskAlloc> &inarray,"
+      "MaskedArray<T>::MaskedArray (const MaskedArray<T> &inarray,"
       " const MaskedLogicalArray &inmask, bool isreadonly)"
       " - arrays do not conform"));
    }
@@ -233,8 +233,8 @@ isRO ( (inarray.isRO || isreadonly))
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(const MaskedArray<T, ArrayAlloc, MaskAlloc> &other, bool isreadonly)
+template<typename T>
+MaskedArray<T>::MaskedArray(const MaskedArray<T> &other, bool isreadonly)
 : pArray (), pMask (),
 nelemValid (other.nelemValid), nelemValidIsOK (other.nelemValidIsOK),
 isRO ( (other.isRO || isreadonly))
@@ -248,8 +248,8 @@ isRO ( (other.isRO || isreadonly))
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(const MaskedArray<T, ArrayAlloc, MaskAlloc> &other)
+template<typename T>
+MaskedArray<T>::MaskedArray(const MaskedArray<T> &other)
 : pArray (), pMask (),
 nelemValid (other.nelemValid), nelemValidIsOK (other.nelemValidIsOK),
 isRO (other.isRO)
@@ -262,8 +262,8 @@ isRO (other.isRO)
 
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>::MaskedArray(MaskedArray<T, ArrayAlloc, MaskAlloc>&& source)
+template<typename T>
+MaskedArray<T>::MaskedArray(MaskedArray<T>&& source)
 : pArray (std::move(source.pArray)),
 pMask (std::move(source.pMask)),
 nelemValid (source.nelemValid),
@@ -277,13 +277,13 @@ isRO (source.isRO)
   assert(source.ok());
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> void
-MaskedArray<T, ArrayAlloc, MaskAlloc>::setData (const array_type &data,
+template<typename T> void
+MaskedArray<T>::setData (const array_type &data,
 const mask_type &mask,
 bool isReadOnly) {
   if (data.shape() != mask.shape()) {
     throw (ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::setData(const array_type &,"
+      "MaskedArray<T>::setData(const array_type &,"
       " const LogicalArray &, bool)"
       " - arrays do not conform"));
    }
@@ -291,29 +291,29 @@ bool isReadOnly) {
   pMask.reset( new mask_type (mask.copy()) );
   nelemValid = 0;
   nelemValidIsOK = false;
-  isRO  = isReadOnly; 
+  isRO  = isReadOnly;
   assert(ok());
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> void
-MaskedArray<T, ArrayAlloc, MaskAlloc>::setData (const MaskedArray<T, ArrayAlloc, MaskAlloc> & array,
+template<typename T> void
+MaskedArray<T>::setData (const MaskedArray<T> & array,
 bool isReadOnly){
   pArray.reset( new array_type(array.getArray()) );
   pMask.reset( new LogicalArray(array.getMask().copy()) );
   nelemValid = 0;
   nelemValidIsOK = false;
-  isRO  = isReadOnly; 
+  isRO  = isReadOnly;
 
   assert(ok());
  }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::copy(bool isreadonly) const
+template<typename T>
+MaskedArray<T> MaskedArray<T>::copy(bool isreadonly) const
 {
   assert(ok());
 
-  MaskedArray<T, ArrayAlloc, MaskAlloc> retval (pArray->copy(), *pMask, isreadonly);
+  MaskedArray<T> retval (pArray->copy(), *pMask, isreadonly);
   retval.nelemValid = nelemValid;
   retval.nelemValidIsOK = nelemValidIsOK;
 
@@ -321,12 +321,12 @@ MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::cop
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::copy() const
+template<typename T>
+MaskedArray<T> MaskedArray<T>::copy() const
 {
   assert(ok());
 
-  MaskedArray<T, ArrayAlloc, MaskAlloc> retval (pArray->copy(), *pMask);
+  MaskedArray<T> retval (pArray->copy(), *pMask);
   retval.nelemValid = nelemValid;
   retval.nelemValidIsOK = nelemValidIsOK;
 
@@ -334,55 +334,55 @@ MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::cop
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::operator() (const LogicalArray &mask) const
+template<typename T>
+MaskedArray<T> MaskedArray<T>::operator() (const LogicalArray &mask) const
 {
   assert(ok());
 
-  MaskedArray<T, ArrayAlloc, MaskAlloc> ret (*this, mask);
+  MaskedArray<T> ret (*this, mask);
   return ret;
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::operator()
+template<typename T>
+MaskedArray<T> MaskedArray<T>::operator()
 (const MaskedLogicalArray &mask) const
 {
   assert(ok());
 
-  MaskedArray<T, ArrayAlloc, MaskAlloc> ret (*this, mask);
+  MaskedArray<T> ret (*this, mask);
   return ret;
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::operator() (const IPosition &start,
+template<typename T>
+MaskedArray<T> MaskedArray<T>::operator() (const IPosition &start,
 const IPosition &end)
 {
   assert(ok());
-  return MaskedArray<T, ArrayAlloc, MaskAlloc> ((*pArray)(start,end), (*pMask)(start,end), isRO);
+  return MaskedArray<T> ((*pArray)(start,end), (*pMask)(start,end), isRO);
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::operator() (const IPosition &start,
+template<typename T>
+MaskedArray<T> MaskedArray<T>::operator() (const IPosition &start,
 const IPosition &end,
 const IPosition &inc)
 {
   assert(ok());
-  return MaskedArray<T, ArrayAlloc, MaskAlloc> ((*pArray)(start,end,inc), (*pMask)(start,end,inc),
+  return MaskedArray<T> ((*pArray)(start,end,inc), (*pMask)(start,end,inc),
     isRO);
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::operator() (const Slicer &slicer)
+template<typename T>
+MaskedArray<T> MaskedArray<T>::operator() (const Slicer &slicer)
 {
   assert(ok());
-  return MaskedArray<T, ArrayAlloc, MaskAlloc> ((*pArray)(slicer), (*pMask)(slicer), isRO);
+  return MaskedArray<T> ((*pArray)(slicer), (*pMask)(slicer), isRO);
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-const Array<T, ArrayAlloc> &MaskedArray<T, ArrayAlloc, MaskAlloc>::getArray() const
+template<typename T>
+const Array<T> &MaskedArray<T>::getArray() const
 {
   assert(ok());
 
@@ -390,8 +390,8 @@ const Array<T, ArrayAlloc> &MaskedArray<T, ArrayAlloc, MaskAlloc>::getArray() co
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-const Array<LogicalArrayElem, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>::getMask() const
+template<typename T>
+const Array<LogicalArrayElem> & MaskedArray<T>::getMask() const
 {
   assert(ok());
 
@@ -399,7 +399,7 @@ const Array<LogicalArrayElem, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray<T, ArrayAlloc, MaskAlloc>::ndim() const
+template<typename T> size_t MaskedArray<T>::ndim() const
 {
   assert(ok());
 
@@ -407,7 +407,7 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray<T, ArrayAlloc, MaskAlloc>::nelementsValid() const
+template<typename T> size_t MaskedArray<T>::nelementsValid() const
 {
   assert(ok());
 
@@ -429,7 +429,7 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray
 
     freeMaskStorage(maskStorage, maskDelete);
 
-    MaskedArray<T, ArrayAlloc, MaskAlloc> *nonconstThis = (MaskedArray<T, ArrayAlloc, MaskAlloc> *) this;
+    MaskedArray<T> *nonconstThis = (MaskedArray<T> *) this;
     nonconstThis->nelemValid = nelemValidTmp;
     nonconstThis->nelemValidIsOK = true;
    }
@@ -438,7 +438,7 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray<T, ArrayAlloc, MaskAlloc>::nelements() const
+template<typename T> size_t MaskedArray<T>::nelements() const
 {
   assert(ok());
 
@@ -446,7 +446,7 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> size_t MaskedArray
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> bool MaskedArray<T, ArrayAlloc, MaskAlloc>::ok() const
+template<typename T> bool MaskedArray<T>::ok() const
 {
   if (!pArray && !pMask) return true;                       // default constructed is ok
   if (!pArray || !pMask) return false;                      // not both set is not ok
@@ -454,7 +454,7 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> bool MaskedArray<T
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> bool MaskedArray<T, ArrayAlloc, MaskAlloc>::conform(const array_type &other) const
+template<typename T> bool MaskedArray<T>::conform(const array_type &other) const
 {
   assert(ok());
 
@@ -462,8 +462,8 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> bool MaskedArray<T
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-bool MaskedArray<T, ArrayAlloc, MaskAlloc>::conform(const MaskedArray<T, ArrayAlloc, MaskAlloc> &other) const
+template<typename T>
+bool MaskedArray<T>::conform(const MaskedArray<T> &other) const
 {
   assert(ok());
 
@@ -471,17 +471,17 @@ bool MaskedArray<T, ArrayAlloc, MaskAlloc>::conform(const MaskedArray<T, ArrayAl
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> void MaskedArray<T, ArrayAlloc, MaskAlloc>::setReadOnly() const
+template<typename T> void MaskedArray<T>::setReadOnly() const
 {
   assert(ok());
 
-  MaskedArray<T, ArrayAlloc, MaskAlloc> *nonconstThis = (MaskedArray<T, ArrayAlloc, MaskAlloc> *) this;
+  MaskedArray<T> *nonconstThis = (MaskedArray<T> *) this;
   nonconstThis->isRO = true;
 }
 
 
-template <typename T, typename ArrayAlloc, typename MaskAlloc>
-Array<T, ArrayAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray () const
+template <typename T>
+Array<T> MaskedArray<T>::getCompressedArray () const
 {
   array_type result (IPosition (1,nelementsValid()));
 
@@ -517,12 +517,12 @@ Array<T, ArrayAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (
 }
 
 
-template <typename T, typename ArrayAlloc, typename MaskAlloc>
-Array<T, ArrayAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (const IPosition & shape) const
+template <typename T>
+Array<T> MaskedArray<T>::getCompressedArray (const IPosition & shape) const
 {
   if (int(nelementsValid()) != shape.product()) {
     throw (ArrayError
-      ("void MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (const IPosition & shape)"
+      ("void MaskedArray<T>::getCompressedArray (const IPosition & shape)"
         " - input shape will create Array with incorrect number of elements"));
 
    }
@@ -561,12 +561,12 @@ Array<T, ArrayAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (
 }
 
 
-template <typename T, typename ArrayAlloc, typename MaskAlloc>
-void MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (array_type & inarr) const
+template <typename T>
+void MaskedArray<T>::getCompressedArray (array_type & inarr) const
 {
   if (nelementsValid() != inarr.nelements()) {
     throw (ArrayError
-      ("void MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (array_type & inarr)"
+      ("void MaskedArray<T>::getCompressedArray (array_type & inarr)"
         " - input Array number of elements is incorrect"));
 
    }
@@ -601,12 +601,12 @@ void MaskedArray<T, ArrayAlloc, MaskAlloc>::getCompressedArray (array_type & ina
 }
 
 
-template <typename T, typename ArrayAlloc, typename MaskAlloc>
-void MaskedArray<T, ArrayAlloc, MaskAlloc>::setCompressedArray (const array_type & inarr)
+template <typename T>
+void MaskedArray<T>::setCompressedArray (const array_type & inarr)
 {
   if (nelementsValid() != inarr.nelements()) {
     throw (ArrayError
-      ("void MaskedArray<T, ArrayAlloc, MaskAlloc>::setCompressedArray (const array_type & inarr)"
+      ("void MaskedArray<T>::setCompressedArray (const array_type & inarr)"
         " - input array number of elements is incorrect"));
 
    }
@@ -641,8 +641,8 @@ void MaskedArray<T, ArrayAlloc, MaskAlloc>::setCompressedArray (const array_type
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-const T * MaskedArray<T, ArrayAlloc, MaskAlloc>::getArrayStorage (bool &deleteIt) const
+template<typename T>
+const T * MaskedArray<T>::getArrayStorage (bool &deleteIt) const
 {
   assert(ok());
 
@@ -650,8 +650,8 @@ const T * MaskedArray<T, ArrayAlloc, MaskAlloc>::getArrayStorage (bool &deleteIt
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-void MaskedArray<T, ArrayAlloc, MaskAlloc>::freeArrayStorage(const T *&storage, bool deleteIt) const
+template<typename T>
+void MaskedArray<T>::freeArrayStorage(const T *&storage, bool deleteIt) const
 {
   assert(ok());
 
@@ -659,8 +659,8 @@ void MaskedArray<T, ArrayAlloc, MaskAlloc>::freeArrayStorage(const T *&storage, 
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-const LogicalArrayElem * MaskedArray<T, ArrayAlloc, MaskAlloc>::getMaskStorage (bool &deleteIt) const
+template<typename T>
+const LogicalArrayElem * MaskedArray<T>::getMaskStorage (bool &deleteIt) const
 {
   assert(ok());
 
@@ -668,7 +668,7 @@ const LogicalArrayElem * MaskedArray<T, ArrayAlloc, MaskAlloc>::getMaskStorage (
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> void  MaskedArray<T, ArrayAlloc, MaskAlloc>::freeMaskStorage
+template<typename T> void  MaskedArray<T>::freeMaskStorage
 (const LogicalArrayElem *&storage, bool deleteIt) const
 {
   assert(ok());
@@ -678,8 +678,8 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> void  MaskedArray<
 
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::operator=
+template<typename T>
+MaskedArray<T>& MaskedArray<T>::operator=
   (const array_type &inarray)
 {
   assert(ok());
@@ -690,20 +690,20 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::op
     nelemValid = 0;
     nelemValidIsOK = false;
     isRO  = false;
-    
+
     return *this;
   }
 
   if (!conform(inarray)) {
     throw(ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>::operator= "
+      "MaskedArray<T> & MaskedArray<T>::operator= "
       "(const array_type &inarray)"
       "- Conformance error."));
    }
 
   if (isRO) {
     throw(ArrayError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>::operator= "
+      "MaskedArray<T> & MaskedArray<T>::operator= "
       "(const array_type &inarray)"
       "- this is read only."));
    }
@@ -737,8 +737,8 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::op
   return *this;
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::operator=
+template<typename T>
+MaskedArray<T>& MaskedArray<T>::operator=
   (array_type&& inarray)
 {
   assert(ok());
@@ -756,9 +756,9 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::op
   }
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::operator=
-  (const MaskedArray<T, ArrayAlloc, MaskAlloc> &other)
+template<typename T>
+MaskedArray<T>& MaskedArray<T>::operator=
+  (const MaskedArray<T> &other)
 {
   assert(ok());
 
@@ -772,15 +772,15 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::op
 
   if (!conform(other)) {
     throw(ArrayConformanceError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>::operator= "
-      "(const MaskedArray<T, ArrayAlloc, MaskAlloc> &other)"
+      "MaskedArray<T> & MaskedArray<T>::operator= "
+      "(const MaskedArray<T> &other)"
       "- Conformance error."));
    }
 
   if (isRO) {
     throw(ArrayError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>::operator= "
-      "(const MaskedArray<T, ArrayAlloc, MaskAlloc> &other)"
+      "MaskedArray<T> & MaskedArray<T>::operator= "
+      "(const MaskedArray<T> &other)"
       "- this is read only."));
    }
 
@@ -820,15 +820,15 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::op
   return *this;
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::operator=
-  (MaskedArray<T, ArrayAlloc, MaskAlloc>&& other)
+template<typename T>
+MaskedArray<T>& MaskedArray<T>::operator=
+  (MaskedArray<T>&& other)
 {
   assert(ok());
 
   if (other.isReadOnly())
     return operator=(other);
-  
+
   if (this == &other)
     return *this;
 
@@ -848,14 +848,14 @@ MaskedArray<T, ArrayAlloc, MaskAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::op
   }
 }
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc> MaskedArray<T, ArrayAlloc, MaskAlloc> &MaskedArray<T, ArrayAlloc, MaskAlloc>::operator=(const T &val)
+template<typename T> MaskedArray<T> &MaskedArray<T>::operator=(const T &val)
 {
   assert(ok());
   if (!pArray) return *this;
 
   if (isRO) {
     throw(ArrayError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc> & MaskedArray<T, ArrayAlloc, MaskAlloc>::operator= (const T &val)"
+      "MaskedArray<T> & MaskedArray<T>::operator= (const T &val)"
       "- this is read only."));
    }
 
@@ -883,14 +883,14 @@ template<typename T, typename ArrayAlloc, typename MaskAlloc> MaskedArray<T, Arr
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-T * MaskedArray<T, ArrayAlloc, MaskAlloc>::getRWArrayStorage (bool &deleteIt) const
+template<typename T>
+T * MaskedArray<T>::getRWArrayStorage (bool &deleteIt) const
 {
   assert(ok());
 
   if (isRO) {
     throw(ArrayError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::getRWArrayStorage (bool &deleteIt) const"
+      "MaskedArray<T>::getRWArrayStorage (bool &deleteIt) const"
       "- this is read only."));
    }
 
@@ -898,14 +898,14 @@ T * MaskedArray<T, ArrayAlloc, MaskAlloc>::getRWArrayStorage (bool &deleteIt) co
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-void MaskedArray<T, ArrayAlloc, MaskAlloc>::putArrayStorage(T *&storage, bool deleteAndCopy) const
+template<typename T>
+void MaskedArray<T>::putArrayStorage(T *&storage, bool deleteAndCopy) const
 {
   assert(ok());
 
   if (isRO) {
     throw(ArrayError(
-      "MaskedArray<T, ArrayAlloc, MaskAlloc>::putArrayStorage (bool deleteAndCopy) const"
+      "MaskedArray<T>::putArrayStorage (bool deleteAndCopy) const"
       "- this is read only."));
    }
 
@@ -913,14 +913,14 @@ void MaskedArray<T, ArrayAlloc, MaskAlloc>::putArrayStorage(T *&storage, bool de
 }
 
 
-template<typename T, typename ArrayAlloc, typename MaskAlloc>
-Array<T, ArrayAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::getRWArray() const
+template<typename T>
+Array<T>& MaskedArray<T>::getRWArray() const
 {
   assert(ok());
 
   if (isRO) {
     throw(ArrayError(
-      "array_type & MaskedArray<T, ArrayAlloc, MaskAlloc>::getRWArray () const"
+      "array_type & MaskedArray<T>::getRWArray () const"
       "- this is read only."));
    }
 
@@ -930,8 +930,8 @@ Array<T, ArrayAlloc>& MaskedArray<T, ArrayAlloc, MaskAlloc>::getRWArray() const
 
 //# Global functions.
 
-template<typename TL, typename ArrayAllocL, typename MaskAllocL, typename TR, typename ArrayAllocR>
-bool conform2 (const MaskedArray<TL, ArrayAllocL, MaskAllocL> &left, const Array<TR, ArrayAllocR> &right)
+template<typename TLLL, typename TRR>
+bool conform2 (const MaskedArray<TLLL> &left, const Array<TRR> &right)
 {
   IPosition leftShape (left.shape());
   IPosition rightShape (right.shape());
@@ -940,8 +940,8 @@ bool conform2 (const MaskedArray<TL, ArrayAllocL, MaskAllocL> &left, const Array
  ? true : false;
 }
 
-template<typename TL, typename ArrayAllocL, typename TR, typename ArrayAllocR, typename MaskAllocR>
-bool conform2 (const Array<TL, ArrayAllocL> &left, const MaskedArray<TR, ArrayAllocR, MaskAllocR> &right)
+template<typename TLL, typename TRRR>
+bool conform2 (const Array<TLL> &left, const MaskedArray<TRRR> &right)
 {
   IPosition leftShape (left.shape());
   IPosition rightShape (right.shape());
@@ -950,8 +950,8 @@ bool conform2 (const Array<TL, ArrayAllocL> &left, const MaskedArray<TR, ArrayAl
  ? true : false;
 }
 
-template<typename TL, typename ArrayAllocL, typename MaskAllocL, typename TR, typename ArrayAllocR, typename MaskAllocR>
-bool conform2 (const MaskedArray<TL, ArrayAllocL, MaskAllocL> &left, const MaskedArray<TR, ArrayAllocR, MaskAllocR> &right)
+template<typename TLLL, typename TRRR>
+bool conform2 (const MaskedArray<TLLL> &left, const MaskedArray<TRRR> &right)
 {
   IPosition leftShape (left.shape());
   IPosition rightShape (right.shape());

--- a/casa/Arrays/Matrix.h
+++ b/casa/Arrays/Matrix.h
@@ -83,58 +83,58 @@ namespace casacore { //#Begin casa namespace
 // index operations will be bounds-checked. Neither of these should
 // be defined for production code.
 
-template<typename T, typename Alloc> class Matrix : public Array<T, Alloc>
+template<typename T> class Matrix : public Array<T>
 {
 public:
     // A Matrix of length zero in each dimension; zero origin.
-    Matrix(const Alloc& allocator = Alloc());
+    Matrix();
 
     // A Matrix with "l1" rows and "l2" columns.
     // Fill it with the initial value.
-    Matrix(size_t l1, size_t l2, const T &initialValue = T(), const Alloc& allocator = Alloc());
+    Matrix(size_t l1, size_t l2, const T &initialValue = T());
 
     // An uninitialized Matrix with "l1" rows and "l2" columns.
-    Matrix(size_t l1, size_t l2, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator = Alloc());
+    Matrix(size_t l1, size_t l2, typename Array<T>::uninitializedType);
 
     // A matrix of shape with shape "len".
     // Fill it with the initial value.
-    Matrix(const IPosition &len, const T &initialValue = T(), const Alloc& allocator = Alloc());
+    Matrix(const IPosition &len, const T &initialValue = T());
 
     // An uninitialized matrix of shape with shape "len".
-    Matrix(const IPosition &len, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator = Alloc());
+    Matrix(const IPosition &len, typename Array<T>::uninitializedType);
 
     // The copy/move constructor uses reference semantics.
-    Matrix(const Matrix<T, Alloc>& source);
-    Matrix(Matrix<T, Alloc>&& source);
+    Matrix(const Matrix<T>& source);
+    Matrix(Matrix<T>&& source);
 
     // Construct a Matrix by reference from "source". "source must have
     // ndim() of 2 or less.
-    Matrix(const Array<T, Alloc>& source);
-    Matrix(Array<T, Alloc>&& source);
+    Matrix(const Array<T>& source);
+    Matrix(Array<T>&& source);
 
     // Create an Matrix of a given shape from a pointer.
-    Matrix(const IPosition &shape, T *storage, StorageInitPolicy policy = COPY, const Alloc& allocator = Alloc());
+    Matrix(const IPosition &shape, T *storage, StorageInitPolicy policy = COPY);
     // Create an Matrix of a given shape from a pointer. Because the pointer
     // is const, a copy is always made.
     Matrix(const IPosition &shape, const T *storage);
 
     // Create an identity matrix of side length n. (Could not do this as a constructor
     // because of ambiguities with other constructors).
-    static Matrix<T, Alloc> identity (size_t n);
+    static Matrix<T> identity (size_t n);
 
     // Resize to the given shape
     // <group>
-    using Array<T, Alloc>::resize;
+    using Array<T>::resize;
     void resize(size_t nx, size_t ny, bool copyValues=false);
      // </group>
 
-    Matrix<T, Alloc>& operator=(const Matrix<T, Alloc>& source)
+    Matrix<T>& operator=(const Matrix<T>& source)
     { return assign_conforming(source); }
-    Matrix<T, Alloc>& operator=(Matrix<T, Alloc>&& source)
+    Matrix<T>& operator=(Matrix<T>&& source)
     { return assign_conforming(std::move(source)); }
-    Matrix<T, Alloc>& operator=(const Array<T, Alloc>& source)
+    Matrix<T>& operator=(const Array<T>& source)
     { return assign_conforming(source); }
-    Matrix<T, Alloc>& operator=(Array<T, Alloc>&& source)
+    Matrix<T>& operator=(Array<T>&& source)
     { return assign_conforming(std::move(source)); }
    
     // Copy the values from other to this Matrix. If this matrix has zero
@@ -143,31 +143,31 @@ public:
     // Note that the assign function can be used to assign a
     // non-conforming matrix.
     // <group>
-    Matrix<T, Alloc>& assign_conforming(const Matrix<T, Alloc>& source)
-    { Array<T, Alloc>::assign_conforming(source); return *this; }
-    Matrix<T, Alloc>& assign_conforming(Matrix<T, Alloc>&& source)
-    { Array<T, Alloc>::assign_conforming(std::move(source)); return *this; }
+    Matrix<T>& assign_conforming(const Matrix<T>& source)
+    { Array<T>::assign_conforming(source); return *this; }
+    Matrix<T>& assign_conforming(Matrix<T>&& source)
+    { Array<T>::assign_conforming(std::move(source)); return *this; }
     
-    Matrix<T, Alloc>& assign_conforming(const Array<T, Alloc>& source)
+    Matrix<T>& assign_conforming(const Array<T>& source)
     {
       // TODO Should be supported by the Array class,
       // see Cube::operator=(const Array&)
       
       if (source.ndim() == 2) {
-        Array<T, Alloc>::assign_conforming(source);
+        Array<T>::assign_conforming(source);
       } else {
         // This might work if a.ndim == 1 or 2
-        (*this) = Matrix<T, Alloc>(source);
+        (*this) = Matrix<T>(source);
       }
       return *this;
     }
    
-    Matrix<T, Alloc>& assign_conforming(Array<T, Alloc>&& source)
+    Matrix<T>& assign_conforming(Array<T>&& source)
     {
       if (source.ndim() == 2) {
-        Array<T, Alloc>::assign_conforming(std::move(source));
+        Array<T>::assign_conforming(std::move(source));
       } else {
-        (*this) = Matrix<T, Alloc>(std::move(source));
+        (*this) = Matrix<T>(std::move(source));
       }
       return *this;
     }
@@ -175,21 +175,21 @@ public:
 
     // Copy val into every element of this Matrix; i.e. behaves as if
     // val were a constant conformant matrix.
-    Array<T, Alloc>& operator=(const T &val)
-      { return Array<T, Alloc>::operator=(val); }
+    Array<T>& operator=(const T &val)
+      { return Array<T>::operator=(val); }
 
     // Copy to this those values in marray whose corresponding elements
     // in marray's mask are true.
-    Matrix<T, Alloc>& assign_conforming (const MaskedArray<T> &marray)
-      { Array<T, Alloc>::assign_conforming(marray); return *this; }
+    Matrix<T>& assign_conforming (const MaskedArray<T> &marray)
+      { Array<T>::assign_conforming(marray); return *this; }
 
     // Single-pixel addressing. If AIPS_ARRAY_INDEX_CHECK is defined,
     // bounds checking is performed.
     // <group>
     T &operator()(const IPosition &i)
-      { return Array<T, Alloc>::operator()(i); }
+      { return Array<T>::operator()(i); }
     const T &operator()(const IPosition &i) const 
-      { return Array<T, Alloc>::operator()(i); }
+      { return Array<T>::operator()(i); }
     T &operator()(size_t i1, size_t i2)
       {
 	return this->contiguous_p ? this->begin_p[i1 + i2*yinc()] :
@@ -210,11 +210,11 @@ public:
 
     // Return a MaskedArray.
     MaskedArray<T> operator() (const LogicalArray &mask) const
-      { return Array<T, Alloc>::operator() (mask); }
+      { return Array<T>::operator() (mask); }
 
     // Return a MaskedArray.
     MaskedArray<T> operator() (const LogicalArray &mask)
-      { return Array<T, Alloc>::operator() (mask); }
+      { return Array<T>::operator() (mask); }
 
     // </group>
 
@@ -227,33 +227,33 @@ public:
 
     // Return a MaskedArray.
     MaskedArray<T> operator() (const MaskedLogicalArray &mask) const
-      { return Array<T, Alloc>::operator() (mask); }
+      { return Array<T>::operator() (mask); }
 
     // Return a MaskedArray.
     MaskedArray<T> operator() (const MaskedLogicalArray &mask)
-      { return Array<T, Alloc>::operator() (mask); }
+      { return Array<T>::operator() (mask); }
 
     // </group>
 
 
     // Returns a reference to the i'th row.
     // <group>
-    Vector<T, Alloc> row(size_t i);
-    const Vector<T, Alloc> row(size_t i) const;
+    Vector<T> row(size_t i);
+    const Vector<T> row(size_t i) const;
     // </group>
 
     // Returns a reference to the j'th column
     // <group>
-    Vector<T, Alloc> column(size_t j);
-    const Vector<T, Alloc> column(size_t j) const;
+    Vector<T> column(size_t j);
+    const Vector<T> column(size_t j) const;
     // </group>
 
     // Returns a diagonal from the Matrix. The Matrix must be square.
     // n==0 is the main diagonal. n>0 is above the main diagonal, n<0
     // is below it.
     // <group>
-    Vector<T, Alloc> diagonal(long long n=0);
-    const Vector<T, Alloc> diagonal(long long n=0) const;
+    Vector<T> diagonal(long long n=0);
+    const Vector<T> diagonal(long long n=0) const;
     // </group>
 
     // Take a slice of this matrix. Slices are always indexed starting
@@ -265,27 +265,27 @@ public:
     // vd(Slice(0,10),Slice(10,10)) = -1.0; // 10x10 sub-matrix set to -1.0
     // </srcblock>
     // <group>
-    Matrix<T, Alloc> operator()(const Slice &sliceX, const Slice &sliceY);
-    const Matrix<T, Alloc> operator()(const Slice &sliceX, const Slice &sliceY) const;
+    Matrix<T> operator()(const Slice &sliceX, const Slice &sliceY);
+    const Matrix<T> operator()(const Slice &sliceX, const Slice &sliceY) const;
     // </group>
 
     // Slice using IPositions. Required to be defined, otherwise the base
     // class versions are hidden.
     // <group>
-    Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc,
+    Array<T> operator()(const IPosition &blc, const IPosition &trc,
 			const IPosition &incr)
-      { return Array<T, Alloc>::operator()(blc,trc,incr); }
-    const Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc,
+      { return Array<T>::operator()(blc,trc,incr); }
+    const Array<T> operator()(const IPosition &blc, const IPosition &trc,
                               const IPosition &incr) const
-      { return Array<T, Alloc>::operator()(blc,trc,incr); }
-    Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc)
-      { return Array<T, Alloc>::operator()(blc,trc); }
-    const Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc) const
-      { return Array<T, Alloc>::operator()(blc,trc); }
-    Array<T, Alloc> operator()(const Slicer& slicer)
-      { return Array<T, Alloc>::operator()(slicer); }
-    const Array<T, Alloc> operator()(const Slicer& slicer) const
-      { return Array<T, Alloc>::operator()(slicer); }
+      { return Array<T>::operator()(blc,trc,incr); }
+    Array<T> operator()(const IPosition &blc, const IPosition &trc)
+      { return Array<T>::operator()(blc,trc); }
+    const Array<T> operator()(const IPosition &blc, const IPosition &trc) const
+      { return Array<T>::operator()(blc,trc); }
+    Array<T> operator()(const Slicer& slicer)
+      { return Array<T>::operator()(slicer); }
+    const Array<T> operator()(const Slicer& slicer) const
+      { return Array<T>::operator()(slicer); }
     // </group>
 
     // The length of each axis of the Matrix.
@@ -310,7 +310,7 @@ protected:
     // Remove the degenerate axes from other and store result in this matrix.
     // An exception is thrown if removing degenerate axes does not result
     // in a matrix.
-    virtual void doNonDegenerate(const Array<T, Alloc> &other,
+    virtual void doNonDegenerate(const Array<T> &other,
                                  const IPosition &ignoreAxes) override;
                                  
     virtual size_t fixedDimensionality() const override { return 2; }

--- a/casa/Arrays/Matrix.tcc
+++ b/casa/Arrays/Matrix.tcc
@@ -36,51 +36,44 @@
 
 namespace casacore { //#Begin casa namespace
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(const Alloc& allocator)
-: Array<T, Alloc>(IPosition(2, 0), allocator)
+template<typename T> Matrix<T>::Matrix()
+: Array<T>(IPosition(2, 0))
 {
   assert(ok());
 }
 
-/*template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(const IPosition &len, ArrayInitPolicy initPolicy)
-  : Array<T, Alloc>(len, initPolicy)
+template<typename T> Matrix<T>::Matrix(const IPosition &length, const T &initialValue)
+  : Array<T>(length, initialValue)
 {
-    makeIndexingConstants();
-    AlwaysAssert(len.nelements() == 2, ArrayError);
-}*/
-
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(const IPosition &length, const T &initialValue, const Alloc& allocator)
-  : Array<T, Alloc>(length, initialValue, allocator)
-{
-  Array<T, Alloc>::checkBeforeResize(length);
+  Array<T>::checkBeforeResize(length);
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(const IPosition &length, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator)
-  : Array<T, Alloc>(length, Array<T, Alloc>::uninitialized, allocator)
+template<typename T> Matrix<T>::Matrix(const IPosition &length, typename Array<T>::uninitializedType)
+  : Array<T>(length, Array<T>::uninitialized)
 {
-  Array<T, Alloc>::checkBeforeResize(length);
+  Array<T>::checkBeforeResize(length);
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(size_t l1, size_t l2, const T &initialValue, const Alloc& allocator)
-: Array<T, Alloc>(IPosition(2, l1, l2), initialValue, allocator)
+template<typename T> Matrix<T>::Matrix(size_t l1, size_t l2, const T &initialValue)
+: Array<T>(IPosition(2, l1, l2), initialValue)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(size_t l1, size_t l2, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator)
-: Array<T, Alloc>(IPosition(2, l1, l2), Array<T, Alloc>::uninitialized, allocator)
+template<typename T> Matrix<T>::Matrix(size_t l1, size_t l2, typename Array<T>::uninitializedType)
+: Array<T>(IPosition(2, l1, l2), Array<T>::uninitialized)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(const Matrix<T, Alloc>& source)
-  : Array<T, Alloc>(source)
+template<typename T> Matrix<T>::Matrix(const Matrix<T>& source)
+  : Array<T>(source)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(Matrix<T, Alloc>&& source)
-  : Array<T, Alloc>(std::move(source), IPosition(2, 0))
+template<typename T> Matrix<T>::Matrix(Matrix<T>&& source)
+  : Array<T>(std::move(source), IPosition(2, 0))
 {
   assert(ok());
 }
@@ -88,45 +81,45 @@ template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(Matrix<T, Alloc>&&
 // <thrown>
 //    <item> ArrayNDimError
 // </thrown>
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(const Array<T, Alloc>& source)
-: Array<T, Alloc>(source)
+template<typename T> Matrix<T>::Matrix(const Array<T>& source)
+: Array<T>(source)
 {
   this->checkMatrixShape();
   assert(ok());
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc>::Matrix(Array<T, Alloc>&& source)
-: Array<T, Alloc>(std::move(source))
+template<typename T> Matrix<T>::Matrix(Array<T>&& source)
+: Array<T>(std::move(source))
 {
   this->checkMatrixShape();
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-Matrix<T, Alloc>::Matrix(const IPosition &shape, T *storage,
-                  StorageInitPolicy policy, const Alloc& allocator)
-  : Array<T, Alloc>(shape, storage, policy, allocator)
+template<typename T>
+Matrix<T>::Matrix(const IPosition &shape, T *storage,
+                  StorageInitPolicy policy)
+  : Array<T>(shape, storage, policy)
 {
-  Array<T, Alloc>::checkBeforeResize(shape);
+  Array<T>::checkBeforeResize(shape);
 }
 
-template<typename T, typename Alloc>
-Matrix<T, Alloc>::Matrix(const IPosition &shape, const T *storage)
-  : Array<T, Alloc>(shape, storage)
+template<typename T>
+Matrix<T>::Matrix(const IPosition &shape, const T *storage)
+  : Array<T>(shape, storage)
 {
-  Array<T, Alloc>::checkBeforeResize(shape);
+  Array<T>::checkBeforeResize(shape);
 }
 
-template<typename T, typename Alloc> void Matrix<T, Alloc>::resize(size_t nx, size_t ny, bool copyValues)
+template<typename T> void Matrix<T>::resize(size_t nx, size_t ny, bool copyValues)
 {
-  Array<T, Alloc>::resize(IPosition{ssize_t(nx), ssize_t(ny)}, copyValues);
+  Array<T>::resize(IPosition{ssize_t(nx), ssize_t(ny)}, copyValues);
   assert(ok());
 }
 
 // <thrown>
 //    <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc> Matrix<T, Alloc> Matrix<T, Alloc>::operator()(const Slice &sliceX,
+template<typename T> Matrix<T> Matrix<T>::operator()(const Slice &sliceX,
 						  const Slice &sliceY)
 {
   assert(ok());
@@ -152,41 +145,41 @@ template<typename T, typename Alloc> Matrix<T, Alloc> Matrix<T, Alloc>::operator
 
     // Check that the selected slice is valid
     if (s1 < 1 || s2<1) {
-	throw(ArrayError("Matrix<T, Alloc>::operator()(Slice,Slice) : step < 1"));
+	throw(ArrayError("Matrix<T>::operator()(Slice,Slice) : step < 1"));
     } else if (l1 < 0  || l2 < 0) {
-	throw(ArrayError("Matrix<T, Alloc>::operator()(Slice,Slice) : length < 0"));
+	throw(ArrayError("Matrix<T>::operator()(Slice,Slice) : length < 0"));
     } else if ((b1+(l1-1)*s1 >= this->length_p(0)) || 
 	       (b2+(l2-1)*s2 >= this->length_p(1))) {
-	throw(ArrayError("Matrix<T, Alloc>::operator()(Slice,Slice): desired slice"
+	throw(ArrayError("Matrix<T>::operator()(Slice,Slice): desired slice"
 			 " extends beyond the end of the array"));
     } else if (b1 < 0 || b2 < 0) {
-	throw(ArrayError("Matrix<T, Alloc>::operator()(Slice,Slice) : start of slice "
+	throw(ArrayError("Matrix<T>::operator()(Slice,Slice) : start of slice "
 			 "before beginning of matrix"));
     }
 
-    // For simplicity, just use the Array<T, Alloc> slicing. If this is found to be
+    // For simplicity, just use the Array<T> slicing. If this is found to be
     // a performance drag, we could special case this as we do for Vector.
     IPosition blc(2,b1,b2);
     IPosition trc(2,b1+(l1-1)*s1,b2+(l2-1)*s2);
     IPosition incr(2,s1,s2);
     return this->operator()(blc,trc,incr);
 }
-template<typename T, typename Alloc> const Matrix<T, Alloc> Matrix<T, Alloc>::operator()
+template<typename T> const Matrix<T> Matrix<T>::operator()
   (const Slice &sliceX, const Slice &sliceY) const
 {
-    return const_cast<Matrix<T, Alloc>*>(this)->operator() (sliceX, sliceY);
+    return const_cast<Matrix<T>*>(this)->operator() (sliceX, sliceY);
 }
 
 // <thrown>
 //   <item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Vector<T, Alloc> Matrix<T, Alloc>::row(size_t n)
+template<typename T> Vector<T> Matrix<T>::row(size_t n)
 {
   assert(ok());
     if ((long long)(n) >= this->length_p(0)) {
-	throw(ArrayConformanceError("Matrix<T, Alloc>::row - row < 0 or > end"));
+	throw(ArrayConformanceError("Matrix<T>::row - row < 0 or > end"));
     }
-    Matrix<T, Alloc> tmp((*this)(n, Slice())); // A reference
+    Matrix<T> tmp((*this)(n, Slice())); // A reference
     tmp.ndimen_p = 1;
     tmp.length_p(0) = tmp.length_p(1);
     tmp.inc_p(0) = this->steps_p(1);
@@ -199,19 +192,19 @@ template<typename T, typename Alloc> Vector<T, Alloc> Matrix<T, Alloc>::row(size
     tmp.nels_p = tmp.length_p(0);
     tmp.contiguous_p = tmp.isStorageContiguous();
     tmp.makeSteps();
-    return tmp; // should match Vector<T, Alloc>(const Array<T, Alloc> &)
+    return tmp; // should match Vector<T>(const Array<T> &)
 }
 
 // <thrown>
 //   <item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Vector<T, Alloc> Matrix<T, Alloc>::column(size_t n)
+template<typename T> Vector<T> Matrix<T>::column(size_t n)
 {
   assert(ok());
     if ((long long)(n) >= this->length_p(1)) {
-	throw(ArrayConformanceError("Matrix<T, Alloc>::column - column < 0 or > end"));
+	throw(ArrayConformanceError("Matrix<T>::column - column < 0 or > end"));
     }
-    Matrix<T, Alloc> tmp((*this)(Slice(), n)); // A reference
+    Matrix<T> tmp((*this)(Slice(), n)); // A reference
     tmp.ndimen_p = 1;
     tmp.length_p.resize (1);
     tmp.inc_p.resize (1);
@@ -219,56 +212,56 @@ template<typename T, typename Alloc> Vector<T, Alloc> Matrix<T, Alloc>::column(s
     tmp.nels_p = tmp.length_p(0);
     tmp.contiguous_p = tmp.isStorageContiguous();
     tmp.makeSteps();
-    return tmp; // should match Vector<T, Alloc>(const Array<T, Alloc> &)
+    return tmp; // should match Vector<T>(const Array<T> &)
 
 }
 
 // <thrown>
 //   <item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> Vector<T, Alloc> Matrix<T, Alloc>::diagonal(long long n)
+template<typename T> Vector<T> Matrix<T>::diagonal(long long n)
 {
   assert(ok());
-    Matrix<T, Alloc> tmp(*this);
+    Matrix<T> tmp(*this);
     tmp.begin_p += tmp.makeDiagonal (0, n);
     tmp.makeSteps();
-    return tmp;  // should match Vector<T, Alloc>(const Array<T, Alloc> &)
+    return tmp;  // should match Vector<T>(const Array<T> &)
 }
 
-template<typename T, typename Alloc> const Vector<T, Alloc> Matrix<T, Alloc>::row(size_t n) const
+template<typename T> const Vector<T> Matrix<T>::row(size_t n) const
 {
     assert(ok());
     // Cast away constness of this so we do not have to duplicate code.
     // Because the return type is const we are not actually violating
     // constness.
-    Matrix<T, Alloc> *This = const_cast<Matrix<T, Alloc>*>(this);
+    Matrix<T> *This = const_cast<Matrix<T>*>(this);
     return This->row(n);
 }
 
-template<typename T, typename Alloc> const Vector<T, Alloc> Matrix<T, Alloc>::column(size_t n) const
+template<typename T> const Vector<T> Matrix<T>::column(size_t n) const
 {
   assert(ok());
     // Cast away constness of this so we do not have to duplicate code.
     // Because the return type is const we are not actually violating
     // constness.
-    Matrix<T, Alloc> *This = const_cast<Matrix<T, Alloc>*>(this);
+    Matrix<T> *This = const_cast<Matrix<T>*>(this);
     return This->column(n);
 }
 
 // If the matrix isn't square, this will throw an exception.
-template<typename T, typename Alloc> const Vector<T, Alloc> Matrix<T, Alloc>::diagonal(long long n) const
+template<typename T> const Vector<T> Matrix<T>::diagonal(long long n) const
 {
   assert(ok());
     // Cast away constness of this so we do not have to duplicate code.
     // Because the return type is const we are not actually violating
     // constness.
-    Matrix<T, Alloc> *This = const_cast<Matrix<T, Alloc>*>(this);
+    Matrix<T> *This = const_cast<Matrix<T>*>(this);
     return This->diagonal(n);
 }
 
-template<typename T, typename Alloc> Matrix<T, Alloc> Matrix<T, Alloc>::identity(size_t n)
+template<typename T> Matrix<T> Matrix<T>::identity(size_t n)
 {
-    Matrix<T, Alloc> m(n, n, T(0));
+    Matrix<T> m(n, n, T(0));
     T* ptr = m.data();
     for (size_t i=0; i<n; i++) {
         *ptr = T(1);
@@ -277,11 +270,11 @@ template<typename T, typename Alloc> Matrix<T, Alloc> Matrix<T, Alloc>::identity
     return m;
 }
 
-template<typename T, typename Alloc>
-void Matrix<T, Alloc>::doNonDegenerate (const Array<T, Alloc> &other,
+template<typename T>
+void Matrix<T>::doNonDegenerate (const Array<T> &other,
                                  const IPosition &ignoreAxes)
 {
-    Array<T, Alloc> tmp(*this);
+    Array<T> tmp(*this);
     tmp.nonDegenerate (other, ignoreAxes);
     if (tmp.ndim() != 2) {
 	throw (ArrayError ("Matrix::nonDegenerate (other, ignoreAxes) - "
@@ -291,15 +284,15 @@ void Matrix<T, Alloc>::doNonDegenerate (const Array<T, Alloc> &other,
     this->reference (tmp);
 }
 
-template<typename T, typename Alloc> bool Matrix<T, Alloc>::ok() const
+template<typename T> bool Matrix<T>::ok() const
 {
-    return ( (this->ndim() == 2) ? (Array<T, Alloc>::ok()) : false );
+    return ( (this->ndim() == 2) ? (Array<T>::ok()) : false );
 }
 
-template<typename T, typename Alloc>
-void Matrix<T, Alloc>::preTakeStorage(const IPosition &shape)
+template<typename T>
+void Matrix<T>::preTakeStorage(const IPosition &shape)
 {
-  Array<T, Alloc>::preTakeStorage(shape);
+  Array<T>::preTakeStorage(shape);
   if(shape.nelements() != 2)
     throw ArrayError("shape.nelements() != 2");
 }

--- a/casa/Arrays/MatrixIter.h
+++ b/casa/Arrays/MatrixIter.h
@@ -62,26 +62,26 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // average /= float(cube.shape()(2));  // divide by the number of planes
 // </srcblock>
 
-template<typename T, typename Alloc=std::allocator<T>>
-class MatrixIterator : public ArrayIterator<T, Alloc>
+template<typename T>
+class MatrixIterator : public ArrayIterator<T>
 {
 public:
     // Iterate by matrices through array "a".
     // The first 2 axes form the cursor axes.
-    explicit MatrixIterator(Array<T, Alloc> &a);
+    explicit MatrixIterator(Array<T> &a);
 
     // Iterate by matrices through array "a".
     // The given axes form the cursor axes.
-    MatrixIterator(Array<T, Alloc> &a, size_t cursorAxis1, size_t cursorAxis2);
+    MatrixIterator(Array<T> &a, size_t cursorAxis1, size_t cursorAxis2);
 
     // Return the matrix at the current position.
-    Matrix<T, Alloc> &matrix() {return *(Matrix<T, Alloc> *)(this->ap_p.get());}
+    Matrix<T> &matrix() {return *(Matrix<T> *)(this->ap_p.get());}
 
 private:
     // Not implemented.
-    MatrixIterator(const MatrixIterator<T, Alloc> &) = delete;
+    MatrixIterator(const MatrixIterator<T> &) = delete;
     // Not implemented.
-    MatrixIterator<T, Alloc> &operator=(const MatrixIterator<T, Alloc> &) = delete;
+    MatrixIterator<T> &operator=(const MatrixIterator<T> &) = delete;
 };
 
 // 

--- a/casa/Arrays/MatrixIter.tcc
+++ b/casa/Arrays/MatrixIter.tcc
@@ -30,22 +30,22 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<typename T, typename Alloc>
-MatrixIterator<T, Alloc>::MatrixIterator(Array<T, Alloc> &a)
-: ArrayIterator<T, Alloc>(a, 2)
+template<typename T>
+MatrixIterator<T>::MatrixIterator(Array<T> &a)
+: ArrayIterator<T>(a, 2)
 {
     // We need to ensure that ap points at a Matrix
-    this->ap_p.reset( new Matrix<T, Alloc>(*this->ap_p) ); // reference
+    this->ap_p.reset( new Matrix<T>(*this->ap_p) ); // reference
 }
 
-template<typename T, typename Alloc>
-MatrixIterator<T, Alloc>::MatrixIterator(Array<T, Alloc> &a,
+template<typename T>
+MatrixIterator<T>::MatrixIterator(Array<T> &a,
 						    size_t cursorAxis1,
 						    size_t cursorAxis2)
-: ArrayIterator<T, Alloc>(a, IPosition(2, cursorAxis1, cursorAxis2), true)
+: ArrayIterator<T>(a, IPosition(2, cursorAxis1, cursorAxis2), true)
 {
     // We need to ensure that ap points at a Matrix
-    this->ap_p.reset( new Matrix<T, Alloc>(*this->ap_p) );  // reference
+    this->ap_p.reset( new Matrix<T>(*this->ap_p) );  // reference
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/Arrays/Vector.h
+++ b/casa/Arrays/Vector.h
@@ -78,7 +78,7 @@ namespace casacore { //#Begin namespace casacore
 // index operations will be bounds-checked. Neither of these should
 // be defined for production code.
 
-template<typename T, typename Alloc> class Vector : public Array<T, Alloc>
+template<typename T> class Vector : public Array<T>
 {
 public:
     // A zero-length Vector.
@@ -99,8 +99,8 @@ public:
 
     // An uninitialized Vector with a defined length.
     // <group>
-    Vector(size_t Length, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator=Alloc());
-    Vector(const IPosition& Length, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator=Alloc());
+    Vector(size_t Length, typename Array<T>::uninitializedType);
+    Vector(const IPosition& Length, typename Array<T>::uninitializedType);
     // </group>
     
     // Create a Vector from the given std::vector "other." Make it length "nr"
@@ -110,33 +110,31 @@ public:
     
     // Create a Vector of length other.size() and copy over its values.
     // This used to take a 'Block'
-    explicit Vector(const std::vector<T> &other, const Alloc& allocator=Alloc());
+    explicit Vector(const std::vector<T> &other);
 
     // Create a Vector from an initializer list.
     Vector(std::initializer_list<T> list);
 
     // Create a reference to other.
-    Vector(const Vector<T, Alloc> &other);
+    Vector(const Vector<T> &other);
     
     // Move
-    Vector(Vector<T, Alloc>&& source) noexcept;
+    Vector(Vector<T>&& source) noexcept;
     
     // Create a reference to the other array.
     // It is always possible if the array has zero or one axes.
     // If it has > 1 axes, it is only possible if the array has at most
     // one axis with length > 1. In that case the degenerated axes are removed.
-    Vector(const Array<T, Alloc> &other);
+    Vector(const Array<T> &other);
 
     // Create an Vector of a given shape from a pointer.
     Vector(const IPosition &shape, T *storage, StorageInitPolicy policy = COPY);
-    // Create an Vector of a given shape from a pointer.
-    Vector(const IPosition &shape, T *storage, StorageInitPolicy policy, Alloc& allocator);
     // Create an Vector of a given shape from a pointer. Because the pointer
     // is const, a copy is always made.
     Vector(const IPosition &shape, const T *storage);
 
     template<typename InputIterator>
-    Vector(InputIterator startIter, InputIterator endIter, const Alloc& allocator = Alloc());
+    Vector(InputIterator startIter, InputIterator endIter);
 
     // Create a Vector from an STL vector (see <src>tovector()</src> in
     // <linkto class=Array>Array</linkto>  for the reverse operation).
@@ -162,7 +160,7 @@ public:
     //# be hidden).
     // Resize without argument is equal to resize(0, false).
     // <group>
-    using Array<T, Alloc>::resize;
+    using Array<T>::resize;
     void resize(size_t len, bool copyValues=false)
       { if (len != this->nelements()) resize(IPosition(1,len), copyValues); }
     virtual void resize(const IPosition &len, bool copyValues=false) final override;
@@ -177,25 +175,25 @@ public:
     // TODO unlike Array, a Vector assign to an empty Vector does
     // not create a reference but does a value copy of the source.
     // This should be made consistent.
-    using Array<T, Alloc>::assign_conforming;
-    Vector<T, Alloc>& assign_conforming(const Vector<T, Alloc>& source)
+    using Array<T>::assign_conforming;
+    Vector<T>& assign_conforming(const Vector<T>& source)
     {
       return assign_conforming_implementation(source, std::is_copy_assignable<T>());
     }
-    Vector<T, Alloc>& assign_conforming(Vector<T, Alloc>&& source);
+    Vector<T>& assign_conforming(Vector<T>&& source);
     // source must be a 1-dimensional array.
-    Vector<T, Alloc>& assign_conforming(const Array<T, Alloc>& source);
-    Vector<T, Alloc>& assign_conforming(Array<T, Alloc>&& source);
+    Vector<T>& assign_conforming(const Array<T>& source);
+    Vector<T>& assign_conforming(Array<T>&& source);
     // </group>
 
-    using Array<T, Alloc>::operator=;
-    Vector<T, Alloc>& operator=(const Vector<T, Alloc>& source)
+    using Array<T>::operator=;
+    Vector<T>& operator=(const Vector<T>& source)
     { return assign_conforming(source); }
-    Vector<T, Alloc>& operator=(Vector<T, Alloc>&& source)
+    Vector<T>& operator=(Vector<T>&& source)
     { return assign_conforming(std::move(source)); }
-    Vector<T, Alloc>& operator=(const Array<T, Alloc>& source)
+    Vector<T>& operator=(const Array<T>& source)
     { assign_conforming(source); return *this; }
-    Vector<T, Alloc>& operator=(Array<T, Alloc>&& source)
+    Vector<T>& operator=(Array<T>&& source)
     { assign_conforming(std::move(source)); return *this; }
 
     // Convert a Vector to a Block, resizing the block and copying values.
@@ -240,27 +238,27 @@ public:
     // vd(Slice(0,10)) = -1.0; // First 10 elements of vd set to -1
     // </srcblock>
     // <group>
-    Vector<T, Alloc> operator()(const Slice &slice);
-    const Vector<T, Alloc> operator()(const Slice &slice) const;
+    Vector<T> operator()(const Slice &slice);
+    const Vector<T> operator()(const Slice &slice) const;
     // </group>
 
     // Slice using IPositions. Required to be defined, otherwise the base
     // class versions are hidden.
     // <group>
-    Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc,
+    Array<T> operator()(const IPosition &blc, const IPosition &trc,
 			const IPosition &incr)
-      { return Array<T, Alloc>::operator()(blc,trc,incr); }
-    const Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc,
+      { return Array<T>::operator()(blc,trc,incr); }
+    const Array<T> operator()(const IPosition &blc, const IPosition &trc,
                               const IPosition &incr) const
-      { return Array<T, Alloc>::operator()(blc,trc,incr); }
-    Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc)
-      { return Array<T, Alloc>::operator()(blc,trc); }
-    const Array<T, Alloc> operator()(const IPosition &blc, const IPosition &trc) const
-      { return Array<T, Alloc>::operator()(blc,trc); }
-    Array<T, Alloc> operator()(const Slicer& slicer)
-      { return Array<T, Alloc>::operator()(slicer); }
-    const Array<T, Alloc> operator()(const Slicer& slicer) const
-      { return Array<T, Alloc>::operator()(slicer); }
+      { return Array<T>::operator()(blc,trc,incr); }
+    Array<T> operator()(const IPosition &blc, const IPosition &trc)
+      { return Array<T>::operator()(blc,trc); }
+    const Array<T> operator()(const IPosition &blc, const IPosition &trc) const
+      { return Array<T>::operator()(blc,trc); }
+    Array<T> operator()(const Slicer& slicer)
+      { return Array<T>::operator()(slicer); }
+    const Array<T> operator()(const Slicer& slicer) const
+      { return Array<T>::operator()(slicer); }
     // </group>
 
     // The array is masked by the input LogicalArray.
@@ -314,8 +312,8 @@ protected:
     virtual size_t fixedDimensionality() const final override { return 1; }
 
 private:
-    Vector<T, Alloc>& assign_conforming_implementation(const Vector<T, Alloc> &v, std::false_type isCopyable);
-    Vector<T, Alloc>& assign_conforming_implementation(const Vector<T, Alloc> &v, std::true_type isCopyable);
+    Vector<T>& assign_conforming_implementation(const Vector<T> &v, std::false_type isCopyable);
+    Vector<T>& assign_conforming_implementation(const Vector<T> &v, std::true_type isCopyable);
   
     // Helper functions for constructors.
     void initVector(const std::vector<T>&, long long nr);      // copy semantics
@@ -325,10 +323,10 @@ private:
     // and
     // Vector<literal>(iterator, iterator)
     template<typename InputIterator>
-    Vector(InputIterator startIter, InputIterator endIter, const Alloc& allocator, std::false_type /* T is not a literal */);
+    Vector(InputIterator startIter, InputIterator endIter, std::false_type /* T is not a literal */);
     
     template<typename InputIterator>
-    Vector(InputIterator startIter, InputIterator endIter, const Alloc& allocator, std::true_type /* T is literal */);
+    Vector(InputIterator startIter, InputIterator endIter, std::true_type /* T is literal */);
 };
 
 } //#End namespace casacore

--- a/casa/Arrays/Vector.tcc
+++ b/casa/Arrays/Vector.tcc
@@ -36,112 +36,112 @@
 
 namespace casacore { //#Begin casa namespace
 
-template<typename T, typename Alloc> Vector<T, Alloc>::Vector()
-  : Array<T, Alloc>(IPosition(1,0))
+template<typename T> Vector<T>::Vector()
+  : Array<T>(IPosition(1,0))
 {
   assert(ok());
 }
 
 
-template<typename T, typename Alloc> Vector<T, Alloc>::Vector(size_t Length)
-: Array<T, Alloc>(IPosition(1, Length))
+template<typename T> Vector<T>::Vector(size_t Length)
+: Array<T>(IPosition(1, Length))
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>::Vector(const IPosition& len)
-  : Array<T, Alloc>(len)
+template<typename T> Vector<T>::Vector(const IPosition& len)
+  : Array<T>(len)
 { 
-  Array<T, Alloc>::checkBeforeResize(len);
+  Array<T>::checkBeforeResize(len);
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>::Vector(size_t length, const T &initialValue)
-: Array<T, Alloc>(IPosition(1, length), initialValue)
+template<typename T> Vector<T>::Vector(size_t length, const T &initialValue)
+: Array<T>(IPosition(1, length), initialValue)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>::Vector(const IPosition& length, const T &initialValue)
-  : Array<T, Alloc>(length, initialValue)
+template<typename T> Vector<T>::Vector(const IPosition& length, const T &initialValue)
+  : Array<T>(length, initialValue)
 {
-  Array<T, Alloc>::checkBeforeResize(length);
+  Array<T>::checkBeforeResize(length);
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(size_t length, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator)
-  : Array<T, Alloc>(IPosition(1, length), Array<T, Alloc>::uninitialized, allocator)
+template<typename T>
+Vector<T>::Vector(size_t length, typename Array<T>::uninitializedType)
+  : Array<T>(IPosition(1, length), Array<T>::uninitialized)
 {
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const IPosition& length, typename Array<T, Alloc>::uninitializedType, const Alloc& allocator)
-  : Array<T, Alloc>(length, Array<T, Alloc>::uninitialized, allocator)
+template<typename T>
+Vector<T>::Vector(const IPosition& length, typename Array<T>::uninitializedType)
+  : Array<T>(length, Array<T>::uninitialized)
 {
-  Array<T, Alloc>::checkBeforeResize(length);
+  Array<T>::checkBeforeResize(length);
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const std::vector<T> &other, long long nr)
-: Array<T, Alloc>(IPosition(1, other.size()))
+template<typename T>
+Vector<T>::Vector(const std::vector<T> &other, long long nr)
+: Array<T>(IPosition(1, other.size()))
 {
   initVector (other, nr);
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const std::vector<T> &other, const Alloc& allocator)
-: Array<T, Alloc>(IPosition(1, other.size()), const_cast<T*>(other.data()), allocator)
+template<typename T>
+Vector<T>::Vector(const std::vector<T> &other)
+: Array<T>(IPosition(1, other.size()), const_cast<T*>(other.data()))
 {
   assert(ok());
 }
 
 template<>
-inline Vector<bool, std::allocator<bool>>::Vector(const std::vector<bool>& input, const std::allocator<bool>& allocator)
-: Array<bool, std::allocator<bool>>(IPosition(1, input.size()), input.begin(), allocator)
+inline Vector<bool>::Vector(const std::vector<bool>& input)
+: Array<bool>(IPosition(1, input.size()), input.begin())
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc>
+template<typename T>
 template<typename InputIterator>
-Vector<T, Alloc>::Vector(InputIterator startIter, InputIterator endIter, const Alloc& allocator) : Vector<T, Alloc>(startIter, endIter, allocator, std::is_integral<InputIterator>())
+Vector<T>::Vector(InputIterator startIter, InputIterator endIter) : Vector<T>(startIter, endIter, std::is_integral<InputIterator>())
 { }
 
-// Constructor for Vector(nonintegral, nonintegral, allocator)
-template<typename T, typename Alloc>
+// Constructor for Vector(nonintegral, nonintegral)
+template<typename T>
 template<typename InputIterator>
-Vector<T, Alloc>::Vector(InputIterator startIter, InputIterator endIter, const Alloc& allocator, std::false_type) :
-  Array<T, Alloc>(IPosition(1, std::distance(startIter, endIter)), startIter, allocator)
+Vector<T>::Vector(InputIterator startIter, InputIterator endIter, std::false_type) :
+  Array<T>(IPosition(1, std::distance(startIter, endIter)), startIter)
 {
   assert(ok());
 } 
 
-// Constructor for Vector(integral, integral, allocator)
-template<typename T, typename Alloc>
+// Constructor for Vector(integral, integral)
+template<typename T>
 template<typename Integral>
-Vector<T, Alloc>::Vector(Integral length, Integral initialValue, const Alloc& allocator, std::true_type) :
-Array<T, Alloc>(IPosition(1, length), initialValue, allocator)
+Vector<T>::Vector(Integral length, Integral initialValue, std::true_type) :
+Array<T>(IPosition(1, length), initialValue)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(std::initializer_list<T> list)
-: Array<T, Alloc>(list)
+template<typename T>
+Vector<T>::Vector(std::initializer_list<T> list)
+: Array<T>(list)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const Vector<T, Alloc> &other)
-: Array<T, Alloc>(other)
+template<typename T>
+Vector<T>::Vector(const Vector<T> &other)
+: Array<T>(other)
 {
   assert(ok());
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(Vector<T, Alloc>&& source) noexcept
-: Array<T, Alloc>(std::move(source), IPosition(1, 0))
+template<typename T>
+Vector<T>::Vector(Vector<T>&& source) noexcept
+: Array<T>(std::move(source), IPosition(1, 0))
 {
   assert(ok());
 }
@@ -149,9 +149,9 @@ Vector<T, Alloc>::Vector(Vector<T, Alloc>&& source) noexcept
 // <thrown>
 //    <item> ArrayNDimError
 // </thrown>
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const Array<T, Alloc> &other)
-: Array<T, Alloc>(other)
+template<typename T>
+Vector<T>::Vector(const Array<T> &other)
+: Array<T>(other)
 {
     // If not 1 dimension, adjust shape if possible.
     if (this->ndim() != 1) {
@@ -160,21 +160,15 @@ Vector<T, Alloc>::Vector(const Array<T, Alloc> &other)
     assert(ok());
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const IPosition &shape, T *storage, 
+template<typename T>
+Vector<T>::Vector(const IPosition &shape, T *storage,
 		  StorageInitPolicy policy)
-  : Array<T, Alloc>(shape, storage, policy)
+  : Array<T>(shape, storage, policy)
 { }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const IPosition &shape, T *storage,
-                  StorageInitPolicy policy, Alloc& allocator)
-  : Array<T, Alloc>(shape, storage, policy, allocator)
-{ }
-
-template<typename T, typename Alloc>
-Vector<T, Alloc>::Vector(const IPosition &shape, const T *storage)
-  : Array<T, Alloc>(shape, storage)
+template<typename T>
+Vector<T>::Vector(const IPosition &shape, const T *storage)
+  : Array<T>(shape, storage)
 { }
 
 // Copy from the block. Copy the number of elements specified or
@@ -182,15 +176,15 @@ Vector<T, Alloc>::Vector(const IPosition &shape, const T *storage)
 // <thrown>
 //    <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc>
-void Vector<T, Alloc>::initVector(const std::vector<T> &other, long long nr)
+template<typename T>
+void Vector<T>::initVector(const std::vector<T> &other, long long nr)
 {
     size_t n = nr;
     if (nr <= 0) {
       n = other.size();
     }
     if (n > other.size())
-      throw(ArrayError("Vector<T, Alloc>::initVector(const Block<T> &other"
+      throw(ArrayError("Vector<T>::initVector(const Block<T> &other"
         ", long long nr) - nr > other.nelements()"));
     if (this->nelements() != n) {
       this->resize(n);
@@ -204,50 +198,50 @@ void Vector<T, Alloc>::initVector(const std::vector<T> &other, long long nr)
 // <thrown>
 //    <item> ArrayConformanceError
 // </thrown>
-template<typename T, typename Alloc> void Vector<T, Alloc>::resize(const IPosition& l, bool copyValues)
+template<typename T> void Vector<T>::resize(const IPosition& l, bool copyValues)
 {
   assert(ok());
   if (copyValues) {
-    Vector<T, Alloc> oldref(*this);
-    Array<T, Alloc>::resize(l, false);
+    Vector<T> oldref(*this);
+    Array<T>::resize(l, false);
     size_t minNels = std::min(this->nelements(), oldref.nelements());
     move_n_with_stride(oldref.begin_p, minNels, this->begin_p,
     this->inc_p(0), oldref.inc_p(0));
   } else {
-    Array<T, Alloc>::resize(l, false);
+    Array<T>::resize(l, false);
   }
   assert(ok());
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming(const Array<T, Alloc>& a)
+template<typename T> Vector<T>& Vector<T>::assign_conforming(const Array<T>& a)
 {
   assert(ok());
-  Vector<T, Alloc> tmp(a);
+  Vector<T> tmp(a);
   assign_conforming(tmp);
   return *this;
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming(Array<T, Alloc>&& a)
+template<typename T> Vector<T>& Vector<T>::assign_conforming(Array<T>&& a)
 {
   assert(ok());
-  Vector<T, Alloc> tmp(std::move(a));
+  Vector<T> tmp(std::move(a));
   assign_conforming(tmp);
   return *this;
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming_implementation(const Vector<T, Alloc> &, std::false_type /*movable?*/)
+template<typename T> Vector<T>& Vector<T>::assign_conforming_implementation(const Vector<T> &, std::false_type /*movable?*/)
 {
   throw std::runtime_error("assign called for which a copy is required, while element type is not copyable");
 }
 
-template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming_implementation(const Vector<T, Alloc> &other, std::true_type /*movable?*/)
+template<typename T> Vector<T>& Vector<T>::assign_conforming_implementation(const Vector<T> &other, std::true_type /*movable?*/)
 {
     assert(ok());
     if (this != &other) {
         if (! this->copyVectorHelper (other)) {
 	    // Block was empty, so allocate new block.
           // TODO think about semantics of allocator!
-	    this->data_p.reset( new arrays_internal::Storage<T, Alloc>(this->length_p(0), other.data_p->get_allocator()) );
+	    this->data_p.reset( new arrays_internal::Storage<T>(this->length_p(0)) );
 	    this->begin_p = this->data_p->data();
 	}
 	this->setEndIter();
@@ -257,15 +251,15 @@ template<typename T, typename Alloc> Vector<T, Alloc>& Vector<T, Alloc>::assign_
     return *this;
 }
 
-template<typename T, typename Alloc>
-Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming(Vector<T, Alloc>&& source)
+template<typename T>
+Vector<T>& Vector<T>::assign_conforming(Vector<T>&& source)
 {
   assert(ok());
   if(this->nrefs() > 1 || source.nrefs() > 1 || this->data_p->is_shared() || source.data_p->is_shared())
     assign_conforming(source);
   else if(source.ndim() == 0)
   {
-    Vector<T, Alloc> empty;
+    Vector<T> empty;
     casacore::swap(empty, *this);
   }
   else
@@ -276,8 +270,8 @@ Vector<T, Alloc>& Vector<T, Alloc>::assign_conforming(Vector<T, Alloc>&& source)
 // <thrown>
 //    <item> ArrayError
 // </thrown>
-template<typename T, typename Alloc>
-Vector<T, Alloc> Vector<T, Alloc>::operator()(const Slice &slice)
+template<typename T>
+Vector<T> Vector<T>::operator()(const Slice &slice)
 {
     assert(ok());
     long long b, l, s;       // begin length step
@@ -293,14 +287,14 @@ Vector<T, Alloc> Vector<T, Alloc>::operator()(const Slice &slice)
 
     // Check that the selected slice is valid
     if (s < 1) {
-	throw(ArrayError("Vector<T, Alloc>::operator()(Slice) : step < 1"));
+	throw(ArrayError("Vector<T>::operator()(Slice) : step < 1"));
     } else if (l < 0) {
-	throw(ArrayError("Vector<T, Alloc>::operator()(Slice) : length < 0"));
+	throw(ArrayError("Vector<T>::operator()(Slice) : length < 0"));
     } else if (b+(l-1)*s >= this->length_p(0)) {
-	throw(ArrayError("Vector<T, Alloc>::operator()(Slice) : Desired slice extends"
+	throw(ArrayError("Vector<T>::operator()(Slice) : Desired slice extends"
 			 " beyond the end of the array"));
     } else if (b < 0) {
-	throw(ArrayError("Vector<T, Alloc>::operator()(Slice) : start of slice before "
+	throw(ArrayError("Vector<T>::operator()(Slice) : start of slice before "
 			 "beginning of vector"));
     }
 
@@ -309,7 +303,7 @@ Vector<T, Alloc> Vector<T, Alloc>::operator()(const Slice &slice)
     // more efficient.
 
     // Create the vector that will be the slice into this
-    Vector<T, Alloc> vp(*this);
+    Vector<T> vp(*this);
 
     // Increment vp's begin so that it is at the selected position
     vp.begin_p += b*this->steps()[0];
@@ -322,22 +316,22 @@ Vector<T, Alloc> Vector<T, Alloc>::operator()(const Slice &slice)
     return vp;
 }
 
-template<typename T, typename Alloc> const Vector<T, Alloc> Vector<T, Alloc>::operator()
+template<typename T> const Vector<T> Vector<T>::operator()
   (const Slice &slice) const
 {
-    return const_cast<Vector<T, Alloc>*>(this)->operator() (slice);
+    return const_cast<Vector<T>*>(this)->operator() (slice);
 }
 
-template<typename T, typename Alloc>
-void Vector<T, Alloc>::doNonDegenerate (const Array<T> &other,
+template<typename T>
+void Vector<T>::doNonDegenerate (const Array<T> &other,
                                  const IPosition &ignoreAxes)
 {
-    Array<T, Alloc> tmp(*this);
+    Array<T> tmp(*this);
     tmp.nonDegenerate (other, ignoreAxes);
-    Array<T, Alloc>::reference (tmp);
+    Array<T>::reference (tmp);
 }
 
-template<typename T, typename Alloc> bool Vector<T, Alloc>::ok() const
+template<typename T> bool Vector<T>::ok() const
 {
     return  this->ndim() == 1  &&  Array<T>::ok();
 }

--- a/casa/Arrays/Vector2.tcc
+++ b/casa/Arrays/Vector2.tcc
@@ -30,9 +30,9 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<class T, typename Alloc>
+template<class T>
 template <class U, class V>
-Vector<T, Alloc>::Vector(const std::vector<U, V> &other)
+Vector<T>::Vector(const std::vector<U, V> &other)
   : Array<T>(IPosition(1, other.size()))
 {
   size_t i=0;
@@ -41,10 +41,10 @@ Vector<T, Alloc>::Vector(const std::vector<U, V> &other)
     (*this)[i++] = (T)*pos;
   }
 }
-template<class T, typename Alloc>
+template<class T>
 template<class Iterator>
-Vector<T, Alloc>::Vector(Iterator first, size_t size, int)
-  : Array<T, Alloc>(IPosition(1, size)) {
+Vector<T>::Vector(Iterator first, size_t size, int)
+  : Array<T>(IPosition(1, size)) {
   for (size_t i=0; i<size; ++i, ++first) {
     (*this)[i] = *first;
   }

--- a/casa/Arrays/VectorIter.h
+++ b/casa/Arrays/VectorIter.h
@@ -67,22 +67,22 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // }
 // </srcblock>
 
-template<typename T, typename Alloc=std::allocator<T>>
-class VectorIterator : public ArrayIterator<T, Alloc>
+template<typename T>
+class VectorIterator : public ArrayIterator<T>
 {
 public:
     // Iterate by vector cursors through array "a".
     // The vector cursor is taken for the given axis.
-    explicit VectorIterator(Array<T, Alloc> &a, size_t axis=0);
+    explicit VectorIterator(Array<T> &a, size_t axis=0);
 
     // Return a Vector at the current position.
-    Vector<T, Alloc> &vector() {return *(Vector<T, Alloc> *)this->ap_p.get();}
+    Vector<T> &vector() {return *(Vector<T> *)this->ap_p.get();}
 
 private:
     // Not implemented.
-    VectorIterator(const VectorIterator<T, Alloc> &) = delete;
+    VectorIterator(const VectorIterator<T> &) = delete;
     // Not implemented.
-    VectorIterator<T, Alloc> &operator=(const VectorIterator<T, Alloc> &) = delete;
+    VectorIterator<T> &operator=(const VectorIterator<T> &) = delete;
 };
 
 // 
@@ -97,19 +97,19 @@ private:
 //        ArrayIterator.
 // </note>
 
-template<typename T, typename Alloc=std::allocator<T>> class ReadOnlyVectorIterator 
+template<typename T> class ReadOnlyVectorIterator
 {
 public:
     // <group>
-    explicit ReadOnlyVectorIterator(const Array<T, Alloc> &a, size_t axis=0)
+    explicit ReadOnlyVectorIterator(const Array<T> &a, size_t axis=0)
       : vi(const_cast<Array<T>&>(a), axis) {}
 
     void next()   {vi.next();}
     void reset() {vi.origin();}
     void origin() {vi.origin();}
     
-    const Array<T, Alloc> &array() {return vi.array();}
-    const Vector<T, Alloc> &vector() {return vi.vector();}
+    const Array<T> &array() {return vi.array();}
+    const Vector<T> &vector() {return vi.vector();}
 
     bool atStart() const {return vi.atStart();}
     bool pastEnd() const {return vi.pastEnd();}
@@ -119,11 +119,11 @@ public:
     // </group>
 private:
     // Not implemented.
-    ReadOnlyVectorIterator(const ReadOnlyVectorIterator<T, Alloc> &) = delete;
+    ReadOnlyVectorIterator(const ReadOnlyVectorIterator<T> &) = delete;
     // Not implemented.
-    ReadOnlyVectorIterator<T, Alloc> &operator=(const ReadOnlyVectorIterator<T, Alloc> &) = delete;
+    ReadOnlyVectorIterator<T> &operator=(const ReadOnlyVectorIterator<T> &) = delete;
 
-    VectorIterator<T, Alloc> vi;
+    VectorIterator<T> vi;
 };
 
 

--- a/casa/Arrays/VectorIter.tcc
+++ b/casa/Arrays/VectorIter.tcc
@@ -30,11 +30,11 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template<typename T, typename Alloc> VectorIterator<T, Alloc>::VectorIterator(Array<T, Alloc> &a, size_t axis)
-  : ArrayIterator<T, Alloc>(a, IPosition(1,axis), true)
+template<typename T> VectorIterator<T>::VectorIterator(Array<T> &a, size_t axis)
+  : ArrayIterator<T>(a, IPosition(1,axis), true)
 {
     // We need to ensure that ap points at a vector
-    this->ap_p.reset( new Vector<T, Alloc>(*this->ap_p) ); // reference
+    this->ap_p.reset( new Vector<T>(*this->ap_p) ); // reference
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/Arrays/VectorSTLIterator.h
+++ b/casa/Arrays/VectorSTLIterator.h
@@ -60,7 +60,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // </ul>
 // </synopsis>
 
-template <typename T, typename Alloc=std::allocator<T>>
+template <typename T>
 class VectorSTLIterator
 : public std::iterator<std::random_access_iterator_tag, T> {
  public:
@@ -77,14 +77,14 @@ class VectorSTLIterator
   // the same as if created from <src>Vector.begin()</src>. Copy
   // constructor and assignment can be the default ones.
   // <group>
-  explicit VectorSTLIterator(const Vector<T, Alloc> &c)
+  explicit VectorSTLIterator(const Vector<T> &c)
     : start_p(const_cast<T*>(c.data())), 
       step_p (std::max(ssize_t(1), c.steps()(0))),
       iter_p (const_cast<T*>(c.data()))
   {}
   VectorSTLIterator() : start_p(0), step_p(1), iter_p(0)
   {}
-  VectorSTLIterator(const typename Array<T, Alloc>::IteratorSTL &c)
+  VectorSTLIterator(const typename Array<T>::IteratorSTL &c)
     : start_p(c.pos()), 
       step_p (std::max(ssize_t(1), c.steps()(0))),
       iter_p (start_p)
@@ -106,19 +106,19 @@ class VectorSTLIterator
     iterator t = *this; iter_p+=step_p; return t; }; 
   iterator &operator--() { iter_p-=step_p; return *this; };
   iterator operator--(int) {
-    VectorSTLIterator<T, Alloc> t = *this;iter_p-=step_p; return t; }; 
+    VectorSTLIterator<T> t = *this;iter_p-=step_p; return t; };
   iterator &operator+=(difference_type i) {
     iter_p+=i*step_p; return *this; };
   iterator &operator-=(difference_type i) {
     iter_p-=i*step_p; return *this; };
   iterator operator+(difference_type i) const {
-    VectorSTLIterator<T, Alloc> t = *this; return t+=i; };
+    VectorSTLIterator<T> t = *this; return t+=i; };
   iterator operator-(difference_type i) const {
-    VectorSTLIterator<T, Alloc> t = *this; return t-=i; };
+    VectorSTLIterator<T> t = *this; return t-=i; };
   // </group>
   // Size related
   // <group>
-  difference_type operator-(const VectorSTLIterator<T, Alloc> &x) const {
+  difference_type operator-(const VectorSTLIterator<T> &x) const {
     return (iter_p-x.iter_p)/step_p; };
   // </group>
   // Comparisons

--- a/casa/Arrays/test/tAllocator.cc
+++ b/casa/Arrays/test/tAllocator.cc
@@ -130,17 +130,6 @@ BOOST_AUTO_TEST_CASE(poolallocator)
   alloc.deallocate(c, 1);
 }
 
-BOOST_AUTO_TEST_CASE(custom_allocator_array)
-{
-  PoolAllocator<int> allocA(1024), allocB(1024);
-  Array<int, PoolAllocator<int>>
-    a(allocA),
-    b(IPosition(2, 3), 1982, allocA);
-  a = std::move(b);
-  Array<int, PoolAllocator<int>> c(IPosition(4, 1), allocB);
-  c.assign( a );
-}
-
 BOOST_AUTO_TEST_CASE(array_shared_storage)
 {
   int storage = 42;

--- a/casa/Arrays/test/tArray.cc
+++ b/casa/Arrays/test/tArray.cc
@@ -677,20 +677,19 @@ BOOST_AUTO_TEST_CASE( life_cycle_7 )
   IPosition const shape(2, 2, 3);
   size_t const nelems = shape.product();
   LifecycleChecker::clear();
-  std::allocator<LifecycleChecker> allocator;
-  LifecycleChecker *ptr = allocator.allocate(shape.product());
+  LifecycleChecker *ptr = std::allocator<LifecycleChecker>().allocate(shape.product());
   for (size_t i = 0; i < nelems; ++i) {
-      allocator.construct(&ptr[i]);
+      std::allocator<LifecycleChecker>().construct(&ptr[i]);
   }
   {
     Array<LifecycleChecker> a;
-    a.takeStorage(shape, ptr, SHARE, allocator);
+    a.takeStorage(shape, ptr, SHARE);
     a.resize(IPosition(2, 3, 3), false);
   }
   for (size_t i = 0; i < nelems; ++i) {
-    allocator.destroy(&ptr[i]);
+    std::allocator<LifecycleChecker>().destroy(&ptr[i]);
   }
-  allocator.deallocate(ptr, nelems);
+  std::allocator<LifecycleChecker>().deallocate(ptr, nelems);
   BOOST_CHECK_EQUAL(LifecycleChecker::ctor_count, LifecycleChecker::dtor_count);
 }
 
@@ -706,7 +705,7 @@ BOOST_AUTO_TEST_CASE( life_cycle_8 )
   }
   {
     Array<LifecycleChecker> a;
-    a.takeStorage(shape, ptr, TAKE_OVER, allocator);
+    a.takeStorage(shape, ptr, TAKE_OVER);
     a.resize(IPosition(2, 3, 3), true);
   }
   BOOST_CHECK_EQUAL(LifecycleChecker::ctor_count, LifecycleChecker::dtor_count);
@@ -721,7 +720,7 @@ BOOST_AUTO_TEST_CASE( life_cycle_9 )
   LifecycleChecker *ptr = allocator.allocate(shape.product());
   {
       Array<LifecycleChecker> a;
-      a.takeStorage(shape, ptr, COPY, allocator);
+      a.takeStorage(shape, ptr, COPY);
   }
   allocator.deallocate(ptr, nelems);
   BOOST_CHECK_EQUAL(LifecycleChecker::ctor_count, LifecycleChecker::dtor_count);
@@ -738,7 +737,7 @@ BOOST_AUTO_TEST_CASE( life_cycle_10 )
     allocator.construct(&ptr[i]);
   }
   {
-    Array<LifecycleChecker> a(shape, ptr, SHARE, allocator);
+    Array<LifecycleChecker> a(shape, ptr, SHARE);
   }
   for (size_t i = 0; i < nelems; ++i) {
     allocator.destroy(&ptr[i]);
@@ -758,7 +757,7 @@ BOOST_AUTO_TEST_CASE( life_cycle_11 )
     allocator.construct(&ptr[i]);
   }
   {
-    Array<LifecycleChecker> a(shape, ptr, TAKE_OVER, allocator);
+    Array<LifecycleChecker> a(shape, ptr, TAKE_OVER);
   }
   BOOST_CHECK_EQUAL(LifecycleChecker::ctor_count, LifecycleChecker::dtor_count);
 }
@@ -771,7 +770,7 @@ BOOST_AUTO_TEST_CASE( life_cycle_12 )
   std::allocator<LifecycleChecker> allocator;
   LifecycleChecker *ptr = allocator.allocate(shape.product());
   {
-      Array<LifecycleChecker> a(shape, ptr, COPY, allocator);
+      Array<LifecycleChecker> a(shape, ptr, COPY);
   }
   allocator.deallocate(ptr, nelems);
   BOOST_CHECK_EQUAL(LifecycleChecker::ctor_count, LifecycleChecker::dtor_count);

--- a/casa/Arrays/test/tBoxedArrayMath.cc
+++ b/casa/Arrays/test/tBoxedArrayMath.cc
@@ -39,8 +39,8 @@ using namespace std;
 
 BOOST_AUTO_TEST_SUITE(boxed_array_math)
 
-template<typename T, typename Alloc>
-void check(const Array<T, Alloc>& a, const IPosition& expectedShape, std::initializer_list<T> expectedValues)
+template<typename T>
+void check(const Array<T>& a, const IPosition& expectedShape, std::initializer_list<T> expectedValues)
 {
   BOOST_CHECK_EQUAL(a.shape(), expectedShape);
   if(a.shape() == expectedShape)
@@ -55,8 +55,8 @@ void check(const Array<T, Alloc>& a, const IPosition& expectedShape, std::initia
     }
   }
 }
-template<typename Alloc>
-void check(const Array<bool, Alloc>& a, const IPosition& expectedShape, std::initializer_list<bool> expectedValues)
+
+void check(const Array<bool>& a, const IPosition& expectedShape, std::initializer_list<bool> expectedValues)
 {
   BOOST_CHECK_EQUAL(a.shape(), expectedShape);
   if(a.shape() == expectedShape)

--- a/casa/IO/ArrayIO.h
+++ b/casa/IO/ArrayIO.h
@@ -98,7 +98,7 @@ class String;
 // Write a formatted copy of the array to the LogIO output object. Merely calls
 // the ostream operator<< in turn.
 template<typename T, typename Alloc>
-LogIO &operator<<(LogIO &os, const Array<T, Alloc> &a);
+LogIO &operator<<(LogIO &os, const Array<T> &a);
 
 // Read or write a binary representation of an Array to a file. Very
 // useful for saving arrays and restoring them later.
@@ -108,13 +108,13 @@ LogIO &operator<<(LogIO &os, const Array<T, Alloc> &a);
 // <group>
 
 template<typename T, typename Alloc>
-AipsIO &operator<< (AipsIO &, const Array<T, Alloc> &);
+AipsIO &operator<< (AipsIO &, const Array<T> &);
 
 template<typename T, typename Alloc>
-void putArray (AipsIO &, const Array<T, Alloc> &, const char* name);
+void putArray (AipsIO &, const Array<T> &, const char* name);
 
 template<typename T, typename Alloc>
-AipsIO &operator>> (AipsIO &, Array<T, Alloc> &);
+AipsIO &operator>> (AipsIO &, Array<T> &);
 
 // </group>
 
@@ -170,10 +170,10 @@ AipsIO &operator>> (AipsIO &, Array<T, Alloc> &);
 // </note>
 // <group>
 template <typename T, typename Alloc>
-void write_array (const Array<T, Alloc>& the_array, const std::string& fileName);
+void write_array (const Array<T>& the_array, const std::string& fileName);
 
 template <typename T, typename Alloc>
-inline void write_array (const Array<T, Alloc>& the_array, const char* fileName)
+inline void write_array (const Array<T>& the_array, const char* fileName)
     { write_array (the_array, std::string(fileName)); }
 // </group>
 
@@ -186,10 +186,10 @@ inline void write_array (const Array<T, Alloc>& the_array, const char* fileName)
 // </note>
 // <group>
 template <typename T, typename Alloc>
-void read_array (Array<T, Alloc>& the_array, const std::string& fileName);
+void read_array (Array<T>& the_array, const std::string& fileName);
 
 template <typename T, typename Alloc>
-inline void read_array (Array<T, Alloc>& the_array, const char* fileName)
+inline void read_array (Array<T>& the_array, const char* fileName)
     { read_array (the_array, std::string(fileName)); }
 // </group>
 
@@ -202,10 +202,10 @@ inline void read_array (Array<T, Alloc>& the_array, const char* fileName)
 
 // <group>
 template <typename T, typename Alloc>
-void readAsciiVector (Vector<T, Alloc>& vec, const char* fileName);
+void readAsciiVector (Vector<T>& vec, const char* fileName);
 
 template <typename T, typename Alloc>
-void writeAsciiVector (const Vector<T, Alloc>& vec, const char* fileName);
+void writeAsciiVector (const Vector<T>& vec, const char* fileName);
 // </group>
 
 // </group>
@@ -215,7 +215,7 @@ AipsIO& operator>> (AipsIO& aio, IPosition& ip);
 LogIO& operator<< (LogIO& os, const IPosition& ip);
 
 template<typename T, typename Alloc>
-Block<T> makeBlock(const Array<T, Alloc>& array);
+Block<T> makeBlock(const Array<T>& array);
 
 template<typename T>
 Vector<T> makeVector(const Block<T>& block);

--- a/casa/IO/ArrayIO.tcc
+++ b/casa/IO/ArrayIO.tcc
@@ -140,8 +140,8 @@ inline LogIO& operator<< (LogIO& os, const IPosition& ip)
     return os;
 }
 
-template<typename T, typename Alloc>
-Block<T> makeBlock(const Array<T, Alloc>& array)
+template<typename T>
+Block<T> makeBlock(const Array<T>& array)
 {
 	Block<T> block(array.nelements());
 	if(array.contiguousStorage())


### PR DESCRIPTION
This simplifies the Array code quite a lot, and probably (not tested) results in a compilation speed up. It also improves compiler error output when a parameter is in error.

Finally, although leaving the template allocator empty results in the default state-less std::allocator, which the compiler should be able to optimize away, in practice this wasn't true. The Array constructor in particular became quite a bit faster by removing the allocator.