### PR TITLE
Make a destructor noexcept

### DIFF
--- a/tables/DataMan/MSMIndColumn.cc
+++ b/tables/DataMan/MSMIndColumn.cc
@@ -68,7 +68,6 @@ void MSMIndColumn::setShape (rownr_t rownr, const IPosition& shape)
     if (ptr->shape().isEqual (shape)) {
       return;
     }
-    ptr->clear(dataType());
     delete ptr;
   }
   // Create the array.
@@ -273,43 +272,32 @@ void MSMIndColumn::remove (rownr_t rownr)
 
 void MSMIndColumn::deleteArray (rownr_t rownr)
 {
-  Data* ptr = MSMINDCOLUMN_GETDATA(rownr);
   // Remove the array for this row (if there).
-  if (ptr != 0) {
-    ptr->clear(dataType());
-    delete ptr;
-  }
+  delete MSMINDCOLUMN_GETDATA(rownr);
 }
 
 
 
   MSMIndColumn::Data::Data (const IPosition& shape, int dtype, int elemSize)
 : shape_p (shape),
-  data_p  (0)
+  data_p  (nullptr),
+  data_is_string(dtype == TpString)
 {
   Int64 nelem = shape.product();
-  if (dtype == TpString) {
+  if (data_is_string) {
     data_p = new String[nelem];
   } else {
     data_p = new char[nelem * elemSize];
   }
 }
 
-MSMIndColumn::Data::~Data() noexcept(false)
+MSMIndColumn::Data::~Data()
 {
-  if (data_p != 0) {
-    throw DataManInternalError("MSMIndColumn::dtor: data array not deleted");
-  }
-}
-
-void MSMIndColumn::Data::clear (int dtype)
-{
-  if (dtype == TpString) {
+  if (data_is_string) {
     delete [] static_cast<String*>(data_p);
   } else {
     delete [] static_cast<char*>(data_p);
   }
-  data_p = 0;
 }
 
 } //# NAMESPACE CASACORE - END

--- a/tables/DataMan/MSMIndColumn.h
+++ b/tables/DataMan/MSMIndColumn.h
@@ -135,9 +135,7 @@ private:
   class Data {
   public:
     Data (const IPosition& shape, int dtype, int elemSize);
-    //# explicitly specify noexcept to squash compiler warning
-    ~Data() noexcept(false);
-    void clear (int dtype);
+    ~Data();
     const IPosition& shape() const {return shape_p;}
     void* data() {return data_p;}
   private:
@@ -145,6 +143,7 @@ private:
     Data& operator= (const Data&);
     IPosition shape_p;
     void* data_p;
+    bool data_is_string;
   };
   // The shape of all arrays in case it is fixed.
   IPosition fixedShape_p;


### PR DESCRIPTION
The change makes the clear function obsolete, so the class becomes more like a typical RAII object.