### PR TITLE
Replace PtrHolder by std::unique_ptr

### DIFF
--- a/casa/BasicMath/Random.cc
+++ b/casa/BasicMath/Random.cc
@@ -28,8 +28,8 @@
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -486,11 +486,11 @@ Random* Random::construct(Random::Types type, RNG* gen) {
 
 Vector<Double> Random::defaultParameters (Random::Types type) {
   MLCG gen;
-  const PtrHolder<Random> ranPtr(construct(type, &gen));
-  if (ranPtr.ptr() == 0) {
+  const std::unique_ptr<Random> ranPtr(construct(type, &gen));
+  if (!ranPtr) {
     return Vector<Double>();
   } else {
-    return ranPtr.ptr()->parameters();
+    return ranPtr->parameters();
   }
 }
 

--- a/casa/Quanta/QuantumHolder.cc
+++ b/casa/Quanta/QuantumHolder.cc
@@ -49,7 +49,9 @@ QuantumHolder::QuantumHolder(const QuantumHolder &other)
   : RecordTransformable(),
     hold_p()
 {
-  if (other.hold_p) hold_p.reset(other.hold_p->clone());
+  if (other.hold_p) {
+    hold_p.reset (other.hold_p->clone());
+  }
 }
 
 //# Destructor
@@ -59,7 +61,7 @@ QuantumHolder::~QuantumHolder() {}
 QuantumHolder &QuantumHolder::operator=(const QuantumHolder &other) {
   if (this != &other) {
     if (other.hold_p) {
-      hold_p.reset(other.hold_p->clone());
+      hold_p.reset (other.hold_p->clone());
     } else {
       hold_p.reset();
     }
@@ -137,32 +139,32 @@ Bool QuantumHolder::isQuantumDComplex() const {
 
 Bool QuantumHolder::isQuantumArrayDouble() const {
   return (hold_p &&
-		(hold_p->type() == Quantum<Array<Double> >::myType() ||
-		 hold_p->type() == Quantum<Vector<Double> >::myType()));
+		(hold_p->type() == Quantum<Array<Double>>::myType() ||
+		 hold_p->type() == Quantum<Vector<Double>>::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayFloat() const {
   return (hold_p &&
-  		(hold_p->type() == Quantum<Array<Float> >::myType() ||
-		 hold_p->type() == Quantum<Vector<Float> >::myType()));
+  		(hold_p->type() == Quantum<Array<Float>>::myType() ||
+		 hold_p->type() == Quantum<Vector<Float>>::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayInt() const {
   return (hold_p &&
-  		(hold_p->type() == Quantum<Array<Int> >::myType() ||
-		 hold_p->type() == Quantum<Vector<Int> >::myType()));
+  		(hold_p->type() == Quantum<Array<Int>>::myType() ||
+		 hold_p->type() == Quantum<Vector<Int>>::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayComplex() const {
   return (hold_p &&
-  		(hold_p->type() == Quantum<Array<Complex> >::myType() ||
-		 hold_p->type() == Quantum<Vector<Complex> >::myType()));
+  		(hold_p->type() == Quantum<Array<Complex>>::myType() ||
+		 hold_p->type() == Quantum<Vector<Complex>>::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayDComplex() const {
   return (hold_p &&
-  		(hold_p->type() == Quantum<Array<DComplex> >::myType() ||
-		 hold_p->type() == Quantum<Vector<DComplex> >::myType()));
+  		(hold_p->type() == Quantum<Array<DComplex>>::myType() ||
+		 hold_p->type() == Quantum<Vector<DComplex>>::myType()));
 }
 
 Bool QuantumHolder::isQuantumVectorDouble() const {
@@ -285,7 +287,7 @@ const Quantum<DComplex> &QuantumHolder::asQuantumDComplex() {
   return static_cast<const Quantum<DComplex>&>(*hold_p);
 }
 
-const Quantum<Vector<Double> > &QuantumHolder::asQuantumVectorDouble() {
+const Quantum<Vector<Double>> &QuantumHolder::asQuantumVectorDouble() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorDouble"));
   }
@@ -307,7 +309,7 @@ const Quantum<Vector<Double> > &QuantumHolder::asQuantumVectorDouble() {
   return static_cast<const Quantum<Vector<Double>>&>(*hold_p);
 }
 
-const Quantum<Vector<Float> > &QuantumHolder::asQuantumVectorFloat() {
+const Quantum<Vector<Float>> &QuantumHolder::asQuantumVectorFloat() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorFloat"));
   }
@@ -329,7 +331,7 @@ const Quantum<Vector<Float> > &QuantumHolder::asQuantumVectorFloat() {
   return static_cast<const Quantum<Vector<Float>>&>(*hold_p);
 }
 
-const Quantum<Vector<Int> > &QuantumHolder::asQuantumVectorInt() {
+const Quantum<Vector<Int>> &QuantumHolder::asQuantumVectorInt() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorInt"));
   }
@@ -351,7 +353,7 @@ const Quantum<Vector<Int> > &QuantumHolder::asQuantumVectorInt() {
   return static_cast<const Quantum<Vector<Int>>&>(*hold_p);
 }
 
-const Quantum<Vector<Complex> > &QuantumHolder::asQuantumVectorComplex() {
+const Quantum<Vector<Complex>> &QuantumHolder::asQuantumVectorComplex() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorComplex"));
   }
@@ -370,7 +372,7 @@ const Quantum<Vector<Complex> > &QuantumHolder::asQuantumVectorComplex() {
   return static_cast<const Quantum<Vector<Complex>>&>(*hold_p);
 }
 
-const Quantum<Vector<DComplex> > &QuantumHolder::asQuantumVectorDComplex() {
+const Quantum<Vector<DComplex>> &QuantumHolder::asQuantumVectorDComplex() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorDComplex"));
   }
@@ -389,7 +391,7 @@ const Quantum<Vector<DComplex> > &QuantumHolder::asQuantumVectorDComplex() {
   return static_cast<const Quantum<Vector<DComplex>>&>(*hold_p);
 }
 
-const Quantum<Array<Double> > &QuantumHolder::asQuantumArrayDouble() {
+const Quantum<Array<Double>> &QuantumHolder::asQuantumArrayDouble() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayDouble"));
   }
@@ -407,7 +409,7 @@ const Quantum<Array<Double> > &QuantumHolder::asQuantumArrayDouble() {
   return static_cast<const Quantum<Array<Double>>&>(*hold_p);
 }
 
-const Quantum<Array<Float> > &QuantumHolder::asQuantumArrayFloat() {
+const Quantum<Array<Float>> &QuantumHolder::asQuantumArrayFloat() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayFloat"));
   }
@@ -425,7 +427,7 @@ const Quantum<Array<Float> > &QuantumHolder::asQuantumArrayFloat() {
   return static_cast<const Quantum<Array<Float>>&>(*hold_p);
 }
 
-const Quantum<Array<Int> > &QuantumHolder::asQuantumArrayInt() {
+const Quantum<Array<Int>> &QuantumHolder::asQuantumArrayInt() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayInt"));
   }
@@ -443,7 +445,7 @@ const Quantum<Array<Int> > &QuantumHolder::asQuantumArrayInt() {
   return static_cast<const Quantum<Array<Int>>&>(*hold_p);
 }
 
-const Quantum<Array<Complex> > &QuantumHolder::asQuantumArrayComplex() {
+const Quantum<Array<Complex>> &QuantumHolder::asQuantumArrayComplex() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayComplex"));
   }
@@ -458,7 +460,7 @@ const Quantum<Array<Complex> > &QuantumHolder::asQuantumArrayComplex() {
   return static_cast<const Quantum<Array<Complex>>&>(*hold_p);
 }
 
-const Quantum<Array<DComplex> > &QuantumHolder::asQuantumArrayDComplex() {
+const Quantum<Array<DComplex>> &QuantumHolder::asQuantumArrayDComplex() {
   if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayDComplex"));
   }
@@ -485,70 +487,70 @@ Bool QuantumHolder::fromRecord(String &error,
     {
       Double vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Double>(vl, un));
+      hold_p.reset (new Quantum<Double>(vl, un));
       return True;
     }
     case TpFloat:
     {
       Float vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Float>(vl, un));
+      hold_p.reset (new Quantum<Float>(vl, un));
       return True;
     }
     case TpInt:
     {
       Int vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Int>(vl, un));
+      hold_p.reset (new Quantum<Int>(vl, un));
       return True;
     }
     case TpComplex:
     {
       Complex vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Complex>(vl, un));
+      hold_p.reset (new Quantum<Complex>(vl, un));
       return True;
     }
     case TpDComplex:
     {
       DComplex vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<DComplex>(vl, un));
+      hold_p.reset (new Quantum<DComplex>(vl, un));
       return True;
     }
     case TpArrayDouble:
     {
       Array<Double> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Array<Double> >(vl, un));
+      hold_p.reset (new Quantum<Array<Double>>(vl, un));
       return True;
     }
     case TpArrayFloat:
     {
       Array<Float> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Array<Float> >(vl, un));
+      hold_p.reset (new Quantum<Array<Float>>(vl, un));
       return True;
     }
     case TpArrayInt:
     {
       Array<Int> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Array<Int> >(vl, un));
+      hold_p.reset (new Quantum<Array<Int>>(vl, un));
       return True;
     }
     case TpArrayComplex:
     {
       Array<Complex> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Array<Complex> >(vl, un));
+      hold_p.reset (new Quantum<Array<Complex>>(vl, un));
       return True;
     }
     case TpArrayDComplex:
     {
       Array<DComplex> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.reset(new Quantum<Array<DComplex> >(vl, un));
+      hold_p.reset (new Quantum<Array<DComplex>>(vl, un));
       return True;
     }
     default:
@@ -567,7 +569,7 @@ Bool QuantumHolder::fromString(String &error,
       in + String("\": Illegal input units or format\n");
     return False;
   }
-  hold_p.reset(new Quantum<Double>(res));
+  hold_p.reset (new Quantum<Double>(res));
   return True;
 }
 
@@ -663,11 +665,11 @@ void QuantumHolder::toReal(const uInt &tp) {
   }
   Unit x = hold_p->getFullUnit();
   if (tp == Quantum<Double>::myType()) {
-    hold_p.reset(new Quantum<Double>(d1, x));
+    hold_p.reset (new Quantum<Double>(d1, x));
   } else if (tp == Quantum<Float>::myType()) {
-    hold_p.reset(new Quantum<Float>(Float(d1), x));
+    hold_p.reset (new Quantum<Float>(Float(d1), x));
   } else if (tp == Quantum<Int>::myType()) {
-    hold_p.reset(new Quantum<Int>(Int(d1), x));
+    hold_p.reset (new Quantum<Int>(Int(d1), x));
   }
 }
 
@@ -701,9 +703,9 @@ void QuantumHolder::toComplex(const uInt &tp) {
   }
   Unit x = hold_p->getFullUnit();
   if (tp == Quantum<Complex>::myType()) {
-    hold_p.reset(new Quantum<Complex>(Complex(d1), x));
+    hold_p.reset (new Quantum<Complex>(Complex(d1), x));
   } else  if (tp == Quantum<DComplex>::myType()) {
-    hold_p.reset(new Quantum<DComplex>(d1, x));
+    hold_p.reset (new Quantum<DComplex>(d1, x));
   }
 }
 
@@ -712,23 +714,23 @@ void QuantumHolder::toVector() {
   if (isQuantumDouble()) {
     Vector<Double> d1(1);
     d1(0) = static_cast<Quantum<Double>*>(hold_p.get())->getValue();
-    hold_p.reset(new Quantum<Vector<Double> >(d1, x));
+    hold_p.reset (new Quantum<Vector<Double>>(d1, x));
   } else if (isQuantumFloat()) {
     Vector<Float> d1(1);
     d1(0) = static_cast<Quantum<Float>*>(hold_p.get())->getValue();
-    hold_p.reset(new Quantum<Vector<Float> >(d1, x));
+    hold_p.reset (new Quantum<Vector<Float>>(d1, x));
   } else if (isQuantumInt()) {
     Vector<Int> d1(1);
     d1(0) = static_cast<Quantum<Int>*>(hold_p.get())->getValue();
-    hold_p.reset(new Quantum<Vector<Int> >(d1, x));
+    hold_p.reset (new Quantum<Vector<Int>>(d1, x));
   } else if (isQuantumComplex()) {
     Vector<Complex> d1(1);
     d1(0) = static_cast<Quantum<Complex>*>(hold_p.get())->getValue();
-    hold_p.reset(new Quantum<Vector<Complex> >(d1, x));
+    hold_p.reset (new Quantum<Vector<Complex>>(d1, x));
   } else if (isQuantumDComplex()) {
     Vector<DComplex> d1(1);
     d1(0) = static_cast<Quantum<DComplex>*>(hold_p.get())->getValue();
-    hold_p.reset(new Quantum<Vector<DComplex> >(d1, x));
+    hold_p.reset (new Quantum<Vector<DComplex>>(d1, x));
   }
 }
 

--- a/casa/Quanta/QuantumHolder.cc
+++ b/casa/Quanta/QuantumHolder.cc
@@ -49,7 +49,7 @@ QuantumHolder::QuantumHolder(const QuantumHolder &other)
   : RecordTransformable(),
     hold_p()
 {
-  if (other.hold_p.ptr()) hold_p.set(other.hold_p.ptr()->clone());
+  if (other.hold_p) hold_p.reset(other.hold_p->clone());
 }
 
 //# Destructor
@@ -58,10 +58,10 @@ QuantumHolder::~QuantumHolder() {}
 //# Operators
 QuantumHolder &QuantumHolder::operator=(const QuantumHolder &other) {
   if (this != &other) {
-    if (other.hold_p.ptr()) {
-      hold_p.set(other.hold_p.ptr()->clone());
+    if (other.hold_p) {
+      hold_p.reset(other.hold_p->clone());
     } else {
-      hold_p.clear();
+      hold_p.reset();
     }
   }
   return *this;
@@ -69,27 +69,27 @@ QuantumHolder &QuantumHolder::operator=(const QuantumHolder &other) {
 
 //# Member Functions
 Bool QuantumHolder::isEmpty() const {
-  return (!hold_p.ptr());
+  return (!hold_p);
 }
 
 Bool QuantumHolder::isQuantum() const {
-  return (hold_p.ptr());
+  return (static_cast<Bool>(hold_p));
 }
 
 Bool QuantumHolder::isScalar() const {
-  return (hold_p.ptr() && nelements() == 1);
+  return (hold_p && nelements() == 1);
 }
 
 Bool QuantumHolder::isVector() const {
-  return (hold_p.ptr() && ndim() == 1);
+  return (hold_p && ndim() == 1);
 }
 
 Bool QuantumHolder::isArray() const {
-  return (hold_p.ptr() && ndim() > 0);
+  return (hold_p && ndim() > 0);
 }
 
 Bool QuantumHolder::isReal() const {
-  return (hold_p.ptr() &&
+  return (hold_p &&
 		(isQuantumDouble() ||
 		 isQuantumFloat() ||
 		 isQuantumInt() ||
@@ -99,7 +99,7 @@ Bool QuantumHolder::isReal() const {
 }
 
 Bool QuantumHolder::isComplex() const {
-  return (hold_p.ptr() &&
+  return (hold_p &&
 		(isQuantumComplex() ||
 		 isQuantumDComplex() ||
 		 isQuantumArrayComplex() ||
@@ -107,62 +107,62 @@ Bool QuantumHolder::isComplex() const {
 }
 
 Bool QuantumHolder::isQuantity() const {
-  return (hold_p.ptr() && isQuantumDouble());
+  return (hold_p && isQuantumDouble());
 }
 
 Bool QuantumHolder::isQuantumDouble() const {
-  return (hold_p.ptr() &&
-		hold_p.ptr()->type() == Quantum<Double>::myType());
+  return (hold_p &&
+		hold_p->type() == Quantum<Double>::myType());
 }
 
 Bool QuantumHolder::isQuantumFloat() const {
-  return (hold_p.ptr() &&
-		hold_p.ptr()->type() == Quantum<Float>::myType());
+  return (hold_p &&
+		hold_p->type() == Quantum<Float>::myType());
 }
 
 Bool QuantumHolder::isQuantumInt() const {
-  return (hold_p.ptr() &&
-		hold_p.ptr()->type() == Quantum<Int>::myType());
+  return (hold_p &&
+		hold_p->type() == Quantum<Int>::myType());
 }
 
 Bool QuantumHolder::isQuantumComplex() const {
-  return (hold_p.ptr() &&
-		hold_p.ptr()->type() == Quantum<Complex>::myType());
+  return (hold_p &&
+		hold_p->type() == Quantum<Complex>::myType());
 }
 
 Bool QuantumHolder::isQuantumDComplex() const {
-  return (hold_p.ptr() &&
-		hold_p.ptr()->type() == Quantum<DComplex>::myType());
+  return (hold_p &&
+		hold_p->type() == Quantum<DComplex>::myType());
 }
 
 Bool QuantumHolder::isQuantumArrayDouble() const {
-  return (hold_p.ptr() &&
-		(hold_p.ptr()->type() == Quantum<Array<Double> >::myType() ||
-		 hold_p.ptr()->type() == Quantum<Vector<Double> >::myType()));
+  return (hold_p &&
+		(hold_p->type() == Quantum<Array<Double> >::myType() ||
+		 hold_p->type() == Quantum<Vector<Double> >::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayFloat() const {
-  return (hold_p.ptr() &&
-  		(hold_p.ptr()->type() == Quantum<Array<Float> >::myType() ||
-		 hold_p.ptr()->type() == Quantum<Vector<Float> >::myType()));
+  return (hold_p &&
+  		(hold_p->type() == Quantum<Array<Float> >::myType() ||
+		 hold_p->type() == Quantum<Vector<Float> >::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayInt() const {
-  return (hold_p.ptr() &&
-  		(hold_p.ptr()->type() == Quantum<Array<Int> >::myType() ||
-		 hold_p.ptr()->type() == Quantum<Vector<Int> >::myType()));
+  return (hold_p &&
+  		(hold_p->type() == Quantum<Array<Int> >::myType() ||
+		 hold_p->type() == Quantum<Vector<Int> >::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayComplex() const {
-  return (hold_p.ptr() &&
-  		(hold_p.ptr()->type() == Quantum<Array<Complex> >::myType() ||
-		 hold_p.ptr()->type() == Quantum<Vector<Complex> >::myType()));
+  return (hold_p &&
+  		(hold_p->type() == Quantum<Array<Complex> >::myType() ||
+		 hold_p->type() == Quantum<Vector<Complex> >::myType()));
 }
 
 Bool QuantumHolder::isQuantumArrayDComplex() const {
-  return (hold_p.ptr() &&
-  		(hold_p.ptr()->type() == Quantum<Array<DComplex> >::myType() ||
-		 hold_p.ptr()->type() == Quantum<Vector<DComplex> >::myType()));
+  return (hold_p &&
+  		(hold_p->type() == Quantum<Array<DComplex> >::myType() ||
+		 hold_p->type() == Quantum<Vector<DComplex> >::myType()));
 }
 
 Bool QuantumHolder::isQuantumVectorDouble() const {
@@ -186,55 +186,55 @@ Bool QuantumHolder::isQuantumVectorDComplex() const {
 }
 
 Int QuantumHolder::nelements() const {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for nelements"));
   } else if (isQuantumArrayDouble()) {
-    return ((Quantum<Array<Double> > *)(hold_p.ptr()))->getValue().nelements();
+    return (static_cast<Quantum<Array<Double>>*>(hold_p.get()))->getValue().nelements();
   } else if (isQuantumArrayFloat()) {
-    return ((Quantum<Array<Float> > *)(hold_p.ptr()))->getValue().nelements();
+    return (static_cast<Quantum<Array<Float>>*>(hold_p.get()))->getValue().nelements();
   } else if (isQuantumArrayInt()) {
-    return ((Quantum<Array<Int> > *)(hold_p.ptr()))->getValue().nelements();
+    return (static_cast<Quantum<Array<Int>>*>(hold_p.get()))->getValue().nelements();
   } else if (isQuantumArrayComplex()) {
-    return ((Quantum<Array<Complex> > *)(hold_p.ptr()))->getValue().nelements();
+    return (static_cast<Quantum<Array<Complex>>*>(hold_p.get()))->getValue().nelements();
   } else if (isQuantumArrayDComplex()) {
-    return ((Quantum<Array<DComplex> > *)(hold_p.ptr()))->getValue().nelements();
+    return (static_cast<Quantum<Array<DComplex>>*>(hold_p.get()))->getValue().nelements();
   }
   return 1;
 }
 
 Int QuantumHolder::ndim() const {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for ndim"));
   } else if (isQuantumArrayDouble()) {
-    return ((Quantum<Array<Double> > *)(hold_p.ptr()))->getValue().ndim();
+    return (static_cast<Quantum<Array<Double>>*>(hold_p.get()))->getValue().ndim();
   } else if (isQuantumArrayFloat()) {
-    return ((Quantum<Array<Float> > *)(hold_p.ptr()))->getValue().ndim();
+    return (static_cast<Quantum<Array<Float>>*>(hold_p.get()))->getValue().ndim();
   } else if (isQuantumArrayInt()) {
-    return ((Quantum<Array<Int> > *)(hold_p.ptr()))->getValue().ndim();
+    return (static_cast<Quantum<Array<Int>>*>(hold_p.get()))->getValue().ndim();
   } else if (isQuantumArrayComplex()) {
-    return ((Quantum<Array<Complex> > *)(hold_p.ptr()))->getValue().ndim();
+    return (static_cast<Quantum<Array<Complex>>*>(hold_p.get()))->getValue().ndim();
   } else if (isQuantumArrayDComplex()) {
-    return ((Quantum<Array<DComplex> > *)(hold_p.ptr()))->getValue().ndim();
+    return (static_cast<Quantum<Array<DComplex>>*>(hold_p.get()))->getValue().ndim();
   }
   return 0;
 }
 
 const QBase &QuantumHolder::asQuantum() const {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantum"));
   }
-  return *hold_p.ptr();
+  return *hold_p;
 }
 
 const Quantum<Double> &QuantumHolder::asQuantity() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumDouble"));
   }
   if (!isReal() || !isScalar()) {
     throw(AipsError("Wrong QuantumHolder to convert asQuantumDouble"));
   }
   if (!isQuantity()) toReal(Quantum<Double>::myType());
-  return (const Quantum<Double> &) *hold_p.ptr();
+  return static_cast<const Quantum<Double>&>(*hold_p);
 }
 
 const Quantum<Double> &QuantumHolder::asQuantumDouble() {
@@ -242,51 +242,51 @@ const Quantum<Double> &QuantumHolder::asQuantumDouble() {
 }
 
 const Quantum<Float> &QuantumHolder::asQuantumFloat() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumFloat"));
   }
   if (!isReal() || !isScalar()) {
     throw(AipsError("Wrong QuantumHolder to convert asQuantumFloat"));
   }
   if (!isQuantumFloat()) toReal(Quantum<Float>::myType());
-  return (const Quantum<Float> &) *hold_p.ptr();
+  return static_cast<const Quantum<Float>&>(*hold_p);
 }
 
 const Quantum<Int> &QuantumHolder::asQuantumInt() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumInt"));
   }
   if (!isReal() || !isScalar()) {
     throw(AipsError("Wrong QuantumHolder to convert asQuantumInt"));
   }
   if (!isQuantumInt()) toReal(Quantum<Int>::myType());
-  return (const Quantum<Int> &) *hold_p.ptr();
+  return static_cast<const Quantum<Int>&>(*hold_p);
 }
 
 const Quantum<Complex> &QuantumHolder::asQuantumComplex() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumComplex"));
   }
   if (!isScalar()) {
     throw(AipsError("Wrong QuantumHolder to convert asQuantumComplex"));
   }
   if (!isQuantumComplex()) toComplex(Quantum<Complex>::myType());
-  return (const Quantum<Complex> &) *hold_p.ptr();
+  return static_cast<const Quantum<Complex>&>(*hold_p);
 }
 
 const Quantum<DComplex> &QuantumHolder::asQuantumDComplex() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumDComplex"));
   }
   if (!isScalar()) {
     throw(AipsError("Wrong QuantumHolder to convert asQuantumDComplex"));
   }
   if (!isQuantumDComplex()) toComplex(Quantum<DComplex>::myType());
-  return (const Quantum<DComplex> &) *hold_p.ptr();
+  return static_cast<const Quantum<DComplex>&>(*hold_p);
 }
 
 const Quantum<Vector<Double> > &QuantumHolder::asQuantumVectorDouble() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorDouble"));
   }
   if (isArray()) {
@@ -294,7 +294,7 @@ const Quantum<Vector<Double> > &QuantumHolder::asQuantumVectorDouble() {
       throw(AipsError("Cannot convert to QuantumVectorDouble"));
     }
     if (ndim() != 1) {
-      ((Quantum<Array<Double> > *)(hold_p.ptr()))->getValue().
+      (static_cast<Quantum<Array<Double>>*>(hold_p.get()))->getValue().
 	reform(IPosition(1, nelements()));
     }
   } else {
@@ -304,11 +304,11 @@ const Quantum<Vector<Double> > &QuantumHolder::asQuantumVectorDouble() {
     if (!isQuantumDouble()) toReal(Quantum<Double>::myType());
     toVector();
   }
-  return (const Quantum<Vector<Double> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Vector<Double>>&>(*hold_p);
 }
 
 const Quantum<Vector<Float> > &QuantumHolder::asQuantumVectorFloat() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorFloat"));
   }
   if (isArray()) {
@@ -316,7 +316,7 @@ const Quantum<Vector<Float> > &QuantumHolder::asQuantumVectorFloat() {
       throw(AipsError("Cannot convert to QuantumVectorFloat"));
     }
     if (ndim() != 1) {
-      ((Quantum<Array<Float> > *)(hold_p.ptr()))->getValue().
+      (static_cast<Quantum<Array<Float>>*>(hold_p.get()))->getValue().
 	reform(IPosition(1, nelements()));
     }
   } else {
@@ -326,11 +326,11 @@ const Quantum<Vector<Float> > &QuantumHolder::asQuantumVectorFloat() {
     if (!isQuantumFloat()) toReal(Quantum<Float>::myType());
     toVector();
   }
-  return (const Quantum<Vector<Float> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Vector<Float>>&>(*hold_p);
 }
 
 const Quantum<Vector<Int> > &QuantumHolder::asQuantumVectorInt() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorInt"));
   }
   if (isArray()) {
@@ -338,7 +338,7 @@ const Quantum<Vector<Int> > &QuantumHolder::asQuantumVectorInt() {
       throw(AipsError("Cannot convert to QuantumVectorInt"));
     }
     if (ndim() != 1) {
-      ((Quantum<Array<Int> > *)(hold_p.ptr()))->getValue().
+      (static_cast<Quantum<Array<Int>>*>(hold_p.get()))->getValue().
 	reform(IPosition(1, nelements()));
     }
   } else {
@@ -348,11 +348,11 @@ const Quantum<Vector<Int> > &QuantumHolder::asQuantumVectorInt() {
     if (!isQuantumInt()) toReal(Quantum<Int>::myType());
     toVector();
   }
-  return (const Quantum<Vector<Int> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Vector<Int>>&>(*hold_p);
 }
 
 const Quantum<Vector<Complex> > &QuantumHolder::asQuantumVectorComplex() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorComplex"));
   }
   if (isArray()) {
@@ -360,18 +360,18 @@ const Quantum<Vector<Complex> > &QuantumHolder::asQuantumVectorComplex() {
       throw(AipsError("Cannot convert to QuantumVectorComplex"));
     }
     if (ndim() != 1) {
-      ((Quantum<Array<Complex> > *)(hold_p.ptr()))->getValue().
+      (static_cast<Quantum<Array<Complex>>*>(hold_p.get()))->getValue().
 	reform(IPosition(1, nelements()));
     }
   } else {
     if (!isQuantumComplex()) toComplex(Quantum<Complex>::myType());
     toVector();
   }
-  return (const Quantum<Vector<Complex> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Vector<Complex>>&>(*hold_p);
 }
 
 const Quantum<Vector<DComplex> > &QuantumHolder::asQuantumVectorDComplex() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumVectorDComplex"));
   }
   if (isArray()) {
@@ -379,18 +379,18 @@ const Quantum<Vector<DComplex> > &QuantumHolder::asQuantumVectorDComplex() {
       throw(AipsError("Cannot convert to QuantumVectorDComplex"));
     }
     if (ndim() != 1) {
-      ((Quantum<Array<DComplex> > *)(hold_p.ptr()))->getValue().
+      (static_cast<Quantum<Array<DComplex>>*>(hold_p.get()))->getValue().
 	reform(IPosition(1, nelements()));
     }
   } else {
     if (!isQuantumDComplex()) toComplex(Quantum<DComplex>::myType());
     toVector();
   }
-  return (const Quantum<Vector<DComplex> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Vector<DComplex>>&>(*hold_p);
 }
 
 const Quantum<Array<Double> > &QuantumHolder::asQuantumArrayDouble() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayDouble"));
   }
   if (isArray()) {
@@ -404,11 +404,11 @@ const Quantum<Array<Double> > &QuantumHolder::asQuantumArrayDouble() {
     if (!isQuantumDouble()) toReal(Quantum<Double>::myType());
     toArray();
   }
-  return (const Quantum<Array<Double> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Array<Double>>&>(*hold_p);
 }
 
 const Quantum<Array<Float> > &QuantumHolder::asQuantumArrayFloat() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayFloat"));
   }
   if (isArray()) {
@@ -422,11 +422,11 @@ const Quantum<Array<Float> > &QuantumHolder::asQuantumArrayFloat() {
     if (!isQuantumFloat()) toReal(Quantum<Float>::myType());
     toArray();
   }
-  return (const Quantum<Array<Float> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Array<Float>>&>(*hold_p);
 }
 
 const Quantum<Array<Int> > &QuantumHolder::asQuantumArrayInt() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayInt"));
   }
   if (isArray()) {
@@ -440,11 +440,11 @@ const Quantum<Array<Int> > &QuantumHolder::asQuantumArrayInt() {
     if (!isQuantumInt()) toReal(Quantum<Int>::myType());
     toArray();
   }
-  return (const Quantum<Array<Int> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Array<Int>>&>(*hold_p);
 }
 
 const Quantum<Array<Complex> > &QuantumHolder::asQuantumArrayComplex() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayComplex"));
   }
   if (isArray()) {
@@ -455,11 +455,11 @@ const Quantum<Array<Complex> > &QuantumHolder::asQuantumArrayComplex() {
     if (!isQuantumComplex()) toComplex(Quantum<Complex>::myType());
     toArray();
   }
-  return (const Quantum<Array<Complex> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Array<Complex>>&>(*hold_p);
 }
 
 const Quantum<Array<DComplex> > &QuantumHolder::asQuantumArrayDComplex() {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty QuantumHolder argument for asQuantumArrayDComplex"));
   }
   if (isArray()) {
@@ -470,7 +470,7 @@ const Quantum<Array<DComplex> > &QuantumHolder::asQuantumArrayDComplex() {
     if (!isQuantumDComplex()) toComplex(Quantum<DComplex>::myType());
     toArray();
   }
-  return (const Quantum<Array<DComplex> > &) *hold_p.ptr();
+  return static_cast<const Quantum<Array<DComplex>>&>(*hold_p);
 }
 
 Bool QuantumHolder::fromRecord(String &error,
@@ -485,70 +485,70 @@ Bool QuantumHolder::fromRecord(String &error,
     {
       Double vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Double>(vl, un));
+      hold_p.reset(new Quantum<Double>(vl, un));
       return True;
     }
     case TpFloat:
     {
       Float vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Float>(vl, un));
+      hold_p.reset(new Quantum<Float>(vl, un));
       return True;
     }
     case TpInt:
     {
       Int vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Int>(vl, un));
+      hold_p.reset(new Quantum<Int>(vl, un));
       return True;
     }
     case TpComplex:
     {
       Complex vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Complex>(vl, un));
+      hold_p.reset(new Quantum<Complex>(vl, un));
       return True;
     }
     case TpDComplex:
     {
       DComplex vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<DComplex>(vl, un));
+      hold_p.reset(new Quantum<DComplex>(vl, un));
       return True;
     }
     case TpArrayDouble:
     {
       Array<Double> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Array<Double> >(vl, un));
+      hold_p.reset(new Quantum<Array<Double> >(vl, un));
       return True;
     }
     case TpArrayFloat:
     {
       Array<Float> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Array<Float> >(vl, un));
+      hold_p.reset(new Quantum<Array<Float> >(vl, un));
       return True;
     }
     case TpArrayInt:
     {
       Array<Int> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Array<Int> >(vl, un));
+      hold_p.reset(new Quantum<Array<Int> >(vl, un));
       return True;
     }
     case TpArrayComplex:
     {
       Array<Complex> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Array<Complex> >(vl, un));
+      hold_p.reset(new Quantum<Array<Complex> >(vl, un));
       return True;
     }
     case TpArrayDComplex:
     {
       Array<DComplex> vl;
       in.get(RecordFieldId("value"), vl);
-      hold_p.set(new Quantum<Array<DComplex> >(vl, un));
+      hold_p.reset(new Quantum<Array<DComplex> >(vl, un));
       return True;
     }
     default:
@@ -567,61 +567,60 @@ Bool QuantumHolder::fromString(String &error,
       in + String("\": Illegal input units or format\n");
     return False;
   }
-  hold_p.set(new Quantum<Double>(res));
+  hold_p.reset(new Quantum<Double>(res));
   return True;
 }
 
 Bool QuantumHolder::toRecord(String &error, RecordInterface &out) const {
-  if (hold_p.ptr()) {
+  if (hold_p) {
     if (out.isDefined("value")) out.removeField(RecordFieldId("value"));
     if (isQuantumDouble()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Double> *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Double>*>(hold_p.get()))->getValue()));
     } else if (isQuantumFloat()) {
       out.define(RecordFieldId("value"),
-                 (((Quantum<Float> *)(hold_p.ptr()))->getValue()));
+                 ((static_cast<Quantum<Float>*>(hold_p.get()))->getValue()));
     } else if (isQuantumInt()) {
       out.define(RecordFieldId("value"),
-                 (((Quantum<Int> *)(hold_p.ptr()))->getValue()));
+                 ((static_cast<Quantum<Int>*>(hold_p.get()))->getValue()));
     } else if (isQuantumComplex()) {
       out.define(RecordFieldId("value"),
-                 (((Quantum<Complex> *)(hold_p.ptr()))->getValue()));
+                 ((static_cast<Quantum<Complex>*>(hold_p.get()))->getValue()));
     } else if (isQuantumDComplex()) {
       out.define(RecordFieldId("value"),
-                 (((Quantum<DComplex> *)(hold_p.ptr()))->getValue()));
+                 ((static_cast<Quantum<DComplex>*>(hold_p.get()))->getValue()));
     } else if (isQuantumVectorDouble()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Vector<Double> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Vector<Double>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumVectorFloat()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Vector<Float> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Vector<Float>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumVectorInt()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Vector<Int> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Vector<Int>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumVectorComplex()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Vector<Complex> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Vector<Complex>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumVectorDComplex()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Vector<DComplex> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Vector<DComplex>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumArrayDouble()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Array<Double> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Array<Double>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumArrayFloat()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Array<Float> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Array<Float>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumArrayInt()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Array<Int> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Array<Int>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumArrayComplex()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Array<Complex> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Array<Complex>>*>(hold_p.get()))->getValue()));
     } else if (isQuantumArrayDComplex()) {
       out.define(RecordFieldId("value"),
-		 (((Quantum<Array<DComplex> > *)(hold_p.ptr()))->getValue()));
+		 ((static_cast<Quantum<Array<DComplex>>*>(hold_p.get()))->getValue()));
     }
-    out.define(RecordFieldId("unit"),
-	       String(hold_p.ptr()->getFullUnit().getName()));
+    out.define(RecordFieldId("unit"), hold_p->getFullUnit().getName());
     return True;
   }
   error += String("No Quantum specified in QuantumHolder::toRecord\n");
@@ -647,28 +646,28 @@ void QuantumHolder::toReal(const uInt &tp) {
   if (isArray()) {
     IPosition stx(ndim(), 0);
     if (isQuantumArrayDouble()) {
-      d1 = Double(((Quantum<Array<Double> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Double>>*>(hold_p.get())->getValue()(stx);
     } else if (isQuantumArrayFloat()) {
-      d1 = Double(((Quantum<Array<Float> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Float>>*>(hold_p.get())->getValue()(stx);
     } else if (isQuantumArrayInt()) {
-      d1 = Double(((Quantum<Array<Int> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Int>>*>(hold_p.get())->getValue()(stx);
     }
   } else {
     if (isQuantumDouble()) {
-      d1 = Double(((Quantum<Double> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Double>*>(hold_p.get())->getValue();
     } else if (isQuantumFloat()) {
-      d1 = Double(((Quantum<Float> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Float>*>(hold_p.get())->getValue();
     } else if (isQuantumInt()) {
-      d1 = Double(((Quantum<Int> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Int>*>(hold_p.get())->getValue();
     }
   }
-  Unit x = hold_p.ptr()->getFullUnit();
+  Unit x = hold_p->getFullUnit();
   if (tp == Quantum<Double>::myType()) {
-    hold_p.set(new Quantum<Double>(d1, x));
+    hold_p.reset(new Quantum<Double>(d1, x));
   } else if (tp == Quantum<Float>::myType()) {
-    hold_p.set(new Quantum<Float>(Float(d1), x));
+    hold_p.reset(new Quantum<Float>(Float(d1), x));
   } else if (tp == Quantum<Int>::myType()) {
-    hold_p.set(new Quantum<Int>(Int(d1), x));
+    hold_p.reset(new Quantum<Int>(Int(d1), x));
   }
 }
 
@@ -677,59 +676,59 @@ void QuantumHolder::toComplex(const uInt &tp) {
   if (isArray()) {
     IPosition stx(ndim(), 0);
     if (isQuantumArrayDouble()) {
-      d1 = DComplex(((Quantum<Array<Double> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Double>>*>(hold_p.get())->getValue()(stx);
     } else if (isQuantumArrayFloat()) {
-      d1 = DComplex(((Quantum<Array<Float> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Float>>*>(hold_p.get())->getValue()(stx);
     } else if (isQuantumArrayInt()) {
-      d1 = DComplex(((Quantum<Array<Int> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Int>>*>(hold_p.get())->getValue()(stx);
     } else if (isQuantumArrayComplex()) {
-      d1 = (((Quantum<Array<Complex> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<Complex>>*>(hold_p.get())->getValue()(stx);
     } else if (isQuantumArrayDComplex()) {
-      d1 = (((Quantum<Array<DComplex> > *)(hold_p.ptr()))->getValue()(stx));
+      d1 = static_cast<Quantum<Array<DComplex>>*>(hold_p.get())->getValue()(stx);
     }
   } else {
     if (isQuantumDouble()) {
-      d1 = DComplex(((Quantum<Double> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Double>*>(hold_p.get())->getValue();
     } else if (isQuantumFloat()) {
-      d1 = DComplex(((Quantum<Float> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Float>*>(hold_p.get())->getValue();
     } else if (isQuantumInt()) {
-      d1 = DComplex(((Quantum<Int> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Int>*>(hold_p.get())->getValue();
     } else if (isQuantumComplex()) {
-      d1 = (((Quantum<Complex> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<Complex>*>(hold_p.get())->getValue();
     } else if (isQuantumDComplex()) {
-      d1 = (((Quantum<DComplex> *)(hold_p.ptr()))->getValue());
+      d1 = static_cast<Quantum<DComplex>*>(hold_p.get())->getValue();
     }
   }
-  Unit x = hold_p.ptr()->getFullUnit();
+  Unit x = hold_p->getFullUnit();
   if (tp == Quantum<Complex>::myType()) {
-    hold_p.set(new Quantum<Complex>(Complex(d1), x));
+    hold_p.reset(new Quantum<Complex>(Complex(d1), x));
   } else  if (tp == Quantum<DComplex>::myType()) {
-    hold_p.set(new Quantum<DComplex>(d1, x));
+    hold_p.reset(new Quantum<DComplex>(d1, x));
   }
 }
 
 void QuantumHolder::toVector() {
-  Unit x = hold_p.ptr()->getFullUnit();
+  Unit x = hold_p->getFullUnit();
   if (isQuantumDouble()) {
     Vector<Double> d1(1);
-    d1(0) = ((Quantum<Double> *)(hold_p.ptr()))->getValue();
-    hold_p.set(new Quantum<Vector<Double> >(d1, x));
+    d1(0) = static_cast<Quantum<Double>*>(hold_p.get())->getValue();
+    hold_p.reset(new Quantum<Vector<Double> >(d1, x));
   } else if (isQuantumFloat()) {
     Vector<Float> d1(1);
-    d1(0) = ((Quantum<Float> *)(hold_p.ptr()))->getValue();
-    hold_p.set(new Quantum<Vector<Float> >(d1, x));
+    d1(0) = static_cast<Quantum<Float>*>(hold_p.get())->getValue();
+    hold_p.reset(new Quantum<Vector<Float> >(d1, x));
   } else if (isQuantumInt()) {
     Vector<Int> d1(1);
-    d1(0) = ((Quantum<Int> *)(hold_p.ptr()))->getValue();
-    hold_p.set(new Quantum<Vector<Int> >(d1, x));
+    d1(0) = static_cast<Quantum<Int>*>(hold_p.get())->getValue();
+    hold_p.reset(new Quantum<Vector<Int> >(d1, x));
   } else if (isQuantumComplex()) {
     Vector<Complex> d1(1);
-    d1(0) = ((Quantum<Complex> *)(hold_p.ptr()))->getValue();
-    hold_p.set(new Quantum<Vector<Complex> >(d1, x));
+    d1(0) = static_cast<Quantum<Complex>*>(hold_p.get())->getValue();
+    hold_p.reset(new Quantum<Vector<Complex> >(d1, x));
   } else if (isQuantumDComplex()) {
     Vector<DComplex> d1(1);
-    d1(0) = ((Quantum<DComplex> *)(hold_p.ptr()))->getValue();
-    hold_p.set(new Quantum<Vector<DComplex> >(d1, x));
+    d1(0) = static_cast<Quantum<DComplex>*>(hold_p.get())->getValue();
+    hold_p.reset(new Quantum<Vector<DComplex> >(d1, x));
   }
 }
 

--- a/casa/Quanta/QuantumHolder.h
+++ b/casa/Quanta/QuantumHolder.h
@@ -63,18 +63,18 @@ template <class Qtype> class Quantum;
 // can handle toRecord() and fromRecord() conversions.
 // A QuantumHolder
 // is created empty, from a Quantum (e.g. a <src>Quantum<Double></src>) or a
-// <src>Quantum<Vector<Float> ></src>).
+// <src>Quantum<Vector<Float>></src>).
 //
 // The accepted range of Quantums is:
 // <ul>
 //  <li> <src>Quantum<Int>, Quantum<Float>, Quantum<Double> == Quantity</src>
 //  <li> <src>Quantum<Complex>, Quantum<DComplex></src>
-//  <li> <src>Quantum<Vector<Int> >, Quantum<Vector<Float> ></src>, 
-//	 <src>Quantum<Vector<Double> ></src>
-//  <li> <src>Quantum<Vector<Complex> >, Quantum<Vector<DComplex> ></src>
-//  <li> <src>Quantum<Array<Int> >, Quantum<Array<Float> ></src>, 
-//	 <src>Quantum<Array<Double> ></src>
-//  <li> <src>Quantum<Array<Complex> >, Quantum<Array<DComplex> ></src>
+//  <li> <src>Quantum<Vector<Int>>, Quantum<Vector<Float>></src>, 
+//	 <src>Quantum<Vector<Double>></src>
+//  <li> <src>Quantum<Vector<Complex>>, Quantum<Vector<DComplex>></src>
+//  <li> <src>Quantum<Array<Int>>, Quantum<Array<Float>></src>, 
+//	 <src>Quantum<Array<Double>></src>
+//  <li> <src>Quantum<Array<Complex>>, Quantum<Array<DComplex>></src>
 // </ul>
 // Scalars in the same group can be converted to any in the same group (e.g.
 // Int to Double); Vectors of length 1 can be converted to scalars in the 
@@ -185,16 +185,16 @@ public:
   const Quantum<Int> &asQuantumInt() ;
   const Quantum<Complex> &asQuantumComplex() ;
   const Quantum<DComplex> &asQuantumDComplex() ;
-  const Quantum<Vector<Double> > &asQuantumVectorDouble() ;
-  const Quantum<Vector<Float> > &asQuantumVectorFloat() ;
-  const Quantum<Vector<Int> > &asQuantumVectorInt() ;
-  const Quantum<Vector<Complex> > &asQuantumVectorComplex() ;
-  const Quantum<Vector<DComplex> > &asQuantumVectorDComplex() ;
-  const Quantum<Array<Double> > &asQuantumArrayDouble() ;
-  const Quantum<Array<Float> > &asQuantumArrayFloat() ;
-  const Quantum<Array<Int> > &asQuantumArrayInt() ;
-  const Quantum<Array<Complex> > &asQuantumArrayComplex() ;
-  const Quantum<Array<DComplex> > &asQuantumArrayDComplex() ;
+  const Quantum<Vector<Double>> &asQuantumVectorDouble() ;
+  const Quantum<Vector<Float>> &asQuantumVectorFloat() ;
+  const Quantum<Vector<Int>> &asQuantumVectorInt() ;
+  const Quantum<Vector<Complex>> &asQuantumVectorComplex() ;
+  const Quantum<Vector<DComplex>> &asQuantumVectorDComplex() ;
+  const Quantum<Array<Double>> &asQuantumArrayDouble() ;
+  const Quantum<Array<Float>> &asQuantumArrayFloat() ;
+  const Quantum<Array<Int>> &asQuantumArrayInt() ;
+  const Quantum<Array<Complex>> &asQuantumArrayComplex() ;
+  const Quantum<Array<DComplex>> &asQuantumArrayDComplex() ;
   // </group>
 
   // Create a Quantum from a record or a string.

--- a/casa/Quanta/QuantumHolder.h
+++ b/casa/Quanta/QuantumHolder.h
@@ -29,9 +29,9 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/RecordTransformable.h>
 #include <casacore/casa/BasicSL/Complexfwd.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -227,7 +227,7 @@ private:
 
 //# Data Members
   // Pointer to a Quantity
-  PtrHolder<QBase> hold_p;
+  std::unique_ptr<QBase> hold_p;
 
 //# General member functions
   // Convert to a different real scalar quantum

--- a/casa/Utilities.h
+++ b/casa/Utilities.h
@@ -39,7 +39,6 @@
 #include <casacore/casa/Utilities/DynBuffer.h>
 #include <casacore/casa/Utilities/Fallible.h>
 #include <casacore/casa/Utilities/GenSort.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/Regex.h>
 #include <casacore/casa/Utilities/Sequence.h>
 #include <casacore/casa/Utilities/Sort.h>
@@ -96,9 +95,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //  <ul>
 //   <li> <linkto class=CountedPtr>Counted pointers</linkto>
 //    provide support for reference counting.
-//   <li> <linkto class=PtrHolder>Pointer holders</linkto>
-//    can be used to hold allocated pointers which should be deleted
-//    when an exception is thrown.
 //  </ul> 
 //  <li> Datatype utilities
 //  <ul>

--- a/casa/Utilities/PtrHolder.h
+++ b/casa/Utilities/PtrHolder.h
@@ -26,6 +26,8 @@
 #ifndef CASA_PTRHOLDER_H
 #define CASA_PTRHOLDER_H
 
+#warning PtrHolder.h is deprecated; std::unique_ptr should be used instead
+
 //# Includes
 #include <casacore/casa/aips.h>
 

--- a/coordinates/Coordinates/SpectralCoordinate.cc
+++ b/coordinates/Coordinates/SpectralCoordinate.cc
@@ -440,7 +440,7 @@ Bool SpectralCoordinate::toWorld (Vector<Double> &world,
 // Convert to World (Hz)
 
     Bool ok = True;
-    if (_tabular.ptr()) {
+    if (_tabular) {
        ok = _tabular->toWorld(world, pixel);
        if (!ok) set_error(_tabular->errorMessage());
     } else {
@@ -495,7 +495,7 @@ Bool SpectralCoordinate::toPixel (Vector<Double> &pixel,
 
 // Convert to pixel
 
-    if (_tabular.ptr()) {
+    if (_tabular) {
        ok = _tabular->toPixel(pixel, world_tmp1);
        if (!ok) set_error(_tabular->errorMessage());
     } else {
@@ -530,7 +530,7 @@ Bool SpectralCoordinate::toWorldMany (Matrix<Double>& world,
 // Convert to world (Hz)
 
    Bool ok = True;
-   if (_tabular.ptr()) {
+   if (_tabular) {
       ok = _tabular->toWorldMany(world, pixel, failures);
       if (!ok) set_error(_tabular->errorMessage());
    } else {
@@ -572,7 +572,7 @@ Bool SpectralCoordinate::toPixelMany (Matrix<Double>& pixel,
 // Convert to pixel
 
     Bool ok = True;
-    if (_tabular.ptr()) {
+    if (_tabular) {
        _tabular->toPixelMany(pixel, world2, failures);
        if (!ok) set_error(_tabular->errorMessage());
     } else {        
@@ -602,7 +602,7 @@ Vector<String> SpectralCoordinate::worldAxisUnits() const
 
 Vector<Double> SpectralCoordinate::referencePixel() const
 {
-    if (_tabular.ptr()) {
+    if (_tabular) {
        return _tabular->referencePixel();
     } else {
        Vector<Double> crpix(1);
@@ -614,7 +614,7 @@ Vector<Double> SpectralCoordinate::referencePixel() const
 
 Matrix<Double> SpectralCoordinate::linearTransform() const
 {
-    if (_tabular.ptr()) {
+    if (_tabular) {
        return _tabular->linearTransform();
     } else {
        Matrix<Double> tmp(1,1);
@@ -629,7 +629,7 @@ Vector<Double> SpectralCoordinate::increment() const
 // Get in Hz
 
     Vector<Double> value(1);
-    if (_tabular.ptr()) {
+    if (_tabular) {
        value= _tabular->increment();
     } else {
        value[0] = wcs_p.cdelt[0];
@@ -649,7 +649,7 @@ Vector<Double> SpectralCoordinate::referenceValue() const
 // Get in Hz
 
     Vector<Double> value(1);
-    if (_tabular.ptr()) {
+    if (_tabular) {
        value= _tabular->referenceValue();
     } else {
        value[0] = wcs_p.crval[0];
@@ -881,7 +881,7 @@ Bool SpectralCoordinate::setReferencePixel(const Vector<Double> &refPix)
     }
 //
     Bool ok= True;
-    if (_tabular.ptr()) {
+    if (_tabular) {
        ok = _tabular->setReferencePixel(refPix);
        if (!ok) set_error (_tabular->errorMessage());
     } else {
@@ -906,7 +906,7 @@ Bool SpectralCoordinate::setLinearTransform(const Matrix<Double> &xform)
        return False;
     }
 //
-    if (_tabular.ptr()) {
+    if (_tabular) {
        ok = _tabular->setLinearTransform(xform);
        if (!ok) set_error(_tabular->errorMessage());
     } else {
@@ -936,7 +936,7 @@ Bool SpectralCoordinate::setIncrement (const Vector<Double>& incr)
 // Now set
 
     Bool ok= True;
-    if (_tabular.ptr()) {
+    if (_tabular) {
        ok = _tabular->setIncrement(value);
        if (!ok) set_error (_tabular->errorMessage());
     } else {
@@ -965,7 +965,7 @@ Bool SpectralCoordinate::setReferenceValue(const Vector<Double>& refval)
     fromCurrent (value);
 //
     Bool ok= True;
-    if (_tabular.ptr()) {
+    if (_tabular) {
        ok = _tabular->setReferenceValue(value);
        if (!ok) set_error (_tabular->errorMessage());
     } else {
@@ -987,7 +987,7 @@ Double SpectralCoordinate::restFrequency() const
 
 Vector<Double> SpectralCoordinate::pixelValues() const
 {
-    if (_tabular.ptr()) {
+    if (_tabular) {
        return _tabular->pixelValues();
     } else {
        Vector<Double> pixels;
@@ -998,7 +998,7 @@ Vector<Double> SpectralCoordinate::pixelValues() const
 Vector<Double> SpectralCoordinate::worldValues() const
 {
     Vector<Double> worlds;
-    if (_tabular.ptr()) {
+    if (_tabular) {
        worlds = _tabular->worldValues();    // Hz
        toCurrent(worlds);
     }
@@ -1288,7 +1288,7 @@ Bool SpectralCoordinate::near(const Coordinate& other,
 // LinearXForm components
 //Tabular spectral coordinates with 1 channel has increment 0. by definition in TabularCoordinates !
 //so linear transform test is bound to fail so skip for that case
-   if( !(_tabular.ptr() && (_tabular->pixelValues()).nelements()==1))
+   if( !(_tabular && (_tabular->pixelValues()).nelements()==1))
      {
       LinearXform thisVal(referencePixel(), increment(), linearTransform());
       LinearXform thatVal(sCoord.referencePixel(), sCoord.increment(), sCoord.linearTransform());
@@ -1333,7 +1333,7 @@ Bool SpectralCoordinate::save(RecordInterface &container,
 
 // We may have TC (for tabular coordinates) or not.
 
-	if (_tabular.ptr()) {
+	if (_tabular) {
 		ok = (_tabular->save(subrec, "tabular"));   // Always Hz
 	} else {
 		ok = wcsSave (subrec, wcs_p, "wcs");          // Always Hz
@@ -1987,7 +1987,7 @@ Coordinate* SpectralCoordinate::makeFourierCoordinate (const Vector<Bool>& axes,
 // shape is the shape of the image for all axes in this coordinate
 //
 {
-   if (_tabular.ptr()) {
+   if (_tabular) {
       set_error("Cannot Fourier Transform a non-linear SpectralCoordinate");
       return 0;
    }
@@ -2432,12 +2432,12 @@ void SpectralCoordinate::copy (const SpectralCoordinate &other) {
 // Copy TabularCoordinate or wcs structure. Only one of the two
 // is allocated at any given time.
 
-    if (other._tabular.ptr()) {
+    if (other._tabular) {
        _tabular.reset(new TabularCoordinate(*(other._tabular)));
     }
     else {
-    	if (_tabular.ptr()) {
-    		_tabular.reset(0);
+    	if (_tabular) {
+    		_tabular.reset();
     	}
        copy_wcs(other.wcs_p, wcs_p);
        set_wcs(wcs_p);
@@ -2473,7 +2473,7 @@ void SpectralCoordinate::_setTabulatedFrequencies(const Vector<Double>& freqs) {
 }
 
 ostream& SpectralCoordinate::print(ostream& os) const {
-    os << "tabular " << _tabular.ptr() << endl;
+    os << "tabular " << _tabular.get() << endl;
     os << "to_hz_p " <<  to_hz_p << endl;
     os << "to_m_p " << to_m_p << endl;
     os << "type_p " << MFrequency::showType(type_p) << endl;
@@ -2499,7 +2499,7 @@ ostream& SpectralCoordinate::print(ostream& os) const {
 }
 
 Bool SpectralCoordinate::isTabular() const {
-	return _tabular.ptr();
+  return static_cast<Bool>(_tabular);
 }
 
 ostream &operator<<(ostream &os, const SpectralCoordinate& spcoord) {

--- a/coordinates/Coordinates/SpectralCoordinate.h
+++ b/coordinates/Coordinates/SpectralCoordinate.h
@@ -37,7 +37,7 @@
 #include <casacore/measures/Measures/MPosition.h>
 #include <casacore/measures/Measures/MEpoch.h>
 #include <casacore/casa/Quanta/Quantum.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
+#include <memory>
 
 #include <wcslib/wcs.h>
 
@@ -590,7 +590,7 @@ public:
 
 private:
 
-    SPtrHolder<TabularCoordinate> _tabular;            // Tabular coordinate OR
+    std::unique_ptr<TabularCoordinate> _tabular;       // Tabular coordinate OR
     mutable ::wcsprm wcs_p;                            // wcs structure is used 
     Double to_hz_p;                                    // Convert from current world units to Hz
     Double to_m_p;                                     // Convert from current wavelength units to m

--- a/images/Images/ExtendImage.h
+++ b/images/Images/ExtendImage.h
@@ -30,7 +30,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/images/Images/ImageInterface.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -185,8 +185,8 @@ public:
 
 private:
   //# itsImagePtr points to the parent image.
-  PtrHolder<ImageInterface<T> > itsImagePtr;
-  PtrHolder<ExtendLattice<T> >  itsExtLatPtr;
+  std::unique_ptr<ImageInterface<T> > itsImagePtr;
+  std::unique_ptr<ExtendLattice<T> >  itsExtLatPtr;
 
   //# Make members of parent class known.
 public:

--- a/images/Images/ExtendImage.h
+++ b/images/Images/ExtendImage.h
@@ -185,8 +185,8 @@ public:
 
 private:
   //# itsImagePtr points to the parent image.
-  std::unique_ptr<ImageInterface<T> > itsImagePtr;
-  std::unique_ptr<ExtendLattice<T> >  itsExtLatPtr;
+  std::unique_ptr<ImageInterface<T>> itsImagePtr;
+  std::unique_ptr<ExtendLattice<T>>  itsExtLatPtr;
 
   //# Make members of parent class known.
 public:

--- a/images/Images/ExtendImage.tcc
+++ b/images/Images/ExtendImage.tcc
@@ -40,8 +40,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template<class T>
 ExtendImage<T>::ExtendImage()
-: itsImagePtr  (0),
-  itsExtLatPtr (0)
 {}
 
 template<class T>
@@ -57,7 +55,7 @@ ExtendImage<T>::ExtendImage (const ImageInterface<T>& image,
     throw AipsError ("ExtendImage - "
 		     "new csys or shape incompatible with old ones");
   }
-  itsExtLatPtr.set(new ExtendLattice<T> (image, newShape, newAxes, stretchAxes));
+  itsExtLatPtr.reset(new ExtendLattice<T> (image, newShape, newAxes, stretchAxes));
   setCoordsMember (newCsys);
   this->setImageInfoMember (itsImagePtr->imageInfo());
   this->setMiscInfoMember (itsImagePtr->miscInfo());
@@ -79,8 +77,8 @@ ExtendImage<T>& ExtendImage<T>::operator= (const ExtendImage<T>& other)
 {
   if (this != &other) {
     ImageInterface<T>::operator= (other);
-    itsImagePtr.set(other.itsImagePtr->cloneII());
-    itsExtLatPtr.set(new ExtendLattice<T> (*other.itsExtLatPtr));
+    itsImagePtr.reset(other.itsImagePtr->cloneII());
+    itsExtLatPtr.reset(new ExtendLattice<T> (*other.itsExtLatPtr));
   }
   return *this;
 }

--- a/images/Images/ImageStatistics.tcc
+++ b/images/Images/ImageStatistics.tcc
@@ -678,7 +678,7 @@ template <class T> Bool ImageStatistics<T>::_computeFlux(
     ReadOnlyVectorIterator<AccumType> sumIt(sum);
     ReadOnlyVectorIterator<AccumType> nPtsIt(npts);
     VectorIterator<AccumType> fluxIt(flux);
-    std::unique_ptr<ReadOnlyVectorIterator<Double> > beamAreaIter(
+    std::unique_ptr<ReadOnlyVectorIterator<Double>> beamAreaIter(
         gotBeamArea ? new ReadOnlyVectorIterator<Double>(beamArea) : nullptr
     );
     uInt n1 = nPtsIt.vector().nelements();

--- a/images/Images/ImageStatistics.tcc
+++ b/images/Images/ImageStatistics.tcc
@@ -50,6 +50,7 @@
 #include <casacore/casa/iomanip.h>
 #include <casacore/casa/stdlib.h>
 #include <casacore/casa/sstream.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -677,8 +678,8 @@ template <class T> Bool ImageStatistics<T>::_computeFlux(
     ReadOnlyVectorIterator<AccumType> sumIt(sum);
     ReadOnlyVectorIterator<AccumType> nPtsIt(npts);
     VectorIterator<AccumType> fluxIt(flux);
-    PtrHolder<ReadOnlyVectorIterator<Double> > beamAreaIter(
-        gotBeamArea ? new ReadOnlyVectorIterator<Double>(beamArea) : 0
+    std::unique_ptr<ReadOnlyVectorIterator<Double> > beamAreaIter(
+        gotBeamArea ? new ReadOnlyVectorIterator<Double>(beamArea) : nullptr
     );
     uInt n1 = nPtsIt.vector().nelements();
     while (!nPtsIt.pastEnd()) {

--- a/images/Images/ImageUtilities.cc
+++ b/images/Images/ImageUtilities.cc
@@ -52,7 +52,6 @@
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/LinearSearch.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/iostream.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN

--- a/images/Images/ImageUtilities.h
+++ b/images/Images/ImageUtilities.h
@@ -30,15 +30,14 @@
 #include <casacore/scimath/Mathematics/GaussianBeam.h>
 #include <casacore/lattices/Lattices/TiledShape.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
 template <class T> class ImageInterface;
 template <class T> class Quantum;
-template <class T> class PtrHolder;
 class CoordinateSystem;
 class Coordinate;
 class String;
@@ -89,7 +88,7 @@ public:
   // applied.
   //  <group>
   template<class T>
-  static void openImage (PtrHolder<ImageInterface<T> >& image,
+  static void openImage (std::unique_ptr<ImageInterface<T> >& image,
                          const String& fileName);
 
   template<class T>
@@ -123,7 +122,7 @@ public:
    template <typename T>
    static void addDegenerateAxes (
 		   LogIO& os,
-		   PtrHolder<ImageInterface<T> >& outImage,
+		   std::unique_ptr<ImageInterface<T> >& outImage,
 		   const ImageInterface<T>& inImage,
 		   const String& outFile, Bool direction,
 		   Bool spectral, const String& stokes,

--- a/images/Images/ImageUtilities.h
+++ b/images/Images/ImageUtilities.h
@@ -88,7 +88,7 @@ public:
   // applied.
   //  <group>
   template<class T>
-  static void openImage (std::unique_ptr<ImageInterface<T> >& image,
+  static void openImage (std::unique_ptr<ImageInterface<T>>& image,
                          const String& fileName);
 
   template<class T>
@@ -96,7 +96,7 @@ public:
                          const String& fileName);
 
   template<class T>
-  static std::shared_ptr<ImageInterface<T> > openImage (const String& fileName);
+  static std::shared_ptr<ImageInterface<T>> openImage (const String& fileName);
 //  </group>
 
 // Copy MiscInfo, ImageInfo, brightness unit and logger (history) from in to out
@@ -122,7 +122,7 @@ public:
    template <typename T>
    static void addDegenerateAxes (
 		   LogIO& os,
-		   std::unique_ptr<ImageInterface<T> >& outImage,
+		   std::unique_ptr<ImageInterface<T>>& outImage,
 		   const ImageInterface<T>& inImage,
 		   const String& outFile, Bool direction,
 		   Bool spectral, const String& stokes,

--- a/images/Images/ImageUtilities2.tcc
+++ b/images/Images/ImageUtilities2.tcc
@@ -51,7 +51,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <typename T> void ImageUtilities::addDegenerateAxes(
-	LogIO& os, PtrHolder<ImageInterface<T> >& outImage,
+        LogIO& os, std::unique_ptr<ImageInterface<T> >& outImage,
 	const ImageInterface<T>& inImage, const String& outFile,
 	Bool direction, Bool spectral, const String& stokes,
 	Bool linear, Bool tabular, Bool overwrite,
@@ -85,12 +85,12 @@ template <typename T> void ImageUtilities::addDegenerateAxes(
 	if (outFile.empty()) {
 		os << LogIO::NORMAL << "Creating (temp)image of shape "
 			<< shape << LogIO::POST;
-		outImage.set(new TempImage<T>(shape, cSys));
+		outImage.reset(new TempImage<T>(shape, cSys));
 	}
 	else {
 		os << LogIO::NORMAL << "Creating image '" << outFile << "' of shape "
 			<< shape << LogIO::POST;
-		outImage.set(new PagedImage<T>(shape, cSys, outFile));
+		outImage.reset(new PagedImage<T>(shape, cSys, outFile));
 	}
 	ImageInterface<T>* pOutImage = outImage.ptr();
 
@@ -286,12 +286,12 @@ template <typename T> void ImageUtilities::openImage(
 }
 
 template <typename T> void ImageUtilities::openImage(
-	PtrHolder<ImageInterface<T> >& image,
+        std::unique_ptr<ImageInterface<T> >& image,
 	const String& fileName
 ) {
    ImageInterface<T>* p = 0;
    ImageUtilities::openImage(p, fileName);
-   image.set(p);
+   image.reset(p);
 }
 
 template <typename T>

--- a/images/Images/ImageUtilities2.tcc
+++ b/images/Images/ImageUtilities2.tcc
@@ -51,7 +51,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <typename T> void ImageUtilities::addDegenerateAxes(
-        LogIO& os, std::unique_ptr<ImageInterface<T> >& outImage,
+        LogIO& os, std::unique_ptr<ImageInterface<T>>& outImage,
 	const ImageInterface<T>& inImage, const String& outFile,
 	Bool direction, Bool spectral, const String& stokes,
 	Bool linear, Bool tabular, Bool overwrite,
@@ -286,7 +286,7 @@ template <typename T> void ImageUtilities::openImage(
 }
 
 template <typename T> void ImageUtilities::openImage(
-        std::unique_ptr<ImageInterface<T> >& image,
+        std::unique_ptr<ImageInterface<T>>& image,
 	const String& fileName
 ) {
    ImageInterface<T>* p = 0;
@@ -295,12 +295,12 @@ template <typename T> void ImageUtilities::openImage(
 }
 
 template <typename T>
-std::shared_ptr<ImageInterface<T> > ImageUtilities::openImage
+std::shared_ptr<ImageInterface<T>> ImageUtilities::openImage
 (const String& fileName)
 {
    ImageInterface<T>* p = 0;
    ImageUtilities::openImage(p, fileName);
-   return std::shared_ptr<ImageInterface<T> > (p);
+   return std::shared_ptr<ImageInterface<T>> (p);
 }
 
 } //# NAMESPACE CASACORE - END

--- a/images/Images/test/tImageUtilities.cc
+++ b/images/Images/test/tImageUtilities.cc
@@ -71,7 +71,7 @@ void doOpens()
 				      True);
 
       {
-         PtrHolder<ImageInterface<Float> > im;
+         std::unique_ptr<ImageInterface<Float> > im;
          ImageUtilities::openImage(im, name1);
       }
       {
@@ -79,7 +79,7 @@ void doOpens()
          im = ImageUtilities::openImage<Float>(name1);
       }
       {
-         PtrHolder<ImageInterface<Float> > im;
+         std::unique_ptr<ImageInterface<Float> > im;
          ImageUtilities::openImage(im, name2);
       }
    }

--- a/images/Images/test/tImageUtilities.cc
+++ b/images/Images/test/tImageUtilities.cc
@@ -71,15 +71,15 @@ void doOpens()
 				      True);
 
       {
-         std::unique_ptr<ImageInterface<Float> > im;
+         std::unique_ptr<ImageInterface<Float>> im;
          ImageUtilities::openImage(im, name1);
       }
       {
-         CountedPtr<ImageInterface<Float> > im;
+         CountedPtr<ImageInterface<Float>> im;
          im = ImageUtilities::openImage<Float>(name1);
       }
       {
-         std::unique_ptr<ImageInterface<Float> > im;
+         std::unique_ptr<ImageInterface<Float>> im;
          ImageUtilities::openImage(im, name2);
       }
    }
@@ -155,7 +155,7 @@ void doTypes()
   dir.removeRecursive();
 }
 
-void listWorld (const Vector<Quantum<Double> >& wPars)
+void listWorld (const Vector<Quantum<Double>>& wPars)
 {
    cerr << "World" << endl;
    if (wPars.nelements()==3){ 

--- a/images/Images/test/tSubImage.cc
+++ b/images/Images/test/tSubImage.cc
@@ -41,11 +41,10 @@
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/Arrays/IPosition.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/iostream.h>
-
+#include <memory>
 
 #include <casacore/casa/namespace.h>
 void testVectorROIter (const Lattice<Float>& sublat,
@@ -314,10 +313,10 @@ void testBeams() {
 	trc[3] = 5.7;
 	LCBox box(blc, trc, shape);
     Record myboxRec = box.toRecord("");
-    PtrHolder<LogIO> log(new LogIO());
-    PtrHolder<ImageRegion> outRegionMgr(
+    std::unique_ptr<LogIO> log(new LogIO());
+    std::unique_ptr<ImageRegion> outRegionMgr(
         ImageRegion::fromRecord(
-            log.ptr(), x.coordinates(),
+            log.get(), x.coordinates(),
             x.shape(), myboxRec
         )
     );

--- a/lattices/LatticeMath/Fit2D.cc
+++ b/lattices/LatticeMath/Fit2D.cc
@@ -41,7 +41,6 @@
 #include <casacore/casa/Quanta/MVAngle.h>
 #include <casacore/scimath/Mathematics/AutoDiff.h>
 #include <casacore/scimath/Mathematics/AutoDiffIO.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/Assert.h>
 
 #include <casacore/casa/iostream.h>

--- a/lattices/LatticeMath/LatticeStatistics.h
+++ b/lattices/LatticeMath/LatticeStatistics.h
@@ -540,7 +540,7 @@ private:
    Double _aOld, _bOld, _aNew, _bNew;
    
    // unset means let the code decide
-   PtrHolder<LatticeStatsAlgorithm> _latticeStatsAlgortihm;
+   std::unique_ptr<LatticeStatsAlgorithm> _latticeStatsAlgortihm;
 
    void _setDefaultCoeffs() {
        // coefficients from timings run on PagedImages on

--- a/lattices/LatticeMath/LatticeStatistics.tcc
+++ b/lattices/LatticeMath/LatticeStatistics.tcc
@@ -57,7 +57,6 @@
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/casa/Utilities/GenSort.h>
 #include <casacore/casa/Utilities/LinearSearch.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/ValType.h>
@@ -169,7 +168,7 @@ LatticeStatistics<T>::LatticeStatistics(const LatticeStatistics<T> &other)
   _aOld(other._aOld), _bOld(other._bOld), _aNew(other._aNew), _bNew(other._bNew),
   _latticeStatsAlgortihm(
       other._latticeStatsAlgortihm
-          ? new LatticeStatsAlgorithm(*other._latticeStatsAlgortihm) : NULL
+          ? new LatticeStatsAlgorithm(*other._latticeStatsAlgortihm) : nullptr
   )
 //
 // Copy constructor.  Storage lattice is not copied.
@@ -239,10 +238,10 @@ LatticeStatistics<T> &LatticeStatistics<T>::operator=(const LatticeStatistics<T>
       _bNew = other._bNew;
       _aOld = other._aOld;
       _bOld = other._bOld;
-      _latticeStatsAlgortihm.set(
+      _latticeStatsAlgortihm.reset(
           other._latticeStatsAlgortihm
               ? new LatticeStatsAlgorithm(*other._latticeStatsAlgortihm)
-              : NULL
+              : nullptr
       );
    }
    return *this;
@@ -815,28 +814,28 @@ Bool LatticeStatistics<T>::configureChauvenet(
 
 template <class T>
 void LatticeStatistics<T>::forceUseStatsFrameworkUsingDataProviders() {
-    _latticeStatsAlgortihm.set(
+    _latticeStatsAlgortihm.reset(
         new LatticeStatsAlgorithm(STATS_FRAMEWORK_DATA_PROVIDERS)
     );
 }
 
 template <class T>
 void LatticeStatistics<T>::forceUseStatsFrameworkUsingArrays() {
-    _latticeStatsAlgortihm.set(
+    _latticeStatsAlgortihm.reset(
         new LatticeStatsAlgorithm(STATS_FRAMEWORK_ARRAYS)
     );
 }
 
 template <class T>
 void LatticeStatistics<T>::forceUseOldTiledApplyMethod() {
-    _latticeStatsAlgortihm.set(
+    _latticeStatsAlgortihm.reset(
         new LatticeStatsAlgorithm(TILED_APPLY)
     );
 }
 
 template <class T>
 void LatticeStatistics<T>::forceAllowCodeDecideWhichAlgortihmToUse() {
-    _latticeStatsAlgortihm.set(NULL);
+    _latticeStatsAlgortihm.reset(nullptr);
 }
 
 template <class T>

--- a/measures/Measures/MeasureHolder.cc
+++ b/measures/Measures/MeasureHolder.cc
@@ -51,7 +51,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Constructors
 MeasureHolder::MeasureHolder() 
-  : hold_p(), mvhold_p(0), convertmv_p(False) {
+  : mvhold_p(0), convertmv_p(False) {
   createMV(0);
 }
 
@@ -60,9 +60,9 @@ MeasureHolder::MeasureHolder(const Measure &in)
 
 MeasureHolder::MeasureHolder(const MeasureHolder &other) 
   : RecordTransformable(),
-    hold_p(), mvhold_p(0), convertmv_p(False)
+    mvhold_p(0), convertmv_p(False)
 {
-  if (other.hold_p.ptr()) hold_p.set(other.hold_p.ptr()->clone());
+  if (other.hold_p) hold_p.reset(other.hold_p->clone());
   createMV(other.mvhold_p.nelements());
   for (uInt i=0; i<mvhold_p.nelements(); i++) {
     mvhold_p[i] = other.mvhold_p[i]->clone();
@@ -77,10 +77,10 @@ MeasureHolder::~MeasureHolder() {
 //# Operators
 MeasureHolder &MeasureHolder::operator=(const MeasureHolder &other) {
   if (this != &other) {
-    if (other.hold_p.ptr()) {
-      hold_p.set(other.hold_p.ptr()->clone());
+    if (other.hold_p) {
+      hold_p.reset(other.hold_p->clone());
     } else {
-      hold_p.clear();
+      hold_p.reset();
     }
     createMV(other.mvhold_p.nelements());
     for (uInt i=0; i<mvhold_p.nelements(); i++) {
@@ -92,117 +92,117 @@ MeasureHolder &MeasureHolder::operator=(const MeasureHolder &other) {
 
 //# Member Functions
 Bool MeasureHolder::isEmpty() const {
-  return (!hold_p.ptr());
+  return (!hold_p);
 }
 
 Bool MeasureHolder::isMeasure() const {
-  return (hold_p.ptr());
+  return static_cast<Bool>(hold_p);
 }
 
 Bool MeasureHolder::isMDirection() const {
-  return (hold_p.ptr() && dynamic_cast<const MDirection*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MDirection*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMDoppler() const {
-  return (hold_p.ptr() && dynamic_cast<const MDoppler*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MDoppler*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMEpoch() const {
-  return (hold_p.ptr() && dynamic_cast<const MEpoch*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MEpoch*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMFrequency() const {
-  return (hold_p.ptr() && dynamic_cast<const MFrequency*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MFrequency*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMPosition() const {
-  return (hold_p.ptr() && dynamic_cast<const MPosition*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MPosition*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMRadialVelocity() const {
-  return (hold_p.ptr() && dynamic_cast<const MRadialVelocity*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MRadialVelocity*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMBaseline() const {
-  return (hold_p.ptr() && dynamic_cast<const MBaseline*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MBaseline*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMuvw() const {
-  return (hold_p.ptr() && dynamic_cast<const Muvw*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const Muvw*>(hold_p.get()));
 }
 
 Bool MeasureHolder::isMEarthMagnetic() const {
-  return (hold_p.ptr() && dynamic_cast<const MEarthMagnetic*>(hold_p.ptr()));
+  return (hold_p && dynamic_cast<const MEarthMagnetic*>(hold_p.get()));
 }
 
 const Measure &MeasureHolder::asMeasure() const {
-  if (!hold_p.ptr()) {
+  if (!hold_p) {
     throw(AipsError("Empty MeasureHolder argument for asMeasure"));
   }
-  return *hold_p.ptr();
+  return *hold_p;
 }
 
 const MDirection &MeasureHolder::asMDirection() const {
-  if (!hold_p.ptr() || !isMDirection()) {
+  if (!hold_p || !isMDirection()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMDirection"));
   }
-  return dynamic_cast<const MDirection &>(*hold_p.ptr());
+  return dynamic_cast<const MDirection &>(*hold_p.get());
 }
 
 const MDoppler &MeasureHolder::asMDoppler() const {
-  if (!hold_p.ptr() || !isMDoppler()) {
+  if (!hold_p || !isMDoppler()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMDoppler"));
   }
-  return dynamic_cast<const MDoppler &>(*hold_p.ptr());
+  return dynamic_cast<const MDoppler &>(*hold_p.get());
 }
 
 const MEpoch &MeasureHolder::asMEpoch() const {
-  if (!hold_p.ptr() || !isMEpoch()) {
+  if (!hold_p || !isMEpoch()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMEpoch"));
   }
-  return dynamic_cast<const MEpoch &>(*hold_p.ptr());
+  return dynamic_cast<const MEpoch &>(*hold_p.get());
 }
 
 const MFrequency &MeasureHolder::asMFrequency() const {
-  if (!hold_p.ptr() || !isMFrequency()) {
+  if (!hold_p || !isMFrequency()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMFrequency"));
   }
-  return dynamic_cast<const MFrequency &>(*hold_p.ptr());
+  return dynamic_cast<const MFrequency &>(*hold_p.get());
 }
 
 const MPosition &MeasureHolder::asMPosition() const {
-  if (!hold_p.ptr() || !isMPosition()) {
+  if (!hold_p || !isMPosition()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMPosition"));
   }
-  return dynamic_cast<const MPosition &>(*hold_p.ptr());
+  return dynamic_cast<const MPosition &>(*hold_p.get());
 }
 
 const MRadialVelocity &MeasureHolder::asMRadialVelocity() const {
-  if (!hold_p.ptr() || !isMRadialVelocity()) {
+  if (!hold_p || !isMRadialVelocity()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMRadialVelocity"));
   }
-  return dynamic_cast<const MRadialVelocity &>(*hold_p.ptr());
+  return dynamic_cast<const MRadialVelocity &>(*hold_p.get());
 }
 
 const MEarthMagnetic &MeasureHolder::asMEarthMagnetic() const {
-  if (!hold_p.ptr() || !isMEarthMagnetic()) {
+  if (!hold_p || !isMEarthMagnetic()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMEarthMagnetic"));
   }
-  return dynamic_cast<const MEarthMagnetic &>(*hold_p.ptr());
+  return dynamic_cast<const MEarthMagnetic &>(*hold_p.get());
 }
 
 const MBaseline &MeasureHolder::asMBaseline() const {
-  if (!hold_p.ptr() || !isMBaseline()) {
+  if (!hold_p || !isMBaseline()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMBaseline"));
   }
-  return dynamic_cast<const MBaseline &>(*hold_p.ptr());
+  return dynamic_cast<const MBaseline &>(*hold_p.get());
 }
 
 const Muvw &MeasureHolder::asMuvw() const {
-  if (!hold_p.ptr() || !isMuvw()) {
+  if (!hold_p || !isMuvw()) {
     throw(AipsError("Empty or wrong MeasureHolder for asMuvw"));
   }
-  return dynamic_cast<const Muvw &>(*hold_p.ptr());
+  return dynamic_cast<const Muvw &>(*hold_p.get());
 }
 
 Bool MeasureHolder::fromRecord(String &error,
@@ -217,16 +217,16 @@ Bool MeasureHolder::fromRecord(String &error,
     }
     String rf;
     in.get(RecordFieldId("refer"), rf);
-    if (!hold_p.ptr()->setRefString(rf)) {
+    if (!hold_p->setRefString(rf)) {
       if (!rf.empty()) {
 	LogIO os(LogOrigin("MeasureHolder", 
 			   String("fromRecord(String, const RecordInterface"),
 			   WHERE));
 	os << LogIO::WARN <<
 	  String("Illegal or unknown reference type '") +
-	  rf + "' for " + downcase(String(hold_p.ptr()->tellMe())) +
+	  rf + "' for " + downcase(String(hold_p->tellMe())) +
 	  " definition. DEFAULT (" + 
-	  hold_p.ptr()->getDefaultType() + ") assumed." <<
+	  hold_p->getDefaultType() + ") assumed." <<
 	  LogIO::POST;
       }
     }
@@ -236,7 +236,7 @@ Bool MeasureHolder::fromRecord(String &error,
       if (!x.fromRecord(error, in.asRecord(RecordFieldId("offset")))) {
 	return False;
       }
-      if (!hold_p.ptr()->setOffset(x.asMeasure())) {
+      if (!hold_p->setOffset(x.asMeasure())) {
 	error += String("Unmatched offset type in MeasureHolder::fromRecord\n");
 	return False;
       }
@@ -271,7 +271,7 @@ Bool MeasureHolder::fromRecord(String &error,
 				q1.asQuantumVectorDouble().getFullUnit());
     if (n > 2) vq(2) = Quantity(q2.asQuantumVectorDouble().getValue()(0),
 				q2.asQuantumVectorDouble().getFullUnit());
-    if (!hold_p.ptr()->putValue(vq)) {
+    if (!hold_p->putValue(vq)) {
       error += String("Illegal quantity in MeasureHolder::fromRecord\n");
       return False;
     }
@@ -294,11 +294,11 @@ Bool MeasureHolder::fromRecord(String &error,
 				    q1.asQuantumVectorDouble().getFullUnit());
 	if (n > 2) vq(2) = Quantity(q2.asQuantumVectorDouble().getValue()(i),
 				    q2.asQuantumVectorDouble().getFullUnit());
-	if (!hold_p.ptr()->putValue(vq)) {
+	if (!hold_p->putValue(vq)) {
 	  error += String("Illegal quantity in MeasureHolder value\n");
 	  return False;
 	}
-	if (!setMV(i, *hold_p.ptr()->getData())) {
+	if (!setMV(i, *hold_p->getData())) {
 	  error += String("Illegal MeasValue in MeasureHolder value\n");
 	  return False;
 	}
@@ -321,16 +321,16 @@ Bool MeasureHolder::fromString(String &error,
 }
 
 Bool MeasureHolder::toRecord(String &error, RecordInterface &out) const {
-  if (hold_p.ptr() && putType(error, out)) {
-    out.define(RecordFieldId("refer"), hold_p.ptr()->getRefString());
-    const Measure *off = hold_p.ptr()->getRefPtr()->offset();
+  if (hold_p && putType(error, out)) {
+    out.define(RecordFieldId("refer"), hold_p->getRefString());
+    const Measure *off = hold_p->getRefPtr()->offset();
     if (off) {
       Record offs;
       if (!MeasureHolder(*off).toRecord(error, offs)) return False;
       out.defineRecord(RecordFieldId("offset"), offs);
     }
     // Make sure units available
-    Vector<Quantum<Double> > res = hold_p.ptr()->getData()->getRecordValue();
+    Vector<Quantum<Double> > res = hold_p->getData()->getRecordValue();
     uInt n(res.nelements());
     uInt nel(nelements());
     Record val;
@@ -397,7 +397,7 @@ void MeasureHolder::toRecord(RecordInterface& out) const {
 
 
 Bool MeasureHolder::toType(String &error, RecordInterface &out) const {
-  if (hold_p.ptr() && putType(error, out)) return True;
+  if (hold_p && putType(error, out)) return True;
   error += String("No Measure specified in MeasureHolder::toType\n");
   return False;    
 }
@@ -434,7 +434,7 @@ MeasValue *MeasureHolder::getMV(uInt pos) const {
 
 Bool MeasureHolder::putType(String &, RecordInterface &out) const {
   out.define(RecordFieldId("type"),
-	     downcase(String(hold_p.ptr()->tellMe())));
+	     downcase(String(hold_p->tellMe())));
   return True;
 }
 
@@ -447,25 +447,25 @@ Bool MeasureHolder::getType(String &error, const RecordInterface &in) {
 Bool MeasureHolder::getType(String &error, const String &in) {
   String tp(in);
   tp.downcase();
-  hold_p.clear();
+  hold_p.reset();
   if (tp == downcase(MDirection::showMe())) {
-    hold_p.set(new MDirection());
+    hold_p.reset(new MDirection());
   } else if (tp == downcase(MDoppler::showMe())) {
-    hold_p.set(new MDoppler());
+    hold_p.reset(new MDoppler());
   } else if (tp == downcase(MEpoch::showMe())) {
-    hold_p.set(new MEpoch());
+    hold_p.reset(new MEpoch());
   } else if (tp == downcase(MFrequency::showMe())) {
-    hold_p.set(new MFrequency());
+    hold_p.reset(new MFrequency());
   } else if (tp == downcase(MPosition::showMe())) {
-    hold_p.set(new MPosition());
+    hold_p.reset(new MPosition());
   } else if (tp == downcase(MRadialVelocity::showMe())) {
-    hold_p.set(new MRadialVelocity());
+    hold_p.reset(new MRadialVelocity());
   } else if (tp == downcase(MBaseline::showMe())) {
-    hold_p.set(new MBaseline());
+    hold_p.reset(new MBaseline());
   } else if (tp == downcase(Muvw::showMe())) {
-    hold_p.set(new Muvw());
+    hold_p.reset(new Muvw());
   } else if (tp == downcase(MEarthMagnetic::showMe())) {
-    hold_p.set(new MEarthMagnetic());
+    hold_p.reset(new MEarthMagnetic());
   } else {
     error = in + " is an unknown measure type";
     return False;

--- a/measures/Measures/MeasureHolder.h
+++ b/measures/Measures/MeasureHolder.h
@@ -28,9 +28,9 @@
 
 //# Includes
 #include <casacore/casa/aips.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/RecordTransformable.h>
 #include <casacore/casa/Containers/Block.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -234,7 +234,7 @@ private:
   
   //# Data Members
   // Pointer to a Measure
-  PtrHolder<Measure> hold_p;
+  std::unique_ptr<Measure> hold_p;
   // Block of pointers to measure values to make a faster interface
   Block<MeasValue *> mvhold_p;
   // Should the mvhold_p be converted into record?

--- a/ms/MSOper/MSSummary.h
+++ b/ms/MSOper/MSSummary.h
@@ -28,7 +28,6 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/ms/MeasurementSets/MSColumns.h>
 #include <memory>
 

--- a/scimath/Functionals/FunctionHolder.h
+++ b/scimath/Functionals/FunctionHolder.h
@@ -28,11 +28,11 @@
 
 //# Includes
 #include <casacore/casa/aips.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/Utilities/RecordTransformable.h>
 #include <casacore/scimath/Functionals/Function.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/BasicSL/String.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -186,13 +186,13 @@ template <class T> class FunctionHolder : public RecordTransformable {
 private:
   //# Data Members
   // Pointer to a Function
-  PtrHolder<Function<T> > hold_p;
+  std::unique_ptr<Function<T> > hold_p;
   // Aids (only filled after a succesful to/fromRecord
   // <group>
   mutable Types nf_p;
   mutable Int order_p;
   mutable String text_p;
-  mutable PtrHolder<RecordInterface> mode_p;
+  mutable std::unique_ptr<RecordInterface> mode_p;
   // </group>
   // List of known names
   mutable Vector<String> nam_p;

--- a/scimath/Functionals/FunctionHolder.h
+++ b/scimath/Functionals/FunctionHolder.h
@@ -186,7 +186,7 @@ template <class T> class FunctionHolder : public RecordTransformable {
 private:
   //# Data Members
   // Pointer to a Function
-  std::unique_ptr<Function<T> > hold_p;
+  std::unique_ptr<Function<T>> hold_p;
   // Aids (only filled after a succesful to/fromRecord
   // <group>
   mutable Types nf_p;
@@ -210,7 +210,7 @@ private:
   template <class U>
     Bool getType(String &error, Function<U> *&fn);
   void setParameters(Function<T> *&fn, const Vector<T> &params);
-  void setParameters(Function<AutoDiff<T> > *&fn, const Vector<T> &params);
+  void setParameters(Function<AutoDiff<T>> *&fn, const Vector<T> &params);
   // </group>
 };
 

--- a/scimath/Functionals/FunctionHolder.tcc
+++ b/scimath/Functionals/FunctionHolder.tcc
@@ -500,7 +500,7 @@ void FunctionHolder<T>::setParameters(Function<T> *&fn,
 }
 
 template <class T>
-void FunctionHolder<T>::setParameters(Function<AutoDiff<T> > *&fn,
+void FunctionHolder<T>::setParameters(Function<AutoDiff<T>> *&fn,
 				      const Vector<T> &params) {
   for (uInt i=0; i<fn->nparameters(); ++i) {
     (*fn)[i] = AutoDiff<T>(params[i], fn->nparameters(), i);

--- a/scimath/StatsFramework/BiweightStatistics.tcc
+++ b/scimath/StatsFramework/BiweightStatistics.tcc
@@ -455,8 +455,8 @@ void BiweightStatistics<CASA_STATP>::_doLocation() {
         ds.getDataProvider()
     );
     const uInt dim = ClassicalStatisticsData::CACHE_PADDING*nThreadsMax;
-    PtrHolder<AccumType> tsxw2(new AccumType[dim], True);
-    PtrHolder<AccumType> tsw2(new AccumType[dim], True);
+    std::unique_ptr<AccumType[]> tsxw2(new AccumType[dim]);
+    std::unique_ptr<AccumType[]> tsw2(new AccumType[dim]);
     // initialize the thread-based sums to 0
     for (uInt i=0; i<nThreadsMax; ++i) {
         uInt idx8 = i * ClassicalStatisticsData::CACHE_PADDING;
@@ -514,8 +514,8 @@ void BiweightStatistics<CASA_STATP>::_doScale() {
         ds.getDataProvider()
     );
     const uInt dim = ClassicalStatisticsData::CACHE_PADDING*nThreadsMax;
-    PtrHolder<AccumType> tsx_M2w4(new AccumType[dim], True);
-    PtrHolder<AccumType> tww_4u2(new AccumType[dim], True);
+    std::unique_ptr<AccumType[]> tsx_M2w4(new AccumType[dim]);
+    std::unique_ptr<AccumType[]> tww_4u2(new AccumType[dim]);
     // initialize the thread-based sums to 0
     for (uInt i=0; i<nThreadsMax; ++i) {
         uInt idx8 = i * ClassicalStatisticsData::CACHE_PADDING;
@@ -575,10 +575,10 @@ void BiweightStatistics<CASA_STATP>::_doLocationAndScale() {
         ds.getDataProvider()
     );
     const uInt dim = ClassicalStatisticsData::CACHE_PADDING*nThreadsMax;
-    PtrHolder<AccumType> tsxw2(new AccumType[dim], True);
-    PtrHolder<AccumType> tsw2(new AccumType[dim], True);
-    PtrHolder<AccumType> tsx_M2w4(new AccumType[dim], True);
-    PtrHolder<AccumType> tww_4u2(new AccumType[dim], True);
+    std::unique_ptr<AccumType[]> tsxw2(new AccumType[dim]);
+    std::unique_ptr<AccumType[]> tsw2(new AccumType[dim]);
+    std::unique_ptr<AccumType[]> tsx_M2w4(new AccumType[dim]);
+    std::unique_ptr<AccumType[]> tww_4u2(new AccumType[dim]);
     // initialize the thread-based sums to 0
     for (uInt i=0; i<nThreadsMax; ++i) {
         uInt idx8 = i * ClassicalStatisticsData::CACHE_PADDING;

--- a/scimath/StatsFramework/ClassicalQuantileComputer.tcc
+++ b/scimath/StatsFramework/ClassicalQuantileComputer.tcc
@@ -275,23 +275,23 @@ ClassicalQuantileComputer<CASA_STATP>::_binCounts(
     const uInt nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds->getDataProvider()
     );
-    // The PtrHolders hold references to C arrays of length
+    // The std::unique_ptr-s hold references to C arrays of length
     // ClassicalStatisticsData::CACHE_PADDING*nThreadsMax.
     // Only every CACHE_PADDING*nth element will be populated
-    PtrHolder<std::vector<std::vector<uInt64>>> tBins(
+    std::unique_ptr<std::vector<std::vector<uInt64>>[]> tBins(
         new std::vector<std::vector<uInt64> >[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
-    PtrHolder<std::vector<CountedPtr<AccumType>>> tSameVal(
+    std::unique_ptr<std::vector<CountedPtr<AccumType>>[]> tSameVal(
         new std::vector<CountedPtr<AccumType>>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
-    PtrHolder<std::vector<Bool>> tAllSame(
+    std::unique_ptr<std::vector<Bool>[]> tAllSame(
         new std::vector<Bool>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
         uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
@@ -422,10 +422,10 @@ void ClassicalQuantileComputer<CASA_STATP>::_createDataArray(DataArray& ary) {
     const auto nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds->getDataProvider()
     );
-    PtrHolder<std::vector<AccumType>> tAry(
+    std::unique_ptr<std::vector<AccumType>[]> tAry(
         new std::vector<AccumType>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
     while (True) {
         const auto& chunk = ds->initLoopVars();
@@ -645,15 +645,15 @@ void ClassicalQuantileComputer<CASA_STATP>::_createDataArrays(
     const uInt nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds->getDataProvider()
     );
-    PtrHolder<std::vector<std::vector<AccumType>>> tArys(
+    std::unique_ptr<std::vector<std::vector<AccumType>>[]> tArys(
         new std::vector<std::vector<AccumType>>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
-    PtrHolder<uInt64> tCurrentCount(
+    std::unique_ptr<uInt64[]> tCurrentCount(
         new uInt64[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
         uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;

--- a/scimath/StatsFramework/ClassicalStatistics.h
+++ b/scimath/StatsFramework/ClassicalStatistics.h
@@ -39,8 +39,6 @@
 
 namespace casacore {
 
-template <class T> class PtrHolder;
-
 // Class to calculate statistics in a "classical" sense, ie using accumulators
 // with no special filtering beyond optional range filtering etc.
 //

--- a/scimath/StatsFramework/ClassicalStatistics.tcc
+++ b/scimath/StatsFramework/ClassicalStatistics.tcc
@@ -31,7 +31,7 @@
 #include <casacore/scimath/StatsFramework/ClassicalStatisticsData.h>
 #include <casacore/scimath/StatsFramework/StatisticsIncrementer.h>
 #include <casacore/scimath/StatsFramework/StatisticsUtilities.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
+#include <memory>
 
 #include <iomanip>
 
@@ -459,10 +459,10 @@ StatsData<AccumType> ClassicalStatistics<CASA_STATP>::_getStatistics() {
     uInt nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds.getDataProvider()
     );
-    PtrHolder<StatsData<AccumType> > tStats(
+    std::unique_ptr<StatsData<AccumType>[]> tStats(
         new StatsData<AccumType>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
     for (uInt i=0; i<nThreadsMax; ++i) {
         uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*i;
@@ -847,15 +847,15 @@ void ClassicalStatistics<CASA_STATP>::_doMinMax(
     const uInt nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds.getDataProvider()
     );
-    PtrHolder<CountedPtr<AccumType> > tmin(
+    std::unique_ptr<CountedPtr<AccumType>[]> tmin(
         new CountedPtr<AccumType>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
-    PtrHolder<CountedPtr<AccumType> > tmax(
+    std::unique_ptr<CountedPtr<AccumType>[]> tmax(
         new CountedPtr<AccumType>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
     while (True) {
         const auto& chunk = ds.initLoopVars();
@@ -980,20 +980,20 @@ uInt64 ClassicalStatistics<CASA_STATP>::_doMinMaxNpts(
     const uInt nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds.getDataProvider()
     );
-    PtrHolder<CountedPtr<AccumType> > tmin(
+    std::unique_ptr<CountedPtr<AccumType>[]> tmin(
         new CountedPtr<AccumType>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
-    PtrHolder<CountedPtr<AccumType> > tmax(
+    std::unique_ptr<CountedPtr<AccumType>[]> tmax(
         new CountedPtr<AccumType>[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
-    PtrHolder<uInt64> npts(
+    std::unique_ptr<uInt64[]> npts(
         new uInt64[
             ClassicalStatisticsData::CACHE_PADDING*nThreadsMax
-        ], True
+        ]
     );
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
         uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;
@@ -1124,8 +1124,8 @@ uInt64 ClassicalStatistics<CASA_STATP>::_doNpts() {
     const uInt nThreadsMax = StatisticsUtilities<AccumType>::nThreadsMax(
         ds.getDataProvider()
     );
-    PtrHolder<uInt64> npts(
-        new uInt64[ClassicalStatisticsData::CACHE_PADDING*nThreadsMax], True
+    std::unique_ptr<uInt64[]> npts(
+        new uInt64[ClassicalStatisticsData::CACHE_PADDING*nThreadsMax]
     );
     for (uInt tid=0; tid<nThreadsMax; ++tid) {
         uInt idx8 = ClassicalStatisticsData::CACHE_PADDING*tid;

--- a/scimath/StatsFramework/StatisticsDataset.h
+++ b/scimath/StatsFramework/StatisticsDataset.h
@@ -30,9 +30,9 @@
 
 #include <casacore/scimath/StatsFramework/StatisticsTypes.h>
 
+
 namespace casacore {
 
-template <class T> class PtrHolder;
 
 // Representation of a statistics dataset used in statistics framework
 // calculatations.
@@ -66,12 +66,12 @@ public:
         uInt dataStride;
         // associated ranges. If nullptr, then there are none. If not, the
         // second member of the pair indicates if they are include ranges.
-        PtrHolder<std::pair<DataRanges, Bool>> ranges;
+        std::unique_ptr<std::pair<DataRanges, Bool>> ranges;
         // associated mask. If nullptr, then there is no mask.
         // If there is a mask, the second member is the mask stride.
-        PtrHolder<std::pair<MaskIterator, uInt>> mask;
+        std::unique_ptr<std::pair<MaskIterator, uInt>> mask;
         // associated weights. If nullptr, then there are no weights.
-        PtrHolder<WeightsIterator> weights;
+        std::unique_ptr<WeightsIterator> weights;
     };
 
     StatisticsDataset();

--- a/scimath/StatsFramework/StatisticsDataset.tcc
+++ b/scimath/StatsFramework/StatisticsDataset.tcc
@@ -27,8 +27,6 @@
 #define SCIMATH_STATISTICSDATASET_TCC
 
 #include <casacore/scimath/StatsFramework/StatisticsDataset.h>
-
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/scimath/StatsFramework/ClassicalStatisticsData.h>
 
 namespace casacore {
@@ -238,9 +236,9 @@ CASA_STATD void StatisticsDataset<CASA_STATP>::initIterators() {
         _dsiter = _dataStrides.begin();
         _citer = _counts.begin();
     }
-    _chunk.ranges.clear();
-    _chunk.mask.clear();
-    _chunk.weights.clear();
+    _chunk.ranges.reset();
+    _chunk.mask.reset();
+    _chunk.weights.reset();
 }
 
 CASA_STATD
@@ -250,20 +248,20 @@ StatisticsDataset<CASA_STATP>::initLoopVars() {
         _chunk.data = _dataProvider->getData();
         _chunk.count = _dataProvider->getCount();
         _chunk.dataStride = _dataProvider->getStride();
-        _chunk.ranges.set(
+        _chunk.ranges.reset(
             _dataProvider->hasRanges()
             ? new std::pair<DataRanges, Bool>(
                 _dataProvider->getRanges(), _dataProvider->isInclude()
             ) : nullptr
         );
-        _chunk.mask.set(
+        _chunk.mask.reset(
             _dataProvider->hasMask()
             ? new std::pair<MaskIterator, uInt>(
                 _dataProvider->getMask(), _dataProvider->getMaskStride()
             )
             : nullptr
         );
-        _chunk.weights.set(
+        _chunk.weights.reset(
             _dataProvider->hasWeights()
             ? new WeightsIterator(_dataProvider->getWeights()) : nullptr
         );
@@ -273,20 +271,20 @@ StatisticsDataset<CASA_STATP>::initLoopVars() {
         _chunk.count = *_citer;
         _chunk.dataStride = *_dsiter;
         auto rangeI = _dataRanges.find(_dataCount);
-        _chunk.ranges.set(
+        _chunk.ranges.reset(
             rangeI == _dataRanges.end() ? nullptr
             : new std::pair<DataRanges, Bool>(
                 rangeI->second, _isIncludeRanges.find(_dataCount)->second
             )
         );
         auto maskI = _masks.find(_dataCount);
-        _chunk.mask.set(
+        _chunk.mask.reset(
             maskI == _masks.end() ? nullptr
             : new std::pair<MaskIterator, uInt>(
                 maskI->second, _maskStrides.find(_dataCount)->second
             )
         );
-        _chunk.weights.set(
+        _chunk.weights.reset(
             _weights.find(_dataCount) == _weights.end()
             ? nullptr : new WeightsIterator(_weights.find(_dataCount)->second)
         );

--- a/scimath/StatsFramework/StatisticsUtilities.h
+++ b/scimath/StatsFramework/StatisticsUtilities.h
@@ -37,8 +37,6 @@
 
 namespace casacore {
 
-template <class T> class PtrHolder;
-
 CASA_STATD class StatsDataProvider;
 
 // Various statistics related methods for the statistics framework.
@@ -192,9 +190,9 @@ public:
         std::vector<BinCountArray>& bins,
         std::vector<CountedPtr<AccumType> >& sameVal,
         std::vector<Bool>& allSame,
-        const PtrHolder<std::vector<BinCountArray>>& tBins,
-        const PtrHolder<std::vector<CountedPtr<AccumType>>>& tSameVal,
-        const PtrHolder<std::vector<Bool>>& tAllSame, uInt nThreadsMax
+        const std::unique_ptr<std::vector<BinCountArray>[]>& tBins,
+        const std::unique_ptr<std::vector<CountedPtr<AccumType>>[]>& tSameVal,
+        const std::unique_ptr<std::vector<Bool>[]>& tAllSame, uInt nThreadsMax
     );
 
     // use two statistics sets to get the statistics set that would

--- a/scimath/StatsFramework/StatisticsUtilities.tcc
+++ b/scimath/StatsFramework/StatisticsUtilities.tcc
@@ -30,7 +30,6 @@
 
 #include <casacore/casa/OS/OMP.h>
 #include <casacore/casa/Utilities/GenSort.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/scimath/StatsFramework/ClassicalStatisticsData.h>
 
 #include <iostream>
@@ -295,9 +294,9 @@ template <class AccumType>
 void StatisticsUtilities<AccumType>::mergeResults(
     std::vector<BinCountArray>& bins,
     std::vector<CountedPtr<AccumType>>& sameVal, std::vector<Bool>& allSame,
-    const PtrHolder<std::vector<BinCountArray>>& tBins,
-    const PtrHolder<std::vector<CountedPtr<AccumType>>>& tSameVal,
-    const PtrHolder<std::vector<Bool>>& tAllSame, uInt nThreadsMax
+    const std::unique_ptr<std::vector<BinCountArray>[]>& tBins,
+    const std::unique_ptr<std::vector<CountedPtr<AccumType>>[]>& tSameVal,
+    const std::unique_ptr<std::vector<Bool>[]>& tAllSame, uInt nThreadsMax
 ) {
     // merge results from individual threads (tBins, tSameVal, tAllSame)
     // into single data structures (bins, sameVal, allSame)

--- a/tables/DataMan/MSMIndColumn.cc
+++ b/tables/DataMan/MSMIndColumn.cc
@@ -283,7 +283,7 @@ void MSMIndColumn::deleteArray (rownr_t rownr)
 
 
 
-  MSMIndColumn::Data::Data (const IPosition& shape, int dtype, int elemSize)
+MSMIndColumn::Data::Data (const IPosition& shape, int dtype, int elemSize)
 : shape_p (shape),
   data_p  (0)
 {

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -48,7 +48,6 @@
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Containers/ValueHolder.h>
 #include <casacore/casa/Utilities/Sort.h>
-#include <casacore/casa/Utilities/PtrHolder.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/GenSort.h>
 #include <casacore/casa/IO/AipsIO.h>


### PR DESCRIPTION
All instances of (S)PtrHolder have been replaced by std::unique_ptr. Both scalar and array values are addressed.
In a few files it also required changing casts, which have been replaced by static_cast.