### PR TITLE
Fix String.h hash namespace

### DIFF
--- a/casa/BasicSL/String.h
+++ b/casa/BasicSL/String.h
@@ -1035,12 +1035,14 @@ inline ostream &operator<<(ostream &s, const String &x) {
 
 
 // Define the hash function for String, so unordered_set<String> can be used.
+namespace std {
 template<>
-struct std::hash<casacore::String>
+struct hash<casacore::String>
 {
   std::size_t operator()(casacore::String const& k) const noexcept
     { return std::hash<std::string>()(k); }
 };
 
+}
 
 #endif


### PR DESCRIPTION
Casa build fails with the attached error when using the latest Casacore version: 
In file included from casacore/casacore/casa/Exceptions/Error.h:31:0,
                 from binding/source/conversions_python.cc:6:
casacore/casacore/casa/BasicSL/String.h:1039:13: error: specialization of ‘template<class _Tp> struct std::hash’ in different namespace [-fpermissive]
 struct std::hash<casacore::String>

This patch fixes the compilation error.
