### PR TITLE
Replace CountedPtr by std::shared_ptr in IO framework

### DIFF
--- a/casa/IO/AipsIO.h
+++ b/casa/IO/AipsIO.h
@@ -184,11 +184,11 @@ public:
     // for which a <linkto class=FilebufIO>FilebufIO</linkto>
     // object has been created.
     // The actual IO is done via a CanonicalIO object on top of it.
-    explicit AipsIO (ByteIO*);
+    explicit AipsIO (const std::shared_ptr<ByteIO>&);
 
     // Construct from a stream object derived from TypeIO, thus from
     // a stream on top of ByteIOn doing the possible conversions.
-    explicit AipsIO (TypeIO*);
+    explicit AipsIO (const std::shared_ptr<TypeIO>&);
 
     // Close if not done yet
     ~AipsIO();
@@ -202,7 +202,6 @@ public:
     void open (const String& fileName,
                ByteIO::OpenOption = ByteIO::Old,
                uInt filebufSize=65536,
-               ////		     uInt filebufSize=1048576,
                const std::shared_ptr<MultiFileBase>& = std::shared_ptr<MultiFileBase>());
 
     // Open by connecting to the given byte stream.
@@ -211,11 +210,11 @@ public:
     // object has been created.
     // The actual IO is done via a CanonicalIO object on top of it.
     // An exception is thrown if the object contains an already open file.
-    void open (ByteIO*);
+    void open (const std::shared_ptr<ByteIO>&);
 
     // Open by connecting to the given typed byte stream.
     // An exception is thrown if the object contains an already open file.
-    void open (TypeIO*);
+    void open (const std::shared_ptr<TypeIO>&);
 
     // Close file opened
     void close();
@@ -456,9 +455,9 @@ private:
     // The cached object type.
     String       objectType_p;
     // The file object.
-    ByteIO*      file_p;
+    std::shared_ptr<ByteIO> file_p;
     // The actual IO object.
-    TypeIO*      io_p;
+    std::shared_ptr<TypeIO> io_p;
     // Is the file is seekable?
     Bool         seekable_p;
     // magic value to check sync.

--- a/casa/IO/BaseSinkSource.cc
+++ b/casa/IO/BaseSinkSource.cc
@@ -33,8 +33,8 @@ BaseSinkSource::BaseSinkSource()
 : itsTypeIO ()
 {}
 
-BaseSinkSource::BaseSinkSource (TypeIO* typeIO, Bool takeOver)
-: itsTypeIO (typeIO, takeOver)
+BaseSinkSource::BaseSinkSource (const std::shared_ptr<TypeIO>& typeIO)
+: itsTypeIO (typeIO)
 {}
 
 BaseSinkSource::BaseSinkSource (const BaseSinkSource& sinkSource)
@@ -51,17 +51,6 @@ BaseSinkSource& BaseSinkSource::operator= (const BaseSinkSource& sinkSource)
 
 BaseSinkSource::~BaseSinkSource()
 {}
-
-
-TypeIO& BaseSinkSource::typeIO()
-{
-    return *itsTypeIO;
-}
-
-const TypeIO& BaseSinkSource::typeIO() const
-{
-    return *itsTypeIO;
-}
 
 Int64 BaseSinkSource::seek (Int64 offset, ByteIO::SeekOption option)
 {
@@ -89,7 +78,7 @@ Bool BaseSinkSource::isSeekable() const
 
 Bool BaseSinkSource::isNull() const
 {
-    return itsTypeIO.null();
+    return !itsTypeIO;
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/IO/BaseSinkSource.h
+++ b/casa/IO/BaseSinkSource.h
@@ -29,7 +29,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/IO/TypeIO.h>
 #include <casacore/casa/IO/ByteIO.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -81,11 +81,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 class BaseSinkSource
 {
 public: 
-    // This functions returns a reference to itsTypeIO.
-    // <group>
-    TypeIO& typeIO();
-    const TypeIO& typeIO() const;
-    // </group>
+    // This functions returns the shared pointer to itsTypeIO.
+    const std::shared_ptr<TypeIO>& typeIO() const
+      { return itsTypeIO; }
 
     // This function sets the position on the given offset.
     // The seek option defines from which position the seek is done.
@@ -109,10 +107,10 @@ public:
 protected:
     BaseSinkSource();
 
-    // Construct using the given TypeIO. If takeOver is true the this class
-    // will delete the supplied pointer. Otherwise the caller is responsible
-    // for this.
-    BaseSinkSource (TypeIO* typeIO, Bool takeOver=False);
+    // Construct using the given TypeIO.
+    // The constructor does not copy the object, but only keeps a pointer to it.
+    // It takes over the given pointer and deletes.
+    BaseSinkSource (const std::shared_ptr<TypeIO>& typeIO);
 
     // The copy constructor uses reference semantics
     BaseSinkSource (const BaseSinkSource& BaseSinkSource);
@@ -124,7 +122,7 @@ protected:
 
 
     // This variable keeps a pointer to a TypeIO.
-    CountedPtr<TypeIO> itsTypeIO;
+    std::shared_ptr<TypeIO> itsTypeIO;
 };
 
 

--- a/casa/IO/BucketFile.cc
+++ b/casa/IO/BucketFile.cc
@@ -67,12 +67,12 @@ BucketFile::BucketFile (const String& fileName,
 {
     // Create the file.
     if (mfile_p) {
-      file_p = new MFFileIO (mfile_p, name_p, ByteIO::New);
+      file_p.reset (new MFFileIO (mfile_p, name_p, ByteIO::New));
       isMapped_p = False;
       bufSize_p  = 0;
     } else {
       fd_p   = FiledesIO::create (name_p.chars());
-      file_p = new FiledesIO (fd_p, name_p);
+      file_p.reset (new FiledesIO (fd_p, name_p));
     }
     createMapBuf();
 }
@@ -101,12 +101,12 @@ BucketFile::~BucketFile()
     close();
 }
 
-CountedPtr<ByteIO> BucketFile::makeFilebufIO (uInt bufferSize)
+std::shared_ptr<ByteIO> BucketFile::makeFilebufIO (uInt bufferSize)
 {
   if (mfile_p) {
     return file_p;
   }
-  return new FilebufIO (fd_p, bufferSize);
+  return std::shared_ptr<ByteIO>(new FilebufIO (fd_p, bufferSize));
 }
 
 
@@ -114,7 +114,7 @@ void BucketFile::close()
 {
     if (file_p) {
         deleteMapBuf();
-	file_p = CountedPtr<ByteIO>();
+	file_p.reset();
         FiledesIO::close (fd_p);
 	fd_p   = -1;
     }
@@ -125,11 +125,11 @@ void BucketFile::open()
 {
     if (! file_p) {
       if (mfile_p) {
-        file_p = new MFFileIO (mfile_p, name_p,
-                               isWritable_p ? ByteIO::Update : ByteIO::Old);
+        file_p.reset (new MFFileIO (mfile_p, name_p,
+                                    isWritable_p ? ByteIO::Update : ByteIO::Old));
       } else {
         fd_p   = FiledesIO::open (name_p.chars(), isWritable_p);
-        file_p = new FiledesIO (fd_p, name_p);
+        file_p.reset (new FiledesIO (fd_p, name_p));
       }
       createMapBuf();
     }
@@ -168,7 +168,7 @@ void BucketFile::remove()
     } else {
       DOos::remove (name_p, False, False);
     }
-    file_p = CountedPtr<ByteIO>();
+    file_p.reset();
 }
 
 

--- a/casa/IO/BucketFile.h
+++ b/casa/IO/BucketFile.h
@@ -32,9 +32,8 @@
 #include <casacore/casa/IO/MMapfdIO.h>
 #include <casacore/casa/IO/FilebufIO.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <unistd.h>
-
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -136,7 +135,7 @@ public:
 
     // Make a (temporary) buffered IO object for this file.
     // That object should not close the file.
-    virtual CountedPtr<ByteIO> makeFilebufIO (uInt bufferSize);
+    virtual std::shared_ptr<ByteIO> makeFilebufIO (uInt bufferSize);
 
     // Get the mapped file object.
     MMapfdIO* mappedFile()
@@ -200,7 +199,7 @@ private:
     uInt bufSize_p;
     int  fd_p;    //  fd (if used) of unbuffered file
     // The unbuffered file.
-    CountedPtr<ByteIO> file_p;
+    std::shared_ptr<ByteIO> file_p;
     // The optional mapped file.
     MMapfdIO* mappedFile_p;
     // The optional buffered file.

--- a/casa/IO/ByteSink.cc
+++ b/casa/IO/ByteSink.cc
@@ -33,8 +33,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 ByteSink::ByteSink()
 {}
 
-ByteSink::ByteSink (TypeIO* typeIO, Bool takeOver)
-: BaseSinkSource (typeIO, takeOver)
+ByteSink::ByteSink (const std::shared_ptr<TypeIO>& typeIO)
+: BaseSinkSource (typeIO)
 {
     if (!isWritable()) {
 	throw (AipsError ("ByteSink is not writable"));

--- a/casa/IO/ByteSink.h
+++ b/casa/IO/ByteSink.h
@@ -97,11 +97,10 @@ public:
     // This creates an invalid object, but is present for convenience.
     ByteSink();
 
-    // Construct from given TypeIO object.  The constructor does not copy the
-    // object, but only keeps a pointer to it. If takeOver is true the this
-    // class will delete the supplied pointer. Otherwise the caller is
-    // responsible for this.
-    ByteSink (TypeIO* typeIO, Bool takeOver=False);
+    // Construct from given TypeIO object.
+    // The constructor does not copy the object, but only keeps a pointer to it.
+    // It takes over the given pointer and deletes.
+    ByteSink (const std::shared_ptr<TypeIO>& typeIO);
  
     // The copy constructor uses reference semantics
     ByteSink (const ByteSink& sink);

--- a/casa/IO/ByteSinkSource.cc
+++ b/casa/IO/ByteSinkSource.cc
@@ -32,8 +32,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 ByteSinkSource::ByteSinkSource ()
 {}
 
-ByteSinkSource::ByteSinkSource (TypeIO* typeIO, Bool takeOver)
-  : BaseSinkSource (typeIO, takeOver)
+ByteSinkSource::ByteSinkSource (const std::shared_ptr<TypeIO>& typeIO)
+  : BaseSinkSource (typeIO)
 {}
 
 ByteSinkSource::ByteSinkSource (const ByteSinkSource& sinkSource)

--- a/casa/IO/ByteSinkSource.h
+++ b/casa/IO/ByteSinkSource.h
@@ -94,11 +94,10 @@ public:
     // This creates an invalid object, but is present for convenience.
     ByteSinkSource();
 
-    // Construct from given TypeIO object.  The constructor does not copy the
-    // object, but only keeps a pointer to it. If takeOver is true the this
-    // class will delete the supplied pointer. Otherwise the caller is
-    // responsible for this.
-    ByteSinkSource (TypeIO* typeIO, Bool takeOver=False);
+    // Construct from given TypeIO object.
+    // The constructor does not copy the object, but only keeps a pointer to it.
+    // It takes over the given pointer and deletes.
+    ByteSinkSource (const std::shared_ptr<TypeIO>& typeIO);
 
     // The copy constructor uses reference semantics
     ByteSinkSource (const ByteSinkSource& sinkSource);

--- a/casa/IO/ByteSource.cc
+++ b/casa/IO/ByteSource.cc
@@ -33,8 +33,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 ByteSource::ByteSource()
 {}
 
-ByteSource::ByteSource (TypeIO* typeIO, Bool takeOver)
-: BaseSinkSource (typeIO, takeOver)
+ByteSource::ByteSource (const std::shared_ptr<TypeIO>& typeIO)
+: BaseSinkSource (typeIO)
 {    
     if (!isReadable()) {
 	throw (AipsError ("ByteSource is not readable"));

--- a/casa/IO/ByteSource.h
+++ b/casa/IO/ByteSource.h
@@ -93,11 +93,10 @@ public:
     // This creates an invalid object, but is present for convenience.
     ByteSource();
 
-    // Construct from given TypeIO object.  The constructor does not copy the
-    // object, but only keeps a pointer to it. If takeOver is true the this
-    // class will delete the supplied pointer. Otherwise the caller is
-    // responsible for this.
-    ByteSource (TypeIO* typeIO, Bool takeOver=False);
+    // Construct from given TypeIO object.
+    // The constructor does not copy the object, but only keeps a pointer to it.
+    // It takes over the given pointer and deletes.
+    ByteSource (const std::shared_ptr<TypeIO>& typeIO);
 
     // The copy constructor uses reference semantics
     ByteSource (const ByteSource& source);

--- a/casa/IO/CanonicalIO.cc
+++ b/casa/IO/CanonicalIO.cc
@@ -29,8 +29,9 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-CanonicalIO::CanonicalIO (ByteIO* byteIO, uInt bufferLength, Bool takeOver)
-: TypeIO          (byteIO, takeOver), 
+CanonicalIO::CanonicalIO (const std::shared_ptr<ByteIO>& byteIO,
+                          uInt bufferLength)
+: TypeIO          (byteIO),
   itsBuffer       (new char[bufferLength]),
   itsBufferLength (bufferLength)
 {}

--- a/casa/IO/CanonicalIO.h
+++ b/casa/IO/CanonicalIO.h
@@ -80,10 +80,10 @@ public:
     // length <src>bufferLength</src>. For arrays not fitting in this buffer,
     // it uses a temporary buffer allocated on the heap.
     // <p>
-    // If takeOver is True the this class will delete the supplied
-    // pointer. Otherwise the caller is responsible for this.
-    explicit CanonicalIO (ByteIO* byteIO, uInt bufferLength=4096,
-			  Bool takeOver=False);
+    // This class takes over the pointer and will be responsible for deleting the
+    // ByteIO pointer.
+    explicit CanonicalIO (const std::shared_ptr<ByteIO>& byteIO,
+                          uInt bufferLength=4096);
 
     // The copy constructor uses reference semantics
     CanonicalIO (const CanonicalIO& canonicalIO);

--- a/casa/IO/ConversionIO.cc
+++ b/casa/IO/ConversionIO.cc
@@ -31,10 +31,11 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-ConversionIO::ConversionIO (DataConversion* dataConversion,
-			    ByteIO* byteIO, uInt bufferLength, Bool takeOver)
-: TypeIO          (byteIO, takeOver),
-  itsConversion   (dataConversion, takeOver),
+ConversionIO::ConversionIO (const std::shared_ptr<DataConversion>& dataConversion,
+			    const std::shared_ptr<ByteIO>& byteIO,
+                            uInt bufferLength)
+: TypeIO          (byteIO),
+  itsConversion   (dataConversion),
   itsBuffer       (new char[bufferLength]),
   itsBufferLength (bufferLength)
 {

--- a/casa/IO/ConversionIO.h
+++ b/casa/IO/ConversionIO.h
@@ -28,7 +28,7 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/IO/TypeIO.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 //# The following should be a declaration. But our Complex & DComplex classes
 //# are a typedef hence this does not work. Replace the following with
 //# forward declarations when Complex and DComplex are no longer typedefs.
@@ -82,11 +82,11 @@ public:
     // length <src>bufferLength</src>. For arrays not fitting in this buffer,
     // it uses a temporary buffer allocated on the heap.
     // <p>
-    // If takeOver is True this this class will be responsible for deleting the
-    // DataConversion and ByteIO pointers.  Otherwise it is the callers
-    // responsibility.
-    ConversionIO (DataConversion* dataConversion, ByteIO* byteIO,
-		  uInt bufferLength=4096, Bool takeOver=False);
+    // This class takes over the pointers and will be responsible for deleting the
+    // DataConversion and ByteIO pointers.
+    ConversionIO (const std::shared_ptr<DataConversion>& dataConversion,
+                  const std::shared_ptr<ByteIO>& byteIO,
+		  uInt bufferLength=4096);
 
     // The copy constructor uses reference semantics
     ConversionIO (const ConversionIO& conversionIO);
@@ -141,7 +141,7 @@ private:
 
 
     //# The data.
-    CountedPtr<DataConversion> itsConversion;
+    std::shared_ptr<DataConversion> itsConversion;
     uInt itsSizeChar;
     uInt itsSizeuChar;
     uInt itsSizeShort;

--- a/casa/IO/LECanonicalIO.cc
+++ b/casa/IO/LECanonicalIO.cc
@@ -29,8 +29,9 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-LECanonicalIO::LECanonicalIO (ByteIO* byteIO, uInt bufferLength, Bool takeOver)
-: TypeIO          (byteIO, takeOver), 
+LECanonicalIO::LECanonicalIO (const std::shared_ptr<ByteIO>& byteIO,
+                              uInt bufferLength)
+: TypeIO          (byteIO),
   itsBuffer       (new char[bufferLength]),
   itsBufferLength (bufferLength)
 {}

--- a/casa/IO/LECanonicalIO.h
+++ b/casa/IO/LECanonicalIO.h
@@ -77,10 +77,10 @@ public:
     // length <src>bufferLength</src>. For arrays not fitting in this buffer,
     // it uses a temporary buffer allocated on the heap.
     // <p>
-    // If takeOver is True the this class will delete the supplied
-    // pointer. Otherwise the caller is responsible for this.
-    explicit LECanonicalIO (ByteIO* byteIO, uInt bufferLength=4096,
-			    Bool takeOver=False);
+    // This class takes over the pointer and will be responsible for deleting the
+    // ByteIO pointer.
+    explicit LECanonicalIO (const std::shared_ptr<ByteIO>& byteIO,
+                            uInt bufferLength=4096);
 
     // The copy constructor uses reference semantics
     LECanonicalIO (const LECanonicalIO& canonicalIO);

--- a/casa/IO/LockFile.h
+++ b/casa/IO/LockFile.h
@@ -316,8 +316,7 @@ private:
     //# The member variables.
     FileLocker   itsLocker;
     FileLocker   itsUseLocker;
-    FiledesIO*   itsFileIO;
-    CanonicalIO* itsCanIO;
+    std::shared_ptr<FiledesIO>   itsFileIO;
     Bool         itsWritable;         //# lock file is writable?
     Bool         itsAddToList;        //# Should acquire add to request list?
     double       itsInterval;         //# interval between inspections

--- a/casa/IO/MultiFile.cc
+++ b/casa/IO/MultiFile.cc
@@ -182,9 +182,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // If too large, the remainder is written into continuation blocks.
     // There are 2 sets of continuation blocks to avoid that the header
     // gets corrupted in case of a crash while writing the header.
-    MemoryIO mio(itsBlockSize, itsBlockSize);
-    CanonicalIO cio(&mio);
-    AipsIO aio(&cio);
+    MemoryIO* mio = new MemoryIO(itsBlockSize, itsBlockSize);
+    std::shared_ptr<ByteIO> bio(mio);
+    std::shared_ptr<TypeIO> cio(new CanonicalIO(bio));
+    AipsIO aio(cio);
     itsHdrCounter++;
     Int64 zero64 = 0;
     uInt  zero32 = 0;
@@ -192,17 +193,17 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Int   version = 2;
     // Start with a zero to distinguish it from version 1.
     // The first value in version 1 is always > 0.
-    cio.write (1, &zero64);
-    cio.write (1, &zero64);        // room for first cont.block (writeRemainder)
-    cio.write (1, &itsHdrCounter);
-    cio.write (1, &version);
-    cio.write (1, &zero32);        // headerCRC
-    cio.write (1, &zero64);        // header size
-    cio.write (1, &itsBlockSize);
-    cio.write (1, &itsNrBlock);
+    cio->write (1, &zero64);
+    cio->write (1, &zero64);        // room for first cont.block (writeRemainder)
+    cio->write (1, &itsHdrCounter);
+    cio->write (1, &version);
+    cio->write (1, &zero32);        // headerCRC
+    cio->write (1, &zero64);        // header size
+    cio->write (1, &itsBlockSize);
+    cio->write (1, &itsNrBlock);
     if (itsUseCRC) char8[0] = 1;
-    cio.write (8, char8);
-    AlwaysAssert (mio.length() == 64, AipsError);
+    cio->write (8, char8);
+    AlwaysAssert (mio->length() == 64, AipsError);
     // First write general info and file names, etc.
     aio.putstart ("MultiFile", version);
     aio << itsInfo;
@@ -210,16 +211,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Write the used and free blocknrs in packed format but outside
     // the AipsIO object because that is limited to 4 GB.
     for (const MultiFileInfo& fileInfo : info()) {
-      writeVector (cio, packIndex(fileInfo.blockNrs));
+      writeVector (*cio, packIndex(fileInfo.blockNrs));
     }
-    writeVector (cio, packIndex(freeBlocks()));
-    writeVector (cio, itsCRC);
+    writeVector (*cio, packIndex(freeBlocks()));
+    writeVector (*cio, itsCRC);
     // Calculate the size including the continuation blocknrs and number of
     // actually used blocknrs.
     // If continuation is needed, they might change and cannot
     // be written yet.
-    Int64 todo = mio.length();
-    DebugAssert (todo <= mio.allocated(), AipsError);
+    Int64 todo = mio->length();
+    DebugAssert (todo <= mio->allocated(), AipsError);
     Int64 totalSize = todo + 2*sizeof(uInt) + (2 + itsHdrCont[0].blockNrs.size() +
                               itsHdrCont[1].blockNrs.size()) * sizeof(Int64);
     // Allocate a temp buffer if header too large or if O_DIRECT.
@@ -229,18 +230,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
                           itsUseODirect);
     // First write the remainder and adjust the header as needed.
     if (hasRemainder) {
-      writeRemainder (mio, cio, mfbuf);
+      writeRemainder (*mio, *cio, mfbuf);
     } else {
       // No remainder, so write the continuation blocknrs here.
       // None are used in the current set.
-      writeVector (cio, itsHdrCont[0].blockNrs);
-      writeVector (cio, itsHdrCont[1].blockNrs);
+      writeVector (*cio, itsHdrCont[0].blockNrs);
+      writeVector (*cio, itsHdrCont[1].blockNrs);
       itsNrContUsed[itsHdrContInx] = 0;
-      cio.write (2, itsNrContUsed);
+      cio->write (2, itsNrContUsed);
     }
     // Writing the first part of the header is done as the last step.
-    uChar* buf = const_cast<uChar*>(mio.getBuffer());
-    todo = mio.length();
+    uChar* buf = const_cast<uChar*>(mio->getBuffer());
+    todo = mio->length();
     CanonicalConversion::fromLocal (buf+32, todo);  // header size
     if (itsUseCRC) {
       uInt crc = calcCRC (buf, todo);
@@ -257,7 +258,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
   }
 
-  void MultiFile::writeRemainder (MemoryIO& mio, CanonicalIO& cio,
+  void MultiFile::writeRemainder (MemoryIO& mio, TypeIO& cio,
                                   MultiFileBuffer& mfbuf)
   {
     char* iobuf = mfbuf.data();
@@ -318,7 +319,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     CanonicalConversion::fromLocal (buf+48, itsNrBlock);
   }
 
-  void MultiFile::writeVector (CanonicalIO& cio, const std::vector<Int64>& index)
+  void MultiFile::writeVector (TypeIO& cio, const std::vector<Int64>& index)
   {
     // Write in the same way as AipsIO is doing.
     Int64 sz = index.size();
@@ -328,7 +329,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
   }
 
-  void MultiFile::writeVector (CanonicalIO& cio, const std::vector<uInt>& index)
+  void MultiFile::writeVector (TypeIO& cio, const std::vector<uInt>& index)
   {
     // Write in the same way as AipsIO is doing.
     Int64 sz = index.size();
@@ -338,7 +339,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
   }
 
-  void MultiFile::readVector (CanonicalIO& cio, std::vector<Int64>& index)
+  void MultiFile::readVector (TypeIO& cio, std::vector<Int64>& index)
   {
     Int64 sz;
     cio.read (1, &sz);
@@ -350,7 +351,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
   }
 
-  void MultiFile::readVector (CanonicalIO& cio, std::vector<uInt>& index)
+  void MultiFile::readVector (TypeIO& cio, std::vector<uInt>& index)
   {
     Int64 sz;
     cio.read (1, &sz);
@@ -453,9 +454,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       iohdr.read (headerSize - itsBlockSize, &(buf[itsBlockSize]));
     }
     // Read all header info from the memory buffer.
-    MemoryIO mio(&(buf[leadSize]), headerSize - leadSize);
-    CanonicalIO cio(&mio);
-    AipsIO aio(&cio);
+    std::shared_ptr<ByteIO> bio(new MemoryIO(&(buf[leadSize]), headerSize - leadSize));
+    std::shared_ptr<TypeIO> cio(new CanonicalIO(bio));
+    AipsIO aio(cio);
     Int version = aio.getstart ("MultiFile");
     AlwaysAssert (version==1, AipsError);
     aio >> itsNrBlock;
@@ -511,17 +512,17 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     }
     // Read all header info from the memory buffer.
-    MemoryIO mio(&(buf[leadSize]), headerSize - leadSize);
-    CanonicalIO cio(&mio);
-    AipsIO aio(&cio);
+    std::shared_ptr<ByteIO> bio(new MemoryIO(&(buf[leadSize]), headerSize - leadSize));
+    std::shared_ptr<TypeIO> cio(new CanonicalIO(bio));
+    AipsIO aio(cio);
     Int vers = aio.getstart ("MultiFile");
     AlwaysAssert (vers==version, AipsError);
     aio >> itsInfo;
     aio.getend();
-    getInfoVersion2 (contBlockNr, cio);
+    getInfoVersion2 (contBlockNr, *cio);
   }
 
-  void MultiFile::getInfoVersion2 (Int64 contBlockNr, CanonicalIO& cio)
+  void MultiFile::getInfoVersion2 (Int64 contBlockNr, TypeIO& cio)
   {
     std::vector<Int64> bl;
     for (MultiFileInfo& fileInfo: itsInfo) {

--- a/casa/IO/MultiFile.h
+++ b/casa/IO/MultiFile.h
@@ -35,7 +35,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   //# Forward declarations.
   class ByteIO;
-  class CanonicalIO;
+  class TypeIO;
   class MemoryIO;
 
 
@@ -199,16 +199,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Initialize the MultiFile object.
     void init (ByteIO::OpenOption option);
     // Read the file info for the new version 2.
-    void getInfoVersion2 (Int64 contBlockNr, CanonicalIO& aio);
+    void getInfoVersion2 (Int64 contBlockNr, TypeIO& aio);
     // Write a vector of Int64.
-    void writeVector (CanonicalIO& cio, const std::vector<Int64>& index);
-    void writeVector (CanonicalIO& cio, const std::vector<uInt>& index);
+    void writeVector (TypeIO& cio, const std::vector<Int64>& index);
+    void writeVector (TypeIO& cio, const std::vector<uInt>& index);
     // Read a vector of Int64.
-    void readVector (CanonicalIO& cio, std::vector<Int64>& index);
-    void readVector (CanonicalIO& cio, std::vector<uInt>& index);
+    void readVector (TypeIO& cio, std::vector<Int64>& index);
+    void readVector (TypeIO& cio, std::vector<uInt>& index);
     // Write the remainder of the header (in case exceeding 1 block).
     // <src>iobuf</src> should be large enough
-    void writeRemainder (MemoryIO& mio, CanonicalIO&, MultiFileBuffer& mfbuf);
+    void writeRemainder (MemoryIO& mio, TypeIO&, MultiFileBuffer& mfbuf);
     // Read the remainder of the header into the buffer.
     void readRemainder (Int64 headerSize, Int64 blockNr, std::vector<char>& buf);
     // Truncate the file if blocks are freed at the end.

--- a/casa/IO/RawIO.cc
+++ b/casa/IO/RawIO.cc
@@ -28,8 +28,8 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-RawIO::RawIO (ByteIO* byteIO, Bool takeOver)
-: TypeIO (byteIO, takeOver)
+RawIO::RawIO (const std::shared_ptr<ByteIO>& byteIO)
+: TypeIO (byteIO)
 {}
 
 RawIO::RawIO (const RawIO& that)

--- a/casa/IO/RawIO.h
+++ b/casa/IO/RawIO.h
@@ -72,9 +72,8 @@ class RawIO: public TypeIO
 {
 public: 
     // Constructor.  The read/write functions will use the given ByteIO object
-    // as the data store.  If takeOver is True the this class will delete the
-    // supplied pointer. Otherwise the caller is responsible for this.
-    explicit RawIO (ByteIO* byteIO, Bool takeOver=False);
+    // as the data store.
+    explicit RawIO (const std::shared_ptr<ByteIO>& byteIO);
 
     // The copy constructor uses reference semantics
     RawIO (const RawIO& rawIO);

--- a/casa/IO/TypeIO.cc
+++ b/casa/IO/TypeIO.cc
@@ -30,8 +30,8 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-TypeIO::TypeIO (ByteIO* byteIO, Bool takeOver)
-: itsByteIO(byteIO, takeOver) 
+TypeIO::TypeIO (const std::shared_ptr<ByteIO>& byteIO)
+  : itsByteIO(byteIO)
 {}
 
 TypeIO::TypeIO (const TypeIO& that)

--- a/casa/IO/TypeIO.h
+++ b/casa/IO/TypeIO.h
@@ -28,7 +28,7 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/IO/ByteIO.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 //# The following should be a forward declaration. But our Complex & DComplex
 //# classes are a typedef hence this does not work. Replace the following with
 //# forward declarations when Complex and DComplex are no longer typedefs.
@@ -80,7 +80,9 @@ public:
     // Constructor.
     // The read/write functions will use the given ByteIO object
     // as the data store.
-    explicit TypeIO (ByteIO* byteIO, Bool takeOver=False);
+    // This class takes over the pointers and will be responsible for deleting the
+    // ByteIO pointer.
+    explicit TypeIO (const std::shared_ptr<ByteIO>& byteIO);
 
     virtual ~TypeIO();
     
@@ -151,7 +153,7 @@ public:
 
 protected:    
     // This variable keeps a pointer to a ByteIO.
-    CountedPtr<ByteIO> itsByteIO;
+    std::shared_ptr<ByteIO> itsByteIO;
 
     // The copy constructor uses reference semantics.
     TypeIO (const TypeIO& TypeIO);

--- a/casa/IO/test/tAipsIO.cc
+++ b/casa/IO/test/tAipsIO.cc
@@ -97,18 +97,19 @@ void doit (Bool doExcp)
   }
 
   cout << endl << "Test using MemoryIO ..." << endl;
-  MemoryIO membuf;
+  MemoryIO* membuf = new MemoryIO();
+  std::shared_ptr<ByteIO> bmembuf(membuf);
   {
-    RawIO rawio(&membuf);
-    AipsIO io2(&rawio);
+    std::shared_ptr<TypeIO> rawio(new RawIO(bmembuf));
+    AipsIO io2(rawio);
     doIO (doExcp, True, io2);
   }
-  const uChar* iobuf = membuf.getBuffer();
-  uInt bufleng = membuf.length();
-  MemoryIO membuf2(iobuf, bufleng);
+  const uChar* iobuf = membuf->getBuffer();
+  uInt bufleng = membuf->length();
+  std::shared_ptr<ByteIO> bmembuf2(new MemoryIO(iobuf, bufleng));
   {
-    RawIO rawio(&membuf2);
-    AipsIO io2(&rawio);
+    std::shared_ptr<TypeIO> rawio(new RawIO(bmembuf2));
+    AipsIO io2(rawio);
     doIO (doExcp, False, io2);
   }
 }

--- a/casa/IO/test/tByteSink.cc
+++ b/casa/IO/test/tByteSink.cc
@@ -53,10 +53,10 @@ int main ()
 	uChar    testuChar = 'B';
 	String   testString("This is a teststring");
 
-	RegularFileIO regularFileIO (Path("tByteSink_tmp.dat"),
-				     ByteIO::New);
-	CanonicalIO canonicalIO(&regularFileIO);
-	ByteSink  sink(&canonicalIO);
+        std::shared_ptr<ByteIO> regularFileIO
+          (new RegularFileIO (Path("tByteSink_tmp.dat"), ByteIO::New));
+        std::shared_ptr<TypeIO> canonicalIO (new CanonicalIO(regularFileIO));
+	ByteSink sink(canonicalIO);
 	cout << sink.isReadable() << endl;
 	cout << sink.isWritable() << endl;
 	cout << sink.isSeekable() << endl;
@@ -107,9 +107,10 @@ int main ()
 	uChar    testuChar;
 	String   testString;
 
-	RegularFileIO regularFileIO (Path("tByteSink_tmp.dat"));
-	CanonicalIO canonicalIO(&regularFileIO);
-	ByteSource  source(&canonicalIO);
+        std::shared_ptr<ByteIO> regularFileIO
+          (new RegularFileIO (Path("tByteSink_tmp.dat")));
+        std::shared_ptr<TypeIO> canonicalIO (new CanonicalIO(regularFileIO));
+	ByteSource source(canonicalIO);
 
 	source.seek(0);
 	cout << source.isReadable() << endl;

--- a/casa/IO/test/tByteSinkSource.cc
+++ b/casa/IO/test/tByteSinkSource.cc
@@ -42,16 +42,14 @@ int main ()
 				     ByteIO::New);
     }
     {
-	RegularFileIO regularFileIO (Path("tByteSinkSource_tmp.dat1"),
-				     ByteIO::New);
-	CanonicalIO canonicalIO(&regularFileIO);
-	CanonicalIO canonicalIO1(canonicalIO);
-	canonicalIO1 = canonicalIO;
+        std::shared_ptr<ByteIO> regularFileIO
+          (new RegularFileIO (Path("tByteSinkSource_tmp.dat1"), ByteIO::New));
+        std::shared_ptr<TypeIO> canonicalIO(new CanonicalIO(regularFileIO));
 
-	ByteSinkSource sinkSource(&canonicalIO);
+	ByteSinkSource sinkSource(canonicalIO);
 	ByteSinkSource sinkSource1(sinkSource);
 	sinkSource1 = sinkSource; 
-	ByteSinkSource sinkSource2(&(sinkSource.typeIO()));
+	ByteSinkSource sinkSource2(sinkSource.typeIO());
     }
     {
 	Bool     testBool = True;
@@ -69,10 +67,10 @@ int main ()
 	uChar    testuChar = 'B';
 	String   testString("This is a teststring");
 
-	RegularFileIO regularFileIO (Path("tByteSinkSource_tmp.dat1"),
-				     ByteIO::New);
-	CanonicalIO canonicalIO(&regularFileIO);
-	ByteSinkSource  sinkSource(&canonicalIO);
+        std::shared_ptr<ByteIO> regularFileIO
+          (new RegularFileIO (Path("tByteSinkSource_tmp.dat1"), ByteIO::New));
+        std::shared_ptr<TypeIO> canonicalIO(new CanonicalIO(regularFileIO));
+	ByteSinkSource  sinkSource(canonicalIO);
 
 	cout << sinkSource.isReadable() << endl;
 	cout << sinkSource.isWritable() << endl;
@@ -171,16 +169,16 @@ int main ()
 	cout << testString    << endl;
     }
     {
-	RegularFileIO regularFileIO (Path("tByteSinkSource_tmp.dat1"),
-				     ByteIO::Update);
-	CanonicalIO canonicalIO(&regularFileIO, 5);
-	ByteSinkSource sinkSource(&canonicalIO);
+        std::shared_ptr<ByteIO> regularFileIO
+          (new RegularFileIO (Path("tByteSinkSource_tmp.dat1"), ByteIO::Update));
+        std::shared_ptr<TypeIO> canonicalIO(new CanonicalIO(regularFileIO, 5));
+	ByteSinkSource sinkSource(canonicalIO);
 
-	String   testString;
+	String testString;
 	sinkSource << "This is a teststring";
 	sinkSource.seek (0);
 	sinkSource >> testString;
-	cout << testString    << endl;
+	cout << testString << endl;
     }
     {
 	try {

--- a/casa/IO/test/tTypeIO.cc
+++ b/casa/IO/test/tTypeIO.cc
@@ -131,34 +131,35 @@ void doIt (TypeIO* io)
 
 int main()
 {
-    RegularFileIO regularFileIO (Path("tTypeIO_tmp.dat"), ByteIO::New);
-    CanonicalIO canonicalIO (&regularFileIO);
+    std::shared_ptr<ByteIO> regularFileIO
+      (new RegularFileIO (Path("tTypeIO_tmp.dat"), ByteIO::New));
+    CanonicalIO canonicalIO (regularFileIO);
     doIt (&canonicalIO);
 
-    LECanonicalIO lecanonicalIO (&regularFileIO);
+    LECanonicalIO lecanonicalIO (regularFileIO);
     doIt (&lecanonicalIO);
 
-    RawIO rawIO (&regularFileIO);
+    RawIO rawIO (regularFileIO);
     doIt (&rawIO);
 
-    CanonicalDataConversion canConv;
-    ConversionIO canConvIO (&canConv, &regularFileIO);
+    std::shared_ptr<DataConversion> canConv (new CanonicalDataConversion());
+    ConversionIO canConvIO (canConv, regularFileIO);
     doIt (&canConvIO);
     
-    LECanonicalDataConversion lecanConv;
-    ConversionIO lecanConvIO (&lecanConv, &regularFileIO);
+    std::shared_ptr<DataConversion> lecanConv (new LECanonicalDataConversion());
+    ConversionIO lecanConvIO (lecanConv, regularFileIO);
     doIt (&lecanConvIO);
     
-    IBMDataConversion ibmConv;
-    ConversionIO ibmConvIO (&ibmConv, &regularFileIO);
+    std::shared_ptr<DataConversion> ibmConv (new IBMDataConversion());
+    ConversionIO ibmConvIO (ibmConv, regularFileIO);
     doIt (&ibmConvIO);
     
-    VAXDataConversion vaxConv;
-    ConversionIO vaxConvIO (&vaxConv, &regularFileIO);
+    std::shared_ptr<DataConversion> vaxConv (new VAXDataConversion());
+    ConversionIO vaxConvIO (vaxConv, regularFileIO);
     doIt (&vaxConvIO);
     
-    RawDataConversion rawConv;
-    ConversionIO rawConvIO (&rawConv, &regularFileIO);
+    std::shared_ptr<DataConversion> rawConv (new RawDataConversion());
+    ConversionIO rawConvIO (rawConv, regularFileIO);
     doIt (&rawConvIO);
     
     cout << "OK" << endl;

--- a/images/Images/test/tTempImage.cc
+++ b/images/Images/test/tTempImage.cc
@@ -136,9 +136,9 @@ void doIt (TempImage<Int>& scratch)
 // Stream, unstream, and check the image.
 void streamImage (ImageInterface<Int>& img)
 {
-  MemoryIO membuf;
-  CanonicalIO canio (&membuf);
-  AipsIO os (&canio);
+  std::shared_ptr<ByteIO> membuf(new MemoryIO());
+  std::shared_ptr<TypeIO> canio (new CanonicalIO(membuf));
+  AipsIO os (canio);
   // Write the image.
   os.putstart("Image", 1);
   {

--- a/scimath/Fitting/test/tLSQFit.cc
+++ b/scimath/Fitting/test/tLSQFit.cc
@@ -352,8 +352,8 @@ int main() {
       val1f[0] = 1;
       for (uInt j1=1; j1<6; j1++) val1f[j1] = val1f[j1-1]*511;
       lsq5.makeNorm(val1f, 1.0f, val12f[511]);
-      MemoryIO memio;
-      AipsIO aio(&memio);
+      std::shared_ptr<ByteIO> memio(new MemoryIO());
+      AipsIO aio(memio);
       lsq5.toAipsIO (aio);
       LSQFit lsq6;
       aio.setpos (0);

--- a/tables/DataMan/ISMBase.cc
+++ b/tables/DataMan/ISMBase.cc
@@ -309,13 +309,13 @@ void ISMBase::readIndex()
 {
     file_p->seek (0);
     // Use the file given by the BucketFile object.
-    CountedPtr<ByteIO> fio = file_p->makeFilebufIO (1024);
-    TypeIO* tio;
+    std::shared_ptr<ByteIO> fio = file_p->makeFilebufIO (1024);
+    std::shared_ptr<TypeIO> tio;
     // It is stored in canonical or local format.
     if (asBigEndian()) {
-      tio = new CanonicalIO (fio.get());
+        tio.reset (new CanonicalIO (fio));
     }else{
-      tio = new LECanonicalIO (fio.get());
+        tio.reset (new LECanonicalIO (fio));
     }
     AipsIO os (tio);
     uInt version = os.getstart ("IncrementalStMan");
@@ -353,7 +353,6 @@ void ISMBase::readIndex()
     os.setpos (512 + off * bucketSize_p);
     index_p->get (os);
     os.close();
-    delete tio;
 }
 
 void ISMBase::writeIndex()
@@ -365,13 +364,13 @@ void ISMBase::writeIndex()
     // Write a few items at the beginning of the file.
     file_p->seek (0);
     // Use the file given by the BucketFile object.
-    CountedPtr<ByteIO> fio = file_p->makeFilebufIO (1024);
-    TypeIO* tio;
+    std::shared_ptr<ByteIO> fio = file_p->makeFilebufIO (1024);
+    std::shared_ptr<TypeIO> tio;
     // Store it in canonical or local format.
     if (asBigEndian()) {
-      tio = new CanonicalIO (fio.get());
+        tio.reset (new CanonicalIO (fio));
     }else{
-      tio = new LECanonicalIO (fio.get());
+        tio.reset (new LECanonicalIO (fio));
     }
     AipsIO os (tio);
     // The endian switch is a new feature. So only put it if little endian
@@ -394,7 +393,6 @@ void ISMBase::writeIndex()
     os.setpos (512 + off * bucketSize_p);
     index_p->put (os);
     os.close();
-    delete tio;
 }
     
 

--- a/tables/DataMan/StArrayFile.cc
+++ b/tables/DataMan/StArrayFile.cc
@@ -59,14 +59,14 @@ StManArrayFile::StManArrayFile (const String& fname, ByteIO::OpenOption fop,
     }
     //# Open file name as input and/or output; throw exception if it fails.
     if (mfile) {
-      file_p = new MFFileIO (mfile, fname, fop);
+      file_p.reset (new MFFileIO (mfile, fname, fop));
     } else {
-      file_p = new RegularFileIO (RegularFile(fname), fop, bufferSize);
+      file_p.reset (new RegularFileIO (RegularFile(fname), fop, bufferSize));
     }
     if (bigEndian) {
-	iofil_p = new CanonicalIO (file_p);
+      iofil_p.reset (new CanonicalIO (file_p));
     }else{
-	iofil_p = new LECanonicalIO (file_p);
+      iofil_p.reset (new LECanonicalIO (file_p));
     }
     AlwaysAssert (iofil_p != 0, AipsError);
     swput_p = iofil_p->isWritable();
@@ -91,8 +91,6 @@ StManArrayFile::~StManArrayFile ()
 {
     //# Write the version and file length at the beginning.
     flush (False);
-    delete iofil_p;
-    delete file_p;
 }
 
 

--- a/tables/DataMan/StArrayFile.h
+++ b/tables/DataMan/StArrayFile.h
@@ -273,8 +273,8 @@ public:
     // </group>
 
 private:
-    ByteIO* file_p;                //# File object
-    TypeIO* iofil_p;               //# IO object
+    std::shared_ptr<ByteIO> file_p;                //# File object
+    std::shared_ptr<TypeIO> iofil_p;               //# IO object
     Int64   leng_p;                //# File length
     uInt    version_p;             //# Version of StArrayFile file
     Bool    swput_p;               //# True = put is possible

--- a/tables/DataMan/test/tTiledFileAccess.cc
+++ b/tables/DataMan/test/tTiledFileAccess.cc
@@ -53,8 +53,9 @@ int main()
     {
       Bool deleteIt;
       const Float* dataPtr = arr.getStorage (deleteIt);
-      RegularFileIO fios(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New);
-      CanonicalIO ios (&fios);
+      std::shared_ptr<ByteIO> fios
+        (new RegularFileIO(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New));
+      CanonicalIO ios (fios);
       ios.write (shape.product(), dataPtr);
       arr.freeStorage (dataPtr, deleteIt);
     }
@@ -92,8 +93,9 @@ int main()
     {
       Bool deleteIt;
       const Float* dataPtr = arr.getStorage (deleteIt);
-      RegularFileIO fios(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New);
-      RawIO ios (&fios);
+      std::shared_ptr<ByteIO> fios
+        (new RegularFileIO(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New));
+      RawIO ios (fios);
       uChar nr  = 0;
       off2 = ios.write (1, &nr);
       ios.write (shape.product(), dataPtr);
@@ -132,10 +134,11 @@ int main()
     {
       Bool deleteIt;
       const DComplex* dataPtr = arr.getStorage (deleteIt);
-      RegularFileIO fios(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New);
-      CanonicalIO ios (&fios);
+      std::shared_ptr<ByteIO> fios
+        (new RegularFileIO(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New));
+      CanonicalIO ios (fios);
       off2 = ios.write (shape.product(), dataPtr);
-      RawIO cios (&fios);
+      RawIO cios (fios);
       cios.write (shape.product(), dataPtr);
       arr.freeStorage (dataPtr, deleteIt);
     }
@@ -198,8 +201,9 @@ int main()
     {
       Bool deleteIt;
       const uChar* dataPtr = arrs.getStorage (deleteIt);
-      RegularFileIO fios(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New);
-      CanonicalIO ios (&fios);
+      std::shared_ptr<ByteIO> fios
+        (new RegularFileIO(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New));
+      CanonicalIO ios (fios);
       ios.write (shape.product(), dataPtr);
       arrs.freeStorage (dataPtr, deleteIt);
     }
@@ -232,8 +236,9 @@ int main()
     {
       Bool deleteIt;
       const Short* dataPtr = arrs.getStorage (deleteIt);
-      RegularFileIO fios(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New);
-      CanonicalIO ios (&fios);
+      std::shared_ptr<ByteIO> fios
+        (new RegularFileIO(RegularFile("tTiledFileAccess_tmp.dat"), ByteIO::New));
+      CanonicalIO ios (fios);
       ios.write (shape.product(), dataPtr);
       arrs.freeStorage (dataPtr, deleteIt);
     }

--- a/tables/TaQL/test/tTaQLNode.cc
+++ b/tables/TaQL/test/tTaQLNode.cc
@@ -110,8 +110,8 @@ void seltab (const String& str)
   }
   // Save and restore the parse tree.
   // See if it gives the same result.
-  MemoryIO mio;
-  AipsIO aio(&mio);
+  std::shared_ptr<ByteIO> mio (new MemoryIO());
+  AipsIO aio(mio);
   node.save (aio);
   aio.setpos (0);
   TaQLNode node2 = TaQLNode::restore (aio);

--- a/tables/Tables/ColumnSet.cc
+++ b/tables/Tables/ColumnSet.cc
@@ -800,17 +800,18 @@ Bool ColumnSet::putFile (Bool writeTable, AipsIO& ios,
     }
     //# Now write out the data in all data managers.
     //# Keep track if a data manager indeed wrote something.
-    MemoryIO memio;
-    AipsIO aio(&memio);
+    MemoryIO* memio = new MemoryIO();
+    std::shared_ptr<ByteIO> bmemio(memio);
+    AipsIO aio(bmemio);
     for (uInt i=0; i<blockDataMan_p.nelements(); i++) {
         if (BLOCKDATAMANVAL(i)->flush (aio, fsync)) {
 	    dataManChanged_p[i] = True;
 	    written = True;
 	}
 	if (writeTable) {
-	    ios.put (uInt(memio.length()), memio.getBuffer());
+	    ios.put (uInt(memio->length()), memio->getBuffer());
 	}
-	memio.clear();
+	memio->clear();
     }
     if (multiFile_p) {
       multiFile_p->flush();
@@ -820,7 +821,7 @@ Bool ColumnSet::putFile (Bool writeTable, AipsIO& ios,
 
 
 rownr_t ColumnSet::getFile (AipsIO& ios, Table& tab, rownr_t nrrow, Bool bigEndian,
-                         const TSMOption& tsmOption)
+                            const TSMOption& tsmOption)
 {
     //# If the first value is negative, it is the version.
     //# Otherwise it is nrrow_p.
@@ -893,8 +894,8 @@ rownr_t ColumnSet::getFile (AipsIO& ios, Table& tab, rownr_t nrrow, Bool bigEndi
 	uChar* data;
 	uInt leng;
 	ios.getnew (leng, data);
-	MemoryIO memio (data, leng);
-	AipsIO aio(&memio);
+        std::shared_ptr<ByteIO> bmemio (new MemoryIO(data, leng));
+	AipsIO aio(bmemio);
 	rownr_t nrrow = BLOCKDATAMANVAL(i)->open64 (nrrow_p, aio);
         if (nrrow > nrrow_p) {
           nrrow_p = nrrow;

--- a/tables/Tables/ScaRecordColData.cc
+++ b/tables/Tables/ScaRecordColData.cc
@@ -174,8 +174,8 @@ void ScalarRecordColumnData::getRecord (rownr_t rownr, TableRecord& rec) const
 	dataColPtr_p->getArrayV (rownr, data);
 	Bool deleteIt;
 	const uChar* buf = data.getStorage (deleteIt);
-	MemoryIO memio (buf, shape(0));
-	AipsIO aio(&memio);
+        std::shared_ptr<ByteIO> bmemio (new MemoryIO (buf, shape(0)));
+	AipsIO aio(bmemio);
 	rec.getRecord (aio, TableAttr(dataManager()->table()));
 	data.freeStorage (buf, deleteIt);
     }
@@ -183,11 +183,12 @@ void ScalarRecordColumnData::getRecord (rownr_t rownr, TableRecord& rec) const
 
 void ScalarRecordColumnData::putRecord (rownr_t rownr, const TableRecord& rec)
 {
-    MemoryIO memio;
-    AipsIO aio(&memio);
+    MemoryIO* memio = new MemoryIO();
+    std::shared_ptr<ByteIO> bmemio (memio);
+    AipsIO aio(bmemio);
     rec.putRecord (aio, TableAttr(dataManager()->table().tableName()));
-    IPosition shape (1, Int(memio.length()));
-    Vector<uChar> data(shape, (uChar*)(memio.getBuffer()), SHARE);
+    IPosition shape (1, Int(memio->length()));
+    Vector<uChar> data(shape, (uChar*)(memio->getBuffer()), SHARE);
     dataColPtr_p->setShape (rownr, shape);
     dataColPtr_p->putArrayV (rownr, data);
 }

--- a/tables/Tables/TableSyncData.cc
+++ b/tables/Tables/TableSyncData.cc
@@ -38,7 +38,9 @@ TableSyncData::TableSyncData()
   itsModifyCounter      (0),
   itsTableChangeCounter (0)
 {
-    itsAipsIO.open (&itsMemIO);
+    itsMemIO = new MemoryIO();
+    itsByteIO.reset (itsMemIO);
+    itsAipsIO.open (itsByteIO);
 }
 
 TableSyncData::~TableSyncData()
@@ -80,7 +82,7 @@ void TableSyncData::write (rownr_t nrrow, uInt nrcolumn, Bool tableChanged,
     // Now write the data into the memoryIO object.
     // Use 32-bit for the row number if it fits.
     // First clear it.
-    itsMemIO.clear();
+    itsMemIO->clear();
     if (itsNrrow > DataManager::MAXROWNR32) {
       itsAipsIO.putstart ("sync", 2);
       itsAipsIO << itsNrrow;
@@ -105,7 +107,7 @@ void TableSyncData::write (rownr_t nrrow)
     // Now write the data into the memoryIO object.
     // Use 32-bit for the row number if it fits.
     // First clear it.
-    itsMemIO.clear();
+    itsMemIO->clear();
     if (itsNrrow > DataManager::MAXROWNR32) {
       itsAipsIO.putstart ("sync", 2);
       itsAipsIO << itsNrrow;
@@ -125,7 +127,7 @@ Bool TableSyncData::read (rownr_t& nrrow, uInt& nrcolumn, Bool& tableChanged,
     // When no columns, don't read the remaining part (then it is used
     // by an external filler).
     Int nrcol = -1;
-    if (itsMemIO.length() > 0) {
+    if (itsMemIO->length() > 0) {
         uint version = itsAipsIO.getstart ("sync");
         if (version > 2) {
           throw TableError ("TableSyncData version " + String::toString(version) +
@@ -144,7 +146,7 @@ Bool TableSyncData::read (rownr_t& nrrow, uInt& nrcolumn, Bool& tableChanged,
     if (nrcol < 0) {
 	tableChanged = True;
 	dataManChanged.set (True);
-	if (itsMemIO.length() > 0) {
+	if (itsMemIO->length() > 0) {
 	    itsAipsIO.getend();
 	    return True;                       // not empty
 	}

--- a/tables/Tables/TableSyncData.h
+++ b/tables/Tables/TableSyncData.h
@@ -120,15 +120,16 @@ private:
     uInt        itsModifyCounter;
     uInt        itsTableChangeCounter;
     Block<uInt> itsDataManChangeCounter;
-    MemoryIO    itsMemIO;
+    MemoryIO*   itsMemIO;                  //# deleted by shared_ptr below
     AipsIO      itsAipsIO;
+    std::shared_ptr<ByteIO> itsByteIO;     //# deletes itsMemIO
 };
 
 
 
 inline MemoryIO& TableSyncData::memoryIO()
 {
-    return itsMemIO;
+    return *itsMemIO;
 }
 inline uInt TableSyncData::getModifyCounter() const
 {


### PR DESCRIPTION
The IO framework used CountedPtr in a way that its object does not need to be deleted. This has been changed by requiring to use a normal std::shared_ptr. 
