### PR TITLE
Change ImageUtilities2.tcc outImage.ptr() to get()

### DIFF
--- a/images/Images/ImageUtilities2.tcc
+++ b/images/Images/ImageUtilities2.tcc
@@ -92,7 +92,7 @@ template <typename T> void ImageUtilities::addDegenerateAxes(
 			<< shape << LogIO::POST;
 		outImage.reset(new PagedImage<T>(shape, cSys, outFile));
 	}
-	ImageInterface<T>* pOutImage = outImage.ptr();
+	ImageInterface<T>* pOutImage = outImage.get();
 
 	// Generate output masks
 


### PR DESCRIPTION
PR #1280 missed a ptr() call in ImageUtilities2.tcc