### PR TITLE
Fix leftovers of old whatType() calls in LatticeHistograms

### DIFF
--- a/lattices/LatticeMath/LatticeHistograms.tcc
+++ b/lattices/LatticeMath/LatticeHistograms.tcc
@@ -805,8 +805,7 @@ Bool LatticeHistograms<T>::displayOneHistogram (const T& linearSum,
 
 // Write values of the display axes on the plot
  
-   T* dummy = 0;
-   DataType type = whatType(dummy);
+   DataType type = whatType<T>();
    Float nchar = 0.5;
    if (type==TpComplex) nchar = 1.5;
    String coords = writeCoordinates(histPos);
@@ -960,8 +959,7 @@ void LatticeHistograms<T>::listStatistics(LogIO& os,
       setStream(os3, oPrec); setStream(os4, oPrec); setStream(os5, oPrec);
       setStream(os6, oPrec); setStream(os7, oPrec);
 //
-      T* dummy = 0;
-      DataType type = whatType(dummy);
+      DataType type = whatType<T>();
       Int oWidth;
       if (type==TpFloat) {  
          oWidth = 15;               //


### PR DESCRIPTION
This updates some old leftovers of the old whatType() functions that were still around in the LatticeHistograms template.

In this PR: https://github.com/casacore/casacore/pull/1185/files#diff-511c3c4d4bebbedf81577943a6ec6f82cd76907d3f7ba19b244d637b1533a8fa the old whatType() functions were replaced by template specializations. There were some old style dummy+whatType calls left in LatticeHistogram.tcc that break compilation of one test (ImageAnalysis/test/dImageHistograms.cc) added now in the new CASA build system.
