### PR TITLE
allow for TableProxy reuse

### DIFF
--- a/tables/Tables/TableProxy.h
+++ b/tables/Tables/TableProxy.h
@@ -684,7 +684,7 @@ public:
     return arr;
   }
 
-private:
+protected:
 
   // Get the column info for toAscii.
   Bool getColInfo (const String& colName, Bool useBrackets,


### PR DESCRIPTION
CASA also uses the TableProxy class. I would like to add new functionality and it would be useful to be able to access TableProxy::getValueFromTable( ... ) from a derived class.