### PR TITLE
Fix array indexing bug that causes invalid memory access in ms spw selection.

### DIFF
--- a/ms/MSSel/MSSpwIndex.cc
+++ b/ms/MSSel/MSSpwIndex.cc
@@ -512,7 +512,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			    << "Using the maximum of the channel width range." 
 			    << LogIO::WARN;
 		    }
-		  step=fabs(freqList(i+2)/maxCW);
+		  step=fabs(freqList(j+2)/maxCW);
 		  // 
 		  // Enforce start < stop and step > 0.  
 		  //


### PR DESCRIPTION
Fixed line is inside two for loops: one for spw using index "i" and another for freqList using index "j". Here, array indices are mixed up so that "i" is used for freqList. Correct index should be "j".

This bug caused invalid memory access. In one of CASA's unit test, sdimaging_test_selection.test_spw_id_default_frequency, valgrind reported the following invalid memory access:
```
==1117991== Invalid read of size 4
==1117991==    at 0xE2EE9098: casa6core::MSSpwIndex::convertToChannelIndex(casa6core::Vector<int, std::allocator<int> > const&, casa6core::Vector<float, std::allocator<float> > const&, int&) (in /work/dev/nakazato/git/casa6/casatools/build/lib.linux-x86_64-3.6/casatools/__casac__/lib/libcasatools.cpython-36m-x86_64-linux-gnu.so)
==1117991==    by 0xE2EC9600: MSSpwGramparse() (in /work/dev/nakazato/git/casa6/casatools/build/lib.linux-x86_64-3.6/casatools/__casac__/lib/libcasatools.cpython-36m-x86_64-linux-gnu.so)
==1117991==    by 0xE2ECB5D1: casa6core::baseMSSpwGramParseCommand(casa6core::MSSpwParse*, casa6core::String const&, casa6core::Vector<int, std::allocator<int> >&, casa6core::Matrix<int, std::allocator<int> >&, casa6core::Vector<int, std::allocator<int> >&) (in /work/dev/nakazato/git/casa6/casatools/build/lib.linux-x86_64-3.6/casatools/__casac__/lib/libcasatools.cpython-36m-x86_64-linux-gnu.so)
``` 
More specifically, `nSpw` (`spw.nelements()`) was 3 and `nFList` (`freqList.nelements()`)was 4 in this test case. As a result array index `i+2` can become 4 so that buffer overrun occurred by accessing `freqList[4]`. After the fix, the above memory error disappeared. 