### PR TITLE
Replace CountedPtr by std::shared_ptr in lattices

### DIFF
--- a/casa/Utilities/COWPtr.h
+++ b/casa/Utilities/COWPtr.h
@@ -27,7 +27,7 @@
 #define CASA_COWPTR_H
 
 #include <casacore/casa/aips.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -181,8 +181,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <class T> class COWPtr
 {
-public:
+private:
+  // Helper class to make deletion of object optional.
+  class Deleter {
+  public:
+    Deleter (Bool deleteIt) : deleteIt_p (deleteIt)
+      {}
+    void operator() (T * data) const
+      { if (deleteIt_p) delete data; }
+  private:
+    Bool deleteIt_p;
+  };
+
   
+public:
   // The default constructor: used to create a null pointer which is 
   // delete-able by the destructor.  It is not "readOnly" so that it may be
   // changed by the COWPtr<T>::set() function.
@@ -226,14 +238,7 @@ public:
   // <note> The only copying done (if ever) is upon a call to 
   // COWPtr<T>::rwRef().
   // </note>
-  // The <src>setReadOnly</src> function is the same as <src>set</src>, but
-  // forces <src>deleteIt=False</src> and <src>ReadOnly=True</src>. In
-  // that way a const object can also be safely referenced by COWPtr.
-  // <group>
   void set(T *obj, Bool deleteIt = True, Bool readOnly = False);
-  void setReadOnly (const T *obj);
-  void setReadOnly ();
-  // </group>
 
   // return a const reference to the object.
   inline const T &ref() const;
@@ -261,45 +266,33 @@ public:
   Bool makeUnique(); 
 
 protected:
-  CountedPtr<T> obj_p;
+  std::shared_ptr<T> obj_p;
   Bool const_p;
 };
 
 
 
-// Make our own default pointer - deleteIt==True by default, const_p==False
+//# Make our own default pointer - deleteIt==True by default, const_p==False
 template <class T> inline COWPtr<T>::COWPtr()
-:obj_p(static_cast<T *>(0), True), const_p(False)
-{
-  // does nothing
-} 
+  : obj_p   (nullptr, Deleter(True)),
+    const_p (False)
+{} 
 
-// copy ctor with reference semantics
+//# copy ctor with reference semantics
 template <class T> inline COWPtr<T>::COWPtr(const COWPtr<T> &other)
-: obj_p(other.obj_p), const_p(other.const_p)
-{
-  // does nothing
-}
+  : obj_p   (other.obj_p),
+    const_p (other.const_p)
+{}
 
 //assignment operator with reference semantics
 template <class T> 
 inline COWPtr<T> &COWPtr<T>::operator=(const COWPtr<T> &other)
 {
-  if (this != &other){
-    obj_p = other.obj_p;
+  if (this != &other) {
+    obj_p   = other.obj_p;
     const_p = other.const_p;
   }
   return *this;
-}
-
-template <class T> inline void COWPtr<T>::setReadOnly (const T *obj)
-{
-  set ((T*)obj, False, True);
-}
-
-template <class T> inline void COWPtr<T>::setReadOnly ()
-{
-  const_p = True;
 }
 
 template <class T> inline const T *COWPtr<T>::operator->() const
@@ -325,7 +318,7 @@ template <class T> inline T &COWPtr<T>::rwRef()
 
 template <class T> inline Bool COWPtr<T>::isNull() const
 {
-  return obj_p.null();
+  return !obj_p;
 }
 
 template <class T> inline Bool COWPtr<T>::isReadOnly() const
@@ -335,7 +328,7 @@ template <class T> inline Bool COWPtr<T>::isReadOnly() const
 
 template <class T> inline Bool COWPtr<T>::isUnique() const
 {
-  return (const_p || obj_p.nrefs()>1) ? False : True;
+  return (const_p || obj_p.use_count()>1) ? False : True;
 }
 
 

--- a/casa/Utilities/COWPtr.h
+++ b/casa/Utilities/COWPtr.h
@@ -284,7 +284,9 @@ template <class T> inline COWPtr<T>::COWPtr()
 template <class T> inline COWPtr<T>::COWPtr(const COWPtr<T> &other)
   : obj_p   (other.obj_p),
     const_p (other.const_p)
-{}
+{
+  // does nothing
+}
 
 //assignment operator with reference semantics
 template <class T> 

--- a/casa/Utilities/COWPtr.h
+++ b/casa/Utilities/COWPtr.h
@@ -276,7 +276,9 @@ protected:
 template <class T> inline COWPtr<T>::COWPtr()
   : obj_p   (nullptr, Deleter(True)),
     const_p (False)
-{} 
+{
+  // does nothing
+} 
 
 //# copy ctor with reference semantics
 template <class T> inline COWPtr<T>::COWPtr(const COWPtr<T> &other)

--- a/casa/Utilities/COWPtr.tcc
+++ b/casa/Utilities/COWPtr.tcc
@@ -33,7 +33,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 template <class T> COWPtr<T>::COWPtr(T *obj, Bool deleteIt, Bool readOnly)
   : obj_p   (obj, Deleter(deleteIt)),
     const_p (readOnly)
-{}
+{
+  // does nothing
+}  
 
 template <class T> void COWPtr<T>::set(T *obj, Bool deleteIt, Bool readOnly)
 {

--- a/casa/Utilities/COWPtr.tcc
+++ b/casa/Utilities/COWPtr.tcc
@@ -31,30 +31,31 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <class T> COWPtr<T>::COWPtr(T *obj, Bool deleteIt, Bool readOnly)
-: obj_p(obj, deleteIt), const_p(readOnly)
-{
-  // does nothing
-}
+  : obj_p   (obj, Deleter(deleteIt)),
+    const_p (readOnly)
+{}
 
 template <class T> void COWPtr<T>::set(T *obj, Bool deleteIt, Bool readOnly)
 {
-  obj_p = CountedPtr<T>(obj, deleteIt);
+  obj_p   = std::shared_ptr<T>(obj, Deleter(deleteIt));
   const_p = readOnly;
 }
 
 // make this a copy if more than one exists. 
 template <class T> Bool COWPtr<T>::makeUnique()
 {
-  Bool val = False;
-  if (const_p || obj_p.nrefs() > 1){
-    T *tmp = new T;
-    *tmp = *obj_p;
-    // CountedPtr assignment operator takes care of deletion of old ptr.
-    obj_p = CountedPtr<T>(tmp, True);
-    const_p = False;
-    val = True;
+  Bool madeCopy = False;
+  if (const_p  ||  obj_p.use_count() > 1) {
+    // A copy has to be made.
+    // Use default ctor and assignment because copy ctor of e.g. Array
+    // has reference semantics.
+    std::shared_ptr<T> tmp(new T, Deleter(True));
+    *tmp     = *obj_p;
+    obj_p.swap (tmp);
+    const_p  = False;
+    madeCopy = True;
   } 
-  return val;
+  return madeCopy;
 }
 
 

--- a/casa/Utilities/test/dCOWptr.out
+++ b/casa/Utilities/test/dCOWptr.out
@@ -1,0 +1,8 @@
+The original array is:[0, 1, 2, 3]
+Array 1 is a reference to it:[0, 1, 2, 3]
+Modifying array 1 modifies the original array also:[10, 1, 2, 3]
+Or accessing it via the COWptr gives the same answer:[10, 1, 2, 3]
+Array 1 has been modified using COWptr functions:[10, 11, 2, 3]
+But the normally accessed Array 1 is unchanged:[10, 1, 2, 3]
+As is the original array:[10, 1, 2, 3]
+as the COWptr has made a copy

--- a/casa/Utilities/test/tCOWPtr.cc
+++ b/casa/Utilities/test/tCOWPtr.cc
@@ -167,13 +167,6 @@ static Bool testFunc(Array<Float> *ptr, const Array<Float> &array,
   copy = COW;
   AlwaysAssert(allEQ(*copy, array), AipsError);
 
-  // test setReadOnly
-  if (!deleteIt) {
-    copy.setReadOnly(foo);
-    AlwaysAssert(allEQ(*copy, *foo), AipsError);
-    AlwaysAssert(copy.isReadOnly(), AipsError);
-  }
-
   if (!deleteIt) {
     delete foo;
     delete bar;
@@ -200,17 +193,11 @@ int main()
     Array<Float> *ptr = new Array<float>(array.copy());
     AlwaysAssert(ptr, AipsError); 
     AlwaysAssert(testFunc(ptr, array, True, True), AipsError);
-// the following can be uncommented when the CountedPtr class
-// is made to set the deleted pointer to NULL.
-//    AlwaysAssert(!ptr, AipsError); 
 
     // Case 1: a non-const which controls the ptr.
     ptr = new Array<float>(array.copy());
     AlwaysAssert(ptr, AipsError); 
     AlwaysAssert(testFunc(ptr, array, True, False), AipsError);
-// the following can be uncommented when the CountedPtr class
-// is made to set the deleted pointer to NULL.
-//    AlwaysAssert(!ptr, AipsError); 
 
     // Case 2: a const which doesn't control the pointer
     ptr = new Array<float>(array.copy());

--- a/images/Images/FITSImage.cc
+++ b/images/Images/FITSImage.cc
@@ -165,11 +165,6 @@ FITSImage& FITSImage::operator=(const FITSImage& other)
    return *this;
 } 
  
-FITSImage::~FITSImage()
-{
-}
-
-
 LatticeBase* FITSImage::openFITSImage (const String& name,
 				       const MaskSpecifier& spec)
 {

--- a/images/Images/FITSImage.h
+++ b/images/Images/FITSImage.h
@@ -116,7 +116,7 @@ public:
   FITSImage(const FITSImage& other);
 
   // Destructor does nothing
-  virtual ~FITSImage();
+  virtual ~FITSImage() = default;
 
   // Assignment (reference semantics)
   FITSImage& operator=(const FITSImage& other);

--- a/images/Images/FITSImage.h
+++ b/images/Images/FITSImage.h
@@ -266,8 +266,8 @@ private:
   String         name_p;
   String         fullname_p;
   MaskSpecifier  maskSpec_p;
-  CountedPtr<TiledFileAccess> pTiledFile_p;
-  Lattice<Bool>* pPixelMask_p;
+  std::shared_ptr<TiledFileAccess> pTiledFile_p;
+  std::unique_ptr<Lattice<Bool>>   pPixelMask_p;
   TiledShape     shape_p;
   Float          scale_p;
   Float          offset_p;

--- a/images/Images/FITSQualityImage.cc
+++ b/images/Images/FITSQualityImage.cc
@@ -55,7 +55,6 @@
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/Quanta/Unit.h>
 #include <casacore/measures/Measures/Quality.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/Utilities/ValType.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Exceptions/Error.h>

--- a/images/Images/HDF5Image.h
+++ b/images/Images/HDF5Image.h
@@ -31,6 +31,7 @@
 #include <casacore/images/Images/ImageInterface.h>
 #include <casacore/images/Images/ImageAttrHandlerHDF5.h>
 #include <casacore/lattices/Lattices/HDF5Lattice.h>
+#include <memory>
 
 //# Forward Declarations
 #include <casacore/casa/iosfwd.h>
@@ -280,7 +281,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   private:
     // Function to return the internal HDF5File object to the RegionHandler.
-    static const CountedPtr<HDF5File>& getFile (void* imagePtr);
+    static const std::shared_ptr<HDF5File>& getFile (void* imagePtr);
 
     // This must be called in every constructor and place where the image
     // is attached to a new image.

--- a/images/Images/HDF5Image.tcc
+++ b/images/Images/HDF5Image.tcc
@@ -338,7 +338,7 @@ HDF5Image<T>& HDF5Image<T>::operator+= (const Lattice<T>& other)
 }
 
 template<class T>
-const CountedPtr<HDF5File>& HDF5Image<T>::getFile (void* imagePtr)
+const std::shared_ptr<HDF5File>& HDF5Image<T>::getFile (void* imagePtr)
 {
   HDF5Image<T>* im = static_cast<HDF5Image<T>*>(imagePtr);
   return im->map_p.file();

--- a/images/Images/ImageAttrHandlerHDF5.cc
+++ b/images/Images/ImageAttrHandlerHDF5.cc
@@ -48,7 +48,7 @@ namespace casacore {
     itsGroupMap.clear();
     // If ATTRGROUPS is defined, get all groups in it.
     if (HDF5Group::exists (hid, "ATTRGROUPS")) {
-      itsGroup.reset (new HDF5Group(hid, "ATTRGROUPS", true));
+      itsGroup = std::make_shared<HDF5Group>(hid, "ATTRGROUPS", true);
       vector<String> names = HDF5Group::linkNames (*itsGroup);
       for (uInt i=0; i<names.size(); ++i) {
         // Add group to map, but with a null object. It gets filled once
@@ -62,7 +62,7 @@ namespace casacore {
         throw AipsError("ImageAttrHandlerHDF5: cannot add ATTRGROUPS because "
                         "image is not writable");
       }
-      itsGroup.reset (new HDF5Group(hid, "ATTRGROUPS", false));
+      itsGroup = std::make_shared<HDF5Group>(hid, "ATTRGROUPS", false);
       itsCanWrite = True;
     }
     return *this;

--- a/images/Images/ImageAttrHandlerHDF5.cc
+++ b/images/Images/ImageAttrHandlerHDF5.cc
@@ -48,7 +48,7 @@ namespace casacore {
     itsGroupMap.clear();
     // If ATTRGROUPS is defined, get all groups in it.
     if (HDF5Group::exists (hid, "ATTRGROUPS")) {
-      itsGroup = CountedPtr<HDF5Group>(new HDF5Group(hid, "ATTRGROUPS", true));
+      itsGroup.reset (new HDF5Group(hid, "ATTRGROUPS", true));
       vector<String> names = HDF5Group::linkNames (*itsGroup);
       for (uInt i=0; i<names.size(); ++i) {
         // Add group to map, but with a null object. It gets filled once
@@ -62,7 +62,7 @@ namespace casacore {
         throw AipsError("ImageAttrHandlerHDF5: cannot add ATTRGROUPS because "
                         "image is not writable");
       }
-      itsGroup = CountedPtr<HDF5Group>(new HDF5Group(hid, "ATTRGROUPS", false));
+      itsGroup.reset (new HDF5Group(hid, "ATTRGROUPS", false));
       itsCanWrite = True;
     }
     return *this;

--- a/images/Images/ImageAttrHandlerHDF5.h
+++ b/images/Images/ImageAttrHandlerHDF5.h
@@ -32,7 +32,6 @@
 #include <casacore/images/Images/ImageAttrHandler.h>
 #include <casacore/images/Images/ImageAttrGroupHDF5.h>
 #include <casacore/casa/HDF5/HDF5Group.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <map>
 
 namespace casacore {
@@ -132,7 +131,7 @@ public:
 
 private:
   Bool                                itsCanWrite;    //# writable?
-  CountedPtr<HDF5Group>               itsGroup;       //# HDF5 group to add to
+  std::shared_ptr<HDF5Group>          itsGroup;       //# HDF5 group to add to
   std::map<String,ImageAttrGroupHDF5> itsGroupMap;    //# attribute groups
 };
 

--- a/images/Images/ImageExprParse.cc
+++ b/images/Images/ImageExprParse.cc
@@ -64,7 +64,7 @@ static uInt theNrNodes;
 static Table theLastTable;
 
 //# Hold a pointer to the last HDF5 file to lookup unqualified region names.
-static CountedPtr<HDF5File> theLastHDF5;
+static std::shared_ptr<HDF5File> theLastHDF5;
 
 #define SAVE_GLOBALS \
  const Block<LatticeExprNode>* savTempLattices=theTempLattices; \
@@ -74,7 +74,7 @@ static CountedPtr<HDF5File> theLastHDF5;
  Block<Bool>  savNodesType=theNodesType; \
  uInt savNrNodes=theNrNodes; \
  Table savLastTable=theLastTable; \
- CountedPtr<HDF5File> savLastHDF5=theLastHDF5;
+ std::shared_ptr<HDF5File> savLastHDF5=theLastHDF5;
 
 #define RESTORE_GLOBALS \
  theTempLattices=savTempLattices; \
@@ -98,7 +98,7 @@ void imageExprParse_clear()
 // Is there no last table or HDF5 file?
 Bool imageExprParse_hasNoLast()
 {
-  return (theLastTable.isNull() && theLastHDF5.null());
+  return (theLastTable.isNull() && !theLastHDF5);
 }
 
 //# Initialize static members.
@@ -154,7 +154,7 @@ Table& ImageExprParse::getRegionTable (void*, Bool)
   return theLastTable;
 }
 
-const CountedPtr<HDF5File>& ImageExprParse::getRegionHDF5 (void*)
+const std::shared_ptr<HDF5File>& ImageExprParse::getRegionHDF5 (void*)
 {
   return theLastHDF5;
 }
@@ -670,7 +670,7 @@ LatticeExprNode ImageExprParse::makeLRNode() const
 	  Table table (fileName);
 	  theLastTable = table;
 	} else if (HDF5File::isHDF5(fileName)) {
-	  theLastHDF5  = new HDF5File(fileName);
+	  theLastHDF5 = std::make_shared<HDF5File>(fileName);
 	  theLastTable = Table();
 	} else {
 	  throw (AipsError ("ImageExprParse: the table used in region name'"
@@ -684,7 +684,7 @@ LatticeExprNode ImageExprParse::makeLRNode() const
       RegionHandlerTable regHand(getRegionTable, 0);
       regPtr = regHand.getRegion (names[index], RegionHandler::Any, False);
     }
-    if (! theLastHDF5.null()) {
+    if (theLastHDF5) {
       RegionHandlerHDF5 regHand(getRegionHDF5, 0);
       regPtr = regHand.getRegion (names[index], RegionHandler::Any, False);
     }
@@ -772,7 +772,7 @@ Bool ImageExprParse::tryLatticeNode (LatticeExprNode& node,
     if (type == "PagedImage") {
       theLastTable = Table(name);
     } else if (type == "HDF5Image") {
-      theLastHDF5  = new HDF5File(name);
+      theLastHDF5 = std::make_shared<HDF5File>(name);
       theLastTable = Table();
     }
     delete pLatt;

--- a/images/Images/ImageExprParse.h
+++ b/images/Images/ImageExprParse.h
@@ -34,7 +34,6 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/casa/stdvector.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/HDF5/HDF5File.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -314,7 +313,7 @@ private:
     static Table& getRegionTable (void*, Bool);
 
     // Callback function for RegionHandlerHDF5 to get the file to be used.
-    static const CountedPtr<HDF5File>& getRegionHDF5 (void*);
+    static const std::shared_ptr<HDF5File>& getRegionHDF5 (void*);
 
     //# A 'global' node object to hold the resulting expression.
     static LatticeExprNode theirNode;

--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -862,10 +862,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
     //
     fhi.applyMask = False;
-    fhi.pMask = 0;
+    fhi.pMask.reset();
     if (image.isMasked()) {
       fhi.applyMask = True;
-      fhi.pMask.reset (new Array<Bool>(IPosition(0,0)));
+      fhi.pMask = std::make_shared<Array<Bool>>(IPosition(0,0));
     }
     //
     // Find scale factors

--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -865,7 +865,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     fhi.pMask = 0;
     if (image.isMasked()) {
       fhi.applyMask = True;
-      fhi.pMask = new Array<Bool>(IPosition(0,0));
+      fhi.pMask.reset (new Array<Bool>(IPosition(0,0)));
     }
     //
     // Find scale factors

--- a/images/Images/ImageFITSConverter.h
+++ b/images/Images/ImageFITSConverter.h
@@ -33,7 +33,7 @@
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/Utilities/DataType.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 
 #ifndef WCSLIB_GETWCSTAB
@@ -76,7 +76,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     IPosition newShape;
     IPosition cursorOrder;
     FitsKeywordList kw;
-    CountedPtr<Array<Bool> > pMask;
+    std::shared_ptr<Array<Bool>> pMask;
   };
 
 

--- a/images/Images/ImageFITSConverter.tcc
+++ b/images/Images/ImageFITSConverter.tcc
@@ -206,15 +206,15 @@ void ImageFITSConverterImpl<HDUType>::FITSToImage(
 	// delete it if its not needed.
 
 	ImageRegion maskReg;
-	LatticeIterator<Bool>* pMaskIter = 0;
+        std::unique_ptr<LatticeIterator<Bool>> pMaskIter;
 	Bool madeMask = False;
 	if (bitpix<0 || isBlanked) {
 		maskReg = pNewImage->makeMask ("mask0", False, False);
 		LCRegion& mask = maskReg.asMask();
 		LatticeStepper pMaskStepper (shape, cursorShape,
 				IPosition::makeAxisPath(ndim));
-		pMaskIter = new LatticeIterator<Bool>(mask, pMaskStepper);
-		pMaskIter->reset();
+		pMaskIter.reset (new LatticeIterator<Bool>(mask, pMaskStepper));
+		pMaskIter->reset();   // reset iterator
 		madeMask = True;
 	}
 
@@ -293,9 +293,6 @@ void ImageFITSConverterImpl<HDUType>::FITSToImage(
 				pNewImage->defineRegion ("mask0", maskReg, RegionHandler::Masks);
 				pNewImage->setDefaultMask(String("mask0"));
 			}
-			// Clean up pointers
-
-			delete pMaskIter;
 		}
 	}
 	catch (const AipsError& x) {

--- a/images/Images/ImageProxy.cc
+++ b/images/Images/ImageProxy.cc
@@ -220,7 +220,7 @@ namespace casacore { //# name space casa begins
     concatImages (images, axis);
   }
 
-  ImageProxy::ImageProxy (const CountedPtr<LatticeBase>& image)
+  ImageProxy::ImageProxy (const std::shared_ptr<LatticeBase>& image)
     : itsLattice       (image),
       itsImageFloat    (0),
       itsImageDouble   (0),
@@ -229,7 +229,7 @@ namespace casacore { //# name space casa begins
       itsCoordSys      (0),
       itsAttrHandler   (0)
   {
-    if (! itsLattice.null()) {
+    if (itsLattice) {
       setup();
     }
   }
@@ -243,7 +243,7 @@ namespace casacore { //# name space casa begins
       itsCoordSys      (0),
       itsAttrHandler   (0)
   {
-    if (! itsLattice.null()) {
+    if (itsLattice) {
       setup();
     }
   }
@@ -253,7 +253,7 @@ namespace casacore { //# name space casa begins
     if (this != &that) {
       close();
       itsLattice = that.itsLattice;
-      if (! itsLattice.null()) {
+      if (itsLattice) {
         setup();
       }
     }
@@ -306,7 +306,7 @@ namespace casacore { //# name space casa begins
 
   void ImageProxy::close()
   {
-    itsLattice       = CountedPtr<LatticeBase>();
+    itsLattice.reset();
     itsImageFloat    = 0;
     itsImageDouble   = 0;
     itsImageComplex  = 0;
@@ -317,7 +317,7 @@ namespace casacore { //# name space casa begins
 
   void ImageProxy::checkNull() const
   {
-    if (itsLattice.null()) {
+    if (!itsLattice) {
       throw AipsError ("ImageProxy does not contain an image object");
     }
   }
@@ -479,14 +479,14 @@ namespace casacore { //# name space casa begins
 
   void ImageProxy::setup (LatticeBase* lattice)
   {
-    itsLattice = lattice;
+    itsLattice.reset (lattice);
     setup();
   }
 
   void ImageProxy::setup()
   {
-    // Get raw pointer from the CountedPtr.
-    LatticeBase* lattice = &(*itsLattice);
+    // Get raw pointer from the std::shared_ptr.
+    LatticeBase* lattice = itsLattice.get();
     switch (lattice->dataType()) {
     case TpFloat:
       itsImageFloat = dynamic_cast<ImageInterface<Float>*>(lattice);

--- a/images/Images/ImageProxy.h
+++ b/images/Images/ImageProxy.h
@@ -31,9 +31,9 @@
 #include <casacore/images/Images/MaskSpecifier.h>
 #include <casacore/lattices/Lattices/LatticeBase.h>
 #include <casacore/lattices/Lattices/TiledShape.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/Containers/ValueHolder.h>
 #include <casacore/casa/Containers/Record.h>
+#include <memory>
 
 namespace casacore {
 
@@ -124,7 +124,7 @@ namespace casacore {
                 Int dummy=0);
 
     // Construct from an existing image object.
-    ImageProxy (const CountedPtr<LatticeBase>&);
+    ImageProxy (const std::shared_ptr<LatticeBase>&);
 
     // Copy constructor (reference semantics).
     ImageProxy (const ImageProxy&);
@@ -464,13 +464,13 @@ namespace casacore {
 
     //# Data members.
     //# itsLattice is the real data; the pointers are for type convenience only.
-    CountedPtr<LatticeBase>   itsLattice;
-    ImageInterface<Float>*    itsImageFloat;
-    ImageInterface<Double>*   itsImageDouble;
-    ImageInterface<Complex>*  itsImageComplex;
-    ImageInterface<DComplex>* itsImageDComplex;
-    const CoordinateSystem*   itsCoordSys;
-    ImageAttrHandler*         itsAttrHandler;
+    std::shared_ptr<LatticeBase>   itsLattice;
+    ImageInterface<Float>*         itsImageFloat;
+    ImageInterface<Double>*        itsImageDouble;
+    ImageInterface<Complex>*       itsImageComplex;
+    ImageInterface<DComplex>*      itsImageDComplex;
+    const CoordinateSystem*        itsCoordSys;
+    ImageAttrHandler*              itsAttrHandler;
   };
 
 } // end namespace casacore

--- a/images/Images/ImageProxy.h
+++ b/images/Images/ImageProxy.h
@@ -465,12 +465,12 @@ namespace casacore {
     //# Data members.
     //# itsLattice is the real data; the pointers are for type convenience only.
     std::shared_ptr<LatticeBase>   itsLattice;
-    ImageInterface<Float>*         itsImageFloat;
-    ImageInterface<Double>*        itsImageDouble;
-    ImageInterface<Complex>*       itsImageComplex;
-    ImageInterface<DComplex>*      itsImageDComplex;
-    const CoordinateSystem*        itsCoordSys;
-    ImageAttrHandler*              itsAttrHandler;
+    ImageInterface<Float>*         itsImageFloat;     //# reference, so no delete
+    ImageInterface<Double>*        itsImageDouble;    //# reference, so no delete
+    ImageInterface<Complex>*       itsImageComplex;   //# reference, so no delete
+    ImageInterface<DComplex>*      itsImageDComplex;  //# reference, so no delete
+    const CoordinateSystem*        itsCoordSys;       //# reference, so no delete
+    ImageAttrHandler*              itsAttrHandler;    //# reference, so no delete
   };
 
 } // end namespace casacore

--- a/images/Images/ImageStatistics.h
+++ b/images/Images/ImageStatistics.h
@@ -177,7 +177,7 @@ private:
 
    LogIO os_p;
    const ImageInterface<T>* pInImage_p;
-   std::shared_ptr<const ImageInterface<T> > _inImPtrMgr;
+   std::shared_ptr<const ImageInterface<T>> _inImPtrMgr;
    IPosition blc_;
    Int precision_;
    Bool _showRobust, _recordMessages, _listStats;

--- a/images/Images/ImageUtilities.h
+++ b/images/Images/ImageUtilities.h
@@ -30,7 +30,6 @@
 #include <casacore/scimath/Mathematics/GaussianBeam.h>
 #include <casacore/lattices/Lattices/TiledShape.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN

--- a/images/Images/LELImageCoord.h
+++ b/images/Images/LELImageCoord.h
@@ -33,7 +33,7 @@
 #include <casacore/images/Images/ImageInfo.h>
 #include <casacore/tables/Tables/TableRecord.h>
 #include <casacore/casa/Quanta/Unit.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -137,7 +137,7 @@ public:
   virtual Int doCompare (const LELImageCoord& other) const;
 
 private:
-  CountedPtr<CoordinateSystem> coords_p;
+  std::shared_ptr<CoordinateSystem> coords_p;
   ImageInfo   imageInfo_p;
   Unit        unit_p;
   TableRecord miscInfo_p;

--- a/images/Images/MIRIADImage.cc
+++ b/images/Images/MIRIADImage.cc
@@ -52,7 +52,6 @@
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/Quanta/Unit.h>
 #include <casacore/casa/Quanta/UnitMap.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/Utilities/ValType.h>
 #include <casacore/casa/Utilities/Regex.h>
 #include <casacore/casa/BasicSL/String.h>
@@ -317,7 +316,7 @@ void MIRIADImage::tempClose()
 {
    if (! isClosed_p) {
       delete pPixelMask_p;
-      pTiledFile_p = 0;
+      pTiledFile_p.reset();
       isClosed_p = True;
    }
 }
@@ -437,10 +436,10 @@ void MIRIADImage::open()
 
    // The tile shape must not be a subchunk in all dimensions
 
-   pTiledFile_p = new TiledFileAccess(iname, fileOffset_p,
-				      shape_p.shape(), shape_p.tileShape(),
-                                      dataType_p, TSMOption(),
-				      writable, canonical);
+   pTiledFile_p = std::make_shared<TiledFileAccess>(iname, fileOffset_p,
+                                                    shape_p.shape(), shape_p.tileShape(),
+                                                    dataType_p, TSMOption(),
+                                                    writable, canonical);
 
    // Shares the pTiledFile_p pointer. 
 

--- a/images/Images/MIRIADImage.h
+++ b/images/Images/MIRIADImage.h
@@ -258,7 +258,7 @@ private:
   MaskSpecifier  maskSpec_p;
   Unit           unit_p;
   Record         rec_p;
-  CountedPtr<TiledFileAccess> pTiledFile_p;
+  std::shared_ptr<TiledFileAccess> pTiledFile_p;
   Lattice<Bool>* pPixelMask_p;
   //  Float          scale_p;
   //  Float          offset_p;

--- a/images/Images/test/tImageStatistics2.cc
+++ b/images/Images/test/tImageStatistics2.cc
@@ -54,7 +54,7 @@ int main() {
 		RO_LatticeIterator<Float> imIter(im);
 		/*
 		{
-			CountedPtr<StatsDataProvider<Double, const Float*, const Bool* > > dataProvider
+			std::shared_ptr<StatsDataProvider<Double, const Float*, const Bool* > > dataProvider
 				= new LatticeStatsDataProvider<Double, Float>(im);
 			ClassicalStatistics<Double, const Float*> cs;
 			cs.setDataProvider(dataProvider);
@@ -333,7 +333,7 @@ int main() {
 		/*
         {
 			cout << endl << "This should produce the desired results" << endl;
-		    CountedPtr<StatsDataProvider<Double, const Float*, const Bool* > > dataProvider
+		    std::shared_ptr<StatsDataProvider<Double, const Float*, const Bool* > > dataProvider
                 = new LatticeStatsDataProvider<Double, Float>(im);
 			ClassicalStatistics<Double, const Float*> cs;
             cout << im.name() << endl; 
@@ -359,7 +359,7 @@ int main() {
 
 		{
 			cout << endl << "This should produce the desired results" << endl;
-			CountedPtr<StatsDataProvider<Double, const Float*, const Bool* > > dataProvider
+			std::shared_ptr<StatsDataProvider<Double, const Float*, const Bool* > > dataProvider
 				= new LatticeStatsDataProvider<Double, Float>(im);
 			ClassicalStatistics<Double, const Float*> cs;
 			cs.setDataProvider(dataProvider);

--- a/images/Images/test/tImageUtilities.cc
+++ b/images/Images/test/tImageUtilities.cc
@@ -75,7 +75,7 @@ void doOpens()
          ImageUtilities::openImage(im, name1);
       }
       {
-         CountedPtr<ImageInterface<Float>> im;
+         std::shared_ptr<ImageInterface<Float>> im;
          im = ImageUtilities::openImage<Float>(name1);
       }
       {

--- a/images/Regions/RegionHandlerHDF5.h
+++ b/images/Regions/RegionHandlerHDF5.h
@@ -85,7 +85,7 @@ class RegionHandlerHDF5: public RegionHandler
 {
 public: 
   // The HDF5File object needed for the region operations.
-  typedef const CountedPtr<HDF5File>& GetCallback (void* objectPtr);
+  typedef const std::shared_ptr<HDF5File>& GetCallback (void* objectPtr);
 
   RegionHandlerHDF5 (GetCallback* callback, void* objectPtr);
 
@@ -174,7 +174,7 @@ public:
 
 private:
   // Get the file object.
-  const CountedPtr<HDF5File>& file() const
+  const std::shared_ptr<HDF5File>& file() const
     { return itsCallback (itsObjectPtr); }
 
   // Find field number of the region group to which a region belongs

--- a/images/Regions/test/tRegionHandler.cc
+++ b/images/Regions/test/tRegionHandler.cc
@@ -50,8 +50,8 @@ Table& getTable (void*, Bool)
   return theTable;
 }
 
-CountedPtr<HDF5File> theHDF5File;
-const CountedPtr<HDF5File>& getHDF5File (void*)
+std::shared_ptr<HDF5File> theHDF5File;
+const std::shared_ptr<HDF5File>& getHDF5File (void*)
 {
   return theHDF5File;
 }
@@ -159,7 +159,7 @@ int main()
     AlwaysAssertExit (! File("tRegionHandler_tmp.lat/reg2n").exists());
     // Test regions in HDF5 only if supported.
     if (HDF5Object::hasHDF5Support()) {
-      theHDF5File = new HDF5File ("tRegionHandler_tmp.hdf5", ByteIO::New);
+      theHDF5File = std::make_shared<HDF5File>("tRegionHandler_tmp.hdf5", ByteIO::New);
       RegionHandlerHDF5 reghdf5 (getHDF5File, 0);
       doIt (reghdf5);
     }

--- a/lattices/LEL/LELBinary.h
+++ b/lattices/LEL/LELBinary.h
@@ -107,8 +107,8 @@ public:
 // Constructor takes operation and left and right expressions
 // to be operated upon
    LELBinary(const LELBinaryEnums::Operation op, 
-	     const CountedPtr<LELInterface<T> >& pLeftExpr,
-	     const CountedPtr<LELInterface<T> >& pRightExpr);
+	     const std::shared_ptr<LELInterface<T>>& pLeftExpr,
+	     const std::shared_ptr<LELInterface<T>>& pRightExpr);
 
 // Destructor 
   ~LELBinary();
@@ -136,8 +136,8 @@ public:
 
 private:
    LELBinaryEnums::Operation op_p;
-   CountedPtr<LELInterface<T> > pLeftExpr_p;
-   CountedPtr<LELInterface<T> > pRightExpr_p;
+   std::shared_ptr<LELInterface<T>> pLeftExpr_p;
+   std::shared_ptr<LELInterface<T>> pRightExpr_p;
 };
 
 
@@ -212,8 +212,8 @@ public:
 // Constructor takes operation and left and right expressions
 // to be operated upon. It can only handle the comparison operators.
    LELBinaryCmp(const LELBinaryEnums::Operation op, 
-		const CountedPtr<LELInterface<T> >& pLeftExpr,
-		const CountedPtr<LELInterface<T> >& pRightExpr);
+		const std::shared_ptr<LELInterface<T>>& pLeftExpr,
+		const std::shared_ptr<LELInterface<T>>& pRightExpr);
 
 // Destructor 
   ~LELBinaryCmp();
@@ -241,8 +241,8 @@ public:
 
 private:
    LELBinaryEnums::Operation op_p;
-   CountedPtr<LELInterface<T> > pLeftExpr_p;
-   CountedPtr<LELInterface<T> > pRightExpr_p;
+   std::shared_ptr<LELInterface<T>> pLeftExpr_p;
+   std::shared_ptr<LELInterface<T>> pRightExpr_p;
 };
 
 
@@ -313,8 +313,8 @@ public:
 // Constructor takes operation and left and right expressions
 // to be operated upon.
    LELBinaryBool(const LELBinaryEnums::Operation op, 
-		 const CountedPtr<LELInterface<Bool> >& pLeftExpr,
-		 const CountedPtr<LELInterface<Bool> >& pRightExpr);
+		 const std::shared_ptr<LELInterface<Bool>>& pLeftExpr,
+		 const std::shared_ptr<LELInterface<Bool>>& pRightExpr);
 
 // Destructor 
   ~LELBinaryBool();
@@ -342,8 +342,8 @@ public:
 
 private:
    LELBinaryEnums::Operation op_p;
-   CountedPtr<LELInterface<Bool> > pLeftExpr_p;
-   CountedPtr<LELInterface<Bool> > pRightExpr_p;
+   std::shared_ptr<LELInterface<Bool>> pLeftExpr_p;
+   std::shared_ptr<LELInterface<Bool>> pRightExpr_p;
 };
 
 

--- a/lattices/LEL/LELBinary.tcc
+++ b/lattices/LEL/LELBinary.tcc
@@ -40,8 +40,8 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <class T>
 LELBinary<T>::LELBinary(const LELBinaryEnums::Operation op,
-			const CountedPtr<LELInterface<T> >& pLeftExpr,
-			const CountedPtr<LELInterface<T> >& pRightExpr)
+			const std::shared_ptr<LELInterface<T>>& pLeftExpr,
+			const std::shared_ptr<LELInterface<T>>& pRightExpr)
 : op_p(op)
 {
    setAttr (LELAttribute(pLeftExpr->getAttribute(),
@@ -232,8 +232,8 @@ void LELBinary<T>::resync()
 // LELBinaryCmp
 template <class T>
 LELBinaryCmp<T>::LELBinaryCmp(const LELBinaryEnums::Operation op,
-			      const CountedPtr<LELInterface<T> >& pLeftExpr,
-			      const CountedPtr<LELInterface<T> >& pRightExpr)
+			      const std::shared_ptr<LELInterface<T>>& pLeftExpr,
+			      const std::shared_ptr<LELInterface<T>>& pRightExpr)
 : op_p(op)
 {
    setAttr (LELAttribute(pLeftExpr->getAttribute(),

--- a/lattices/LEL/LELBinary2.cc
+++ b/lattices/LEL/LELBinary2.cc
@@ -35,8 +35,8 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 LELBinaryBool::LELBinaryBool(const LELBinaryEnums::Operation op,
-			     const CountedPtr<LELInterface<Bool> >& pLeftExpr,
-			     const CountedPtr<LELInterface<Bool> >& pRightExpr)
+			     const std::shared_ptr<LELInterface<Bool>>& pLeftExpr,
+			     const std::shared_ptr<LELInterface<Bool>>& pRightExpr)
 : op_p(op)
 {
    if (op == LELBinaryEnums::EQ  ||  op == LELBinaryEnums::NE) {

--- a/lattices/LEL/LELCondition.h
+++ b/lattices/LEL/LELCondition.h
@@ -94,8 +94,8 @@ protected:
 
 public: 
 // Construct the condition on the given expression.
-   LELCondition (const CountedPtr<LELInterface<T> >& expr,
-		 const CountedPtr<LELInterface<Bool> >& cond);
+   LELCondition (const std::shared_ptr<LELInterface<T>>& expr,
+		 const std::shared_ptr<LELInterface<Bool>>& cond);
 
 // Destructor does nothing
   ~LELCondition();
@@ -122,8 +122,8 @@ public:
   // </group>
 
 private:
-   CountedPtr<LELInterface<T> >    pExpr_p;
-   CountedPtr<LELInterface<Bool> > pCond_p;
+   std::shared_ptr<LELInterface<T>>    pExpr_p;
+   std::shared_ptr<LELInterface<Bool>> pCond_p;
 };
 
 

--- a/lattices/LEL/LELCondition.tcc
+++ b/lattices/LEL/LELCondition.tcc
@@ -38,8 +38,8 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <class T>
-LELCondition<T>::LELCondition (const CountedPtr<LELInterface<T> >& expr,
-	                       const CountedPtr<LELInterface<Bool> >& cond)
+LELCondition<T>::LELCondition (const std::shared_ptr<LELInterface<T>>& expr,
+	                       const std::shared_ptr<LELInterface<Bool>>& cond)
 {
 #if defined(AIPS_TRACE)
    cout << "LELCondition:: constructor" << endl;

--- a/lattices/LEL/LELConvert.h
+++ b/lattices/LEL/LELConvert.h
@@ -96,7 +96,7 @@ public:
    
 // Constructor.  <src><F></src> is the type we are coinverting from.
 // <src><T></src> is the type we are converting to.
-   LELConvert (const CountedPtr<LELInterface<F> >& expr);
+   LELConvert (const std::shared_ptr<LELInterface<F>>& expr);
 
 // Destructor does nothing
   ~LELConvert();
@@ -123,7 +123,7 @@ public:
   // </group>
 
 private:
-   CountedPtr<LELInterface<F> > pExpr_p;
+   std::shared_ptr<LELInterface<F>> pExpr_p;
 };
 
 

--- a/lattices/LEL/LELConvert.tcc
+++ b/lattices/LEL/LELConvert.tcc
@@ -39,7 +39,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template <class T, class F>
-LELConvert<T,F>::LELConvert(const CountedPtr<LELInterface<F> >& expr)
+LELConvert<T,F>::LELConvert(const std::shared_ptr<LELInterface<F>>& expr)
 : pExpr_p (expr)
 //
 // F is the type we are converting from

--- a/lattices/LEL/LELCoordinates.cc
+++ b/lattices/LEL/LELCoordinates.cc
@@ -64,14 +64,14 @@ LELCoordinates& LELCoordinates::operator= (const LELCoordinates& other)
 // Return the underlying letter object.
 const LELLattCoordBase& LELCoordinates::coordinates() const
 {
-    AlwaysAssert (!coords_p.null(), AipsError);
+    AlwaysAssert (!isNull(), AipsError);
     return *coords_p;
 }
 
 // Does it have coordinates ?
 Bool LELCoordinates::hasCoordinates() const
 {
-    if (coords_p.null()) {
+    if (isNull()) {
         return False;
     }
     return coords_p->hasCoordinates();
@@ -80,7 +80,7 @@ Bool LELCoordinates::hasCoordinates() const
 // Check if the coordinates of this and that conform.
 Int LELCoordinates::compare (const LELCoordinates& that) const
 {
-    if (coords_p.null()  ||  that.coords_p.null()) {
+    if (isNull()  ||  that.isNull()) {
         return 9;
     }
     return coords_p->compare (*(that.coords_p));

--- a/lattices/LEL/LELCoordinates.h
+++ b/lattices/LEL/LELCoordinates.h
@@ -29,7 +29,7 @@
 
 //# Includes
 #include <casacore/casa/aips.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -67,11 +67,11 @@ class LELLattCoordBase;
 //  CoordinateSystems.
 //  Lattice objects have a member function called <src>lelCoordinates</src>.
 //  This returns a LELCoordinates object.  This object contains a
-//  pointer (actually a CountedPtr) of type
+//  pointer (actually a std::shared_ptr) of type
 //  <linkto class=LELLattCoordBase>LELLattCoordBase</linkto>.  This is the
 //  base class of the letter classes.  For Lattices such as ImageInterface,
 //  this pointer actually points at the derived letter class LELImageCoord.
-//  This class in turn contains a pointer (a CountedPtr) to the actual
+//  This class in turn contains a pointer (a std::shared_ptr) to the actual
 //  CoordinateSystem object.   
 // 
 //  Note that every time the <src>lelCoordinates</src> function is called,
@@ -83,7 +83,7 @@ class LELLattCoordBase;
 //  <br><src>return LELCoordinates (new LELImageCoord (coords_p));</src>
 //  <br>so that the LELCoordinates constructor invokes the LELImageCoord
 //  constructor with the CoordinateSystem as its argument.  However,
-//  the internal use of CountedPtrs makes subsequent constructions inexpensive.
+//  the internal use of std::shared_ptrs makes subsequent constructions inexpensive.
 //
 //  Having a LELCoordinates object in hand, the programmer then has access
 //  to the CoordinateSystem that it ultimately contains.  This is via the
@@ -140,7 +140,7 @@ public:
 
     // Is the coordinates a null object?
     Bool isNull() const
-      { return coords_p.null(); }
+      { return !coords_p; }
 
     // Does the class have true coordinates?
     // It returns False if this is a null object.
@@ -161,7 +161,7 @@ public:
 
 private:
     // The pointer to the underlying object.
-    CountedPtr<LELLattCoordBase> coords_p;
+    std::shared_ptr<LELLattCoordBase> coords_p;
 };
 
 

--- a/lattices/LEL/LELFunction.h
+++ b/lattices/LEL/LELFunction.h
@@ -108,7 +108,7 @@ protected:
 public: 
 // Constructor takes operation and expression to be operated upon
    LELFunction1D(const LELFunctionEnums::Function function,
-		 const CountedPtr<LELInterface<T> >& expr);
+		 const std::shared_ptr<LELInterface<T>>& expr);
 
 // Destructor 
   ~LELFunction1D();
@@ -136,7 +136,7 @@ public:
 
 private:
    LELFunctionEnums::Function   function_p;
-   CountedPtr<LELInterface<T> > pExpr_p;
+   std::shared_ptr<LELInterface<T>> pExpr_p;
 };
 
 
@@ -210,7 +210,7 @@ protected:
 public: 
 // Constructor takes operation and expression to be operated upon
    LELFunctionReal1D(const LELFunctionEnums::Function function,
-		     const CountedPtr<LELInterface<T> >& expr);
+		     const std::shared_ptr<LELInterface<T>>& expr);
 
 // Destructor 
   ~LELFunctionReal1D();
@@ -239,7 +239,7 @@ public:
 
 private:
    LELFunctionEnums::Function function_p;
-   CountedPtr<LELInterface<T> > pExpr_p;
+   std::shared_ptr<LELInterface<T>> pExpr_p;
 };
 
 

--- a/lattices/LEL/LELFunction.tcc
+++ b/lattices/LEL/LELFunction.tcc
@@ -47,7 +47,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // LELFunction1D
 template <class T>
 LELFunction1D<T>::LELFunction1D(const LELFunctionEnums::Function function,
-				const CountedPtr<LELInterface<T> >& expr)
+				const std::shared_ptr<LELInterface<T>>& expr)
 : function_p(function)
 {
    switch (function_p) {
@@ -440,7 +440,7 @@ void LELFunction1D<T>::resync()
 template <class T>
 LELFunctionReal1D<T>::LELFunctionReal1D
                                (const LELFunctionEnums::Function function,
-				const CountedPtr<LELInterface<T> >& expr)
+				const std::shared_ptr<LELInterface<T>>& expr)
 : function_p(function)
 {
    switch (function_p) {
@@ -600,7 +600,7 @@ Bool LELFunctionReal1D<T>::prepareScalarExpr()
    cout << "LELFunctionReal1D::prepare" << endl;
 #endif
 
-   if (! pExpr_p.null()) {
+   if (pExpr_p) {
       return LELInterface<T>::replaceScalarExpr (pExpr_p);
    }
    return False;

--- a/lattices/LEL/LELInterface.h
+++ b/lattices/LEL/LELInterface.h
@@ -31,9 +31,9 @@
 #include <casacore/casa/aips.h>
 #include <casacore/lattices/LEL/LELAttribute.h>
 #include <casacore/casa/Arrays/IPosition.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/Utilities/DataType.h>
 #include <casacore/casa/IO/FileLocker.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -188,7 +188,7 @@ public:
 // If the given expression is a valid scalar, replace it by its result.
 // It returns False if the expression is no scalar or if the expression
 // is an invalid scalar (i.e. with a False mask).
-   static Bool replaceScalarExpr (CountedPtr<LELInterface<T> >& expr);
+   static Bool replaceScalarExpr (std::shared_ptr<LELInterface<T>>& expr);
 
   // Handle locking/syncing of the parts of a lattice expression.
   // <br>By default the functions do not do anything at all.

--- a/lattices/LEL/LELInterface.tcc
+++ b/lattices/LEL/LELInterface.tcc
@@ -77,7 +77,7 @@ Bool LELInterface<T>::replaceScalarExpr (std::shared_ptr<LELInterface<T>>& expr)
     if (!isInvalidScalar  &&  expr->isScalar()) {
         LELScalar<T> tmp = expr->getScalar();
 	if (tmp.mask()) {
-            expr.reset (new LELUnaryConst<T> (tmp.value()));
+          expr = std::make_shared<LELUnaryConst<T>>(tmp.value());
 	} else {
 	    isInvalidScalar = True;
 	}
@@ -85,7 +85,7 @@ Bool LELInterface<T>::replaceScalarExpr (std::shared_ptr<LELInterface<T>>& expr)
 // If the value is an invalid scalar expression, replace by scalar
 // with false mask.
     if (isInvalidScalar) {
-        expr.reset (new LELUnaryConst<T>());
+      expr = std::make_shared<LELUnaryConst<T>>();
     }
     return isInvalidScalar;
 }

--- a/lattices/LEL/LELInterface.tcc
+++ b/lattices/LEL/LELInterface.tcc
@@ -68,7 +68,7 @@ LELArray<T> LELInterface<T>::getArray() const
 }
 
 template<class T>
-Bool LELInterface<T>::replaceScalarExpr (CountedPtr<LELInterface<T> >& expr)
+Bool LELInterface<T>::replaceScalarExpr (std::shared_ptr<LELInterface<T>>& expr)
 {
 // Recursively prepare (optimize) a scalar subexpression
     Bool isInvalidScalar = expr->prepareScalarExpr();
@@ -77,7 +77,7 @@ Bool LELInterface<T>::replaceScalarExpr (CountedPtr<LELInterface<T> >& expr)
     if (!isInvalidScalar  &&  expr->isScalar()) {
         LELScalar<T> tmp = expr->getScalar();
 	if (tmp.mask()) {
-	    expr = new LELUnaryConst<T> (tmp.value());
+            expr.reset (new LELUnaryConst<T> (tmp.value()));
 	} else {
 	    isInvalidScalar = True;
 	}
@@ -85,7 +85,7 @@ Bool LELInterface<T>::replaceScalarExpr (CountedPtr<LELInterface<T> >& expr)
 // If the value is an invalid scalar expression, replace by scalar
 // with false mask.
     if (isInvalidScalar) {
-	expr = new LELUnaryConst<T>();
+        expr.reset (new LELUnaryConst<T>());
     }
     return isInvalidScalar;
 }

--- a/lattices/LEL/LELUnary.h
+++ b/lattices/LEL/LELUnary.h
@@ -188,7 +188,7 @@ public:
 // Constructor takes operation and expression
 // to be operated upon
    LELUnary(const LELUnaryEnums::Operation op, 
-	    const CountedPtr<LELInterface<T> >& pExpr);
+	    const std::shared_ptr<LELInterface<T>>& pExpr);
 
 // Destructor does nothing
   ~LELUnary();
@@ -216,7 +216,7 @@ public:
 
 private:
    LELUnaryEnums::Operation op_p;
-   CountedPtr<LELInterface<T> > pExpr_p;
+   std::shared_ptr<LELInterface<T>> pExpr_p;
 };
 
 
@@ -283,7 +283,7 @@ public:
 // Constructor takes operation and expression
 // to be operated upon
    LELUnaryBool(const LELUnaryEnums::Operation op, 
-		const CountedPtr<LELInterface<Bool> >& pExpr);
+		const std::shared_ptr<LELInterface<Bool>>& pExpr);
 
 // Destructor does nothing
   ~LELUnaryBool();
@@ -311,7 +311,7 @@ public:
 
 private:
    LELUnaryEnums::Operation op_p;
-   CountedPtr<LELInterface<Bool> > pExpr_p;
+   std::shared_ptr<LELInterface<Bool>> pExpr_p;
 };
 
 

--- a/lattices/LEL/LELUnary.tcc
+++ b/lattices/LEL/LELUnary.tcc
@@ -96,7 +96,7 @@ String LELUnaryConst<T>::className() const
 
 template <class T>
 LELUnary<T>::LELUnary(const LELUnaryEnums::Operation op,
-		      const CountedPtr<LELInterface<T> >& pExpr)
+		      const std::shared_ptr<LELInterface<T>>& pExpr)
 : op_p(op), pExpr_p(pExpr)
 {
    this->setAttr(pExpr->getAttribute());

--- a/lattices/LEL/LELUnary2.cc
+++ b/lattices/LEL/LELUnary2.cc
@@ -34,7 +34,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 LELUnaryBool::LELUnaryBool(const LELUnaryEnums::Operation op,
-			   const CountedPtr<LELInterface<Bool> >& pExpr)
+			   const std::shared_ptr<LELInterface<Bool>>& pExpr)
 : op_p(op), pExpr_p(pExpr)
 {
    setAttr(pExpr_p->getAttribute());

--- a/lattices/LEL/LatticeExprNode.cc
+++ b/lattices/LEL/LatticeExprNode.cc
@@ -45,7 +45,6 @@
 #include <casacore/casa/Arrays/Array.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/BasicSL/Constants.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h> 
 #include <casacore/casa/iostream.h>
@@ -76,7 +75,7 @@ LatticeExprNode::~LatticeExprNode()
 }
 
 
-LatticeExprNode::LatticeExprNode(const CountedPtr<LELInterface<Float> >& pExpr)
+LatticeExprNode::LatticeExprNode(const std::shared_ptr<LELInterface<Float>>& pExpr)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (True),
@@ -84,12 +83,12 @@ LatticeExprNode::LatticeExprNode(const CountedPtr<LELInterface<Float> >& pExpr)
   pExprFloat_p    (pExpr)
 {
 #if defined(AIPS_TRACE)
-   cout << "LatticeExprNode:: constructor (CountedPtr<LELInterface<T>>&); pExpr_p.nrefs() = "
+   cout << "LatticeExprNode:: constructor (std::shared_ptr<LELInterface<T>>&); pExpr_p.nrefs() = "
 	<< pExprFloat_p.nrefs() << endl;
 #endif
 }
 
-LatticeExprNode::LatticeExprNode(const CountedPtr<LELInterface<Double> >& pExpr)
+LatticeExprNode::LatticeExprNode(const std::shared_ptr<LELInterface<Double>>& pExpr)
 : donePrepare_p   (False),
   dtype_p         (TpDouble),
   isInvalid_p     (True),
@@ -97,13 +96,13 @@ LatticeExprNode::LatticeExprNode(const CountedPtr<LELInterface<Double> >& pExpr)
   pExprDouble_p   (pExpr)
 {
 #if defined(AIPS_TRACE)
-   cout << "LatticeExprNode:: constructor (CountedPtr<LELInterface<T>>&); pExpr_p.nrefs() = "
+   cout << "LatticeExprNode:: constructor (std::shared_ptr<LELInterface<T>>&); pExpr_p.nrefs() = "
 	<< pExprDouble_p.nrefs() << endl;
 #endif
 }
 
 LatticeExprNode::LatticeExprNode
-                             (const CountedPtr<LELInterface<Complex> >& pExpr)
+                             (const std::shared_ptr<LELInterface<Complex>>& pExpr)
 : donePrepare_p   (False),
   dtype_p         (TpComplex),
   isInvalid_p     (True),
@@ -111,13 +110,13 @@ LatticeExprNode::LatticeExprNode
   pExprComplex_p  (pExpr)
 {
 #if defined(AIPS_TRACE)
-   cout << "LatticeExprNode:: constructor (CountedPtr<LELInterface<T>>&); pExpr_p.nrefs() = "
+   cout << "LatticeExprNode:: constructor (std::shared_ptr<LELInterface<T>>&); pExpr_p.nrefs() = "
 	<< pExprComplex_p.nrefs() << endl;
 #endif
 }
 
 LatticeExprNode::LatticeExprNode
-                             (const CountedPtr<LELInterface<DComplex> >& pExpr)
+                             (const std::shared_ptr<LELInterface<DComplex>>& pExpr)
 : donePrepare_p   (False),
   dtype_p         (TpDComplex),
   isInvalid_p     (True),
@@ -125,12 +124,12 @@ LatticeExprNode::LatticeExprNode
   pExprDComplex_p (pExpr)
 {
 #if defined(AIPS_TRACE)
-   cout << "LatticeExprNode:: constructor (CountedPtr<LELInterface<T>>&); pExpr_p.nrefs() = "
+   cout << "LatticeExprNode:: constructor (std::shared_ptr<LELInterface<T>>&); pExpr_p.nrefs() = "
 	<< pExprDComplex_p.nrefs() << endl;
 #endif
 }
 
-LatticeExprNode::LatticeExprNode(const CountedPtr<LELInterface<Bool> >& pExpr)
+LatticeExprNode::LatticeExprNode(const std::shared_ptr<LELInterface<Bool>>& pExpr)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (True),
@@ -138,7 +137,7 @@ LatticeExprNode::LatticeExprNode(const CountedPtr<LELInterface<Bool> >& pExpr)
   pExprBool_p     (pExpr)
 {
 #if defined(AIPS_TRACE)
-   cout << "LatticeExprNode:: constructor (CountedPtr<LELInterface<T>>&); pExpr_p.nrefs() = "
+   cout << "LatticeExprNode:: constructor (std::shared_ptr<LELInterface<T>>&); pExpr_p.nrefs() = "
 	<< pExprBool_p.nrefs() << endl;
 #endif
 }
@@ -214,7 +213,7 @@ LatticeExprNode::LatticeExprNode (Int64 constant)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELUnaryConst<Float> (constant))
+  pExprFloat_p    (std::make_shared<LELUnaryConst<Float>>(constant))
 { 
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -228,7 +227,7 @@ LatticeExprNode::LatticeExprNode (Int constant)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELUnaryConst<Float> (constant))
+  pExprFloat_p    (std::make_shared<LELUnaryConst<Float>>(constant))
 { 
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -242,7 +241,7 @@ LatticeExprNode::LatticeExprNode (uInt constant)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELUnaryConst<Float> (constant))
+  pExprFloat_p    (std::make_shared<LELUnaryConst<Float>>(constant))
 { 
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -256,7 +255,7 @@ LatticeExprNode::LatticeExprNode (Long constant)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELUnaryConst<Float> (constant))
+  pExprFloat_p    (std::make_shared<LELUnaryConst<Float>>(constant))
 { 
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -270,7 +269,7 @@ LatticeExprNode::LatticeExprNode (Float constant)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELUnaryConst<Float> (constant))
+  pExprFloat_p    (std::make_shared<LELUnaryConst<Float>>(constant))
 { 
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -284,7 +283,7 @@ LatticeExprNode::LatticeExprNode (Double constant)
 : donePrepare_p   (False),
   dtype_p         (TpDouble),
   isInvalid_p     (False),
-  pExprDouble_p   (new LELUnaryConst<Double> (constant))
+  pExprDouble_p   (std::make_shared<LELUnaryConst<Double>>(constant))
 { 
    pAttr_p = &pExprDouble_p->getAttribute();
 
@@ -298,7 +297,7 @@ LatticeExprNode::LatticeExprNode (const Complex& constant)
 : donePrepare_p   (False),
   dtype_p         (TpComplex),
   isInvalid_p     (False),
-  pExprComplex_p  (new LELUnaryConst<Complex> (constant))
+  pExprComplex_p  (std::make_shared<LELUnaryConst<Complex>>(constant))
 { 
    pAttr_p = &pExprComplex_p->getAttribute();
 
@@ -312,7 +311,7 @@ LatticeExprNode::LatticeExprNode (const DComplex& constant)
 : donePrepare_p   (False),
   dtype_p         (TpDComplex),
   isInvalid_p     (False),
-  pExprDComplex_p (new LELUnaryConst<DComplex> (constant))
+  pExprDComplex_p (std::make_shared<LELUnaryConst<DComplex>>(constant))
 { 
    pAttr_p = &pExprDComplex_p->getAttribute();
 
@@ -326,7 +325,7 @@ LatticeExprNode::LatticeExprNode (Bool constant)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (False),
-  pExprBool_p     (new LELUnaryConst<Bool> (constant))
+  pExprBool_p     (std::make_shared<LELUnaryConst<Bool>>(constant))
 { 
    pAttr_p = &pExprBool_p->getAttribute();
 
@@ -351,7 +350,7 @@ LatticeExprNode::LatticeExprNode (const Lattice<Float>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELLattice<Float> (lattice))
+  pExprFloat_p    (std::make_shared<LELLattice<Float>>(lattice))
 {
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -365,7 +364,7 @@ LatticeExprNode::LatticeExprNode (const Lattice<Double>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpDouble),
   isInvalid_p     (False),
-  pExprDouble_p   (new LELLattice<Double> (lattice))
+  pExprDouble_p   (std::make_shared<LELLattice<Double>>(lattice))
 {
    pAttr_p = &pExprDouble_p->getAttribute();
 
@@ -379,7 +378,7 @@ LatticeExprNode::LatticeExprNode (const Lattice<Complex>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpComplex),
   isInvalid_p     (False),
-  pExprComplex_p  (new LELLattice<Complex> (lattice))
+  pExprComplex_p  (std::make_shared<LELLattice<Complex>>(lattice))
 {
    pAttr_p = &pExprComplex_p->getAttribute();
 
@@ -393,7 +392,7 @@ LatticeExprNode::LatticeExprNode (const Lattice<DComplex>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpDComplex),
   isInvalid_p     (False),
-  pExprDComplex_p (new LELLattice<DComplex> (lattice))
+  pExprDComplex_p (std::make_shared<LELLattice<DComplex>>(lattice))
 {
    pAttr_p = &pExprDComplex_p->getAttribute();
 
@@ -407,7 +406,7 @@ LatticeExprNode::LatticeExprNode (const Lattice<Bool>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (False),
-  pExprBool_p     (new LELLattice<Bool> (lattice))
+  pExprBool_p     (std::make_shared<LELLattice<Bool>>(lattice))
 {
    pAttr_p = &pExprBool_p->getAttribute();
 
@@ -422,7 +421,7 @@ LatticeExprNode::LatticeExprNode (const MaskedLattice<Float>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpFloat),
   isInvalid_p     (False),
-  pExprFloat_p    (new LELLattice<Float> (lattice))
+  pExprFloat_p    (std::make_shared<LELLattice<Float>>(lattice))
 {
    pAttr_p = &pExprFloat_p->getAttribute();
 
@@ -436,7 +435,7 @@ LatticeExprNode::LatticeExprNode (const MaskedLattice<Double>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpDouble),
   isInvalid_p     (False),
-  pExprDouble_p   (new LELLattice<Double> (lattice))
+  pExprDouble_p   (std::make_shared<LELLattice<Double>>(lattice))
 {
    pAttr_p = &pExprDouble_p->getAttribute();
 
@@ -450,7 +449,7 @@ LatticeExprNode::LatticeExprNode (const MaskedLattice<Complex>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpComplex),
   isInvalid_p     (False),
-  pExprComplex_p  (new LELLattice<Complex> (lattice))
+  pExprComplex_p  (std::make_shared<LELLattice<Complex>>(lattice))
 {
    pAttr_p = &pExprComplex_p->getAttribute();
 
@@ -464,7 +463,7 @@ LatticeExprNode::LatticeExprNode (const MaskedLattice<DComplex>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpDComplex),
   isInvalid_p     (False),
-  pExprDComplex_p (new LELLattice<DComplex> (lattice))
+  pExprDComplex_p (std::make_shared<LELLattice<DComplex>>(lattice))
 {
    pAttr_p = &pExprDComplex_p->getAttribute();
 
@@ -478,7 +477,7 @@ LatticeExprNode::LatticeExprNode (const MaskedLattice<Bool>& lattice)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (False),
-  pExprBool_p     (new LELLattice<Bool> (lattice))
+  pExprBool_p     (std::make_shared<LELLattice<Bool>>(lattice))
 {
    pAttr_p = &pExprBool_p->getAttribute();
 
@@ -492,7 +491,7 @@ LatticeExprNode::LatticeExprNode (const LCRegion& region)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (False),
-  pExprBool_p     (new LELRegion (new LattRegionHolder(region)))
+  pExprBool_p     (std::make_shared<LELRegion>(new LattRegionHolder(region)))
 {
    pAttr_p = &pExprBool_p->getAttribute();
 
@@ -506,7 +505,7 @@ LatticeExprNode::LatticeExprNode (const Slicer& slicer)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (False),
-  pExprBool_p     (new LELRegion (new LattRegionHolder(LCSlicer(slicer))))
+  pExprBool_p     (std::make_shared<LELRegion>(new LattRegionHolder(LCSlicer(slicer))))
 {
    pAttr_p = &pExprBool_p->getAttribute();
 
@@ -520,7 +519,7 @@ LatticeExprNode::LatticeExprNode (const LattRegionHolder& region)
 : donePrepare_p   (False),
   dtype_p         (TpBool),
   isInvalid_p     (False),
-  pExprBool_p     (new LELRegion (region))
+  pExprBool_p     (std::make_shared<LELRegion>(region))
 {
    pAttr_p = &pExprBool_p->getAttribute();
 
@@ -1113,8 +1112,8 @@ LatticeExprNode sign(const LatticeExprNode& expr)
 		 AipsError);
    Block<LatticeExprNode> arg(1);
    arg[0] = expr.makeFloat();
-   LELFunctionFloat* ptr = new LELFunctionFloat(LELFunctionEnums::SIGN, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionFloat>(LELFunctionEnums::SIGN, arg));
 }
 
 LatticeExprNode ceil(const LatticeExprNode& expr)
@@ -1206,13 +1205,13 @@ LatticeExprNode formComplex(const LatticeExprNode& left,
    if (left.dataType()==TpFloat && right.dataType()==TpFloat) {
       arg[0] = left.makeFloat();
       arg[1] = right.makeFloat();
-      return new LELFunctionComplex (LELFunctionEnums::COMPLEX, arg);
+      return LatticeExprNode
+        (std::make_shared<LELFunctionComplex>(LELFunctionEnums::COMPLEX, arg));
    }
    arg[0] = left.makeDouble();
    arg[1] = right.makeDouble();
-   LELFunctionDComplex* ptr = new LELFunctionDComplex
-                                           (LELFunctionEnums::COMPLEX, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionDComplex>(LELFunctionEnums::COMPLEX, arg));
 }
 
 
@@ -1296,9 +1295,11 @@ LatticeExprNode fractile (const LatticeExprNode& expr,
    arg[1] = fraction.makeFloat();
    switch (dtype) {
    case TpFloat:
-      return new LELFunctionFloat (LELFunctionEnums::FRACTILE1D, arg);
+      return LatticeExprNode
+        (std::make_shared<LELFunctionFloat>(LELFunctionEnums::FRACTILE1D, arg));
    case TpDouble:
-      return new LELFunctionDouble (LELFunctionEnums::FRACTILE1D, arg);
+      return LatticeExprNode
+        (std::make_shared<LELFunctionDouble>(LELFunctionEnums::FRACTILE1D, arg));
    default:
       throw (AipsError ("LatticeExprNode::fractile - "
 			"Bool or complex argument used in real "
@@ -1323,9 +1324,11 @@ LatticeExprNode fractileRange (const LatticeExprNode& expr,
    arg[1] = fraction.makeFloat();
    switch (dtype) {
    case TpFloat:
-       return new LELFunctionFloat (LELFunctionEnums::FRACTILERANGE1D, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionFloat>(LELFunctionEnums::FRACTILERANGE1D, arg));
    case TpDouble:
-       return new LELFunctionDouble (LELFunctionEnums::FRACTILERANGE1D, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionDouble>(LELFunctionEnums::FRACTILERANGE1D, arg));
    default:
       throw (AipsError ("LatticeExprNode::fractileRange - "
 			"Bool or complex argument used in real "
@@ -1352,9 +1355,11 @@ LatticeExprNode fractileRange (const LatticeExprNode& expr,
    arg[2] = fraction2.makeFloat();
    switch (dtype) {
    case TpFloat:
-       return new LELFunctionFloat (LELFunctionEnums::FRACTILERANGE1D, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionFloat>(LELFunctionEnums::FRACTILERANGE1D, arg));
    case TpDouble:
-       return new LELFunctionDouble (LELFunctionEnums::FRACTILERANGE1D, arg);
+     return LatticeExprNode
+        (std::make_shared<LELFunctionDouble>(LELFunctionEnums::FRACTILERANGE1D, arg));
    default:
       throw (AipsError ("LatticeExprNode::fractileRange - "
 			"Bool or complex argument used in real "
@@ -1475,11 +1480,13 @@ LatticeExprNode spectralindex (const LatticeExprNode& left,
    case TpFloat:
       arg[0] = left.makeFloat();
       arg[1] = right.makeFloat();
-      return new LELSpectralIndex<Float> (arg);
+      return LatticeExprNode
+        (std::make_shared<LELSpectralIndex<Float>>(arg));
    case TpDouble:
       arg[0] = left.makeDouble();
       arg[1] = right.makeDouble();
-      return new LELSpectralIndex<Double> (arg);
+      return LatticeExprNode
+        (std::make_shared<LELSpectralIndex<Double>>(arg));
    default:
       throw (AipsError ("LatticeExprNode::spectralindex - "
 			"Bool or Complex argument used in function"));
@@ -1626,7 +1633,8 @@ LatticeExprNode operator! (const LatticeExprNode& expr)
    if (expr.isRegion()) {
       return LELRegion::makeComplement (*expr.pExprBool_p);
    }
-   return new LELUnaryBool(LELUnaryEnums::NOT, expr.pExprBool_p);
+   return LatticeExprNode
+     (std::make_shared<LELUnaryBool>(LELUnaryEnums::NOT, expr.pExprBool_p));
 }
 
 LatticeExprNode LatticeExprNode::operator[] (const LatticeExprNode& cond) const
@@ -1653,15 +1661,20 @@ LatticeExprNode LatticeExprNode::operator[] (const LatticeExprNode& cond) const
    switch (dataType()) {
    case TpBool:
       AlwaysAssert (!isRegion(), AipsError);
-      return new LELCondition<Bool> (pExprBool_p, cond.pExprBool_p);
+      return LatticeExprNode
+        (std::make_shared<LELCondition<Bool>>(pExprBool_p, cond.pExprBool_p));
    case TpFloat:
-      return new LELCondition<Float> (pExprFloat_p, cond.pExprBool_p);
+      return LatticeExprNode
+        (std::make_shared<LELCondition<Float>>(pExprFloat_p, cond.pExprBool_p));
    case TpDouble:
-      return new LELCondition<Double> (pExprDouble_p, cond.pExprBool_p);
+      return LatticeExprNode
+        (std::make_shared<LELCondition<Double>>(pExprDouble_p, cond.pExprBool_p));
    case TpComplex:
-      return new LELCondition<Complex> (pExprComplex_p, cond.pExprBool_p);
+      return LatticeExprNode
+        (std::make_shared<LELCondition<Complex>>(pExprComplex_p, cond.pExprBool_p));
    case TpDComplex:
-      return new LELCondition<DComplex> (pExprDComplex_p, cond.pExprBool_p);
+      return LatticeExprNode
+        (std::make_shared<LELCondition<DComplex>>(pExprDComplex_p, cond.pExprBool_p));
    default:
        throw (AipsError ("LatticeExprNode::operator[] - unknown datatype"));
    }
@@ -1677,8 +1690,8 @@ LatticeExprNode indexin (const LatticeExprNode& axis,
    Block<LatticeExprNode> arg(2);
    arg[0] = axis;
    arg[1] = indexFlags;
-   LELFunctionBool* ptr = new LELFunctionBool(LELFunctionEnums::INDEXIN, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionBool>(LELFunctionEnums::INDEXIN, arg));
 }
 
 
@@ -1688,8 +1701,8 @@ LatticeExprNode all (const LatticeExprNode& expr)
    cout << "LatticeExprNode:: 1d function all" << endl;
 #endif
    Block<LatticeExprNode> arg(1, toBool(expr));
-   LELFunctionBool* ptr = new LELFunctionBool(LELFunctionEnums::ALL, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionBool>(LELFunctionEnums::ALL, arg));
 }
 
 LatticeExprNode any (const LatticeExprNode& expr)
@@ -1698,8 +1711,8 @@ LatticeExprNode any (const LatticeExprNode& expr)
    cout << "LatticeExprNode:: 1d function any" << endl;
 #endif
    Block<LatticeExprNode> arg(1, toBool(expr));
-   LELFunctionBool* ptr = new LELFunctionBool(LELFunctionEnums::ANY, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionBool>(LELFunctionEnums::ANY, arg));
 }
 
 LatticeExprNode ntrue (const LatticeExprNode& expr)
@@ -1708,9 +1721,8 @@ LatticeExprNode ntrue (const LatticeExprNode& expr)
    cout << "LatticeExprNode:: 1d function ntrue" << endl;
 #endif
    Block<LatticeExprNode> arg(1, toBool(expr));
-   LELFunctionDouble* ptr = new LELFunctionDouble
-                                           (LELFunctionEnums::NTRUE, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionDouble>(LELFunctionEnums::NTRUE, arg));
 }
 
 LatticeExprNode nfalse (const LatticeExprNode& expr)
@@ -1719,9 +1731,8 @@ LatticeExprNode nfalse (const LatticeExprNode& expr)
    cout << "LatticeExprNode:: 1d function nfalse" << endl;
 #endif
    Block<LatticeExprNode> arg(1, toBool(expr));
-   LELFunctionDouble* ptr = new LELFunctionDouble
-                                           (LELFunctionEnums::NFALSE, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionDouble>(LELFunctionEnums::NFALSE, arg));
 }
 
 LatticeExprNode nelements(const LatticeExprNode& expr)
@@ -1733,9 +1744,8 @@ LatticeExprNode nelements(const LatticeExprNode& expr)
    if (expr.isRegion()) {
       arg[0] = toBool (expr);
    }
-   LELFunctionDouble* ptr = new LELFunctionDouble
-                                           (LELFunctionEnums::NELEM, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionDouble>(LELFunctionEnums::NELEM, arg));
 }
 
 LatticeExprNode ndim (const LatticeExprNode& expr)
@@ -1744,8 +1754,8 @@ LatticeExprNode ndim (const LatticeExprNode& expr)
    cout << "LatticeExprNode:: 1d function ndim" << endl;
 #endif
    Block<LatticeExprNode> arg(1, expr);
-   LELFunctionFloat* ptr = new LELFunctionFloat(LELFunctionEnums::NDIM, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionFloat>(LELFunctionEnums::NDIM, arg));
 }
 
 LatticeExprNode length (const LatticeExprNode& expr,
@@ -1757,8 +1767,8 @@ LatticeExprNode length (const LatticeExprNode& expr,
    Block<LatticeExprNode> arg(2);
    arg[0] = expr;
    arg[1] = axis;
-   LELFunctionFloat* ptr = new LELFunctionFloat(LELFunctionEnums::LENGTH, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionFloat>(LELFunctionEnums::LENGTH, arg));
 }
 
 LatticeExprNode isNaN (const LatticeExprNode& expr)
@@ -1767,8 +1777,8 @@ LatticeExprNode isNaN (const LatticeExprNode& expr)
    cout << "LatticeExprNode:: 1d function isNaN" << endl;
 #endif
    Block<LatticeExprNode> arg(1, expr);
-   LELFunctionBool* ptr = new LELFunctionBool(LELFunctionEnums::ISNAN, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionBool>(LELFunctionEnums::ISNAN, arg));
 }
 
 LatticeExprNode mask (const LatticeExprNode& expr)
@@ -1780,8 +1790,8 @@ LatticeExprNode mask (const LatticeExprNode& expr)
    if (expr.isRegion()) {
       arg[0] = toBool (expr);
    }
-   LELFunctionBool* ptr = new LELFunctionBool(LELFunctionEnums::MASK, arg);
-   return ptr;
+   return LatticeExprNode
+     (std::make_shared<LELFunctionBool>(LELFunctionEnums::MASK, arg));
 }
 
 LatticeExprNode value (const LatticeExprNode& expr)
@@ -1791,7 +1801,8 @@ LatticeExprNode value (const LatticeExprNode& expr)
 #endif
    if (expr.dataType() == TpBool) {
       Block<LatticeExprNode> arg(1, toBool(expr));
-      return new LELFunctionBool (LELFunctionEnums::VALUE, arg);
+      return LatticeExprNode
+        (std::make_shared<LELFunctionBool>(LELFunctionEnums::VALUE, arg));
    }
    return LatticeExprNode::newNumFunc1D (LELFunctionEnums::VALUE, expr);
 }
@@ -1812,23 +1823,28 @@ LatticeExprNode iif (const LatticeExprNode& condition,
    case TpFloat:
        arg[1] = arg1.makeFloat();
        arg[2] = arg2.makeFloat();
-       return new LELFunctionND<Float>(LELFunctionEnums::IIF, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Float>>(LELFunctionEnums::IIF, arg));
    case TpDouble:
        arg[1] = arg1.makeDouble();
        arg[2] = arg2.makeDouble();
-       return new LELFunctionND<Double>(LELFunctionEnums::IIF, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Double>>(LELFunctionEnums::IIF, arg));
    case TpComplex:
        arg[1] = arg1.makeComplex();
        arg[2] = arg2.makeComplex();
-       return new LELFunctionND<Complex>(LELFunctionEnums::IIF, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Complex>>(LELFunctionEnums::IIF, arg));
    case TpDComplex:
        arg[1] = arg1.makeDComplex();
        arg[2] = arg2.makeDComplex();
-       return new LELFunctionND<DComplex>(LELFunctionEnums::IIF, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<DComplex>>(LELFunctionEnums::IIF, arg));
    case TpBool:
        arg[1] = arg1.makeBool();
        arg[2] = arg2.makeBool();
-       return new LELFunctionND<Bool>(LELFunctionEnums::IIF, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Bool>>(LELFunctionEnums::IIF, arg));
    default:
       throw (AipsError ("LatticeExprNode::iif - unknown data type"));
    }
@@ -1848,23 +1864,28 @@ LatticeExprNode replace (const LatticeExprNode& arg1,
    case TpFloat:
        arg[0] = arg1.makeFloat();
        arg[1] = arg2.makeFloat();
-       return new LELFunctionND<Float>(LELFunctionEnums::REPLACE, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Float>>(LELFunctionEnums::REPLACE, arg));
    case TpDouble:
        arg[0] = arg1.makeDouble();
        arg[1] = arg2.makeDouble();
-       return new LELFunctionND<Double>(LELFunctionEnums::REPLACE, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Double>>(LELFunctionEnums::REPLACE, arg));
    case TpComplex:
        arg[0] = arg1.makeComplex();
        arg[1] = arg2.makeComplex();
-       return new LELFunctionND<Complex>(LELFunctionEnums::REPLACE, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Complex>>(LELFunctionEnums::REPLACE, arg));
    case TpDComplex:
        arg[0] = arg1.makeDComplex();
        arg[1] = arg2.makeDComplex();
-       return new LELFunctionND<DComplex>(LELFunctionEnums::REPLACE, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<DComplex>>(LELFunctionEnums::REPLACE, arg));
    case TpBool:
        arg[0] = arg1.makeBool();
        arg[1] = arg2.makeBool();
-       return new LELFunctionND<Bool>(LELFunctionEnums::REPLACE, arg);
+       return LatticeExprNode
+         (std::make_shared<LELFunctionND<Bool>>(LELFunctionEnums::REPLACE, arg));
    default:
       throw (AipsError ("LatticeExprNode::replace - unknown data type"));
    }
@@ -1888,13 +1909,17 @@ LatticeExprNode LatticeExprNode::newNumUnary (LELUnaryEnums::Operation oper,
 {
    switch (expr.dataType()) {
    case TpFloat:
-      return new LELUnary<Float> (oper, expr.pExprFloat_p);
+      return LatticeExprNode
+        (std::make_shared<LELUnary<Float>>(oper, expr.pExprFloat_p));
    case TpDouble:
-      return new LELUnary<Double> (oper, expr.pExprDouble_p);
+      return LatticeExprNode
+        (std::make_shared<LELUnary<Double>>(oper, expr.pExprDouble_p));
    case TpComplex:
-      return new LELUnary<Complex> (oper, expr.pExprComplex_p);
+      return LatticeExprNode
+        (std::make_shared<LELUnary<Complex>>(oper, expr.pExprComplex_p));
    case TpDComplex:
-      return new LELUnary<DComplex> (oper, expr.pExprDComplex_p);
+      return LatticeExprNode
+        (std::make_shared<LELUnary<DComplex>>(oper, expr.pExprDComplex_p));
    default:
       throw (AipsError ("LatticeExprNode::newNumUnary - "
 			"Bool argument used in numerical unary operation"));
@@ -1912,15 +1937,19 @@ LatticeExprNode LatticeExprNode::newNumFunc1D (LELFunctionEnums::Function func,
 {
    switch (expr.dataType()) {
    case TpFloat:
-      return new LELFunction1D<Float> (func, expr.pExprFloat_p);
+     return LatticeExprNode
+       (std::make_shared<LELFunction1D<Float>>(func, expr.pExprFloat_p));
    case TpDouble:
-      return new LELFunction1D<Double> (func, expr.pExprDouble_p);
+     return LatticeExprNode
+       (std::make_shared<LELFunction1D<Double>>(func, expr.pExprDouble_p));
    case TpComplex:
-      return new LELFunction1D<Complex> (func, expr.pExprComplex_p);
+     return LatticeExprNode
+       (std::make_shared<LELFunction1D<Complex>>(func, expr.pExprComplex_p));
    case TpDComplex:
-      return new LELFunction1D<DComplex> (func, expr.pExprDComplex_p);
+     return LatticeExprNode
+       (std::make_shared<LELFunction1D<DComplex>>(func, expr.pExprDComplex_p));
    default:
-      throw (AipsError ("LatticeExprNode::newNumFunc1D - "
+     throw (AipsError ("LatticeExprNode::newNumFunc1D - "
 			"Bool argument used in numerical function"));
    }
    return LatticeExprNode();
@@ -1929,41 +1958,41 @@ LatticeExprNode LatticeExprNode::newNumFunc1D (LELFunctionEnums::Function func,
 
 LatticeExprNode LatticeExprNode::newRealFunc1D (LELFunctionEnums::Function func,
 						const LatticeExprNode& expr)
-//
+{
 // Create a new node for a real numerical function with 1 argument.
 // The result has the same data type as the input.
-// 
-{
    switch (expr.dataType()) {
    case TpFloat:
-      return new LELFunctionReal1D<Float> (func, expr.pExprFloat_p);
+     return LatticeExprNode
+       (std::make_shared<LELFunctionReal1D<Float>>(func, expr.pExprFloat_p));
    case TpDouble:
-      return new LELFunctionReal1D<Double> (func, expr.pExprDouble_p);
+     return LatticeExprNode
+       (std::make_shared<LELFunctionReal1D<Double>>(func, expr.pExprDouble_p));
    default:
-      throw (AipsError ("LatticeExprNode::newRealFunc1D - "
-			"Bool or complex argument used in real "
-			"numerical function"));
+     throw (AipsError ("LatticeExprNode::newRealFunc1D - "
+                       "Bool or complex argument used in real "
+                       "numerical function"));
    }
    return LatticeExprNode();
 }
 
 LatticeExprNode LatticeExprNode::newComplexFunc1D (LELFunctionEnums::Function func,
     						   const LatticeExprNode& expr)
-//
+{
 // Create a new node for a complex numerical function with 1
 // argument. The result has the same data type as the input.
-// 
-{
    Block<LatticeExprNode> arg(1);
    arg[0] = expr;
    switch (expr.dataType()) {
    case TpComplex:
-      return new LELFunctionComplex(func, arg);
+     return LatticeExprNode
+       (std::make_shared<LELFunctionComplex>(func, arg));
    case TpDComplex:
-      return new LELFunctionDComplex(func, arg);
+     return LatticeExprNode
+       (std::make_shared<LELFunctionDComplex>(func, arg));
    default:
-      throw (AipsError ("LatticeExprNode::newComplexFunc1D - "
-			"only complex arguments allowed"));
+     throw (AipsError ("LatticeExprNode::newComplexFunc1D - "
+                       "only complex arguments allowed"));
    }
    return LatticeExprNode();
 }
@@ -1981,13 +2010,15 @@ LatticeExprNode LatticeExprNode::newNumReal1D (LELFunctionEnums::Function func,
    switch (dtype) {
    case TpFloat:
    case TpComplex:
-      return new LELFunctionFloat (func, arg);
+     return  LatticeExprNode
+       (std::make_shared<LELFunctionFloat>(func, arg));
    case TpDouble:
    case TpDComplex:
-      return new LELFunctionDouble (func, arg);
+     return  LatticeExprNode
+       (std::make_shared<LELFunctionDouble>(func, arg));
    default:
-      throw (AipsError ("LatticeExprNode::newNumReal1D - "
-			"output type must be real and numeric"));
+     throw (AipsError ("LatticeExprNode::newNumReal1D - "
+                       "output type must be real and numeric"));
    }
    return LatticeExprNode();
 }
@@ -2008,24 +2039,28 @@ LatticeExprNode LatticeExprNode::newNumFunc2D (LELFunctionEnums::Function func,
    Block<LatticeExprNode> arg(2);
    switch (dtype) {
    case TpFloat:
-      arg[0] = left.makeFloat();
-      arg[1] = right.makeFloat();
-      return new LELFunctionFloat (func, arg);
+       arg[0] = left.makeFloat();
+       arg[1] = right.makeFloat();
+       return LatticeExprNode
+         (std::make_shared<LELFunctionFloat>(func, arg));
    case TpDouble:
-      arg[0] = left.makeDouble();
-      arg[1] = right.makeDouble();
-      return new LELFunctionDouble (func, arg);
+       arg[0] = left.makeDouble();
+       arg[1] = right.makeDouble();
+       return LatticeExprNode
+         (std::make_shared<LELFunctionDouble>(func, arg));
    case TpComplex:
-      arg[0] = left.makeComplex();
-      arg[1] = right.makeComplex();
-      return new LELFunctionComplex (func, arg);
+       arg[0] = left.makeComplex();
+       arg[1] = right.makeComplex();
+       return LatticeExprNode
+         (std::make_shared<LELFunctionComplex>(func, arg));
    case TpDComplex:
-      arg[0] = left.makeDComplex();
-      arg[1] = right.makeDComplex();
-      return new LELFunctionDComplex (func, arg);
+       arg[0] = left.makeDComplex();
+       arg[1] = right.makeDComplex();
+       return LatticeExprNode
+         (std::make_shared<LELFunctionDComplex>(func, arg));
    default:
-      throw (AipsError ("LatticeExprNode::newNumFunc2D - "
-			"Bool argument used in numerical function"));
+       throw (AipsError ("LatticeExprNode::newNumFunc2D - "
+                         "Bool argument used in numerical function"));
    }
    return LatticeExprNode();
 }
@@ -2067,17 +2102,21 @@ LatticeExprNode LatticeExprNode::newNumBinary (LELBinaryEnums::Operation oper,
   makeEqualDim (expr0, expr1);
   switch (dtype) {
   case TpFloat:
-    return new LELBinary<Float> (oper, expr0.pExprFloat_p,
-				 expr1.pExprFloat_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinary<Float>>(oper, expr0.pExprFloat_p,
+                                          expr1.pExprFloat_p));
   case TpDouble:
-    return new LELBinary<Double> (oper, expr0.pExprDouble_p,
-				  expr1.pExprDouble_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinary<Double>>(oper, expr0.pExprDouble_p,
+                                           expr1.pExprDouble_p));
   case TpComplex:
-    return new LELBinary<Complex> (oper, expr0.pExprComplex_p,
-				   expr1.pExprComplex_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinary<Complex>>(oper, expr0.pExprComplex_p,
+                                            expr1.pExprComplex_p));
   default:
-    return new LELBinary<DComplex> (oper, expr0.pExprDComplex_p,
-				    expr1.pExprDComplex_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinary<DComplex>>(oper, expr0.pExprDComplex_p,
+                                             expr1.pExprDComplex_p));
   }
   return LatticeExprNode();
 }
@@ -2105,8 +2144,9 @@ LatticeExprNode LatticeExprNode::newLogBinary (LELBinaryEnums::Operation oper,
   }
   // Make the operands the same dimensionality (if needed and possible).
   makeEqualDim (expr0, expr1);
-  return new LELBinaryBool (oper, expr0.pExprBool_p,
-                            expr1.pExprBool_p);
+  return LatticeExprNode
+    (std::make_shared<LELBinaryBool>(oper, expr0.pExprBool_p,
+                                     expr1.pExprBool_p));
 }
 
 
@@ -2155,20 +2195,25 @@ LatticeExprNode LatticeExprNode::newBinaryCmp (LELBinaryEnums::Operation oper,
   makeEqualDim (expr0, expr1);
   switch (dtype) {
   case TpFloat:
-    return new LELBinaryCmp<Float> (oper, expr0.pExprFloat_p,
-				    expr1.pExprFloat_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinaryCmp<Float>>(oper, expr0.pExprFloat_p,
+                                             expr1.pExprFloat_p));
   case TpDouble:
-    return new LELBinaryCmp<Double> (oper, expr0.pExprDouble_p,
-				     expr1.pExprDouble_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinaryCmp<Double>>(oper, expr0.pExprDouble_p,
+                                              expr1.pExprDouble_p));
   case TpComplex:
-    return new LELBinaryCmp<Complex> (oper, expr0.pExprComplex_p,
-				      expr1.pExprComplex_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinaryCmp<Complex>>(oper, expr0.pExprComplex_p,
+                                               expr1.pExprComplex_p));
   case TpDComplex:
-    return new LELBinaryCmp<DComplex> (oper, expr0.pExprDComplex_p,
-				       expr1.pExprDComplex_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinaryCmp<DComplex>>(oper, expr0.pExprDComplex_p,
+                                                expr1.pExprDComplex_p));
   default:
-    return new LELBinaryBool (oper, expr0.pExprBool_p,
-			      expr1.pExprBool_p);
+    return LatticeExprNode
+      (std::make_shared<LELBinaryBool>(oper, expr0.pExprBool_p,
+                                       expr1.pExprBool_p));
   }
   return LatticeExprNode();
 }
@@ -2239,74 +2284,74 @@ const IPosition& LatticeExprNode::getIPosition() const
    return iposition_p;
 }
 
-CountedPtr<LELInterface<Float> > LatticeExprNode::makeFloat() const
+std::shared_ptr<LELInterface<Float>> LatticeExprNode::makeFloat() const
 {
     switch (dataType()) {
     case TpFloat:
-	return pExprFloat_p;
+      return pExprFloat_p;
     case TpDouble:
-	return new LELConvert<Float,Double> (pExprDouble_p);
+      return std::make_shared<LELConvert<Float,Double>>(pExprDouble_p);
     default:
-	throw (AipsError ("LatticeExprNode::makeFloat - "
-			  "conversion to Float not possible"));
+      throw (AipsError ("LatticeExprNode::makeFloat - "
+                        "conversion to Float not possible"));
     }
 }
 
-CountedPtr<LELInterface<Double> > LatticeExprNode::makeDouble() const
+std::shared_ptr<LELInterface<Double>> LatticeExprNode::makeDouble() const
 {
     switch (dataType()) {
     case TpFloat:
-	return new LELConvert<Double,Float> (pExprFloat_p);
+      return std::make_shared<LELConvert<Double,Float>>(pExprFloat_p);
     case TpDouble:
-	return pExprDouble_p;
+      return pExprDouble_p;
     default:
-	throw (AipsError ("LatticeExprNode::makeDouble - "
-			  "conversion to Double not possible"));
+      throw (AipsError ("LatticeExprNode::makeDouble - "
+                        "conversion to Double not possible"));
     }
 }
 
-CountedPtr<LELInterface<Complex> > LatticeExprNode::makeComplex() const
+std::shared_ptr<LELInterface<Complex>> LatticeExprNode::makeComplex() const
 {
     switch (dataType()) {
     case TpFloat:
-	return new LELConvert<Complex,Float> (pExprFloat_p);
+      return std::make_shared<LELConvert<Complex,Float>>(pExprFloat_p);
     case TpDouble:
-	return new LELConvert<Complex,Double> (pExprDouble_p);
+      return std::make_shared<LELConvert<Complex,Double>>(pExprDouble_p);
     case TpComplex:
-	return pExprComplex_p;
+      return pExprComplex_p;
     case TpDComplex:
-	return new LELConvert<Complex,DComplex> (pExprDComplex_p);
+      return std::make_shared<LELConvert<Complex,DComplex>>(pExprDComplex_p);
     default:
-	throw (AipsError ("LatticeExprNode::makeComplex - "
-			  "conversion to Complex not possible"));
+      throw (AipsError ("LatticeExprNode::makeComplex - "
+                        "conversion to Complex not possible"));
     }
 }
 
-CountedPtr<LELInterface<DComplex> > LatticeExprNode::makeDComplex() const
+std::shared_ptr<LELInterface<DComplex>> LatticeExprNode::makeDComplex() const
 {
     switch (dataType()) {
     case TpFloat:
-	return new LELConvert<DComplex,Float> (pExprFloat_p);
+      return std::make_shared<LELConvert<DComplex,Float>>(pExprFloat_p);
     case TpDouble:
-	return new LELConvert<DComplex,Double> (pExprDouble_p);
+      return std::make_shared<LELConvert<DComplex,Double>>(pExprDouble_p);
     case TpComplex:
-	return new LELConvert<DComplex,Complex> (pExprComplex_p);
+      return std::make_shared<LELConvert<DComplex,Complex>>(pExprComplex_p);
     case TpDComplex:
-	return pExprDComplex_p;
+      return pExprDComplex_p;
     default:
-	throw (AipsError ("LatticeExprNode::makeDComplex - "
-			  "conversion to DComplex not possible"));
+      throw (AipsError ("LatticeExprNode::makeDComplex - "
+                        "conversion to DComplex not possible"));
     }
 }
 
-CountedPtr<LELInterface<Bool> > LatticeExprNode::makeBool() const
+std::shared_ptr<LELInterface<Bool>> LatticeExprNode::makeBool() const
 {
     if (dataType() != TpBool) {
-	throw (AipsError ("LatticeExprNode::makeBool - "
-			  "conversion to Bool not possible"));
+      throw (AipsError ("LatticeExprNode::makeBool - "
+                        "conversion to Bool not possible"));
     }
     if (isRegion()) {
-        return new LELRegionAsBool ((const LELRegion&)(*pExprBool_p));
+      return std::make_shared<LELRegionAsBool>(dynamic_cast<LELRegion&>(*pExprBool_p));
     }
     return pExprBool_p;
 }
@@ -2344,4 +2389,3 @@ Int LatticeExprNode::makeEqualDim (LatticeExprNode& expr0,
 }
 
 } //# NAMESPACE CASACORE - END
-

--- a/lattices/LEL/LatticeExprNode.h
+++ b/lattices/LEL/LatticeExprNode.h
@@ -36,8 +36,8 @@
 #include <casacore/lattices/LEL/LELFunctionEnums.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
 #include <casacore/casa/Arrays/IPosition.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/Utilities/DataType.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -614,11 +614,11 @@ public:
 
 // Convert the expression to another data type.
 // <group>
-   CountedPtr<LELInterface<Float> >    makeFloat() const;
-   CountedPtr<LELInterface<Double> >   makeDouble() const;
-   CountedPtr<LELInterface<Complex> >  makeComplex() const;
-   CountedPtr<LELInterface<DComplex> > makeDComplex() const;
-   CountedPtr<LELInterface<Bool> >     makeBool() const;
+   std::shared_ptr<LELInterface<Float>>    makeFloat() const;
+   std::shared_ptr<LELInterface<Double>>   makeDouble() const;
+   std::shared_ptr<LELInterface<Complex>>  makeComplex() const;
+   std::shared_ptr<LELInterface<DComplex>> makeDComplex() const;
+   std::shared_ptr<LELInterface<Bool>>     makeBool() const;
 // </group>
 
 // Evaluate the expression.
@@ -710,15 +710,15 @@ public:
 // Replace a scalar subexpression by its result.
    Bool replaceScalarExpr();
   
-// Make the object from a Counted<LELInterface> pointer.
+// Make the object from a std::shared_ptr<LELInterface> pointer.
 // Ideally this function is private, but alas it is needed in LELFunction1D,
 // operator==, and more (too many to make them friend).
 // <group>
-   LatticeExprNode(const CountedPtr<LELInterface<Float> >& expr);
-   LatticeExprNode(const CountedPtr<LELInterface<Double> >& expr);
-   LatticeExprNode(const CountedPtr<LELInterface<Complex> >& expr);
-   LatticeExprNode(const CountedPtr<LELInterface<DComplex> >& expr);
-   LatticeExprNode(const CountedPtr<LELInterface<Bool> >& expr);
+   LatticeExprNode(const std::shared_ptr<LELInterface<Float>>& expr);
+   LatticeExprNode(const std::shared_ptr<LELInterface<Double>>& expr);
+   LatticeExprNode(const std::shared_ptr<LELInterface<Complex>>& expr);
+   LatticeExprNode(const std::shared_ptr<LELInterface<DComplex>>& expr);
+   LatticeExprNode(const std::shared_ptr<LELInterface<Bool>>& expr);
 // </group>
 
 // Determine the resulting data type from the given data types.
@@ -828,11 +828,11 @@ private:
    Bool                isInvalid_p;
    IPosition           iposition_p;
    const LELAttribute* pAttr_p;
-   CountedPtr<LELInterface<Float> >    pExprFloat_p;
-   CountedPtr<LELInterface<Double> >   pExprDouble_p;
-   CountedPtr<LELInterface<Complex> >  pExprComplex_p;
-   CountedPtr<LELInterface<DComplex> > pExprDComplex_p;
-   CountedPtr<LELInterface<Bool> >     pExprBool_p;
+   std::shared_ptr<LELInterface<Float>>    pExprFloat_p;
+   std::shared_ptr<LELInterface<Double>>   pExprDouble_p;
+   std::shared_ptr<LELInterface<Complex>>  pExprComplex_p;
+   std::shared_ptr<LELInterface<DComplex>> pExprDComplex_p;
+   std::shared_ptr<LELInterface<Bool>>     pExprBool_p;
 };
 
 

--- a/lattices/LEL/test/tLEL.cc
+++ b/lattices/LEL/test/tLEL.cc
@@ -316,7 +316,7 @@ int main (int argc, const char* argv[])
 //
    cout << endl << "LELUnary<Float>" << endl;
   {
-    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
+    auto pExpr = std::make_shared<LELLattice<Float>>(bF);
 
 // Note that operator+ is not actually implemented in LELUnary because it
 // wouldn't do anything !  It is implemented in LatticeExprNode though
@@ -333,7 +333,7 @@ int main (int argc, const char* argv[])
 // wouldn't do anything !  It is implemented in LatticeExprNode though
 
     cout << "   Operator -" << endl;     
-    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
+    auto pExpr = std::make_shared<LELLattice<Double>>(bD);
     LELUnary<Double> expr(LELUnaryEnums::MINUS, pExpr);
     if (!checkDouble(expr, -bDVal, String("LELUnary"), shape, False, suppress)) ok = False;
   }
@@ -346,7 +346,7 @@ int main (int argc, const char* argv[])
 // wouldn't do anything !  It is implemented in LatticeExprNode though
 
     cout << "   Operator -" << endl;     
-    std::shared_ptr<LELInterface<Complex> > pExpr(new LELLattice<Complex>(bC));
+    auto pExpr = std::make_shared<LELLattice<Complex>>(bC);
     LELUnary<Complex> expr(LELUnaryEnums::MINUS, pExpr);
     if (!checkComplex(expr, -bCVal, String("LELUnary"), shape, False, suppress)) ok = False;
   }
@@ -359,7 +359,7 @@ int main (int argc, const char* argv[])
 // wouldn't do anything !  It is implemented in LatticeExprNode though
 
     cout << "   Operator -" << endl;     
-    std::shared_ptr<LELInterface<DComplex> > pExpr(new LELLattice<DComplex>(bDC));
+    auto pExpr = std::make_shared<LELLattice<DComplex>>(bDC);
     LELUnary<DComplex> expr(LELUnaryEnums::MINUS, pExpr);
     if (!checkDComplex(expr, -bDCVal, String("LELUnary"), shape, False, suppress)) ok = False;
   }
@@ -373,7 +373,7 @@ int main (int argc, const char* argv[])
 
     {
       cout << "   Operator !" << endl;     
-      std::shared_ptr<LELInterface<Bool> > pExpr(new LELLattice<Bool>(aB));
+      auto pExpr = std::make_shared<LELLattice<Bool>>(aB);
       LELUnaryBool expr(LELUnaryEnums::NOT, pExpr);
       if (!checkBool(expr, (!aBVal), String("LELUnaryBool"), shape, False, suppress)) ok = False;
     }
@@ -385,8 +385,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<Float>" << endl;
-    std::shared_ptr<LELInterface<Float> > pExprLeft(new LELLattice<Float>(bF));
-    std::shared_ptr<LELInterface<Float> > pExprRight(new LELLattice<Float>(cF));
+    auto pExprLeft = std::make_shared<LELLattice<Float>>(bF);
+    auto pExprRight = std::make_shared<LELLattice<Float>>(cF);
 
     {
     cout << "   Operator +" << endl;     
@@ -424,8 +424,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<Double>" << endl;
-    std::shared_ptr<LELInterface<Double> > pExprLeft(new LELLattice<Double>(bD));
-    std::shared_ptr<LELInterface<Double> > pExprRight(new LELLattice<Double>(cD));
+    auto pExprLeft = std::make_shared<LELLattice<Double>>(bD);
+    auto pExprRight = std::make_shared<LELLattice<Double>>(cD);
 
     {
     cout << "   Operator +" << endl;     
@@ -462,8 +462,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<Complex>" << endl;
-    std::shared_ptr<LELInterface<Complex> > pExprLeft(new LELLattice<Complex>(bC));
-    std::shared_ptr<LELInterface<Complex> > pExprRight(new LELLattice<Complex>(cC));
+    auto pExprLeft = std::make_shared<LELLattice<Complex>>(bC);
+    auto pExprRight = std::make_shared<LELLattice<Complex>>(cC);
 
     {
     cout << "   Operator +" << endl;     
@@ -500,8 +500,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<DComplex>" << endl;
-    std::shared_ptr<LELInterface<DComplex> > pExprLeft(new LELLattice<DComplex>(bDC));
-    std::shared_ptr<LELInterface<DComplex> > pExprRight(new LELLattice<DComplex>(cDC));
+    auto pExprLeft = std::make_shared<LELLattice<DComplex>>(bDC);
+    auto pExprRight = std::make_shared<LELLattice<DComplex>>(cDC);
 
     {
     cout << "   Operator +" << endl;     
@@ -538,8 +538,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<Float>" << endl;
-    std::shared_ptr<LELInterface<Float> > pExprLeft(new LELLattice<Float>(bF));
-    std::shared_ptr<LELInterface<Float> > pExprRight(new LELLattice<Float>(cF));
+    auto pExprLeft = std::make_shared<LELLattice<Float>>(bF);
+    auto pExprRight = std::make_shared<LELLattice<Float>>(cF);
 
     {
     cout << "   Operator ==" << endl;     
@@ -577,8 +577,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<Double>" << endl;
-    std::shared_ptr<LELInterface<Double> > pExprLeft(new LELLattice<Double>(bD));
-    std::shared_ptr<LELInterface<Double> > pExprRight(new LELLattice<Double>(cD));
+    auto pExprLeft = std::make_shared<LELLattice<Double>>(bD);
+    auto pExprRight = std::make_shared<LELLattice<Double>>(cD);
 
     {
     cout << "   Operator ==" << endl;     
@@ -616,8 +616,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<Complex>" << endl;
-    std::shared_ptr<LELInterface<Complex> > pExprLeft(new LELLattice<Complex>(bC));
-    std::shared_ptr<LELInterface<Complex> > pExprRight(new LELLattice<Complex>(cC));
+    auto pExprLeft = std::make_shared<LELLattice<Complex>>(bC);
+    auto pExprRight = std::make_shared<LELLattice<Complex>>(cC);
 
     {
     cout << "   Operator ==" << endl;     
@@ -655,8 +655,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<DComplex>" << endl;
-    std::shared_ptr<LELInterface<DComplex> > pExprLeft(new LELLattice<DComplex>(bDC));
-    std::shared_ptr<LELInterface<DComplex> > pExprRight(new LELLattice<DComplex>(cDC));
+    auto pExprLeft = std::make_shared<LELLattice<DComplex>>(bDC);
+    auto pExprRight = std::make_shared<LELLattice<DComplex>>(cDC);
 
     {
     cout << "   Operator ==" << endl;     
@@ -694,8 +694,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryBool" << endl;
-    std::shared_ptr<LELInterface<Bool> > pExprLeft(new LELLattice<Bool>(bB));
-    std::shared_ptr<LELInterface<Bool> > pExprRight(new LELLattice<Bool>(cB));
+    auto pExprLeft = std::make_shared<LELLattice<Bool>>(bB);
+    auto pExprRight = std::make_shared<LELLattice<Bool>>(cB);
 
     {
     cout << "   Operator ==" << endl;     
@@ -726,7 +726,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<Float>" << endl;
-    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
+    auto pExpr = std::make_shared<LELLattice<Float>>(bF);
 
     {
     cout << "   Function sin" << endl;     
@@ -839,7 +839,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<Double>" << endl;
-    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
+    auto pExpr = std::make_shared<LELLattice<Double>>(bD);
 
     {
     cout << "   Function sin" << endl;     
@@ -952,7 +952,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<Complex>" << endl;
-    std::shared_ptr<LELInterface<Complex> > pExpr(new LELLattice<Complex>(bC));
+    auto pExpr = std::make_shared<LELLattice<Complex>>(bC);
 
     {
     cout << "   Function sin" << endl;     
@@ -1038,7 +1038,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<DComplex>" << endl;
-    std::shared_ptr<LELInterface<DComplex> > pExpr(new LELLattice<DComplex>(bDC));
+    auto pExpr = std::make_shared<LELLattice<DComplex>>(bDC);
 
     {
     cout << "   Function sin" << endl;     
@@ -1735,8 +1735,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunctionReal1D<Float>" << endl;
-    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
-    std::shared_ptr<LELInterface<Float> > pExpra(new LELLattice<Float>(aF));
+    auto pExpr = std::make_shared<LELLattice<Float>>(bF);
+    auto pExpra = std::make_shared<LELLattice<Float>>(aF);
 
     {
     cout << "   Function asin" << endl;     
@@ -1789,8 +1789,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunctionReal1D<Double>" << endl;
-    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
-    std::shared_ptr<LELInterface<Double> > pExpra(new LELLattice<Double>(aD));
+    auto pExpr = std::make_shared<LELLattice<Double>>(bD);
+    auto pExpra = std::make_shared<LELLattice<Double>>(aD);
 
     {
     cout << "   Function asin" << endl;     
@@ -2267,7 +2267,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << endl << "LELConvert<Float,Double> " << endl;
-    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
+    auto pExpr = std::make_shared<LELLattice<Double>>(bD);
     LELConvert<Float,Double> expr(pExpr);
     FResult = Float(bDVal);
     if (!checkFloat (expr, FResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2275,7 +2275,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Double,Float> " << endl;
-    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
+    auto pExpr = std::make_shared<LELLattice<Float>>(bF);
     LELConvert<Double,Float> expr(pExpr);
     DResult = Double(bFVal);
     if (!checkDouble(expr, DResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2283,7 +2283,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Complex,DComplex> " << endl;
-    std::shared_ptr<LELInterface<DComplex> > pExpr(new LELLattice<DComplex>(bDC));
+    auto pExpr = std::make_shared<LELLattice<DComplex>>(bDC);
     LELConvert<Complex,DComplex> expr(pExpr);
     CResult = Complex(bDCVal.real(), bDCVal.imag());
     if (!checkComplex(expr, CResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2291,7 +2291,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<DComplex,Complex> " << endl;
-    std::shared_ptr<LELInterface<Complex> > pExpr(new LELLattice<Complex>(bC));
+    auto pExpr = std::make_shared<LELLattice<Complex>>(bC);
     LELConvert<DComplex,Complex> expr(pExpr);
     DCResult = bCVal;
     if (!checkDComplex(expr, DCResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2300,7 +2300,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Complex,Float> " << endl;
-    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
+    auto pExpr = std::make_shared<LELLattice<Float>>(bF);
     LELConvert<Complex,Float> expr(pExpr);
     CResult = Complex(bFVal,0.0);
     if (!checkComplex(expr, CResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2308,7 +2308,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Complex,Double> " << endl;
-    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
+    auto pExpr = std::make_shared<LELLattice<Double>>(bD);
     LELConvert<Complex,Double> expr(pExpr);
     CResult = Complex(bDVal,0.0);
     if (!checkComplex(expr, CResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2316,7 +2316,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<DComplex,Float> " << endl;
-    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
+    auto pExpr = std::make_shared<LELLattice<Float>>(bF);
     LELConvert<DComplex,Float> expr(pExpr);
     DCResult = DComplex(bFVal,0.0);
     if (!checkDComplex(expr, DCResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2324,7 +2324,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<DComplex,Double> " << endl;
-    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
+    auto pExpr = std::make_shared<LELLattice<Double>>(bD);
     LELConvert<DComplex,Double> expr(pExpr);
     DCResult = DComplex(bDVal,0.0);
     if (!checkDComplex(expr, DCResult, String("LELConvert"), shape, False, suppress)) ok = False;

--- a/lattices/LEL/test/tLEL.cc
+++ b/lattices/LEL/test/tLEL.cc
@@ -316,7 +316,7 @@ int main (int argc, const char* argv[])
 //
    cout << endl << "LELUnary<Float>" << endl;
   {
-    CountedPtr<LELInterface<Float> > pExpr = new LELLattice<Float>(bF);
+    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
 
 // Note that operator+ is not actually implemented in LELUnary because it
 // wouldn't do anything !  It is implemented in LatticeExprNode though
@@ -333,7 +333,7 @@ int main (int argc, const char* argv[])
 // wouldn't do anything !  It is implemented in LatticeExprNode though
 
     cout << "   Operator -" << endl;     
-    CountedPtr<LELInterface<Double> > pExpr = new LELLattice<Double>(bD);
+    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
     LELUnary<Double> expr(LELUnaryEnums::MINUS, pExpr);
     if (!checkDouble(expr, -bDVal, String("LELUnary"), shape, False, suppress)) ok = False;
   }
@@ -346,7 +346,7 @@ int main (int argc, const char* argv[])
 // wouldn't do anything !  It is implemented in LatticeExprNode though
 
     cout << "   Operator -" << endl;     
-    CountedPtr<LELInterface<Complex> > pExpr = new LELLattice<Complex>(bC);
+    std::shared_ptr<LELInterface<Complex> > pExpr(new LELLattice<Complex>(bC));
     LELUnary<Complex> expr(LELUnaryEnums::MINUS, pExpr);
     if (!checkComplex(expr, -bCVal, String("LELUnary"), shape, False, suppress)) ok = False;
   }
@@ -359,7 +359,7 @@ int main (int argc, const char* argv[])
 // wouldn't do anything !  It is implemented in LatticeExprNode though
 
     cout << "   Operator -" << endl;     
-    CountedPtr<LELInterface<DComplex> > pExpr = new LELLattice<DComplex>(bDC);
+    std::shared_ptr<LELInterface<DComplex> > pExpr(new LELLattice<DComplex>(bDC));
     LELUnary<DComplex> expr(LELUnaryEnums::MINUS, pExpr);
     if (!checkDComplex(expr, -bDCVal, String("LELUnary"), shape, False, suppress)) ok = False;
   }
@@ -373,7 +373,7 @@ int main (int argc, const char* argv[])
 
     {
       cout << "   Operator !" << endl;     
-      CountedPtr<LELInterface<Bool> > pExpr = new LELLattice<Bool>(aB);
+      std::shared_ptr<LELInterface<Bool> > pExpr(new LELLattice<Bool>(aB));
       LELUnaryBool expr(LELUnaryEnums::NOT, pExpr);
       if (!checkBool(expr, (!aBVal), String("LELUnaryBool"), shape, False, suppress)) ok = False;
     }
@@ -385,8 +385,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<Float>" << endl;
-    CountedPtr<LELInterface<Float> > pExprLeft = new LELLattice<Float>(bF);
-    CountedPtr<LELInterface<Float> > pExprRight = new LELLattice<Float>(cF);
+    std::shared_ptr<LELInterface<Float> > pExprLeft(new LELLattice<Float>(bF));
+    std::shared_ptr<LELInterface<Float> > pExprRight(new LELLattice<Float>(cF));
 
     {
     cout << "   Operator +" << endl;     
@@ -424,8 +424,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<Double>" << endl;
-    CountedPtr<LELInterface<Double> > pExprLeft = new LELLattice<Double>(bD);
-    CountedPtr<LELInterface<Double> > pExprRight = new LELLattice<Double>(cD);
+    std::shared_ptr<LELInterface<Double> > pExprLeft(new LELLattice<Double>(bD));
+    std::shared_ptr<LELInterface<Double> > pExprRight(new LELLattice<Double>(cD));
 
     {
     cout << "   Operator +" << endl;     
@@ -462,8 +462,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<Complex>" << endl;
-    CountedPtr<LELInterface<Complex> > pExprLeft = new LELLattice<Complex>(bC);
-    CountedPtr<LELInterface<Complex> > pExprRight = new LELLattice<Complex>(cC);
+    std::shared_ptr<LELInterface<Complex> > pExprLeft(new LELLattice<Complex>(bC));
+    std::shared_ptr<LELInterface<Complex> > pExprRight(new LELLattice<Complex>(cC));
 
     {
     cout << "   Operator +" << endl;     
@@ -500,8 +500,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinary<DComplex>" << endl;
-    CountedPtr<LELInterface<DComplex> > pExprLeft = new LELLattice<DComplex>(bDC);
-    CountedPtr<LELInterface<DComplex> > pExprRight = new LELLattice<DComplex>(cDC);
+    std::shared_ptr<LELInterface<DComplex> > pExprLeft(new LELLattice<DComplex>(bDC));
+    std::shared_ptr<LELInterface<DComplex> > pExprRight(new LELLattice<DComplex>(cDC));
 
     {
     cout << "   Operator +" << endl;     
@@ -538,8 +538,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<Float>" << endl;
-    CountedPtr<LELInterface<Float> > pExprLeft = new LELLattice<Float>(bF);
-    CountedPtr<LELInterface<Float> > pExprRight = new LELLattice<Float>(cF);
+    std::shared_ptr<LELInterface<Float> > pExprLeft(new LELLattice<Float>(bF));
+    std::shared_ptr<LELInterface<Float> > pExprRight(new LELLattice<Float>(cF));
 
     {
     cout << "   Operator ==" << endl;     
@@ -577,8 +577,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<Double>" << endl;
-    CountedPtr<LELInterface<Double> > pExprLeft = new LELLattice<Double>(bD);
-    CountedPtr<LELInterface<Double> > pExprRight = new LELLattice<Double>(cD);
+    std::shared_ptr<LELInterface<Double> > pExprLeft(new LELLattice<Double>(bD));
+    std::shared_ptr<LELInterface<Double> > pExprRight(new LELLattice<Double>(cD));
 
     {
     cout << "   Operator ==" << endl;     
@@ -616,8 +616,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<Complex>" << endl;
-    CountedPtr<LELInterface<Complex> > pExprLeft = new LELLattice<Complex>(bC);
-    CountedPtr<LELInterface<Complex> > pExprRight = new LELLattice<Complex>(cC);
+    std::shared_ptr<LELInterface<Complex> > pExprLeft(new LELLattice<Complex>(bC));
+    std::shared_ptr<LELInterface<Complex> > pExprRight(new LELLattice<Complex>(cC));
 
     {
     cout << "   Operator ==" << endl;     
@@ -655,8 +655,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryCmp<DComplex>" << endl;
-    CountedPtr<LELInterface<DComplex> > pExprLeft = new LELLattice<DComplex>(bDC);
-    CountedPtr<LELInterface<DComplex> > pExprRight = new LELLattice<DComplex>(cDC);
+    std::shared_ptr<LELInterface<DComplex> > pExprLeft(new LELLattice<DComplex>(bDC));
+    std::shared_ptr<LELInterface<DComplex> > pExprRight(new LELLattice<DComplex>(cDC));
 
     {
     cout << "   Operator ==" << endl;     
@@ -694,8 +694,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELBinaryBool" << endl;
-    CountedPtr<LELInterface<Bool> > pExprLeft = new LELLattice<Bool>(bB);
-    CountedPtr<LELInterface<Bool> > pExprRight = new LELLattice<Bool>(cB);
+    std::shared_ptr<LELInterface<Bool> > pExprLeft(new LELLattice<Bool>(bB));
+    std::shared_ptr<LELInterface<Bool> > pExprRight(new LELLattice<Bool>(cB));
 
     {
     cout << "   Operator ==" << endl;     
@@ -726,7 +726,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<Float>" << endl;
-    CountedPtr<LELInterface<Float> > pExpr = new LELLattice<Float>(bF);
+    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
 
     {
     cout << "   Function sin" << endl;     
@@ -839,7 +839,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<Double>" << endl;
-    CountedPtr<LELInterface<Double> > pExpr = new LELLattice<Double>(bD);
+    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
 
     {
     cout << "   Function sin" << endl;     
@@ -952,7 +952,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<Complex>" << endl;
-    CountedPtr<LELInterface<Complex> > pExpr = new LELLattice<Complex>(bC);
+    std::shared_ptr<LELInterface<Complex> > pExpr(new LELLattice<Complex>(bC));
 
     {
     cout << "   Function sin" << endl;     
@@ -1038,7 +1038,7 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunction1D<DComplex>" << endl;
-    CountedPtr<LELInterface<DComplex> > pExpr = new LELLattice<DComplex>(bDC);
+    std::shared_ptr<LELInterface<DComplex> > pExpr(new LELLattice<DComplex>(bDC));
 
     {
     cout << "   Function sin" << endl;     
@@ -1735,8 +1735,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunctionReal1D<Float>" << endl;
-    CountedPtr<LELInterface<Float> > pExpr = new LELLattice<Float>(bF);
-    CountedPtr<LELInterface<Float> > pExpra = new LELLattice<Float>(aF);
+    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
+    std::shared_ptr<LELInterface<Float> > pExpra(new LELLattice<Float>(aF));
 
     {
     cout << "   Function asin" << endl;     
@@ -1789,8 +1789,8 @@ int main (int argc, const char* argv[])
 //
   {
     cout << endl << "LELFunctionReal1D<Double>" << endl;
-    CountedPtr<LELInterface<Double> > pExpr = new LELLattice<Double>(bD);
-    CountedPtr<LELInterface<Double> > pExpra = new LELLattice<Double>(aD);
+    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
+    std::shared_ptr<LELInterface<Double> > pExpra(new LELLattice<Double>(aD));
 
     {
     cout << "   Function asin" << endl;     
@@ -2267,7 +2267,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << endl << "LELConvert<Float,Double> " << endl;
-    CountedPtr<LELInterface<Double> > pExpr = new LELLattice<Double>(bD);
+    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
     LELConvert<Float,Double> expr(pExpr);
     FResult = Float(bDVal);
     if (!checkFloat (expr, FResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2275,7 +2275,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Double,Float> " << endl;
-    CountedPtr<LELInterface<Float> > pExpr = new LELLattice<Float>(bF);
+    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
     LELConvert<Double,Float> expr(pExpr);
     DResult = Double(bFVal);
     if (!checkDouble(expr, DResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2283,7 +2283,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Complex,DComplex> " << endl;
-    CountedPtr<LELInterface<DComplex> > pExpr = new LELLattice<DComplex>(bDC);
+    std::shared_ptr<LELInterface<DComplex> > pExpr(new LELLattice<DComplex>(bDC));
     LELConvert<Complex,DComplex> expr(pExpr);
     CResult = Complex(bDCVal.real(), bDCVal.imag());
     if (!checkComplex(expr, CResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2291,7 +2291,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<DComplex,Complex> " << endl;
-    CountedPtr<LELInterface<Complex> > pExpr = new LELLattice<Complex>(bC);
+    std::shared_ptr<LELInterface<Complex> > pExpr(new LELLattice<Complex>(bC));
     LELConvert<DComplex,Complex> expr(pExpr);
     DCResult = bCVal;
     if (!checkDComplex(expr, DCResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2300,7 +2300,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Complex,Float> " << endl;
-    CountedPtr<LELInterface<Float> > pExpr = new LELLattice<Float>(bF);
+    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
     LELConvert<Complex,Float> expr(pExpr);
     CResult = Complex(bFVal,0.0);
     if (!checkComplex(expr, CResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2308,7 +2308,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<Complex,Double> " << endl;
-    CountedPtr<LELInterface<Double> > pExpr = new LELLattice<Double>(bD);
+    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
     LELConvert<Complex,Double> expr(pExpr);
     CResult = Complex(bDVal,0.0);
     if (!checkComplex(expr, CResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2316,7 +2316,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<DComplex,Float> " << endl;
-    CountedPtr<LELInterface<Float> > pExpr = new LELLattice<Float>(bF);
+    std::shared_ptr<LELInterface<Float> > pExpr(new LELLattice<Float>(bF));
     LELConvert<DComplex,Float> expr(pExpr);
     DCResult = DComplex(bFVal,0.0);
     if (!checkDComplex(expr, DCResult, String("LELConvert"), shape, False, suppress)) ok = False;
@@ -2324,7 +2324,7 @@ int main (int argc, const char* argv[])
 
     {
     cout << "LELConvert<DComplex,Double> " << endl;
-    CountedPtr<LELInterface<Double> > pExpr = new LELLattice<Double>(bD);
+    std::shared_ptr<LELInterface<Double> > pExpr(new LELLattice<Double>(bD));
     LELConvert<DComplex,Double> expr(pExpr);
     DCResult = DComplex(bDVal,0.0);
     if (!checkDComplex(expr, DCResult, String("LELConvert"), shape, False, suppress)) ok = False;

--- a/lattices/LEL/test/tLatticeExprNode.cc
+++ b/lattices/LEL/test/tLatticeExprNode.cc
@@ -206,35 +206,35 @@ Bool doIt (const MaskedLattice<Float>& aF,
    cout << "LatticeExprNode(std::shared_ptr<LELInterface<T>>&) " << endl;
    {
       cout << "  Float" << endl;
-      std::shared_ptr<LELInterface<Float>> pExpr(new LELUnaryConst<Float>(bFVal));
+      auto pExpr = std::make_shared<LELUnaryConst<Float>>(bFVal);
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bFVal);
       if (!compareScalarFloat (expr, expr2, bFVal, shape)) ok = False;
    }
    {
       cout << "  Double" << endl;
-      std::shared_ptr<LELInterface<Double>> pExpr(new LELUnaryConst<Double>(bDVal));
+      auto pExpr = std::make_shared<LELUnaryConst<Double>>(bDVal);
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bDVal);
       if (!compareScalarDouble (expr, expr2, bDVal, shape)) ok = False;
    }
    {
       cout << "  Complex" << endl;
-      std::shared_ptr<LELInterface<Complex>> pExpr(new LELUnaryConst<Complex>(bCVal));
+      auto pExpr = std::make_shared<LELUnaryConst<Complex>>(bCVal);
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bCVal);
       if (!compareScalarComplex (expr, expr2, bCVal, shape)) ok = False;
    }
    {
       cout << "  DComplex" << endl;
-      std::shared_ptr<LELInterface<DComplex>> pExpr(new LELUnaryConst<DComplex>(bDCVal));
+      auto pExpr = std::make_shared<LELUnaryConst<DComplex>>(bDCVal);
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bDCVal);
       if (!compareScalarDComplex (expr, expr2, bDCVal, shape)) ok = False;
    }
    {
       cout << "  Bool" << endl;
-      std::shared_ptr<LELInterface<Bool>> pExpr(new LELUnaryConst<Bool>(bBVal));
+      auto pExpr = std::make_shared<LELUnaryConst<Bool>>(bBVal);
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bBVal);
       if (!compareScalarBool (expr, expr2, bBVal, shape)) ok = False;

--- a/lattices/LEL/test/tLatticeExprNode.cc
+++ b/lattices/LEL/test/tLatticeExprNode.cc
@@ -203,38 +203,38 @@ Bool doIt (const MaskedLattice<Float>& aF,
 //
 
    cout << endl << "LELInterface constructors" << endl;
-   cout << "LatticeExprNode(CountedPtr<LELInterface<T> >&) " << endl;
+   cout << "LatticeExprNode(std::shared_ptr<LELInterface<T>>&) " << endl;
    {
       cout << "  Float" << endl;
-      CountedPtr<LELInterface<Float> > pExpr = new LELUnaryConst<Float>(bFVal);
+      std::shared_ptr<LELInterface<Float>> pExpr(new LELUnaryConst<Float>(bFVal));
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bFVal);
       if (!compareScalarFloat (expr, expr2, bFVal, shape)) ok = False;
    }
    {
       cout << "  Double" << endl;
-      CountedPtr<LELInterface<Double> > pExpr = new LELUnaryConst<Double>(bDVal);
+      std::shared_ptr<LELInterface<Double>> pExpr(new LELUnaryConst<Double>(bDVal));
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bDVal);
       if (!compareScalarDouble (expr, expr2, bDVal, shape)) ok = False;
    }
    {
       cout << "  Complex" << endl;
-      CountedPtr<LELInterface<Complex> > pExpr = new LELUnaryConst<Complex>(bCVal);
+      std::shared_ptr<LELInterface<Complex>> pExpr(new LELUnaryConst<Complex>(bCVal));
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bCVal);
       if (!compareScalarComplex (expr, expr2, bCVal, shape)) ok = False;
    }
    {
       cout << "  DComplex" << endl;
-      CountedPtr<LELInterface<DComplex> > pExpr = new LELUnaryConst<DComplex>(bDCVal);
+      std::shared_ptr<LELInterface<DComplex>> pExpr(new LELUnaryConst<DComplex>(bDCVal));
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bDCVal);
       if (!compareScalarDComplex (expr, expr2, bDCVal, shape)) ok = False;
    }
    {
       cout << "  Bool" << endl;
-      CountedPtr<LELInterface<Bool> > pExpr = new LELUnaryConst<Bool>(bBVal);
+      std::shared_ptr<LELInterface<Bool>> pExpr(new LELUnaryConst<Bool>(bBVal));
       LatticeExprNode expr(pExpr);
       LatticeExprNode expr2(bBVal);
       if (!compareScalarBool (expr, expr2, bBVal, shape)) ok = False;

--- a/lattices/LEL/test/tLatticeExprNode.out
+++ b/lattices/LEL/test/tLatticeExprNode.out
@@ -12,7 +12,7 @@ LatticeExprNode (constant T)
   Bool
 
 LELInterface constructors
-LatticeExprNode(CountedPtr<LELInterface<T> >&) 
+LatticeExprNode(std::shared_ptr<LELInterface<T>>&) 
   Float
   Double
   Complex
@@ -403,7 +403,7 @@ LatticeExprNode (constant T)
   Bool
 
 LELInterface constructors
-LatticeExprNode(CountedPtr<LELInterface<T> >&) 
+LatticeExprNode(std::shared_ptr<LELInterface<T>>&) 
   Float
   Double
   Complex
@@ -794,7 +794,7 @@ LatticeExprNode (constant T)
   Bool
 
 LELInterface constructors
-LatticeExprNode(CountedPtr<LELInterface<T> >&) 
+LatticeExprNode(std::shared_ptr<LELInterface<T>>&) 
   Float
   Double
   Complex

--- a/lattices/LRegions/LCHDF5Mask.cc
+++ b/lattices/LRegions/LCHDF5Mask.cc
@@ -35,7 +35,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {}
 
   LCHDF5Mask::LCHDF5Mask (const TiledShape& latticeShape,
-			  const CountedPtr<HDF5File>& file,
+			  const std::shared_ptr<HDF5File>& file,
 			  const String& maskName)
     : LCRegionSingle (latticeShape.shape()),
       itsBox (IPosition(latticeShape.shape().nelements(), 0),
@@ -48,7 +48,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   LCHDF5Mask::LCHDF5Mask (const TiledShape& maskShape,
 			  const LCBox& box,
-			  const CountedPtr<HDF5File>& file,
+			  const std::shared_ptr<HDF5File>& file,
 			  const String& maskName)
     : LCRegionSingle (box.latticeShape()),
       itsBox (box)

--- a/lattices/LRegions/LCHDF5Mask.h
+++ b/lattices/LRegions/LCHDF5Mask.h
@@ -64,9 +64,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // The default mask shape is the lattice shape.
     // <group>
     LCHDF5Mask (const TiledShape& latticeShape,
-		const CountedPtr<HDF5File>& file, const String& maskName);
+		const std::shared_ptr<HDF5File>& file, const String& maskName);
     LCHDF5Mask (const TiledShape& maskShape, const LCBox& box,
-		const CountedPtr<HDF5File>& file, const String& maskName);
+		const std::shared_ptr<HDF5File>& file, const String& maskName);
     LCHDF5Mask (HDF5Lattice<Bool>& mask, const LCBox& box);
     // </group>
 

--- a/lattices/LatticeMath/LattStatsProgress.cc
+++ b/lattices/LatticeMath/LattStatsProgress.cc
@@ -51,14 +51,16 @@ void LattStatsProgress::initDerived()
 // calls this initDerived function
 // 
 
-  _meter.reset (new ProgressMeter(0.0, Double(expectedNsteps()), String("Generate Storage Image"),
-                                  String("Accumulation Iterations"), String(""), String(""),
-                                  True, max(1,Int(expectedNsteps()/20))));
+   _meter = std::make_shared<ProgressMeter>(
+       0.0, Double(expectedNsteps()), String("Generate Storage Image"),
+       String("Accumulation Iterations"), String(""), String(""),
+       True, max(1,Int(expectedNsteps()/20))
+   );
 }
 
 void LattStatsProgress::nstepsDone (uInt nsteps)
 {
-	_currentStep = nsteps;
+    _currentStep = nsteps;
     _meter->update (_currentStep);
 }
 

--- a/lattices/LatticeMath/LatticeStatistics.tcc
+++ b/lattices/LatticeMath/LatticeStatistics.tcc
@@ -872,14 +872,12 @@ Bool LatticeStatistics<T>::generateStorageLattice() {
        os_p << LogIO::NORMAL1
             << "Creating new statistics storage lattice of shape " << storeLatticeShape << endl << LogIO::POST;
     }
-    pStoreLattice_p.reset(
-        new TempLattice<AccumType>(
-            TiledShape(storeLatticeShape, tileShape), useMemory
-        )
+    pStoreLattice_p = std::make_shared<TempLattice<AccumType>>(
+        TiledShape(storeLatticeShape, tileShape), useMemory
     );
     // Set up min/max location variables
     std::shared_ptr<LattStatsProgress> pProgressMeter(
-        showProgress_p ? new LattStatsProgress() : NULL
+        showProgress_p ? std::make_shared<LattStatsProgress>() : NULL
     );
     Double timeOld = 0;
     Double timeNew = 0;
@@ -1102,7 +1100,7 @@ void LatticeStatistics<T>::_computeStatsUsingArrays(
     }
     std::shared_ptr<DataRanges> range;
     if (! noInclude_p || ! noExclude_p) {
-        range.reset(new DataRanges());
+      range = std::make_shared<DataRanges>();
         range->push_back(std::pair<T, T>(range_p[0], range_p[1]));
     }
     const Bool isChauv = _saf.algorithm() == StatisticsData::CHAUVENETCRITERION;
@@ -1583,9 +1581,9 @@ void LatticeStatistics<T>::_computeQuantiles(
     // computing the median and the quartiles simultaneously minimizes
     // the number of necessary data scans, as opposed to first calling
     // getMedian() and getQuartiles() separately
-    std::shared_ptr<uInt64> npts(new uInt64(knownNpts));
-    std::shared_ptr<AccumType> mymin(new AccumType(knownMin));
-    std::shared_ptr<AccumType> mymax(new AccumType(knownMax));
+    std::shared_ptr<uInt64> npts = std::make_shared<uInt64>(knownNpts);
+    std::shared_ptr<AccumType> mymin = std::make_shared<AccumType>(knownMin);
+    std::shared_ptr<AccumType> mymax = std::make_shared<AccumType>(knownMax);
     median = statsAlg->getMedianAndQuantiles(
         quantiles, fracs, npts, mymin, mymax,
         maxArraySizeBytes, False, nBins
@@ -1609,12 +1607,12 @@ template <class U, class V>
             median, medAbsDevMed, q1, q3, statsAlg,
             stats.npts, *stats.min, *stats.max
         );
-        stats.median.reset(new AccumType(median));
-        stats.medAbsDevMed.reset(new AccumType(medAbsDevMed));
+        stats.median = std::make_shared<AccumType>(median);
+        stats.medAbsDevMed = std::make_shared<AccumType>(medAbsDevMed);
     }
     else {
-        stats.median.reset(new AccumType(0));
-        stats.medAbsDevMed.reset(new AccumType(0));
+        stats.median = std::make_shared<AccumType>(0);
+        stats.medAbsDevMed = std::make_shared<AccumType>(0);
         q1 = 0;
         q3 = 0;
     }

--- a/lattices/LatticeMath/LatticeStatsDataProvider.tcc
+++ b/lattices/LatticeMath/LatticeStatsDataProvider.tcc
@@ -149,7 +149,7 @@ void LatticeStatsDataProvider<T>::setLattice(
                 lattice.advisedMaxPixels()
             )
         );
-        _iter.reset (new RO_LatticeIterator<T>(lattice, stepper));
+        _iter = std::make_shared<RO_LatticeIterator<T>>(lattice, stepper);
     }
     else {
         _iter = NULL;

--- a/lattices/LatticeMath/MaskedLatticeStatsDataProvider.tcc
+++ b/lattices/LatticeMath/MaskedLatticeStatsDataProvider.tcc
@@ -156,7 +156,7 @@ void MaskedLatticeStatsDataProvider<T>::setLattice(
                 lattice.advisedMaxPixels()
             )
         );
-        _iter.reset (new RO_MaskedLatticeIterator<T>(lattice, stepper));
+        _iter = std::make_shared<RO_MaskedLatticeIterator<T>>(lattice, stepper);
     }
     else {
         _iter = NULL;

--- a/lattices/LatticeMath/StatsTiledCollapser.tcc
+++ b/lattices/LatticeMath/StatsTiledCollapser.tcc
@@ -46,17 +46,17 @@ void StatsTiledCollapser<T,U>::init (uInt nOutPixelsPerCollapse) {
 
 template <class T, class U>
 void StatsTiledCollapser<T,U>::initAccumulator (uInt64 n1, uInt64 n3) {
-   _sum.reset (new Block<U>(n1*n3));
-   _sumSq.reset (new Block<U>(n1*n3));
-   _npts.reset (new Block<Double>(n1*n3));
-   _mean.reset (new Block<U>(n1*n3));
-   _variance.reset (new Block<U>(n1*n3));
-   _sigma.reset (new Block<U>(n1*n3));
-   _nvariance.reset (new Block<U>(n1*n3));
+   _sum = std::make_shared<Block<U>>(n1*n3);
+   _sumSq = std::make_shared<Block<U>>(n1*n3);
+   _npts = std::make_shared<Block<Double>>(n1*n3);
+   _mean = std::make_shared<Block<U>>(n1*n3);
+   _variance = std::make_shared<Block<U>>(n1*n3);
+   _sigma = std::make_shared<Block<U>>(n1*n3);
+   _nvariance = std::make_shared<Block<U>>(n1*n3);
 
-   _min.reset (new Block<T>(n1*n3));
-   _max.reset (new Block<T>(n1*n3));
-   _initMinMax.reset (new Block<Bool>(n1*n3));
+   _min = std::make_shared<Block<T>>(n1*n3);
+   _max = std::make_shared<Block<T>>(n1*n3);
+   _initMinMax = std::make_shared<Block<Bool>>(n1*n3);
    _sum->set(0);
    _sumSq->set(0);
    _npts->set(0);
@@ -220,7 +220,7 @@ void StatsTiledCollapser<T,U>::endAccumulator(
     U* sumSqPtr = _sumSq->storage();
     std::shared_ptr<Block<DComplex>> nptsComplex;
     if (! isReal(whatType<U>())) {
-       nptsComplex.reset (new Block<DComplex>(_n1*_n3));
+      nptsComplex = std::make_shared<Block<DComplex>>(_n1*_n3);
     }
     U* nPtsPtr;
     _convertNPts(nPtsPtr, _npts, nptsComplex);

--- a/lattices/Lattices/HDF5Lattice.h
+++ b/lattices/Lattices/HDF5Lattice.h
@@ -136,7 +136,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // HDF5 file. The array gets the given name.
     // Optionally the name of an HDF5 group can be given to create the array in.
     // The group is created if not existing yet.
-    HDF5Lattice (const TiledShape& shape, const CountedPtr<HDF5File>& file,
+    HDF5Lattice (const TiledShape& shape, const std::shared_ptr<HDF5File>& file,
 		 const String& arrayName, const String& groupName = String());
 
     // Reconstruct from a pre-existing HDF5Lattice in the HDF5 file and group
@@ -147,7 +147,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
     // Reconstruct from a pre-existing HDF5Lattice in the HDF5 file and group
     // with the given name.
-    explicit HDF5Lattice (const CountedPtr<HDF5File>& file,
+    explicit HDF5Lattice (const std::shared_ptr<HDF5File>& file,
 			  const String& arrayName,
 			  const String& groupName = String());
 
@@ -184,16 +184,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     virtual String name (Bool stripPath=False) const;
 
     // Return the current HDF5File object.
-    const CountedPtr<HDF5File>& file() const
+    const std::shared_ptr<HDF5File>& file() const
       { return itsFile; }
 
     // Return the current HDF5Group object.
-    const CountedPtr<HDF5Group>& group() const
+    const std::shared_ptr<HDF5Group>& group() const
       { return itsGroup; }
 
-	// Returns the current HDF5DataSet object
-	const CountedPtr<HDF5DataSet>& array() const
-	{ return itsDataSet; }
+    // Returns the current HDF5DataSet object
+    const std::shared_ptr<HDF5DataSet>& array() const
+      { return itsDataSet; }
 
     // Returns the name of this HDF5Lattice.
     const String& arrayName() const
@@ -261,10 +261,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     void checkWritable() const;
 
 
-    CountedPtr<HDF5File>    itsFile;
-    CountedPtr<HDF5Group>   itsGroup;
-    CountedPtr<HDF5DataSet> itsDataSet;
-    IPosition               itsTileShape;
+    std::shared_ptr<HDF5File>    itsFile;
+    std::shared_ptr<HDF5Group>   itsGroup;
+    std::shared_ptr<HDF5DataSet> itsDataSet;
+    IPosition                    itsTileShape;
   };
 
 

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -53,7 +53,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   HDF5Lattice<T>::HDF5Lattice (const TiledShape& shape, const String& fileName,
 			       const String& arrayName, const String& groupName)
   {
-    itsFile = new HDF5File (fileName, ByteIO::New);
+    itsFile.reset (new HDF5File (fileName, ByteIO::New));
     makeArray (shape, arrayName, groupName);
     DebugAssert (ok(), AipsError);
   }
@@ -62,14 +62,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   HDF5Lattice<T>::HDF5Lattice (const TiledShape& shape)
   {
     Path fileName = File::newUniqueName(String("./"), String("HDF5Lattice"));
-    itsFile = new HDF5File (fileName.absoluteName(), ByteIO::Scratch);
+    itsFile.reset (new HDF5File (fileName.absoluteName(), ByteIO::Scratch));
     makeArray (shape, "array", String());
     DebugAssert (ok(), AipsError);
   }
 
   template<typename T>
   HDF5Lattice<T>::HDF5Lattice (const TiledShape& shape,
-			       const CountedPtr<HDF5File>& file,
+			       const std::shared_ptr<HDF5File>& file,
 			       const String& arrayName, const String& groupName)
   : itsFile (file)
   {
@@ -83,16 +83,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     // Open for write if possible.
     if (File(fileName).isWritable()) {
-      itsFile = new HDF5File(fileName, ByteIO::Update);
+      itsFile.reset (new HDF5File(fileName, ByteIO::Update));
     } else {
-      itsFile = new HDF5File(fileName);
+      itsFile.reset (new HDF5File(fileName));
     }
     openArray (arrayName, groupName);
     DebugAssert (ok(), AipsError);
   }
 
   template<typename T>
-  HDF5Lattice<T>::HDF5Lattice (const CountedPtr<HDF5File>& file,
+  HDF5Lattice<T>::HDF5Lattice (const std::shared_ptr<HDF5File>& file,
 			       const String& arrayName, const String& groupName)
   : itsFile (file)
   {
@@ -289,12 +289,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     if (groupName.empty()) {
       // Use root group.
-      itsGroup = new HDF5Group(*itsFile, "/", true);
+      itsGroup.reset (new HDF5Group(*itsFile, "/", true));
     } else {
-      itsGroup = new HDF5Group(*itsFile, groupName, true);
+      itsGroup.reset (new HDF5Group(*itsFile, groupName, true));
     }
     // Open the data set.
-    itsDataSet = new HDF5DataSet (*itsGroup, arrayName, (const T*)0);
+    itsDataSet.reset (new HDF5DataSet (*itsGroup, arrayName, (const T*)0));
     // Calculate tile shape if default tile shape is empty
     itsTileShape = itsDataSet->tileShape();
     if (itsTileShape.empty()) {
@@ -311,14 +311,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     checkWritable();
     if (groupName.empty()) {
       // Use root group.
-      itsGroup = new HDF5Group(*itsFile, "/", true);
+      itsGroup.reset (new HDF5Group(*itsFile, "/", true));
     } else {
       // Create group if not existing yet.
-      itsGroup = new HDF5Group(*itsFile, groupName);
+      itsGroup.reset (new HDF5Group(*itsFile, groupName));
     }
     // Create the data set.
-    itsDataSet = new HDF5DataSet (*itsGroup, arrayName, shape.shape(),
-				  shape.tileShape(), (const T*)0);
+    itsDataSet.reset (new HDF5DataSet (*itsGroup, arrayName, shape.shape(),
+                                       shape.tileShape(), (const T*)0));
     // Calculate tile shape if default tile shape is empty
     itsTileShape = itsDataSet->tileShape();
     if (itsTileShape.empty()) {

--- a/lattices/Lattices/HDF5Lattice.tcc
+++ b/lattices/Lattices/HDF5Lattice.tcc
@@ -53,7 +53,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   HDF5Lattice<T>::HDF5Lattice (const TiledShape& shape, const String& fileName,
 			       const String& arrayName, const String& groupName)
   {
-    itsFile.reset (new HDF5File (fileName, ByteIO::New));
+    itsFile = std::make_shared<HDF5File>(fileName, ByteIO::New);
     makeArray (shape, arrayName, groupName);
     DebugAssert (ok(), AipsError);
   }
@@ -62,7 +62,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   HDF5Lattice<T>::HDF5Lattice (const TiledShape& shape)
   {
     Path fileName = File::newUniqueName(String("./"), String("HDF5Lattice"));
-    itsFile.reset (new HDF5File (fileName.absoluteName(), ByteIO::Scratch));
+    itsFile = std::make_shared<HDF5File>(fileName.absoluteName(), ByteIO::Scratch);
     makeArray (shape, "array", String());
     DebugAssert (ok(), AipsError);
   }
@@ -83,9 +83,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     // Open for write if possible.
     if (File(fileName).isWritable()) {
-      itsFile.reset (new HDF5File(fileName, ByteIO::Update));
+      itsFile = std::make_shared<HDF5File>(fileName, ByteIO::Update);
     } else {
-      itsFile.reset (new HDF5File(fileName));
+      itsFile = std::make_shared<HDF5File>(fileName);
     }
     openArray (arrayName, groupName);
     DebugAssert (ok(), AipsError);
@@ -289,12 +289,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     if (groupName.empty()) {
       // Use root group.
-      itsGroup.reset (new HDF5Group(*itsFile, "/", true));
+      itsGroup = std::make_shared<HDF5Group>(*itsFile, "/", true);
     } else {
-      itsGroup.reset (new HDF5Group(*itsFile, groupName, true));
+      itsGroup = std::make_shared<HDF5Group>(*itsFile, groupName, true);
     }
     // Open the data set.
-    itsDataSet.reset (new HDF5DataSet (*itsGroup, arrayName, (const T*)0));
+    itsDataSet = std::make_shared<HDF5DataSet>(*itsGroup, arrayName, (const T*)0);
     // Calculate tile shape if default tile shape is empty
     itsTileShape = itsDataSet->tileShape();
     if (itsTileShape.empty()) {
@@ -311,14 +311,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     checkWritable();
     if (groupName.empty()) {
       // Use root group.
-      itsGroup.reset (new HDF5Group(*itsFile, "/", true));
+      itsGroup = std::make_shared<HDF5Group>(*itsFile, "/", true);
     } else {
       // Create group if not existing yet.
-      itsGroup.reset (new HDF5Group(*itsFile, groupName));
+      itsGroup = std::make_shared<HDF5Group>(*itsFile, groupName);
     }
     // Create the data set.
-    itsDataSet.reset (new HDF5DataSet (*itsGroup, arrayName, shape.shape(),
-                                       shape.tileShape(), (const T*)0));
+    itsDataSet = std::make_shared<HDF5DataSet>(*itsGroup, arrayName, shape.shape(),
+                                               shape.tileShape(), (const T*)0);
     // Calculate tile shape if default tile shape is empty
     itsTileShape = itsDataSet->tileShape();
     if (itsTileShape.empty()) {

--- a/lattices/Lattices/Lattice.h
+++ b/lattices/Lattices/Lattice.h
@@ -160,7 +160,7 @@ template <class T> class LatticeIterInterface;
 //
 //   const IPosition inputSliceShape(4,nx,ny,1,1);
 //   const IPosition resultSliceShape(4,nx/2+1,ny,1,1);
-//   COWPtr<Array<Float> > 
+//   COWPtr<Array<Float>> 
 //     inputArrPtr(new Array<Float>(inputSliceShape.nonDegenerate()));
 //   Array<Complex> resultArray(resultSliceShape.nonDegenerate());
 //   FFTServer<Float, Complex> FFT2D(inputSliceShape.nonDegenerate());
@@ -286,14 +286,14 @@ public:
   // 'True' if "buffer" is a reference to Lattice data and 'False' if it  
   // is a copy. 
   // <group>   
-  Bool get (COWPtr<Array<T> >& buffer,
+  Bool get (COWPtr<Array<T>>& buffer,
 	    Bool removeDegenerateAxes=False) const;
-  Bool getSlice (COWPtr<Array<T> >& buffer, const Slicer& section,
+  Bool getSlice (COWPtr<Array<T>>& buffer, const Slicer& section,
 		 Bool removeDegenerateAxes=False) const;
-  Bool getSlice (COWPtr<Array<T> >& buffer, const IPosition& start, 
+  Bool getSlice (COWPtr<Array<T>>& buffer, const IPosition& start, 
 		 const IPosition& shape,
 		 Bool removeDegenerateAxes=False) const;
-  Bool getSlice (COWPtr<Array<T> >& buffer, const IPosition& start, 
+  Bool getSlice (COWPtr<Array<T>>& buffer, const IPosition& start, 
 		 const IPosition& shape, const IPosition& stride,
 		 Bool removeDegenerateAxes=False) const;
   Bool get (Array<T>& buffer,

--- a/lattices/Lattices/Lattice.tcc
+++ b/lattices/Lattices/Lattice.tcc
@@ -64,7 +64,7 @@ T Lattice<T>::operator() (const IPosition& where) const
 }
 
 template<class T>
-Bool Lattice<T>::get (COWPtr<Array<T> >& buffer,
+Bool Lattice<T>::get (COWPtr<Array<T>>& buffer,
 		      Bool removeDegenerateAxes) const
 {
   uInt nd = ndim();
@@ -90,7 +90,7 @@ Array<T> Lattice<T>::get (Bool removeDegenerateAxes) const
 }
 
 template<class T>
-Bool Lattice<T>::getSlice (COWPtr<Array<T> >& buffer, const IPosition& start, 
+Bool Lattice<T>::getSlice (COWPtr<Array<T>>& buffer, const IPosition& start, 
 			   const IPosition& shape,
 			   Bool removeDegenerateAxes) const
 {
@@ -99,7 +99,7 @@ Bool Lattice<T>::getSlice (COWPtr<Array<T> >& buffer, const IPosition& start,
 }
 
 template<class T>
-Bool Lattice<T>::getSlice (COWPtr<Array<T> >& buffer, const IPosition& start, 
+Bool Lattice<T>::getSlice (COWPtr<Array<T>>& buffer, const IPosition& start, 
 			   const IPosition& shape,
 			   const IPosition& stride,
 			   Bool removeDegenerateAxes) const
@@ -109,7 +109,7 @@ Bool Lattice<T>::getSlice (COWPtr<Array<T> >& buffer, const IPosition& start,
 }
 
 template<class T>
-Bool Lattice<T>::getSlice (COWPtr<Array<T> >& buffer,
+Bool Lattice<T>::getSlice (COWPtr<Array<T>>& buffer,
 			   const Slicer& section,
 			   Bool removeDegenerateAxes) const
 {
@@ -117,9 +117,9 @@ Bool Lattice<T>::getSlice (COWPtr<Array<T> >& buffer,
   // This is safe, since the array is copied when needed by COWptr.
   Lattice<T>* This = (Lattice<T>*)this;
   // The COWPtr takes over the pointer to the array.
-  Array<T>* arr = new Array<T>;
+  std::unique_ptr<Array<T>> arr(new Array<T>);
   Bool isARef = This->getSlice (*arr, section, removeDegenerateAxes);
-  buffer = COWPtr<Array<T> > (arr, True, isARef);
+  buffer = COWPtr<Array<T>> (arr.release(), isARef);
   return False;
 }
 

--- a/lattices/Lattices/LatticeCache.h
+++ b/lattices/Lattices/LatticeCache.h
@@ -147,7 +147,7 @@ protected:
 
   Block<IPosition> tileLocs;
   Block<Int> tileSequence;
-  Block<Array<T> > tileContents;
+  Block<Array<T>> tileContents;
 
   void writeTile(Int tile);
   void readTile(Int tile, Bool readonly);

--- a/lattices/Lattices/LatticeIterator.h
+++ b/lattices/Lattices/LatticeIterator.h
@@ -31,7 +31,7 @@
 #include <casacore/lattices/Lattices/Lattice.h>
 #include <casacore/lattices/Lattices/LatticeIterInterface.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -251,7 +251,7 @@ public:
 
   // Is the iterator object empty?
   Bool isNull() const
-    { return itsIterPtr.null(); }
+    { return !itsIterPtr; }
 
   // Return the underlying lattice.
   Lattice<T>& lattice() const
@@ -335,7 +335,7 @@ public:
 
 protected:
   // The pointer to the Iterator
-  CountedPtr<LatticeIterInterface<T> > itsIterPtr;
+  std::shared_ptr<LatticeIterInterface<T>> itsIterPtr;
 };
 
 

--- a/lattices/Lattices/LatticeIterator.tcc
+++ b/lattices/Lattices/LatticeIterator.tcc
@@ -1,4 +1,4 @@
-//# LatticeIter.cc: defines the RO_LatticeIterator and LatticeIterator classes
+//# LatticeIterator.cc: defines the RO_LatticeIterator and LatticeIterator classes
 //# Copyright (C) 1994,1995,1996,1997,1998,1999,2000,2003
 //# Associated Universities, Inc. Washington DC, USA.
 //#
@@ -88,7 +88,7 @@ RO_LatticeIterator<T>::RO_LatticeIterator (const RO_LatticeIterator<T>& other)
 template <class T>
 RO_LatticeIterator<T>::~RO_LatticeIterator()
 {
-  // CountedPtr destructor takes care of deletion of the LatticeIterInterface
+  // std::shared_ptr destructor takes care of deletion of the LatticeIterInterface
 }
 
 template <class T>
@@ -107,7 +107,7 @@ RO_LatticeIterator<T> RO_LatticeIterator<T>::copy() const
 {
   RO_LatticeIterator<T> tmp;
   if (!isNull()) {
-    tmp.itsIterPtr = itsIterPtr->clone();
+    tmp.itsIterPtr.reset (itsIterPtr->clone());
   }
   return tmp;
 }
@@ -284,7 +284,7 @@ LatticeIterator<T> LatticeIterator<T>::copy() const
 {
   LatticeIterator<T> tmp;
   if (!isNull()) {
-    tmp.itsIterPtr = itsIterPtr->clone();
+    tmp.itsIterPtr.reset (itsIterPtr->clone());
   }
   return tmp;
 }

--- a/lattices/Lattices/MaskedLattice.h
+++ b/lattices/Lattices/MaskedLattice.h
@@ -150,7 +150,7 @@ class LatticeRegion;
 //
 //   const IPosition inputSliceShape(4,nx,ny,1,1);
 //   const IPosition resultSliceShape(4,nx/2+1,ny,1,1);
-//   COWPtr<Array<Float> > 
+//   COWPtr<Array<Float>> 
 //     inputArrPtr(new Array<Float>(inputSliceShape.nonDegenerate()));
 //   Array<Complex> resultArray(resultSliceShape.nonDegenerate());
 //   FFTServer<Float, Complex> FFT2D(inputSliceShape.nonDegenerate());
@@ -265,14 +265,14 @@ public:
   // If there is no mask, it still works fine.
   // In that case it sizes the buffer correctly and sets it to True.
   // <group>   
-  Bool getMask (COWPtr<Array<Bool> >& buffer,
+  Bool getMask (COWPtr<Array<Bool>>& buffer,
 		Bool removeDegenerateAxes=False) const;
-  Bool getMaskSlice (COWPtr<Array<Bool> >& buffer, const Slicer& section,
+  Bool getMaskSlice (COWPtr<Array<Bool>>& buffer, const Slicer& section,
 		     Bool removeDegenerateAxes=False) const;
-  Bool getMaskSlice (COWPtr<Array<Bool> >& buffer, const IPosition& start, 
+  Bool getMaskSlice (COWPtr<Array<Bool>>& buffer, const IPosition& start, 
 		     const IPosition& shape,
 		     Bool removeDegenerateAxes=False) const;
-  Bool getMaskSlice (COWPtr<Array<Bool> >& buffer, const IPosition& start, 
+  Bool getMaskSlice (COWPtr<Array<Bool>>& buffer, const IPosition& start, 
 		     const IPosition& shape, const IPosition& stride,
 		     Bool removeDegenerateAxes=False) const;
   Bool getMask (Array<Bool>& buffer,

--- a/lattices/Lattices/MaskedLattice.tcc
+++ b/lattices/Lattices/MaskedLattice.tcc
@@ -129,7 +129,7 @@ const LatticeRegion& MaskedLattice<T>::region() const
 
 
 template<class T>
-Bool MaskedLattice<T>::getMask (COWPtr<Array<Bool> >& buffer,
+Bool MaskedLattice<T>::getMask (COWPtr<Array<Bool>>& buffer,
 				Bool removeDegenerateAxes) const
 {
   uInt nd = ndim();
@@ -155,7 +155,7 @@ Array<Bool> MaskedLattice<T>::getMask (Bool removeDegenerateAxes) const
 }
 
 template<class T>
-Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool> >& buffer,
+Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool>>& buffer,
 				     const IPosition& start, 
 				     const IPosition& shape,
 				     Bool removeDegenerateAxes) const
@@ -165,7 +165,7 @@ Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool> >& buffer,
 }
 
 template<class T>
-Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool> >& buffer,
+Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool>>& buffer,
 				     const IPosition& start, 
 				     const IPosition& shape,
 				     const IPosition& stride,
@@ -176,7 +176,7 @@ Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool> >& buffer,
 }
 
 template<class T>
-Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool> >& buffer,
+Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool>>& buffer,
 				     const Slicer& section,
 				     Bool removeDegenerateAxes) const
 {
@@ -184,9 +184,9 @@ Bool MaskedLattice<T>::getMaskSlice (COWPtr<Array<Bool> >& buffer,
   // This is safe, since the array is copied when needed by COWptr.
   MaskedLattice<T>* This = (MaskedLattice<T>*)this;
   // The COWPtr takes over the pointer to the array.
-  Array<Bool>* arr = new Array<Bool>;
+  std::unique_ptr<Array<Bool>> arr(new Array<Bool>);
   Bool isARef = This->getMaskSlice (*arr, section, removeDegenerateAxes);
-  buffer = COWPtr<Array<Bool> > (arr, True, isARef);
+  buffer = COWPtr<Array<Bool>> (arr.release(), isARef);
   return False;
 }
 

--- a/lattices/Lattices/MaskedLatticeIterator.h
+++ b/lattices/Lattices/MaskedLatticeIterator.h
@@ -30,7 +30,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/lattices/Lattices/MaskedLattice.h>
 #include <casacore/lattices/Lattices/LatticeIterator.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -181,7 +181,7 @@ public:
   // It returns the same flag as
   // <linkto class=MaskedLattice>MaskedLattice::getMaskSlice</linkto>.
   // <group>
-  Bool getMask (COWPtr<Array<Bool> >&, Bool removeDegenerateAxes=False) const;
+  Bool getMask (COWPtr<Array<Bool>>&, Bool removeDegenerateAxes=False) const;
   Bool getMask (Array<Bool>&, Bool removeDegenerateAxes=False) const;
   Array<Bool> getMask (Bool removeDegenerateAxes=False) const;
   // </group>
@@ -201,7 +201,12 @@ private:
   // In that case a clone of the original MaskedLattice is used.
   void fillPtr (const MaskedLattice<T>& mlattice);
 
-  CountedPtr<MaskedLattice<T> > itsMaskLattPtr;
+  // The shared pointer is used for automatic deletion.
+  // If not null, it is the same as the normal pointer below.
+  std::shared_ptr<MaskedLattice<T>> itsMaskLattShrPtr;
+  // Pointer to the MaskedLattice.
+  // Deletion (if needed) is done by the shared pointer above.
+  MaskedLattice<T>*                 itsMaskLattPtr;
 };
 
 

--- a/lattices/Lattices/MaskedLatticeIterator.tcc
+++ b/lattices/Lattices/MaskedLatticeIterator.tcc
@@ -75,7 +75,8 @@ template <class T>
 RO_MaskedLatticeIterator<T>::RO_MaskedLatticeIterator
                                  (const RO_MaskedLatticeIterator<T>& other)
 : RO_LatticeIterator<T> (other),
-  itsMaskLattPtr (other.itsMaskLattPtr)
+  itsMaskLattShrPtr (other.itsMaskLattShrPtr),
+  itsMaskLattPtr    (other.itsMaskLattPtr)
 {}
 
 template <class T>
@@ -99,7 +100,8 @@ RO_MaskedLatticeIterator<T>& RO_MaskedLatticeIterator<T>::operator=
 {
   if (this != &other) {
     RO_LatticeIterator<T>::operator= (other);
-    itsMaskLattPtr = other.itsMaskLattPtr;
+    itsMaskLattShrPtr = other.itsMaskLattShrPtr;
+    itsMaskLattPtr    = other.itsMaskLattPtr;
   }
   return *this;
 }
@@ -119,9 +121,11 @@ void RO_MaskedLatticeIterator<T>::fillPtr (const MaskedLattice<T>& mlattice)
   Lattice<T>* lptr = &(RO_LatticeIterator<T>::lattice());
   MaskedLattice<T>* mptr = dynamic_cast<MaskedLattice<T>*>(lptr);
   if (mptr) {
-    itsMaskLattPtr = CountedPtr<MaskedLattice<T> > (mptr, False);
+    itsMaskLattShrPtr.reset();    // no deletion of the pointer
+    itsMaskLattPtr = mptr;
   } else {
-    itsMaskLattPtr = mlattice.cloneML();
+    itsMaskLattShrPtr.reset (mlattice.cloneML());
+    itsMaskLattPtr = itsMaskLattShrPtr.get();
   }
 }
 
@@ -136,7 +140,7 @@ Array<Bool> RO_MaskedLatticeIterator<T>::getMask
 }
 
 template <class T>
-Bool RO_MaskedLatticeIterator<T>::getMask (COWPtr<Array<Bool> >& arr,
+Bool RO_MaskedLatticeIterator<T>::getMask (COWPtr<Array<Bool>>& arr,
 					   Bool removeDegenerateAxes) const
 {
   return itsMaskLattPtr->getMaskSlice (arr, position(), cursorShape(),

--- a/lattices/Lattices/PagedArray.h
+++ b/lattices/Lattices/PagedArray.h
@@ -275,7 +275,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // Table maskTable(maskSetup);
 // PagedArray<Bool> maskArray(IPosition(4,1024,1024,4,256), maskTable);
 // maskArray.set(False);
-// COWPtr<Array<Bool> > maskPtr;
+// COWPtr<Array<Bool>> maskPtr;
 // maskArray.getSlice(maskPtr, IPosition(4,240,240,3,0),
 // 		      IPosition(4,32,32,1,1), IPosition(4,1));
 // maskPtr.rwRef() = True;

--- a/lattices/Lattices/TempLattice.h
+++ b/lattices/Lattices/TempLattice.h
@@ -30,7 +30,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/lattices/Lattices/TempLatticeImpl.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -267,7 +267,7 @@ public:
 			   const IPosition& stride);
   
 private:
-  CountedPtr<TempLatticeImpl<T> > itsImpl;
+  std::shared_ptr<TempLatticeImpl<T>> itsImpl;
 };
 
 

--- a/lattices/Lattices/TempLatticeImpl.h
+++ b/lattices/Lattices/TempLatticeImpl.h
@@ -32,7 +32,7 @@
 #include <casacore/lattices/Lattices/Lattice.h>
 #include <casacore/lattices/Lattices/TiledShape.h>
 #include <casacore/tables/Tables/Table.h>
-#include <casacore/casa/Utilities/CountedPtr.h>
+#include <memory>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -54,7 +54,7 @@ class Table;
 // </prerequisite>
 
 // <synopsis>
-// The class is used as <src>CountedPtr<TempLatticeImpl></src> in class
+// The class is used as <src>std::shared_ptr<TempLatticeImpl></src> in class
 // TempLattice. In that way the making a copy of a TempLattice uses the
 // same object underneath.
 // This was needed to have a correct implementation of tempClose. Otherwise
@@ -98,7 +98,7 @@ public:
 
   // Flush the data.
   void flush()
-    { if (itsTablePtr != 0) itsTablePtr->flush(); }
+    { if (!itsTable.isNull()) itsTable.flush(); }
 
   // Close the Lattice temporarily (if it is paged to disk).
   // It'll be reopened automatically when needed or when
@@ -230,10 +230,10 @@ private:
   void deleteTable();
 
 
-  mutable Table*                  itsTablePtr;
-  mutable CountedPtr<Lattice<T> > itsLatticePtr;
-          String                  itsTableName;
-  mutable Bool                    itsIsClosed;
+  mutable Table                       itsTable;
+  mutable std::shared_ptr<Lattice<T>> itsLatticePtr;
+          String                      itsTableName;
+  mutable Bool                        itsIsClosed;
 };
 
 

--- a/lattices/Lattices/TempLatticeImpl.tcc
+++ b/lattices/Lattices/TempLatticeImpl.tcc
@@ -41,7 +41,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template<class T>
 TempLatticeImpl<T>::TempLatticeImpl() 
-  : itsLatticePtr (new ArrayLattice<T>),
+  : itsLatticePtr (std::make_shared<ArrayLattice<T>>()),
     itsIsClosed   (False)
 {}
 
@@ -83,9 +83,9 @@ void TempLatticeImpl<T>::init (const TiledShape& shape, Double maxMemoryInMB)
     itsTableName = AppInfo::workFileName (Int(memoryReq), "TempLattice");
     SetupNewTable newtab (itsTableName, TableDesc(), Table::Scratch);
     itsTable = Table(newtab, TableLock::PermanentLockingWait);
-    itsLatticePtr.reset (new PagedArray<T> (shape, itsTable));
+    itsLatticePtr = std::make_shared<PagedArray<T>>(shape, itsTable);
   } else {
-    itsLatticePtr.reset (new ArrayLattice<T> (shape.shape()));
+    itsLatticePtr = std::make_shared<ArrayLattice<T>>(shape.shape());
   }
 }
 
@@ -108,7 +108,7 @@ void TempLatticeImpl<T>::tempReopen() const
     itsTable = Table(itsTableName,
                      TableLock(TableLock::PermanentLockingWait),
                      Table::Update);
-    itsLatticePtr.reset (new PagedArray<T> (itsTable));
+    itsLatticePtr = std::make_shared<PagedArray<T>>(itsTable);
     itsIsClosed = False;
   }
   if (!itsTable.isNull()) {

--- a/lattices/Lattices/TempLatticeImpl.tcc
+++ b/lattices/Lattices/TempLatticeImpl.tcc
@@ -41,24 +41,20 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 template<class T>
 TempLatticeImpl<T>::TempLatticeImpl() 
-: itsTablePtr (0),
-  itsIsClosed (False)
-{
-  itsLatticePtr = new ArrayLattice<T>;
-}
+  : itsLatticePtr (new ArrayLattice<T>),
+    itsIsClosed   (False)
+{}
 
 template<class T>
 TempLatticeImpl<T>::TempLatticeImpl (const TiledShape& shape, Int maxMemoryInMB)
-: itsTablePtr (0),
-  itsIsClosed (False)
+  : itsIsClosed (False)
 {
   init (shape, Double(maxMemoryInMB));
 }
 
 template<class T>
 TempLatticeImpl<T>::TempLatticeImpl (const TiledShape& shape, Double maxMemoryInMB)
-: itsTablePtr (0),
-  itsIsClosed (False)
+  : itsIsClosed (False)
 {
   init(shape, maxMemoryInMB);
 }
@@ -68,7 +64,6 @@ TempLatticeImpl<T>::~TempLatticeImpl()
 {
   // Reopen to make sure that temporary table gets deleted.
   doReopen();
-  delete itsTablePtr;
 }
 
 template<class T>
@@ -87,22 +82,21 @@ void TempLatticeImpl<T>::init (const TiledShape& shape, Double maxMemoryInMB)
     // We can use exclusive locking, since nobody else should use the table.
     itsTableName = AppInfo::workFileName (Int(memoryReq), "TempLattice");
     SetupNewTable newtab (itsTableName, TableDesc(), Table::Scratch);
-    itsTablePtr = new Table (newtab, TableLock::PermanentLockingWait);
-    itsLatticePtr = new PagedArray<T> (shape, *itsTablePtr);
+    itsTable = Table(newtab, TableLock::PermanentLockingWait);
+    itsLatticePtr.reset (new PagedArray<T> (shape, itsTable));
   } else {
-    itsLatticePtr = new ArrayLattice<T> (shape.shape());
+    itsLatticePtr.reset (new ArrayLattice<T> (shape.shape()));
   }
 }
 
 template<class T>
 void TempLatticeImpl<T>::tempClose()
 {
-  if (itsTablePtr != 0 && isPaged()) {
+  if (!itsTable.isNull() && isPaged()) {
     // Take care that table does not get deleted, otherwise we cannot reopen.
-    itsTablePtr->unmarkForDelete();
-    delete itsTablePtr;
-    itsTablePtr = 0;
-    itsLatticePtr = 0;           // CountedPtr does delete of pointer
+    itsTable.unmarkForDelete();
+    itsLatticePtr.reset();
+    itsTable = Table();
     itsIsClosed = True;
   }
 }
@@ -111,14 +105,14 @@ template<class T>
 void TempLatticeImpl<T>::tempReopen() const
 {
   if (itsIsClosed && isPaged()) {
-    itsTablePtr = new Table (itsTableName,
-			     TableLock(TableLock::PermanentLockingWait),
-			     Table::Update);
-    itsLatticePtr = new PagedArray<T> (*itsTablePtr);
+    itsTable = Table(itsTableName,
+                     TableLock(TableLock::PermanentLockingWait),
+                     Table::Update);
+    itsLatticePtr.reset (new PagedArray<T> (itsTable));
     itsIsClosed = False;
   }
-  if (itsTablePtr != 0) {
-    itsTablePtr->markForDelete();
+  if (!itsTable.isNull()) {
+    itsTable.markForDelete();
   }
 }
 


### PR DESCRIPTION
This also contains a change in casa/Utilities/COWPtr which is used by lattices.
The deleteIt option in COWPtr needs to be maintained, because it is used by lattices to avoid copying Array objects.