### PR TITLE
Fix build warning in LCSLicer

### DIFF
--- a/lattices/LRegions/LCSlicer.cc
+++ b/lattices/LRegions/LCSlicer.cc
@@ -48,11 +48,11 @@ LCSlicer::LCSlicer (const Vector<Float>& blc, const Vector<Float>& trc,
 		    RegionType::AbsRelType absRel)
 : itsBlc (blc.copy()),
   itsTrc (trc.copy()),
-  itsInc (blc.nelements())
+  itsInc (blc.size())
 {
     itsInc = 1;
-    fillFlags (fractional, absRel, blc.nelements(), trc.nelements(),
-	       itsInc.nelements());
+    fillFlags (fractional, absRel, blc.size(), trc.size(),
+	       itsInc.size());
     fill();
 }
 
@@ -63,8 +63,8 @@ LCSlicer::LCSlicer (const Vector<Float>& blc, const Vector<Float>& trc,
   itsTrc (trc.copy()),
   itsInc (inc.copy())
 {
-    fillFlags (fractional, absRel, blc.nelements(), trc.nelements(),
-	       inc.nelements());
+    fillFlags (fractional, absRel, blc.size(), trc.size(),
+	       inc.size());
     fill();
 }
 
@@ -92,10 +92,10 @@ LCSlicer::LCSlicer (const Vector<Double>& blc, const Vector<Double>& trc,
 		    Bool fractional,
 		    RegionType::AbsRelType absRel)
 {
-    Vector<Double> inc(blc.nelements());
+    Vector<Double> inc(blc.size());
     inc = 1;
-    fillFlags (fractional, absRel, blc.nelements(), trc.nelements(),
-	       inc.nelements());
+    fillFlags (fractional, absRel, blc.size(), trc.size(),
+	       inc.size());
     fillFromDouble (blc, trc, inc);
 }
 
@@ -103,8 +103,8 @@ LCSlicer::LCSlicer (const Vector<Double>& blc, const Vector<Double>& trc,
 		    const Vector<Double>& inc, Bool fractional,
 		    RegionType::AbsRelType absRel)
 {
-    fillFlags (fractional, absRel, blc.nelements(), trc.nelements(),
-	       inc.nelements());
+    fillFlags (fractional, absRel, blc.size(), trc.size(),
+	       inc.size());
     fillFromDouble (blc, trc, inc);
 }
 
@@ -135,10 +135,10 @@ LCSlicer::LCSlicer (const Slicer& slicer)
 LCSlicer::LCSlicer (const IPosition& blc, const IPosition& trc,
 		    RegionType::AbsRelType absRel)
 {
-    IPosition inc(blc.nelements());
+    IPosition inc(blc.size());
     inc = 1;
-    fillFlags (False, absRel, blc.nelements(), trc.nelements(),
-	       inc.nelements());
+    fillFlags (False, absRel, blc.size(), trc.size(),
+	       inc.size());
     fillFromIPosition (blc, trc, inc);
 }
 
@@ -146,8 +146,8 @@ LCSlicer::LCSlicer (const IPosition& blc, const IPosition& trc,
 		    const IPosition& inc,
 		    RegionType::AbsRelType absRel)
 {
-    fillFlags (False, absRel, blc.nelements(), trc.nelements(),
-	       inc.nelements());
+    fillFlags (False, absRel, blc.size(), trc.size(),
+	       inc.size());
     fillFromIPosition (blc, trc, inc);
 }
 
@@ -155,9 +155,9 @@ LCSlicer::LCSlicer (const IPosition& blc, const IPosition& trc,
 		    const IPosition& inc,
 		    const Vector<Int>& absRelBlc,
 		    const Vector<Int>& absRelTrc)
-: itsFracBlc   (blc.nelements()),
-  itsFracTrc   (trc.nelements()),
-  itsFracInc   (inc.nelements()),
+: itsFracBlc   (blc.size()),
+  itsFracTrc   (trc.size()),
+  itsFracInc   (inc.size()),
   itsAbsRelBlc (absRelBlc.copy()),
   itsAbsRelTrc (absRelTrc.copy())
 {
@@ -190,7 +190,7 @@ LCSlicer::~LCSlicer()
 LCSlicer& LCSlicer::operator= (const LCSlicer& other)
 {
     if (this != &other) {
-        uInt nr = other.itsBlc.nelements();
+        uInt nr = other.itsBlc.size();
 	itsBlc.resize (nr);
 	itsTrc.resize (nr);
 	itsInc.resize (nr);
@@ -219,24 +219,24 @@ LCSlicer& LCSlicer::operator= (const LCSlicer& other)
 Bool LCSlicer::operator== (const LCSlicer& other) const
 {
     // Compare private data.
-    if (itsBlc.nelements() != other.itsBlc.nelements()
+    if (itsBlc.size() != other.itsBlc.size()
     ||  itsIsFractional  != other.itsIsFractional
     ||  itsIsAbsolute    != other.itsIsAbsolute
     ||  itsIsUnspecified != other.itsIsUnspecified
     ||  itsIsStrided     != other.itsIsStrided) {
 	return False;
     }
-    for (uInt i=0; i<itsInc.nelements(); i++) {
-	if (!near (itsBlc(i), other.itsBlc(i))
-	||  !near (itsTrc(i), other.itsTrc(i))
-	||  !near (itsInc(i), other.itsInc(i))) {
+    for (uInt i=0; i<itsInc.size(); i++) {
+	if (!near (itsBlc[i], other.itsBlc[i])
+	||  !near (itsTrc[i], other.itsTrc[i])
+	||  !near (itsInc[i], other.itsInc[i])) {
 	    return False;
 	}
-	if (itsFracBlc(i) != other.itsFracBlc(i)
-	||  itsFracTrc(i) != other.itsFracTrc(i)
-	||  itsFracInc(i) != other.itsFracInc(i)
-	||  itsAbsRelBlc(i) != other.itsAbsRelBlc(i)
-	||  itsAbsRelTrc(i) != other.itsAbsRelTrc(i)) {
+	if (itsFracBlc[i] != other.itsFracBlc[i]
+	||  itsFracTrc[i] != other.itsFracTrc[i]
+	||  itsFracInc[i] != other.itsFracInc[i]
+	||  itsAbsRelBlc[i] != other.itsAbsRelBlc[i]
+	||  itsAbsRelTrc[i] != other.itsAbsRelTrc[i]) {
 	    return False;
 	}
     }
@@ -264,17 +264,17 @@ void LCSlicer::fillFromDouble (const Vector<Double>& blc,
 			       const Vector<Double>& inc)
 {
     uInt i;
-    itsBlc.resize (blc.nelements());
-    for (i=0; i<blc.nelements(); i++) {
-        itsBlc(i) = blc(i);
+    itsBlc.resize (blc.size());
+    for (i=0; i<blc.size(); i++) {
+        itsBlc[i] = blc[i];
     }
-    itsTrc.resize (trc.nelements());
-    for (i=0; i<trc.nelements(); i++) {
-        itsTrc(i) = trc(i);
+    itsTrc.resize (trc.size());
+    for (i=0; i<trc.size(); i++) {
+        itsTrc[i] = trc[i];
     }
-    itsInc.resize (inc.nelements());
-    for (i=0; i<inc.nelements(); i++) {
-        itsInc(i) = inc(i);
+    itsInc.resize (inc.size());
+    for (i=0; i<inc.size(); i++) {
+        itsInc[i] = inc[i];
     }
     fill();
 }
@@ -284,17 +284,17 @@ void LCSlicer::fillFromIPosition (const IPosition& blc,
 				  const IPosition& inc)
 {
     uInt i;
-    itsBlc.resize (blc.nelements());
-    for (i=0; i<blc.nelements(); i++) {
-        itsBlc(i) = blc(i);
+    itsBlc.resize (blc.size());
+    for (i=0; i<blc.size(); i++) {
+        itsBlc[i] = blc[i];
     }
-    itsTrc.resize (trc.nelements());
-    for (i=0; i<trc.nelements(); i++) {
-        itsTrc(i) = trc(i);
+    itsTrc.resize (trc.size());
+    for (i=0; i<trc.size(); i++) {
+        itsTrc[i] = trc[i];
     }
-    itsInc.resize (inc.nelements());
-    for (i=0; i<inc.nelements(); i++) {
-        itsInc(i) = inc(i);
+    itsInc.resize (inc.size());
+    for (i=0; i<inc.size(); i++) {
+        itsInc[i] = inc[i];
     }
     fill();
 }
@@ -302,20 +302,20 @@ void LCSlicer::fillFromIPosition (const IPosition& blc,
 void LCSlicer::fill()
 {
     // Check if the corresponding vectors have equal lengths.
-    uInt nrblc = itsBlc.nelements();
-    uInt nrtrc = itsTrc.nelements();
-    uInt nrinc = itsInc.nelements();
-    if (itsFracBlc.nelements() != nrblc
-    ||  itsAbsRelBlc.nelements() != nrblc) {
+    uInt nrblc = itsBlc.size();
+    uInt nrtrc = itsTrc.size();
+    uInt nrinc = itsInc.size();
+    if (itsFracBlc.size() != nrblc
+    ||  itsAbsRelBlc.size() != nrblc) {
         throw (AipsError ("LCSlicer::LCSLicer - "
 			  "blc, fracBlc, and absRelBlc have unequal lengths"));
     }
-    if (itsFracTrc.nelements() != nrtrc
-    ||  itsAbsRelTrc.nelements() != nrtrc) {
+    if (itsFracTrc.size() != nrtrc
+    ||  itsAbsRelTrc.size() != nrtrc) {
         throw (AipsError ("LCSlicer::LCSLicer - "
 			  "trc, fracTrc, and absRelTrc have unequal lengths"));
     }
-    if (itsFracInc.nelements() != nrinc) {
+    if (itsFracInc.size() != nrinc) {
         throw (AipsError ("LCSlicer::LCSLicer - "
 			  "inc and fracInc have unequal lengths"));
     }
@@ -327,9 +327,9 @@ void LCSlicer::fill()
         itsFracBlc.resize (nr, True);
         itsAbsRelBlc.resize (nr, True);
 	for (uInt i=nrblc; i<nr; i++) {
-	    itsBlc(i) = Slicer::MimicSource;
-	    itsFracBlc(i) = False;
-	    itsAbsRelBlc(i) = RegionType::Abs;
+	    itsBlc[i] = Slicer::MimicSource;
+	    itsFracBlc[i] = False;
+	    itsAbsRelBlc[i] = RegionType::Abs;
 	}
     }
     if (nrtrc < nr) {
@@ -337,43 +337,45 @@ void LCSlicer::fill()
         itsFracTrc.resize (nr, True);
         itsAbsRelTrc.resize (nr, True);
 	for (uInt i=nrtrc; i<nr; i++) {
-	    itsTrc(i) = Slicer::MimicSource;
-	    itsFracTrc(i) = False;
-	    itsAbsRelTrc(i) = RegionType::Abs;
+	    itsTrc[i] = Slicer::MimicSource;
+	    itsFracTrc[i] = False;
+	    itsAbsRelTrc[i] = RegionType::Abs;
 	}
     }
     if (nrinc < nr) {
         itsInc.resize (nr, True);
         itsFracInc.resize (nr, True);
 	for (uInt i=nrinc; i<nr; i++) {
-	    itsInc(i) = 1;
-	    itsFracInc(i) = False;
+	    itsInc[i] = 1;
+	    itsFracInc[i] = False;
 	}
     }
     // Check if the region is absloute, fractional, unspecified, or strided.
+    // The float representation of MimicSource is inaccurate (648 instead of 646
+    // as the last digits), so be relaxed in testing it.
     itsIsFractional  = False;
     itsIsAbsolute    = True;
     itsIsUnspecified = False;
     itsIsStrided     = False;
     for (uInt i=0; i<nr; i++) {
-        if (itsBlc(i) == Slicer::MimicSource) {
+        if (static_cast<Int64>(itsBlc[i]) < Slicer::MimicSource+10) {
 	    itsIsUnspecified = True;
-	    itsFracBlc(i) = False;
-	    itsAbsRelBlc(i) = RegionType::Abs;
+	    itsFracBlc[i] = False;
+	    itsAbsRelBlc[i] = RegionType::Abs;
 	}
-	if (itsTrc(i) == Slicer::MimicSource) {
+        if (static_cast<Int64>(itsTrc[i]) < Slicer::MimicSource+10) {
 	    itsIsUnspecified = True;
-	    itsFracTrc(i) = False;
-	    itsAbsRelTrc(i) = RegionType::Abs;
+	    itsFracTrc[i] = False;
+	    itsAbsRelTrc[i] = RegionType::Abs;
 	}
-	if (itsFracBlc(i) || itsFracTrc(i) || itsFracInc(i)) {
+	if (itsFracBlc[i] || itsFracTrc[i] || itsFracInc[i]) {
 	    itsIsFractional = True;
 	}
 	if (itsAbsRelBlc != RegionType::Abs
 	||  itsAbsRelTrc != RegionType::Abs) {
 	    itsIsAbsolute = False;
 	}
-        if (itsInc(i) != 1  ||  itsFracInc(i)) {
+        if (itsInc[i] != 1  ||  itsFracInc[i]) {
 	    itsIsStrided = True;
 	}
     }
@@ -383,20 +385,20 @@ void LCSlicer::fill()
 Slicer LCSlicer::toSlicer (const IPosition& referencePixel,
 			   const IPosition& newLatticeShape) const
 {
-    uInt nr = referencePixel.nelements();
+    uInt nr = referencePixel.size();
     Vector<Float> vec (nr);
     for (uInt i=0; i<nr; i++) {
-        vec(i) = referencePixel(i);
+        vec[i] = referencePixel[i];
     }
     return toSlicer (vec, newLatticeShape);
 }
 Slicer LCSlicer::toSlicer (const Vector<Double>& referencePixel,
 			   const IPosition& newLatticeShape) const
 {
-    uInt nr = referencePixel.nelements();
+    uInt nr = referencePixel.size();
     Vector<Float> vec (nr);
     for (uInt i=0; i<nr; i++) {
-        vec(i) = referencePixel(i);
+        vec[i] = referencePixel[i];
     }
     return toSlicer (vec, newLatticeShape);
 }
@@ -404,13 +406,13 @@ Slicer LCSlicer::toSlicer (const Vector<Float>& referencePixel,
 			   const IPosition& newLatticeShape) const
 {
     uInt i;
-    if (referencePixel.nelements() != newLatticeShape.nelements()) {
+    if (referencePixel.size() != newLatticeShape.size()) {
         throw (AipsError ("LCSlicer::makeComplete - "
 			  "referencePixel and newLatticeShape vectors "
 			  "do not have same length"));
     }
     uInt ndreg = ndim();
-    uInt ndout = newLatticeShape.nelements();
+    uInt ndout = newLatticeShape.size();
     if (ndout < ndreg) {
 	throw (AipsError ("LCSlicer::makeComplete - "
 			  "length of newLatticeShape vector less than "
@@ -425,54 +427,54 @@ Slicer LCSlicer::toSlicer (const Vector<Float>& referencePixel,
     IPosition inc(ndout, 1);
     // Now convert the region's blc,trc,inc to a normal blc,trc,inc.
     for (i=0; i<ndreg; i++) {
-        Float v = itsBlc(i);
-	if (v == Slicer::MimicSource) {
+        Float v = itsBlc[i];
+	if (static_cast<Int64>(v) < Slicer::MimicSource+10) {
 	    v = 0;
 	} else {
-	    if (itsFracBlc(i)) {
-		v *= newLatticeShape(i);
+	    if (itsFracBlc[i]) {
+		v *= newLatticeShape[i];
 	    }
-	    if (itsAbsRelBlc(i) == RegionType::RelRef) {
-		v += referencePixel(i);
-	    } else if (itsAbsRelBlc(i) == RegionType::RelCen) {
-		v += Float(newLatticeShape(i)) / 2;
+	    if (itsAbsRelBlc[i] == RegionType::RelRef) {
+		v += referencePixel[i];
+	    } else if (itsAbsRelBlc[i] == RegionType::RelCen) {
+		v += Float(newLatticeShape[i]) / 2;
 	    }
 	}
-	blc(i) = Int(v + 0.5);
-        v = itsTrc(i);
-	if (v == Slicer::MimicSource) {
-	    v = newLatticeShape(i) - 1;
+	blc[i] = Int(v + 0.5);
+        v = itsTrc[i];
+	if (static_cast<Int64>(v) < Slicer::MimicSource+10) {
+	    v = newLatticeShape[i] - 1;
 	} else {
-	    if (itsFracTrc(i)) {
-		v *= newLatticeShape(i);
+	    if (itsFracTrc[i]) {
+		v *= newLatticeShape[i];
 		v -= 1;
 	    }
-	    if (itsAbsRelTrc(i) == RegionType::RelRef) {
-		v += referencePixel(i);
-	    } else if (itsAbsRelTrc(i) == RegionType::RelCen) {
-		v += Float(newLatticeShape(i)) / 2;
+	    if (itsAbsRelTrc[i] == RegionType::RelRef) {
+		v += referencePixel[i];
+	    } else if (itsAbsRelTrc[i] == RegionType::RelCen) {
+		v += Float(newLatticeShape[i]) / 2;
 	    }
 	}
-	trc(i) = Int(v + 0.5);
-        v = itsInc(i);
-	if (v == Slicer::MimicSource) {
+	trc[i] = Int(v + 0.5);
+        v = itsInc[i];
+	if (static_cast<Int64>(v) < Slicer::MimicSource+10) {
 	    v = 1;
 	} else {
-	    if (itsFracInc(i)) {
-		v *= newLatticeShape(i);
+	    if (itsFracInc[i]) {
+		v *= newLatticeShape[i];
 	    }
 	}
-	inc(i) = Int(v + 0.5);
+	inc[i] = Int(v + 0.5);
     }
     for (i=0; i<ndout; i++) {
 	// Make sure box does not exceed lattice.
-	if (blc(i) < 0) {
-	    blc(i) = 0;
+	if (blc[i] < 0) {
+	    blc[i] = 0;
 	}
-	if (trc(i) >= newLatticeShape(i)) {
-	    trc(i) = newLatticeShape(i) - 1;
+	if (trc[i] >= newLatticeShape[i]) {
+	    trc[i] = newLatticeShape[i] - 1;
 	}
-	if (blc(i) > trc(i)) {
+	if (blc[i] > trc[i]) {
 	    ostringstream bstr, tstr;
 	    bstr << blc;
 	    tstr << trc;
@@ -511,14 +513,12 @@ TableRecord LCSlicer::toRecord (const String&) const
     rec.define ("oneRel", True);
     Vector<Float> blc(itsBlc.copy());
     Vector<Float> trc(itsTrc.copy());
-    for (uInt i=0; i<itsBlc.nelements(); i++) {
-	if ((!itsFracBlc(i)  &&  itsAbsRelBlc(i) == RegionType::Abs)
-        ||  blc(i) == Slicer::MimicSource) {
-	    blc(i)++;
+    for (uInt i=0; i<itsBlc.size(); i++) {
+        if (!itsFracBlc[i]  &&  itsAbsRelBlc[i] == RegionType::Abs) {
+	    blc[i]++;
 	}
-	if ((!itsFracTrc(i)  &&  itsAbsRelTrc(i) == RegionType::Abs)
-        ||  trc(i) == Slicer::MimicSource) {
-	    trc(i)++;
+	if (!itsFracTrc[i]  &&  itsAbsRelTrc[i] == RegionType::Abs) {
+	    trc[i]++;
 	}
     }
     rec.define ("blc", blc);
@@ -550,22 +550,18 @@ LCSlicer* LCSlicer::fromRecord (const TableRecord& rec,
     Vector<Int> arblc (rec.toArrayInt ("arblc"));
     Vector<Int> artrc (rec.toArrayInt ("artrc"));
     // If blc,trc is 1-relative, make it 0-relative by subtracting 1.
-    // Do it only if absolute non-fractional or if MimicSource+1.
+    // Do it only if absolute non-fractional.
+    // The float representation of MimicSource is inaccurate, so
+    // it does not harm subtracting one.
     if (oneRel) {
-      for (i=0; i<std::min(blc.nelements(), fracblc.nelements()); i++) {
-	    if ((! fracblc(i)  &&  arblc(i) == RegionType::Abs)
-            ||  blc(i) == 1+Slicer::MimicSource) {
-		if (blc(i) != Slicer::MimicSource) {
-		    blc(i)--;
-		}
+      for (i=0; i<std::min(blc.size(), fracblc.size()); i++) {
+	    if (! fracblc[i]  &&  arblc[i] == RegionType::Abs) {
+                blc[i]--;
 	    }
 	}
-      for (i=0; i<std::min(trc.nelements(), fractrc.nelements()); i++) {
-	    if ((! fractrc(i)  &&  artrc(i) == RegionType::Abs)
-	    ||  trc(i) == 1+Slicer::MimicSource) {
-		if (trc(i) != Slicer::MimicSource) {
-		    trc(i)--;
-		}
+      for (i=0; i<std::min(trc.size(), fractrc.size()); i++) {
+	    if (! fractrc[i]  &&  artrc[i] == RegionType::Abs) {
+	        trc[i]--;
 	    }
 	}
     }

--- a/lattices/LRegions/LCSlicer.cc
+++ b/lattices/LRegions/LCSlicer.cc
@@ -351,8 +351,8 @@ void LCSlicer::fill()
 	}
     }
     // Check if the region is absloute, fractional, unspecified, or strided.
-    // The float representation of MimicSource is inaccurate (648 instead of 646
-    // as the last digits), so be relaxed in testing it.
+    // The float representation of MimicSource (-2147483646) is inaccurate in the
+    // last digits, so be relaxed in testing it. Use a margin of 10.
     itsIsFractional  = False;
     itsIsAbsolute    = True;
     itsIsUnspecified = False;
@@ -426,6 +426,8 @@ Slicer LCSlicer::toSlicer (const Vector<Float>& referencePixel,
     IPosition trc(newLatticeShape-1);
     IPosition inc(ndout, 1);
     // Now convert the region's blc,trc,inc to a normal blc,trc,inc.
+    // The float representation of MimicSource (-2147483646) is inaccurate in the
+    // last digits, so be relaxed in testing it. Use a margin of 10.
     for (i=0; i<ndreg; i++) {
         Float v = itsBlc[i];
 	if (static_cast<Int64>(v) < Slicer::MimicSource+10) {

--- a/lattices/LRegions/test/tLCSlicer.cc
+++ b/lattices/LRegions/test/tLCSlicer.cc
@@ -213,6 +213,36 @@ void doIt()
         AlwaysAssert(sl.start() == IPosition(4, 100, 100, 0, 0), AipsError);
         AlwaysAssert(sl.end() == IPosition(4, 399, 399, 0, 0), AipsError);
     }
+    // Test if MimicSource works fine, also in to/fromRecord.
+    {
+        Vector<Float> blc(1,Slicer::MimicSource);
+        Vector<Float> trc(1,Slicer::MimicSource);
+        Vector<Float> inc(1,Slicer::MimicSource);
+        Vector<Float> refPix(1,100);
+        IPosition newLatticeShape(1, 400);
+        {
+          LCSlicer lcslicer(blc, trc, False, RegionType::RelRef);
+          Slicer sl = lcslicer.toSlicer(refPix, newLatticeShape);
+          AlwaysAssert(sl.start() == IPosition(1, 0), AipsError);
+          AlwaysAssert(sl.end() == IPosition(1, 399), AipsError);
+          AlwaysAssert(sl.stride() == IPosition(1, 1), AipsError);
+          TableRecord rec = lcslicer.toRecord ("");
+          LCSlicer* sl4 = LCSlicer::fromRecord (rec, "");
+          AlwaysAssertExit (! (*sl4 != lcslicer));
+          delete sl4;
+        }
+        {
+          LCSlicer lcslicer(blc, trc, True, RegionType::Abs);
+          Slicer sl = lcslicer.toSlicer(refPix, newLatticeShape);
+          AlwaysAssert(sl.start() == IPosition(1, 0), AipsError);
+          AlwaysAssert(sl.end() == IPosition(1, 399), AipsError);
+          AlwaysAssert(sl.stride() == IPosition(1, 1), AipsError);
+          TableRecord rec = lcslicer.toRecord ("");
+          LCSlicer* sl4 = LCSlicer::fromRecord (rec, "");
+          AlwaysAssertExit (! (*sl4 != lcslicer));
+          delete sl4;
+        }
+    }
 }
 
 


### PR DESCRIPTION
The compiler warned about using MimicSource as a float number, because it is not exact.
The code has been changed to be more relaxed in the test on MimicSource. It appeared that the test program did not test on it, so MimicSource tests have been added.
