### PR TITLE
Fix build warnings and indentation

### DIFF
--- a/python/Converters/PycArray.cc
+++ b/python/Converters/PycArray.cc
@@ -95,7 +95,7 @@ namespace casacore { namespace python {
     d.setdefault (std::string("shape"),
 		  to_list<IPosition>::makeobject (arr.shape()));
     d.setdefault (std::string("array"), a);
-    return d;
+    return std::move(d);
   }
 
 

--- a/python/Converters/PycBasicData.h
+++ b/python/Converters/PycBasicData.h
@@ -242,9 +242,9 @@ namespace casacore { namespace python {
       typename ContainerType::const_iterator i = c.begin();
       typename ContainerType::const_iterator iEnd = c.end();
       for( ; i != iEnd; ++i) {
-      result.append(*i);
+        result.append(*i);
       }
-      return result;
+      return std::move(result);
     }
     static PyObject* convert (ContainerType const& c)
     {
@@ -261,7 +261,7 @@ namespace casacore { namespace python {
       // Reverse IPosition values.
       boost::python::list result;
       for (int i=c.size()-1; i>=0; --i) {
-    result.append(c[i]);
+        result.append(c[i]);
       }
       return result;
     }
@@ -287,7 +287,7 @@ namespace casacore { namespace python {
       ContainerType::const_iterator iEnd = c.end();
       for( ; i != iEnd; ++i) {
         bool b = *i;
-    result.append(b);
+        result.append(b);
       }
       return result;
     }
@@ -306,7 +306,7 @@ namespace casacore { namespace python {
       ContainerType::const_iterator i = c.begin();
       ContainerType::const_iterator iEnd = c.end();
       for( ; i != iEnd; ++i) {
-    result.append((std::string const&)(*i));
+        result.append((std::string const&)(*i));
       }
       return result;
     }
@@ -325,9 +325,9 @@ namespace casacore { namespace python {
       ContainerType::const_iterator i = c.begin();
       ContainerType::const_iterator iEnd = c.end();
       for( ; i != iEnd; ++i) {
-    result.append((std::string const&)(*i));
+        result.append((std::string const&)(*i));
       }
-      return result;
+      return std::move(result);
     }
     static PyObject* convert (ContainerType const& c)
     {
@@ -344,9 +344,9 @@ namespace casacore { namespace python {
       ContainerType::const_iterator i = c.begin();
       ContainerType::const_iterator iEnd = c.end();
       for( ; i != iEnd; ++i) {
-    result.append((std::string const&)(*i));
+        result.append((std::string const&)(*i));
       }
-      return result;
+      return std::move(result);
     }
     static PyObject* convert (ContainerType const& c)
     {


### PR DESCRIPTION
A build warning said that std::move should be used at a few places.
This has been fixed as well as the indentation that was off at a few places.
