### PR TITLE
Add support for older VLBA archival data

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.h
+++ b/msfits/MSFits/FitsIDItoMS.h
@@ -129,7 +129,7 @@ public:
 
   FITSIDItoMS1(FitsInput& in, const String& correlat,
 	       const Int& obsType=0, const Bool& initFirstMain=True,
-	       const Float& vanVleck=0.0);
+	       const Float& vanVleck=0.0, const Float& corVer=0.0);
 
   ~FITSIDItoMS1();
   
@@ -300,6 +300,7 @@ protected:
   Double lastTime_p;
   Int itsObsType;
   String itsCorrelat;
+  Float itsCorVer;
   Float itsVanVleck;
   MeasurementSet ms_p;
   MSColumns* msc_p;
@@ -315,6 +316,7 @@ protected:
   String weightyp_p;
   Int nStokes_p;
   Int nBand_p;
+  Double visScl_p;
   static std::map<Int,Int> antIdFromNo;
   static std::map<Int,Int> digiLevels;
   static Vector<Double> effChBw;

--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -290,6 +290,7 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 
   // Correlator
   String correlat;
+  Float corVer = 0.0;
   Float vanVleck = 0.0;
 
   // Loop over all HDU in the FITS-IDI file
@@ -303,6 +304,10 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 	correlat = tab.kw("CORRELAT")->asString();
 	correlat.trim();
 	os << LogIO::NORMAL << "Correlator: " << correlat << LogIO::POST;
+      }
+      if(tab.kw("FXCORVER")){
+	corVer = std::stof(tab.kw("FXCORVER")->asString());
+	os << LogIO::NORMAL << "CorVer: " << corVer << LogIO::POST;
       }
       if (tab.kw("VANVLECK")) {
 	vanVleck = tab.kw("VANVLECK")->asFloat();
@@ -321,7 +326,8 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
 
     } else {
       // Process the FITS-IDI input from the position of this binary table
-      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain, vanVleck);
+      FITSIDItoMS1 bintab(infits, correlat, itsObsType, initFirstMain,
+			  vanVleck, corVer);
       initFirstMain = False;
       String hduName = bintab.extname();
       hduName = hduName.before(trailing);


### PR DESCRIPTION
There is some interest to process older VLBA data that was correlated with the old VLBA hardware correlator with CASA.
This needs some additional corrections in the FITS-IDI import code which are implemented in this ticket.

Since this depends on the changes in pull requests #1267 and #1268 I've marked this pull request as draft for now.