### PR TITLE
add C-style header to fix GCC 13.1 compile error on uint16_t 

### DIFF
--- a/tables/Dysco/bytepacker.h
+++ b/tables/Dysco/bytepacker.h
@@ -2,6 +2,7 @@
 #define DYSCO_BYTE_PACKER_H
 
 #include <stdexcept>
+#include <cstdint>
 
 namespace dyscostman {
 


### PR DESCRIPTION
It appears GCC 13.1 no longer includes standard C types and requires explicit inclusion of cstdint. 