### PR TITLE
mirlib: fix minor compilation issues

### DIFF
--- a/mirlib/bug.c
+++ b/mirlib/bug.c
@@ -25,6 +25,9 @@
 /*    pkgw    14dec11 Make errmsg_c public for use in uvio.c            */
 /************************************************************************/
 
+#define X_OPEN_SOURCE 500 // For strdup definition
+#define _DEFAULT_SOURCE // For sys_nerr
+
 #if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/mirlib/dio.c
+++ b/mirlib/dio.c
@@ -341,6 +341,7 @@ void dreaddir_c(char *contxt,char *path,int length)
     Strcpy(path,dp->d_name);
     Strcpy(npath,d->path);    Strcat(npath,path);
     (void)stat(npath,&buf);
-    if(S_IFDIR & buf.st_mode)Strcat(path,"/");
+    if(S_ISDIR(buf.st_mode)
+      Strcat(path,"/");
   }
 }

--- a/mirlib/dio.c
+++ b/mirlib/dio.c
@@ -341,7 +341,8 @@ void dreaddir_c(char *contxt,char *path,int length)
     Strcpy(path,dp->d_name);
     Strcpy(npath,d->path);    Strcat(npath,path);
     (void)stat(npath,&buf);
-    if(S_ISDIR(buf.st_mode))
+    if(S_ISDIR(buf.st_mode)) {
       Strcat(path,"/");
+    }
   }
 }

--- a/mirlib/dio.c
+++ b/mirlib/dio.c
@@ -341,7 +341,7 @@ void dreaddir_c(char *contxt,char *path,int length)
     Strcpy(path,dp->d_name);
     Strcpy(npath,d->path);    Strcat(npath,path);
     (void)stat(npath,&buf);
-    if(S_ISDIR(buf.st_mode)
+    if(S_ISDIR(buf.st_mode))
       Strcat(path,"/");
   }
 }


### PR DESCRIPTION
This is a small PR that prevents compilation issues within the mirlib directory when using gcc 8.5 and several -W options enabled like -Wmissing-declarations . The changes are:
- Defining _XOPEN_SOURCE to get the strdup declaration (man strdup)
- Defining _DEFAULT_SOURCE to get the sys_nerr declaration (man sys_nerr)
- Using I_ISDIR rather than I_IFDIR (https://www.gnu.org/software/libc/manual/html_node/Testing-File-Type.html)