### PR TITLE
Correct allocator_is_always_equal type

### DIFF
--- a/tables/Dysco/uvector.h
+++ b/tables/Dysco/uvector.h
@@ -75,7 +75,7 @@ class uvector : private Alloc
 	static_assert(std::is_standard_layout<Tp>(), "A uvector can only hold classes with standard layout");
 private:
 #if __cplusplus > 201402L
-	typedef std::allocator_traits<allocator_type>::is_always_equal allocator_is_always_equal;
+	typedef typename std::allocator_traits<Alloc>::is_always_equal allocator_is_always_equal
 #else
 	typedef std::false_type allocator_is_always_equal;
 #endif


### PR DESCRIPTION
I discovered this while compiling casacore on c++17.  I suspect this doesn't work because `allocator_is_always_equal` is declared before `allocator_type`. The simplest fix seem to be using `Alloc` when specifying `allocator_is_always_equal`'s type (and which allocator_type is assigned to lower down).