### PR TITLE
Use CMAKE_CXX_STANDARD instead of manually implementing C++ standard selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,13 +198,9 @@ if (NOT CMAKE_BUILD_TYPE)
     endif(_cmpvar STREQUAL "dbg" OR _cmpvar STREQUAL "debug")
 endif (NOT CMAKE_BUILD_TYPE)
 
-# Detect if the compiler supports C++11 if we want to use it.
-check_cxx_compiler_flag(-std=c++11 HAS_CXX11)
-if (HAS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-    message(FATAL_ERROR "Casacore build requires a c++11 compatible compiler")
-endif (HAS_CXX11)
+# Require a C++11 compatible compiler
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Ensure clang is not complaining about unused arguments.
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")


### PR DESCRIPTION
This changes behaviour due to enabling compiler specific extensions by setting e.g. `-std=gnu++11` instead of `-std=c++11` when building with gcc. This might be considered desirable (see #1314) or not, in the latter case additionally `set(CMAKE_CXX_EXTENSIONS OFF)` would keep the `-std=c++11`.