### PR TITLE
Fix compilation when using C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_C_FLAGS "-Qunused-arguments ${CMAKE_C_FLAGS}")
 endif()
 
-# Since 2015, we need pwrite and pwrite (POSIX 2001)
+# Since 2015, we need pread and pwrite (POSIX 2001)
 check_function_exists(pread HAVE_PREAD)
 check_function_exists(pwrite HAVE_PWRITE)
 if (NOT (HAVE_PREAD AND HAVE_PWRITE))

--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -247,7 +247,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          std::allocator_traits<BulkAllocatorImpl>::construct(*this, &ptr[i], src[i]);
+          std::allocator_traits<Allocator>::construct(allocator, &ptr[i], src[i]);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -259,7 +259,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          std::allocator_traits<BulkAllocatorImpl>::construct(*this, &ptr[i], initial_value);
+          std::allocator_traits<Allocator>::construct(allocator, &ptr[i], initial_value);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -270,7 +270,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          std::allocator_traits<BulkAllocatorImpl>::construct(*this, &ptr[i]);
+          std::allocator_traits<Allocator>::construct(allocator, &ptr[i]);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -281,7 +281,7 @@ class Allocator_private {
       for (size_type i = n; i > 0;) {
         --i;
         try {
-          std::allocator_traits<BulkAllocatorImpl>::destroy(*this, &ptr[i]);
+          std::allocator_traits<Allocator>::destroy(allocator, &ptr[i]);
         } catch (...) {
           // Destructor should not raise any exception.
         }

--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -247,7 +247,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          ::new(&ptr[i]) value_type(src[i]);
+          std::allocator_traits<BulkAllocatorImpl>::construct(*this, &ptr[i], src[i]);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -259,7 +259,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          ::new(&ptr[i]) value_type(initial_value);
+          std::allocator_traits<BulkAllocatorImpl>::construct(*this, &ptr[i], initial_value);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -270,7 +270,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          ::new(&ptr[i]) value_type();
+          std::allocator_traits<BulkAllocatorImpl>::construct(*this, &ptr[i]);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -281,7 +281,7 @@ class Allocator_private {
       for (size_type i = n; i > 0;) {
         --i;
         try {
-          ptr[i].~value_type();
+          std::allocator_traits<BulkAllocatorImpl>::destroy(*this, &ptr[i]);
         } catch (...) {
           // Destructor should not raise any exception.
         }

--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -78,13 +78,13 @@ using std11_allocator = std::allocator<T>;
 template<typename T, size_t ALIGNMENT = CASA_DEFAULT_ALIGNMENT>
 struct casacore_allocator: public std11_allocator<T> {
   typedef std11_allocator<T> Super;
-  typedef typename Super::size_type size_type;
-  typedef typename Super::difference_type difference_type;
-  typedef typename Super::pointer pointer;
-  typedef typename Super::const_pointer const_pointer;
-  typedef typename Super::reference reference;
-  typedef typename Super::const_reference const_reference;
-  typedef typename Super::value_type value_type;
+  using size_type = typename Super::size_type;
+  using difference_type = typename Super::difference_type;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using value_type = typename Super::value_type;
 
   static constexpr size_t alignment = ALIGNMENT;
 
@@ -107,7 +107,7 @@ struct casacore_allocator: public std11_allocator<T> {
   }
 
   pointer allocate(size_type elements, const void* = 0) {
-    if (elements > this->max_size()) {
+    if (elements > std::allocator_traits<casacore_allocator>::max_size(*this)) {
       throw std::bad_alloc();
     }
     void *memptr = 0;
@@ -137,14 +137,14 @@ inline bool operator!=(const casacore_allocator<T, ALIGNMENT>&,
 
 template<typename T>
 struct new_del_allocator: public std11_allocator<T> {
-  typedef std11_allocator<T> Super;
-  typedef typename Super::size_type size_type;
-  typedef typename Super::difference_type difference_type;
-  typedef typename Super::pointer pointer;
-  typedef typename Super::const_pointer const_pointer;
-  typedef typename Super::reference reference;
-  typedef typename Super::const_reference const_reference;
-  typedef typename Super::value_type value_type;
+  using Super = std11_allocator<T>;
+  using size_type = typename Super::size_type;
+  using difference_type = typename Super::difference_type;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using value_type = typename Super::value_type;
 
   template<typename TOther>
   struct rebind {
@@ -165,7 +165,7 @@ struct new_del_allocator: public std11_allocator<T> {
   }
 
   pointer allocate(size_type elements, const void* = 0) {
-    if (elements > this->max_size()) {
+    if (elements > std::allocator_traits<new_del_allocator>::max_size(*this)) {
       throw std::bad_alloc();
     }
     return new T[elements];
@@ -214,10 +214,10 @@ class Allocator_private {
 
   template<typename T2>
   struct BulkAllocator {
-    typedef typename std::allocator<T2>::size_type size_type;
-    typedef typename std::allocator<T2>::pointer pointer;
-    typedef typename std::allocator<T2>::const_pointer const_pointer;
-    typedef typename std::allocator<T2>::value_type value_type;
+    using size_type = typename std::allocator<T2>::size_type;
+    using value_type = typename std::allocator<T2>::value_type;
+    using pointer = T2*;
+    using const_pointer = const T2*;
 
     virtual pointer allocate(size_type elements, const void*ptr = 0) = 0;
     virtual void deallocate(pointer ptr, size_type size) = 0;
@@ -247,7 +247,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          allocator.construct(&ptr[i], src[i]);
+          ::new(&ptr[i]) value_type(src[i]);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -259,7 +259,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          allocator.construct(&ptr[i], initial_value);
+          ::new(&ptr[i]) value_type(initial_value);
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -270,7 +270,7 @@ class Allocator_private {
       size_type i = 0;
       try {
         for (i = 0; i < n; ++i) {
-          allocator.construct(&ptr[i]);
+          ::new(&ptr[i]) value_type();
         }
       } catch (...) {
         destroy(ptr, i);  // rollback constructions
@@ -281,7 +281,7 @@ class Allocator_private {
       for (size_type i = n; i > 0;) {
         --i;
         try {
-          allocator.destroy(&ptr[i]);
+          ptr[i].~value_type();
         } catch (...) {
           // Destructor should not raise any exception.
         }


### PR DESCRIPTION
C++20 has removed a few deprecated functions, in particular related to allocators. While it might take a while before we want to compile casacore by default with c++20, projects that make use of Casacore and C++20 also fail to compile because casacore headers do not compile, which is probably becoming more standard in the near future.

In this MR I provided a work-around fix to the allocators in Casacore. I should mention though that the way Casacore uses allocators is deprecated, and probably also unnecessary. One of the places where it is used extensively, is in the Block class, which by itself is also easily replaced by something from std, that would also have proper move semantics. So a future task could be te remove all allocator and block functionality, as to simplify the codebase.