### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/casa/Utilities/Assert.tcc
+++ b/casa/Utilities/Assert.tcc
@@ -34,7 +34,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 template<class t> assert_<t>::assert_(int expr, const char *msg, const char* file, Int line) {
   static char message[1024];
   if (! expr) {
-    sprintf(message,"(%s : %i) %s",file,line,msg);
+    snprintf(message,sizeof(message),"(%s : %i) %s",file,line,msg);
     throw(t(message));
   }
 }
@@ -42,7 +42,7 @@ template<class t> assert_<t>::assert_(int expr, const char *msg, const char* fil
 template<class t> assert_<t>::assert_(const void *ptr, const char *msg, const char* file, Int line) {
   static char message[1024];
   if (! ptr) {
-    sprintf(message,"(%s : %i) %s",file,line,msg);
+    snprintf(message,sizeof(message),"(%s : %i) %s",file,line,msg);
     throw(t(message));
   }
 }


### PR DESCRIPTION
Using the latter triggers a warning on (for example) recent macOS versions as it is inherently unsafe to use.

Fixes #1306