### PR TITLE
Make ObsInfo work without Observatories table

### DIFF
--- a/coordinates/Coordinates/ObsInfo.cc
+++ b/coordinates/Coordinates/ObsInfo.cc
@@ -24,6 +24,7 @@
 //#                        Charlottesville, VA 22903-2475 USA
 
 #include <casacore/coordinates/Coordinates/ObsInfo.h>
+#include <casacore/casa/Logging/LogIO.h>
 #include <casacore/measures/Measures/MeasureHolder.h>
 #include <casacore/measures/Measures/MeasTable.h>
 #include <casacore/measures/Measures/MeasConvert.h>
@@ -118,6 +119,9 @@ ObsInfo& ObsInfo::setTelescope(const String &telescope)
       try {
         telescope_found = MeasTable::Observatory (pos, telescope);
       } catch (std::exception&) {
+        LogIO os(LogOrigin("ObsInfo", "setTelescope", WHERE));
+        os << "Cannot read table of Observatories, continuing ";
+        os << "without telescope position in ObsInfo" << LogIO::WARN;
       }
 
       if (telescope_found) {

--- a/coordinates/Coordinates/ObsInfo.cc
+++ b/coordinates/Coordinates/ObsInfo.cc
@@ -113,7 +113,14 @@ ObsInfo& ObsInfo::setTelescope(const String &telescope)
     telescope_p = telescope;
     if (!isTelPositionSet_p) {
       MPosition pos;
-      if (MeasTable::Observatory (pos, telescope)) {
+      bool telescope_found = false;
+
+      try {
+        telescope_found = MeasTable::Observatory (pos, telescope);
+      } catch (std::exception&) {
+      }
+
+      if (telescope_found) {
         setTelescopePosition (pos);
       }
     }

--- a/coordinates/Coordinates/ObsInfo.cc
+++ b/coordinates/Coordinates/ObsInfo.cc
@@ -116,9 +116,11 @@ ObsInfo& ObsInfo::setTelescope(const String &telescope)
       MPosition pos;
       bool telescope_found = false;
 
+      // Make ObsInfo work even if no Observatories table is installed
+      // since that table is distributed separately in a large package
       try {
         telescope_found = MeasTable::Observatory (pos, telescope);
-      } catch (std::exception&) {
+      } catch (const std::exception&) {
         LogIO os(LogOrigin("ObsInfo", "setTelescope", WHERE));
         os << "Cannot read table of Observatories, continuing ";
         os << "without telescope position in ObsInfo" << LogIO::WARN;


### PR DESCRIPTION
This will make sure an ObsInfo object can be created, even when no Observatories table is present. With this change, also Images can be created without having an Observatories table.

Fixes #1321