### PR TITLE
fixed constness in LatticeCleaner<T>::setMask parameter

### DIFF
--- a/lattices/LatticeMath/LatticeCleaner.h
+++ b/lattices/LatticeMath/LatticeCleaner.h
@@ -172,7 +172,7 @@ public:
   // to implement cleaning based on the signal-to-noise as opposed to the standard cleaning
   // based on the flux. The default threshold value is 0.9, which ensures the behavior of the
   // code is exactly the same as before this parameter has been introduced.
-  void setMask(Lattice<T> & mask, const T& maskThreshold = T(0.9));
+  void setMask(const Lattice<T> & mask, const T& maskThreshold = T(0.9));
 
   // Tell the algorithm to NOT clean just the inner quarter
   // (This is useful when multiscale clean is being used

--- a/lattices/LatticeMath/LatticeCleaner.tcc
+++ b/lattices/LatticeMath/LatticeCleaner.tcc
@@ -253,16 +253,16 @@ void LatticeCleaner<T>::update(const Lattice<T> &dirty)
 
 // add a mask image
 template<class T> 
-void LatticeCleaner<T>::setMask(Lattice<T> & mask, const T& maskThreshold) 
+void LatticeCleaner<T>::setMask(const Lattice<T> & mask, const T& maskThreshold)
 {
   itsMaskThreshold = maskThreshold;
-  IPosition maskShape = mask.shape();
-  IPosition dirtyShape = itsDirty->shape();
+  const IPosition maskShape = mask.shape();
+  const IPosition dirtyShape = itsDirty->shape();
 
-  AlwaysAssert((mask.shape() == itsDirty->shape()), AipsError);
+  AlwaysAssert((maskShape == dirtyShape), AipsError);
 
   // This is not needed after the first steps
-  itsMask = new TempLattice<T>(mask.shape(), itsMemoryMB);
+  itsMask = new TempLattice<T>(maskShape, itsMemoryMB);
   itsMask->copyData(mask);
 
   if (itsScalesValid) {


### PR DESCRIPTION
This is a trivial pull request fixing constness in LatticeCleaner<T>::setMask input parameter. The method doesn't change the input mask lattice (and shouldn't conceptually), so having it passed via const reference (i.e. the same way as it is done for the dirty image and PSF) seems to be more appropriate.

I've also done few minor tweaks to the body of the method which do not alter the functionality (making use of previously unused variables).

P.S. I also noticed that MultiTermLatticeCleaner class has a bit of technical debt / needs some work, if it is working at all (in contrast to LatticeCleaner we don't use it in ASKAPsoft and reimplemented the same algorithm some other way, probably for a reason). Although this class is derived from LatticeCleaner, it does not override setMask method but has a setmask one instead (i.e. all low-case). Ignoring the fact that this is an untidy design, it means that my change suggested in this pull request has no impact. Although a number of methods of MultiTermLatticeCleaner also accept non-const references for no good reason, I decided to leave it as is for now, especially because there seem to be no unit tests for it. 