### PR TITLE
Update macOS runners to macos-12

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   osx:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
       - name: checkout

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -41,7 +41,7 @@ jobs:
             -DBUILD_PYTHON=OFF \
             -DBUILD_PYTHON3=ON \
             -DBoost_NO_BOOST_CMAKE=True \
-            -DCMAKE_Fortran_COMPILER=gfortran-10 \
+            -DCMAKE_Fortran_COMPILER=gfortran-13 \
             -DDATA_DIR=. ..
 
       - name: build


### PR DESCRIPTION
macos-10.15 isn't a supported flavour anymore, and thus actions are blocked from running, an eventually fail with a timeout after 24 hours.