### PR TITLE
Guard against log10(0) in MSLister.cc

### DIFF
--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -540,7 +540,12 @@ void MSLister::selectvis(const String& timerange,
 /// Calculate the max number of digits needed to print the values in an array
 template <class T> uInt maxDigitsToPrint(const Array<T> &values)
 {
-    return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))))+0.5));
+    // Guard against log10(0).
+    if (max(values) == 0) {
+      return 1;
+    } else {
+      return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))))+0.5));
+    }
 }
 
 void MSLister::listData(const int pageRows,


### PR DESCRIPTION
Casa test test_task_listvis crashes when built on macOS Ventura/Clang 14. When maxDigitsToPrint gets an array of zeroes,  log10(0) returns -inf, which then gets turned into comparison of 1 and maximum int value. This patch returns 1 when the max array value is 0. Casa ticket CAS-14214.