### PR TITLE
Add py312 wheels

### DIFF
--- a/docker/make_images.sh
+++ b/docker/make_images.sh
@@ -1,8 +1,10 @@
-#!/bin/bash -ve
+#!/bin/bash -xe
 
 HERE=`dirname "$0"`
 cd $HERE/..
 
+tag=$(git describe --tags)
+
 for i in 37 38 39 310 311 312; do
-    docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:master_wheel${i}
+    docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:${tag}_wheel${i}
 done

--- a/docker/make_images.sh
+++ b/docker/make_images.sh
@@ -3,6 +3,6 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 37 38 39 310 311; do
+for i in 37 38 39 310 311 312; do
     docker build -f docker/py${i}_wheel.docker . -t quay.io/casacore/casacore:master_wheel${i}
 done

--- a/docker/py312_wheel.docker
+++ b/docker/py312_wheel.docker
@@ -1,0 +1,78 @@
+FROM quay.io/pypa/manylinux2014_x86_64
+
+# set python version
+ENV PYMAJOR 3
+ENV PYMINOR 12
+ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}${PYUNICODE}
+
+# boost version
+ENV BOOSTMAJOR 79
+ENV BOOSTMINOR 0
+ENV BOOST 1.${BOOSTMAJOR}.${BOOSTMINOR}
+ENV BOOST_ 1_${BOOSTMAJOR}_${BOOSTMINOR}
+
+# where do we epect casacore data build time and runtime
+ENV CASACORE_DATA /usr/share/casacore/data
+
+# how many threads to use for compiling
+ENV THREADS 4
+
+# install rpms
+RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel readline-devel fftw-devel wcslib-devel gsl-devel
+
+# download other source code
+WORKDIR /tmp
+RUN curl http://www.iausofa.org/2015_0209_F/sofa_f-20150209_a.tar.gz --output /tmp/sofa.tgz
+RUN curl ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar --output /tmp/measures.tgz
+RUN curl https://ufpr.dl.sourceforge.net/project/boost/boost/${BOOST}/boost_${BOOST_}.tar.bz2 --output /tmp/boost.tar.bz2
+
+RUN mkdir /build
+WORKDIR /build
+
+RUN mkdir -p ${CASACORE_DATA}
+WORKDIR ${CASACORE_DATA}
+RUN tar zxvf /tmp/measures.tgz
+
+# install and configure sofa and measures
+WORKDIR /build
+RUN tar zxvf /tmp/sofa.tgz
+WORKDIR /build/sofa/20150209_a/f77/src
+RUN make -j${THREADS}
+
+
+# setup boost
+WORKDIR /build
+RUN tar jxvf /tmp/boost.tar.bz2
+WORKDIR /build/boost_${BOOST_}
+RUN ./bootstrap.sh --prefix=/opt/boost \
+    --with-libraries=python \
+    --with-python=/opt/python/${TARGET}/bin/python \
+    --with-python-version=${PYMAJOR}.${PYMINOR} \
+    --with-python-root=/opt/python/${TARGET}
+RUN ./b2 -j${THREADS} \
+    cxxflags="-fPIC -I/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}${PYUNICODE}/" \
+    link=static,shared install
+
+# casacore wants numpy
+RUN /opt/python/${TARGET}/bin/pip install numpy==1.26.1
+
+# set up casacore
+ADD . /code
+RUN useradd -ms /bin/bash casacore
+RUN chown casacore.casacore /code
+USER casacore
+RUN mkdir /code/build
+WORKDIR /code/build
+RUN cmake .. \
+    -DPython3_ROOT_DIR=/opt/python/${TARGET} \
+    -DPython3_EXECUTABLE=/opt/python/${TARGET}/bin/python3 \
+    -DPython3_LIBRARY=/opt/boost/lib/libboost_python${PYMAJOR}${PYMINOR}.so \
+    -DPython3_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}${PYUNICODE}/ \
+    -DSOFA_ROOT_DIR=/build \
+    -DBUILD_TESTING=OFF \
+    -DDATA_DIR=${CASACORE_DATA} \
+    -DPORTABLE=TRUE \
+    -DCMAKE_INSTALL_PREFIX=/usr/local
+RUN make -j${THREADS}
+USER root
+RUN make install

--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -540,7 +540,12 @@ void MSLister::selectvis(const String& timerange,
 /// Calculate the max number of digits needed to print the values in an array
 template <class T> uInt maxDigitsToPrint(const Array<T> &values)
 {
-    return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))))+0.5));
+    // Guard against log10(0).
+    if (max(values) == 0) {
+      return 1;
+    } else {
+      return (uInt)max(1,(Int)rint(abs(log10(abs(max(values))))+0.5));
+    }
 }
 
 void MSLister::listData(const int pageRows,


### PR DESCRIPTION
Add generation of Python 3.12 wheels.
Also changed the name of the generated docker image files to contain the output of `git describe --tags` instead of the hard-coded `master`.