### PR TITLE
Generate casarc file

### DIFF
--- a/measures/CMakeLists.txt
+++ b/measures/CMakeLists.txt
@@ -15,6 +15,12 @@ if (DATA_DIR)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCASADATA='\"${DATA_DIRX}\"'")
 endif (DATA_DIR)
 
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/casacore.rc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/casacore.rc
+    @ONLY
+)
+
 add_library (casa_measures
 Measures/Aberration.cc
 Measures/EarthField.cc
@@ -165,6 +171,10 @@ DESTINATION include/casacore/measures/TableMeasures
 
 install (FILES ${top_level_headers}
 DESTINATION include/casacore/measures
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/casacore.rc
+    DESTINATION etc
 )
 
 add_subdirectory (Measures/test ${EXCL_ALL})

--- a/measures/casacore.rc.in
+++ b/measures/casacore.rc.in
@@ -1,0 +1,1 @@
+measures.directory: @DATA_DIR@


### PR DESCRIPTION
Generate a casarc file that can be used by the user and copied to a different location. The user could then use the environment variable `CASARCFILES` to point to the desired casarc file.