### PR TITLE
Fix docker GitHub workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,12 @@ name: Publish Docker images
 on:
   push:
     branches:
-      - $repo.default_branch
+      - 'master'
     tags:
       - 'v*'
   pull_request:
     branches:
-      - $repo.default_branch
+      - 'master'
 
 env:
   REGISTRY: quay.io


### PR DESCRIPTION
The new 'docker' GitHub workflow uses a variable to determine the name of the default branch in the repository. However, it turns out that this variable can only be used in workflow _templates_. It is also not possible to use the `github.event` family of variables in the `on:` clause. So, unfortunately, the only way to currently do this is to use a hard-coded name: `'master'`