### PR TITLE
Fix a previous contiguous array fix in Dysco

### DIFF
--- a/tables/Dysco/bytepacker.h
+++ b/tables/Dysco/bytepacker.h
@@ -1,8 +1,8 @@
 #ifndef DYSCO_BYTE_PACKER_H
 #define DYSCO_BYTE_PACKER_H
 
-#include <stdexcept>
 #include <cstdint>
+#include <stdexcept>
 
 namespace dyscostman {
 


### PR DESCRIPTION
#1166 fixed Dysco to support non-contiguous arrays, but introduced a small issue which is fixed in this PR.