### PR TITLE
Update Dysco to include RF norm fixes

### DIFF
--- a/tables/Dysco/aftimeblockencoder.h
+++ b/tables/Dysco/aftimeblockencoder.h
@@ -75,8 +75,6 @@ class AFTimeBlockEncoder : public TimeBlockEncoder {
   void changeAntennaFactor(std::vector<DBufferRow> &data, float *metaBuffer,
                            size_t antennaIndex, size_t antennaCount,
                            size_t polIndex, double factor);
-  void changeChannelFactor(std::vector<DBufferRow> &data, float *metaBuffer,
-                           size_t visIndex, double factor);
 
   void fitToMaximum(std::vector<DBufferRow> &data, float *metaBuffer,
                     const dyscostman::StochasticEncoder<float> &gausEncoder,

--- a/tables/Dysco/rftimeblockencoder.h
+++ b/tables/Dysco/rftimeblockencoder.h
@@ -64,19 +64,16 @@ class RFTimeBlockEncoder : public TimeBlockEncoder {
                  size_t antennaCount);
 
  private:
-  void calculateAntennaeRMS(const std::vector<DBufferRow> &data,
-                            size_t polIndex, size_t antennaCount);
+  void maximizeRows(std::vector<DBufferRow> &data, float *metaBuffer,
+                    const dyscostman::StochasticEncoder<float> &gausEncoder);
+  void maximizeChannels(
+      std::vector<DBufferRow> &data, float *metaBuffer,
+      const dyscostman::StochasticEncoder<float> &gausEncoder);
 
   template <bool UseDithering>
   void encode(const dyscostman::StochasticEncoder<float> &gausEncoder,
               const FBuffer &buffer, float *metaBuffer, symbol_t *symbolBuffer,
               size_t antennaCount, std::mt19937 *rnd);
-
-  void changeChannelFactor(std::vector<DBufferRow> &data, float *metaBuffer,
-                           size_t visIndex, double factor);
-  void fitToMaximum(std::vector<DBufferRow> &data, float *metaBuffer,
-                    const dyscostman::StochasticEncoder<float> &gausEncoder,
-                    size_t antennaCount);
 
   size_t _nPol, _nChannels;
 

--- a/tables/Dysco/threadeddyscocolumn.h
+++ b/tables/Dysco/threadeddyscocolumn.h
@@ -42,6 +42,7 @@ class ThreadedDyscoColumn : public DyscoStManColumn {
   ThreadedDyscoColumn(const ThreadedDyscoColumn &source) = delete;
 
   void operator=(const ThreadedDyscoColumn &source) = delete;
+
   /** Destructor. */
   virtual ~ThreadedDyscoColumn();
 


### PR DESCRIPTION
This PR combines to changes to Dysco:
- https://github.com/aroffringa/dysco/pull/33 ; PR that fixes an issue when using non-standard settings for normalization AND compressing auto-correlations.
- https://github.com/aroffringa/dysco/pull/34 ; various cleanup.