### PR TITLE
Replace insecure sprintf by snprintf

### DIFF
--- a/casa/Containers/RecordDescRep.cc
+++ b/casa/Containers/RecordDescRep.cc
@@ -364,7 +364,7 @@ Int RecordDescRep::fieldNumber (const String& fieldName) const
 String RecordDescRep::makeName (Int whichField) const
 {
     char strc[13];
-    sprintf(strc, "*%i", whichField+1);
+    snprintf(strc, sizeof(strc), "*%i", whichField+1);
     return uniqueName (strc);
 }
 
@@ -375,7 +375,7 @@ String RecordDescRep::uniqueName (const String& name) const
     int n = 0;
     while (fieldNumber(newName) >= 0) {
 	++n;
-	sprintf(strc, "_%i", n);
+	snprintf(strc, sizeof(strc), "_%i", n);
 	newName = name + strc;
     }
     return newName;

--- a/casa/Json/JsonOut.cc
+++ b/casa/Json/JsonOut.cc
@@ -213,7 +213,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       putNull();
     } else {
       char buf[16];
-      sprintf (buf, "%.7g", value);
+      snprintf (buf, sizeof(buf), "%.7g", value);
       // Add a decimal point if needed, otherwise it is integer.
       unsigned i;
       for (i=0; i<sizeof(buf); ++i) {
@@ -234,7 +234,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       putNull();
     } else {
       char buf[24];
-      sprintf (buf, "%.16g", value);
+      snprintf (buf, sizeof(buf), "%.16g", value);
       // Add a decimal point if needed, otherwise it is integer.
       unsigned i;
       for (i=0; i<sizeof(buf); ++i) {

--- a/casa/OS/File.cc
+++ b/casa/OS/File.cc
@@ -35,7 +35,7 @@
 #include <utime.h>                  // needed for utimbuf
 #include <errno.h>                  // needed for errno
 #include <casacore/casa/string.h>                 // needed for strerror
-#include <casacore/casa/stdio.h>                  // needed for sprintf
+#include <casacore/casa/stdio.h>                  // needed for snprintf
 #include <time.h>                   // needed for asctime/localtime on linux
 
 
@@ -253,7 +253,7 @@ Path File::newUniqueName (const String& directory, const String& prefix)
     char str[32];
     // fill str with the pid and the unique number
     uInt seqnr = uniqueSeqnr_p.fetch_add(1);
-    sprintf (str, "%i_%i", Int(getpid()), seqnr);
+    snprintf (str, sizeof(str), "%i_%i", Int(getpid()), seqnr);
     if (directory.empty()  ||  directory.lastchar() == '/') {
 	return Path (directory + prefix + str);
     }

--- a/casa/System/Casarc.cc
+++ b/casa/System/Casarc.cc
@@ -95,7 +95,7 @@ namespace casacore {
 	    if ( home == 0 ) return instance( "casarc" );
 	    struct stat statbuf;
 	    char buf[2048];
-	    sprintf( buf, "%s/.casa", home );
+	    snprintf( buf, sizeof(buf), "%s/.casa", home );
 	    if ( stat( buf, &statbuf ) == 0 ) {
 		if ( S_ISDIR(statbuf.st_mode) ) {
 		    return instance( std::string(buf) + "/rc" );
@@ -192,14 +192,15 @@ namespace casacore {
 #endif
 
 	    int buflen = strlen(buf);
-	    char *copy = (char*) malloc(sizeof(char) * ( start +
-							 (buflen + keyword.length() + value.length() + 5) +
-							 (mapped_file_size - end) ));
+            int copylen = sizeof(char) * ( start +
+                                           (buflen + keyword.length() + value.length() + 5) +
+                                           (mapped_file_size - end) );
+	    char *copy = (char*) malloc(copylen);
 
 	    off_t off = 0;
 	    memcpy( copy, mapped_file, start );
 	    off += start;
-	    sprintf( &copy[off], "%s%s: %s", buf, keyword.c_str(), value.c_str() );
+	    snprintf( &copy[off], copylen-off, "%s%s: %s", buf, keyword.c_str(), value.c_str() );
 
 #if CASARC_DEBUG >= 2
 	    fprintf( stderr, " >>update>>>>>>>>%s<< [%d]\n", &copy[off], strlen(&copy[off]) );

--- a/casa/System/ObjectID2.cc
+++ b/casa/System/ObjectID2.cc
@@ -26,7 +26,7 @@
 
 #include <casacore/casa/System/ObjectID.h>
 #include <casacore/casa/Containers/Block.h>
-#include <casacore/casa/stdio.h>                  // needed for sprintf
+#include <casacore/casa/stdio.h>                  // needed for snprintf
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -67,7 +67,7 @@ String ObjectID::extractIDs (Block<ObjectID>& objectIDs,
 	    objectIDs.resize (n);
 	    objectIDs[n-1] = oid;
 	    char buf[16];
-	    sprintf (buf, "$OBJ#%i#O", n);
+	    snprintf (buf, sizeof(buf), "$OBJ#%i#O", n);
 	    result += buf;
 	    str = str.after(pos+1);
 	}

--- a/fits/FITS/BinTable.cc
+++ b/fits/FITS/BinTable.cc
@@ -181,7 +181,7 @@ BinaryTable::BinaryTable(FitsInput& fitsin, FITSErrorHandler errhandler,
 	   kwname.rtrim(' ');
 	   // if it is indexed, add the index to the keyword
 	   if (kw->isindexed()) {
-	       sprintf(index,"%i",kw->index());
+               snprintf(index,sizeof(index),"%i",kw->index());
 	       kwname = kwname + String(index);
 	   }
 	   //		first check if this keyword exists in kwSet

--- a/fits/FITS/FITSTable2.cc
+++ b/fits/FITS/FITSTable2.cc
@@ -274,7 +274,7 @@ FITSTableWriter::FITSTableWriter(FitsOutput *file,
 	  }
 	  code = "A";
 	  char tdimColName[8];
-	  sprintf(tdimColName,"TDIM%03i",thisColumn);
+	  snprintf(tdimColName,sizeof(tdimColName),"TDIM%03i",thisColumn);
 	  thisColumn++;
 	  String tdimComment = "Shape of " + description.name(i) + " column.";
 	  columns.mk(thisColumn, FITS::TTYPE, tdimColName, tdimComment.chars());

--- a/fits/FITS/fits.cc
+++ b/fits/FITS/fits.cc
@@ -2402,7 +2402,7 @@ Bool FitsKeywordList::basic_rules() {
 }
 
 FitsKeyCardTranslator::FitsKeyCardTranslator(int max) : cardno(0),
-	FitsCardSize(80), FitsMaxCard(36), FitsRecSize(2880), max_errs(max), 
+        max_errs(max), 
 	no_errs_(0) {
 	err_ = new const char * [max_errs];
 	err_cardno_ = new int [max_errs];
@@ -2520,33 +2520,33 @@ void FitsKeyCardTranslator::fmtcard(char *card, const FitsKeyword &k) {
 		    card[29] = (k.asBool() == True ? 'T' : 'F');
 		    break;
 		case FITS::LONG:
-		    sprintf(&card[18],"%12d",k.asInt());
+                    snprintf(&card[18],FitsCardSize-18,"%12d",k.asInt());
 		    card[30] = ' ';
 		    break;
 		case FITS::FLOAT:
-		    sprintf(&card[16],"%#14.7E",k.asFloat());
+		    snprintf(&card[16],FitsCardSize-16,"%#14.7E",k.asFloat());
 		    card[30] = ' ';
 		    break;
 		case FITS::DOUBLE:
-		    sprintf(&card[10],"%#20.12E",k.asDouble()); // optimum %23.15E
+		    snprintf(&card[10],FitsCardSize-10,"%#20.12E",k.asDouble()); // optimum %23.15E
 		    for (i = 29; i < 10; --i) // change the E to a D
 		        if (card[i] == 'E') { card[i] = 'D'; break; }
 		    card[30] = ' ';
 		    break;
 		case FITS::ICOMPLEX:
-		    sprintf(&card[18],"%12d",k.asIComplex().real());
+		    snprintf(&card[18],FitsCardSize-18,"%12d",k.asIComplex().real());
 		    card[30] = ' ';
-		    sprintf(&card[38],"%12d",k.asIComplex().imag());
+		    snprintf(&card[38],FitsCardSize-38,"%12d",k.asIComplex().imag());
 		    card[50] = ' ';
 		    break;
 		case FITS::COMPLEX:
-		    sprintf(&card[16],"%#14.6E",k.asComplex().real());
-		    sprintf(&card[36],"%#14.6E",k.asComplex().imag());
+		    snprintf(&card[16],FitsCardSize-16,"%#14.6E",k.asComplex().real());
+		    snprintf(&card[36],FitsCardSize-36,"%#14.6E",k.asComplex().imag());
 		    card[50] = ' ';
 		    break;
 		case FITS::DCOMPLEX:
-		    sprintf(&card[10],"%#20.12E",k.asDComplex().real());
-		    sprintf(&card[30],"%#20.12E",k.asDComplex().imag());
+		    snprintf(&card[10],FitsCardSize-10,"%#20.12E",k.asDComplex().real());
+		    snprintf(&card[30],FitsCardSize-30,"%#20.12E",k.asDComplex().imag());
 		    for (i = 29; i < 10; --i) // change E to a D
 		        if (card[i] == 'E') { card[i] = 'D'; break; }
 		    for (i = 49; i < 30; --i) // change E to a D

--- a/fits/FITS/fits.h
+++ b/fits/FITS/fits.h
@@ -993,9 +993,9 @@ class FitsKeyCardTranslator {
         static void fmtcard(char *, const FitsKeyword &);
     private:
 	int cardno;		// the current card number within record
-	const int FitsCardSize;
-	const int FitsMaxCard;
-	const int FitsRecSize;
+	static const int FitsCardSize = 80;
+	static const int FitsMaxCard = 36;
+	static const int FitsRecSize = 2880;
 	int max_errs;
 	int no_errs_;
 	const char **err_;

--- a/fits/FITS/fits.h
+++ b/fits/FITS/fits.h
@@ -993,9 +993,9 @@ class FitsKeyCardTranslator {
         static void fmtcard(char *, const FitsKeyword &);
     private:
 	int cardno;		// the current card number within record
-	static const int FitsCardSize = 80;
-	static const int FitsMaxCard = 36;
-	static const int FitsRecSize = 2880;
+	static constexpr int FitsCardSize = 80;
+	static constexpr int FitsMaxCard = 36;
+	static constexpr int FitsRecSize = 2880;
 	int max_errs;
 	int no_errs_;
 	const char **err_;

--- a/fits/FITS/fitsio.cc
+++ b/fits/FITS/fitsio.cc
@@ -635,10 +635,11 @@ int FitsInput::skip_hdu() { //Skip an entire header-data unit
             ffgknm(l_card, l_keyname, &l_namelen, &l_status); // get the keyword name
 
             if (fftrec(l_keyname, &l_status) > 0) { // test keyword name; catches no END
-                sprintf(
-                        l_message,
-                        "Name of keyword no. %d contains illegal character(s): %s",
-                        nextkey, l_keyname);
+                snprintf(
+                         l_message,
+                         sizeof(l_message),
+                         "Name of keyword no. %d contains illegal character(s): %s",
+                         nextkey, l_keyname);
                 errmsg(MISSKEY, l_message);
 
                 if (nextkey % 36 == 0) { // test if at beginning of 36-card record.

--- a/fits/FITS/hdu2.cc
+++ b/fits/FITS/hdu2.cc
@@ -1249,7 +1249,7 @@ int AsciiTableExtension::writerow(FitsOutput &fout) {
 	    } else {
 		switch (fld[i]->fieldtype()) {
 	    	    case FITS::LONG:
-			sprintf(tmp,format[i],*((FitsLong *)(fld[i]->data())));
+                        snprintf(tmp,sizeof(tmp),format[i],*((FitsLong *)(fld[i]->data())));
 			if (strlen(tmp) > fits_width[i]) {
 	    	            errmsg(BADCONV,
 	      "Ascii Table conversion error: numeric value exceeds field size");
@@ -1260,11 +1260,11 @@ int AsciiTableExtension::writerow(FitsOutput &fout) {
 	    		    memcpy(&fitsrow[fits_offset[i]],tmp,fits_width[i]);
 			break;
 		    case FITS::FLOAT:
-			sprintf(tmp,format[i],*((float *)(fld[i]->data())));
+                        snprintf(tmp,sizeof(tmp),format[i],*((float *)(fld[i]->data())));
 			memcpy(&fitsrow[fits_offset[i]],tmp,fits_width[i]);
 			break;
 		    case FITS::DOUBLE:
-			sprintf(tmp,format[i],*((double *)(fld[i]->data())));
+                        snprintf(tmp,sizeof(tmp),format[i],*((double *)(fld[i]->data())));
 			for (t = &tmp[strlen(tmp) - 2]; *t != 'E'; --t) {}
 			*t = 'D'; // Change the 'E' to a 'D' in the format
          memcpy(&fitsrow[fits_offset[i]],tmp,fits_width[i]);

--- a/fits/FITS/test/tBinTable.cc
+++ b/fits/FITS/test/tBinTable.cc
@@ -86,7 +86,8 @@ int main(int argc, const char* argv[])
 
 	Int tabCount = 0;
 	// This allows for constructed names of the form baseName.table.xx
-	char *tabName = new char[baseName.length() + 10];
+        int tabNameLen = baseName.length() + 10;
+	char *tabName = new char[tabNameLen];
 	// construct the FITS input
 	FitsInput infits(inputFilename.chars(), FITS::Disk);
 	if (infits.err() != FitsIO::OK) {
@@ -98,7 +99,7 @@ int main(int argc, const char* argv[])
 	    switch (infits.hdutype()) {
 	    case FITS::BinaryTableHDU:
 	    {
-		sprintf(tabName,"%s.table.%i",baseName.chars(),tabCount++);
+                snprintf(tabName,tabNameLen,"%s.table.%i",baseName.chars(),tabCount++);
 		String tabNameString(tabName);
 		cout << "BinaryTableHDU : " << tabNameString << " ... " ;
 		BinaryTable bintab(infits, FITSError::defaultHandler, 

--- a/fits/FITS/test/tfits5.cc
+++ b/fits/FITS/test/tfits5.cc
@@ -110,7 +110,7 @@ void cvt_table(AsciiTableExtension &x, FitsOutput &fout) {
 		    bk.del();
 		    switch (x.field(n).fieldtype()) {
 			case FITS::CHAR:
-			    sprintf(p,"%dA",x.field(n).fitsfieldsize());
+                            snprintf(p,sizeof(p),"%dA",x.field(n).fitsfieldsize());
 			    bk.mk((n + 1),FITS::TFORM,p);
 			    break;
 			case FITS::LONG:

--- a/lattices/LatticeMath/LatticeStatistics.tcc
+++ b/lattices/LatticeMath/LatticeStatistics.tcc
@@ -2064,36 +2064,36 @@ Bool LatticeStatistics<T>::getLayerStats(
         oDWidth = 2*oDWidth + 3;
     }
 
-    sprintf( buffer, "%d", nPts );
+    snprintf( buffer, sizeof(buffer), "%d", nPts );
     stats.push_back(stat_element("Npts",buffer));
 
-    sprintf( buffer, "%e", sum );
+    snprintf( buffer, sizeof(buffer), "%e", sum );
     stats.push_back(stat_element("Sum",buffer));
 
     if ( _canDoFlux()) {
         Bool unused;
-        sprintf( buffer, "%e", _flux(unused, sum, area ).getValue());
+        snprintf( buffer, sizeof(buffer), "%e", _flux(unused, sum, area ).getValue());
         stats.push_back(stat_element("FluxDensity",buffer));
     }
 
-    sprintf( buffer, "%e", mean );
+    snprintf( buffer, sizeof(buffer), "%e", mean );
     stats.push_back(stat_element("Mean",buffer));
 
     if (doRobust_p) {
-        sprintf( buffer, "%e", median );
+        snprintf( buffer, sizeof(buffer), "%e", median );
         stats.push_back(stat_element("Median",buffer));
     }
 
-    sprintf( buffer, "%e", rms );
+    snprintf( buffer, sizeof(buffer), "%e", rms );
     stats.push_back(stat_element("Rms",buffer));
 
-    sprintf( buffer, "%e", sigma );
+    snprintf( buffer, sizeof(buffer), "%e", sigma );
     stats.push_back(stat_element("Std dev",buffer));
 
-    sprintf( buffer, "%e", dMin );
+    snprintf( buffer, sizeof(buffer), "%e", dMin );
     stats.push_back(stat_element("Minimum",buffer));
 
-    sprintf( buffer, "%e", dMax );
+    snprintf( buffer, sizeof(buffer), "%e", dMax );
     stats.push_back(stat_element("Maximum",buffer));
 
     return True;
@@ -2188,37 +2188,37 @@ Bool LatticeStatistics<T>::getLayerStats(
     for (uInt j=0; j<n1; j++) {
         if (layer == (Int)j || n1 == 1)  {
 
-        sprintf( buffer, "%d", (int) ord.column(NPTS)(j) );
+        snprintf( buffer, sizeof(buffer), "%d", (int) ord.column(NPTS)(j) );
         stats.push_back(stat_element("Npts",buffer));
 
         if (ord.column(NPTS)(j) > 0){
 
-            sprintf( buffer, "%e", ord.column(SUM)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(SUM)(j) );
             stats.push_back(stat_element("Sum",buffer));
 
             if (_canDoFlux()) {
-            sprintf( buffer, "%e", ord.column(FLUX)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(FLUX)(j) );
             stats.push_back(stat_element("FluxDensity",buffer));
             }
 
-            sprintf( buffer, "%e", ord.column(MEAN)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(MEAN)(j) );
             stats.push_back(stat_element("Mean",buffer));
 
             if (doRobust_p){
-            sprintf( buffer, "%e", ord.column(MEDIAN)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(MEDIAN)(j) );
             stats.push_back(stat_element("Median",buffer));
             }
 
-            sprintf( buffer, "%e", ord.column(RMS)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(RMS)(j) );
             stats.push_back(stat_element("Rms",buffer));
 
-            sprintf( buffer, "%e", ord.column(SIGMA)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(SIGMA)(j) );
             stats.push_back(stat_element("Std dev",buffer));
 
-            sprintf( buffer, "%e", ord.column(MIN)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(MIN)(j) );
             stats.push_back(stat_element("Minimum",buffer));
 
-            sprintf( buffer, "%e", ord.column(MAX)(j) );
+            snprintf( buffer, sizeof(buffer), "%e", ord.column(MAX)(j) );
             stats.push_back(stat_element("Maximum",buffer));
         }
         }

--- a/tables/DataMan/DataManager.cc
+++ b/tables/DataMan/DataManager.cc
@@ -48,7 +48,7 @@
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/OS/DynLib.h>
 #include <casacore/tables/DataMan/DataManError.h>
-#include <casacore/casa/stdio.h>                     // for sprintf
+#include <casacore/casa/stdio.h>                     // for snprintf
 
 #ifdef HAVE_ADIOS2
 #include <casacore/tables/DataMan/Adios2StMan.h>
@@ -256,7 +256,7 @@ DataManagerColumn* DataManager::reallocateColumn (DataManagerColumn* column)
 String DataManager::keywordName (const String& keyword) const
 {
     char strc[8];
-    sprintf (strc, "_%i", seqnr_p);
+    snprintf (strc, sizeof(strc), "_%i", seqnr_p);
     return keyword + strc;
 }
 
@@ -265,7 +265,7 @@ String DataManager::keywordName (const String& keyword) const
 String DataManager::fileName() const
 {
     char strc[8];
-    sprintf (strc, ".f%i", seqnr_p);
+    snprintf (strc, sizeof(strc), ".f%i", seqnr_p);
     return table_p->tableName() + "/table" + strc;
 }
 

--- a/tables/DataMan/ISMIndColumn.cc
+++ b/tables/DataMan/ISMIndColumn.cc
@@ -36,7 +36,7 @@
 #include <casacore/casa/OS/LECanonicalConversion.h>
 #include <casacore/tables/DataMan/DataManError.h>
 
-#include <casacore/casa/stdio.h>                     // for sprintf
+#include <casacore/casa/stdio.h>                     // for snprintf
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -283,7 +283,7 @@ void ISMIndColumn::init (ByteIO::OpenOption fileOption)
         iosfile_p = stmanPtr_p->openArrayFile (fileOption);
     } else {
         char strc[8];
-	sprintf (strc, "i%i", seqnr_p);
+	snprintf (strc, sizeof(strc), "i%i", seqnr_p);
 	iosfile_p = new StManArrayFile (stmanPtr_p->fileName() + strc,
 					fileOption, 1, asBigEndian);
     }

--- a/tables/DataMan/StIndArrAIO.cc
+++ b/tables/DataMan/StIndArrAIO.cc
@@ -32,7 +32,7 @@
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/tables/DataMan/DataManError.h>
-#include <casacore/casa/stdio.h>                            //# for sprintf
+#include <casacore/casa/stdio.h>                            //# for snprintf
 
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -89,7 +89,7 @@ void StManColumnIndArrayAipsIO::openFile (ByteIO::OpenOption opt)
         //# Open/create the file holding the arrays in the column.
         if (iosfile_p == 0) {
 	  char strc[8];
-	  sprintf (strc, "i%i", seqnr_p);
+	  snprintf (strc, sizeof(strc), "i%i", seqnr_p);
 	  iosfile_p = new StManArrayFile (stmanPtr_p->fileName() + strc, opt);
 	} else {
 	  iosfile_p->resync();

--- a/tables/DataMan/TSMFile.cc
+++ b/tables/DataMan/TSMFile.cc
@@ -32,7 +32,7 @@
 #include <casacore/tables/DataMan/DataManError.h>
 #include <casacore/casa/IO/AipsIO.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/stdio.h>		// for sprintf
+#include <casacore/casa/stdio.h>		// for snprintf
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 TSMFile::TSMFile (const TiledStMan* stman, uInt fileSequenceNr,
@@ -44,7 +44,7 @@ TSMFile::TSMFile (const TiledStMan* stman, uInt fileSequenceNr,
 {
     // Create the file.
     char strc[8];
-    sprintf (strc, "_TSM%i", fileSeqnr_p);
+    snprintf (strc, sizeof(strc), "_TSM%i", fileSeqnr_p);
     String fileName = stman->fileName() + strc;
     Bool mapOpt = tsmOpt.option() == TSMOption::MMap;
     uInt bufSize = 0;
@@ -81,7 +81,7 @@ TSMFile::TSMFile (const TiledStMan* stman, AipsIO& ios, uInt seqnr,
                                   stman->dataManagerName());
     }
     char strc[8];
-    sprintf (strc, "_TSM%i", fileSeqnr_p);
+    snprintf (strc, sizeof(strc), "_TSM%i", fileSeqnr_p);
     String fileName = stman->fileName() + strc;
     Bool mapOpt = tsmOpt.option() == TSMOption::MMap;
     uInt bufSize = 0;

--- a/tables/DataMan/test/tForwardCol.cc
+++ b/tables/DataMan/test/tForwardCol.cc
@@ -128,7 +128,7 @@ void a (const TableDesc& td)
 	ac.put (i, i+1);
 	ad.put (i, i+2);
 	ae.put (i, i+3);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	af.put (i, str);
 	arr1.put(i,arrf);
 	arr2.put(i,arrf);
@@ -231,7 +231,7 @@ void check(const String& tableName, Int abOffset, Int acOffset)
 	ae.get (i, aeval);
 	af.get (i, afval);
 	ag.get (i, agval);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	if (abval != i+abOffset  ||  acval != i+1+acOffset
         ||  Int(adval) != i+2  ||  aeval != i+3
 	||  afval != str  ||  agval != DComplex(i+2)) {

--- a/tables/DataMan/test/tForwardColRow.cc
+++ b/tables/DataMan/test/tForwardColRow.cc
@@ -126,7 +126,7 @@ void a (const TableDesc& td)
 	ac.put (i, i+1);
 	ad.put (i, i+2);
 	ae.put (i, i+3);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	af.put (i, str);
 	arr1.put(i,arrf);
 	arr2.put(i,arrf);
@@ -231,7 +231,7 @@ void check(const String& tableName, Int abOffset, Int acOffset)
 	    ae.get (i, aeval);
 	    af.get (i, afval);
 	    ag.get (i, agval);
-	    sprintf (str, "V%i", vali);
+	    snprintf (str, sizeof(str), "V%i", vali);
 	    if (abval != Int(vali)+abOffset  ||  acval != Int(vali)+1+acOffset
 		||  adval != vali+2  ||  aeval != vali+3
 		||  afval != str  ||  agval != DComplex(vali+2)) {

--- a/tables/DataMan/test/tStArrayFile.cc
+++ b/tables/DataMan/test/tStArrayFile.cc
@@ -30,7 +30,7 @@
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/iostream.h>
 #include <casacore/casa/sstream.h>
-#include <casacore/casa/stdio.h>                           // for sprintf
+#include <casacore/casa/stdio.h>                           // for snprintf
 
 #include <casacore/casa/namespace.h>
 // <summary> Test program for the StManArrayFile class </summary>
@@ -97,7 +97,7 @@ void a (Bool canonical, uInt version,
 	}
 	ibuf[i] = i;
 	cbuf[i] = Complex(i+1,i+2);
-	sprintf (str, "str %d", i);
+	snprintf (str, sizeof(str), "str %d", i);
 	sbuf[i] = str;
     }
     StManArrayFile io("tStArrayFile_tmp.data", ByteIO::New, version,
@@ -148,7 +148,7 @@ void b (Bool canonical, Int64 off1, Int64 off2, Int64 off3, Int64 off4,
     char str[16];
     Int i;
     for (i=0; i<10000; i++) {
-	sprintf (str, "str %d", i);
+        snprintf (str, sizeof(str), "str %d", i);
 	sbuf[i] = str;
     }
     uInt l1 = io.getShape (off1, shp);
@@ -233,7 +233,7 @@ void c (Bool canonical, Int64 off1, Int64 off2, Int64 off3, Int64 off4)
     char str[16];
     uInt i;
     for (i=0; i<10000; i++) {
-	sprintf (str, "str %d", i);
+        snprintf (str, sizeof(str), "str %d", i);
 	sbuf[i] = str;
     }
     uInt l1 = io.getShape (off1, shp);

--- a/tables/DataMan/test/tStMan.cc
+++ b/tables/DataMan/test/tStMan.cc
@@ -294,7 +294,7 @@ void checktab (const String& prefix)
     String s1(prefix + "str1_");
     String s2(prefix + "str2_");
     for (uInt i=0; i<nrrow; i++) {
-      sprintf (buf, "%d", i);
+      snprintf (buf, sizeof(buf), "%d", i);
       s1 += buf;
       s2 += buf;
       if (s2.length() > 20) {
@@ -411,7 +411,7 @@ void checktab (const String& prefix)
     Array<DComplex> dcarr2 = dca2.getColumn().reform(IPosition(2,2,3*nrrow));
     Array<DComplex> dcarr3 = dca3.getColumn().reform(IPosition(2,2,3*nrrow));
     for (uInt i=0; i<nrrow; i++) {
-      sprintf (buf, "%d", i);
+      snprintf (buf, sizeof(buf), "%d", i);
       s1 += buf;
       s2 += buf;
       if (s2.length() > 20) {
@@ -508,7 +508,7 @@ void checktab (const String& prefix)
 						   IPosition(2,1,2))).
                              reform(IPosition(2,1,2*nrrow));
     for (uInt i=0; i<nrrow; i++) {
-      sprintf (buf, "%d", i);
+      snprintf (buf, sizeof(buf), "%d", i);
       s1 += buf;
       s2 += buf;
       if (s2.length() > 20) {
@@ -608,7 +608,7 @@ void extab (const String& prefix)
   String s2(prefix + "str2_");
   uInt nrrow = tab.nrow();
   for (uInt i=0; i<nrrow; i++) {
-    sprintf (buf, "%d", i);
+    snprintf (buf, sizeof(buf), "%d", i);
     s1 += buf;
     s2 += buf;
     if (s2.length() > 20) {

--- a/tables/DataMan/test/tVirtualTaQLColumn.cc
+++ b/tables/DataMan/test/tVirtualTaQLColumn.cc
@@ -155,7 +155,7 @@ void a (const TableDesc& td)
 	ac.put (i, i+1);
 	ad.put (i, i+2);
 	ae.put (i, i+3);
-	sprintf (str, "V%i_", i);
+	snprintf (str, sizeof(str), "V%i_", i);
 	af.put (i, str);
 	arr1.put(i,arrf);
 	arr2.put(i,arrf);
@@ -222,7 +222,7 @@ void check(const Table& tab, Bool showname)
 	acalc3.get (i, acalc3val);
 	acalc4.get (i, acalc4val);
 	acalcaf.get (i, acalcafval);
-	sprintf (str, "V%i_", i);
+	snprintf (str, sizeof(str), "V%i_", i);
 	if (abval != i  ||  acval != i+1
         ||  Int(adval) != i+2  ||  aeval != i+3
 	||  afval != str  ||  agval != DComplex(i+2)

--- a/tables/Tables/ReadAsciiTable.cc
+++ b/tables/Tables/ReadAsciiTable.cc
@@ -185,7 +185,7 @@ void ReadAsciiTable::getTypes (const IPosition& shape,
 	string1++;
 	char name[24];
 	i++;
-	sprintf (name, " Column%i", i);
+	snprintf (name, sizeof(name), " Column%i", i);
 	strcpy (string2, name);
 	string2 += strlen(name);
 	string2[0] = '\0';

--- a/tables/Tables/TableProxy.cc
+++ b/tables/Tables/TableProxy.cc
@@ -62,7 +62,7 @@
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/iostream.h>
 #include <casacore/casa/sstream.h>
-#include <casacore/casa/stdio.h>                  // needed for sprintf
+#include <casacore/casa/stdio.h>                  // needed for snprintf
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -1172,7 +1172,7 @@ Record TableProxy::getVarColumn (const String& columnName,
   char namebuf[22];
   for (Int64 i=0; i<nrows; i++) {
     // Add the result to the record with field name formed from 1-based rownr.
-    sprintf (namebuf, "r%lli", row+1);
+    snprintf (namebuf, sizeof(namebuf), "r%lli", row+1);
     if (tabcol.isDefined(row)) {
       getValueFromTable(columnName, row, 1, 1, False).toRecord (rec, namebuf);
     } else {

--- a/tables/Tables/test/tColumnsIndex.cc
+++ b/tables/Tables/test/tColumnsIndex.cc
@@ -88,7 +88,7 @@ void a()
 	adouble.put (i, i);
 	acomplex.put (i, Complex(i,0));
 	adcomplex.put (i, DComplex(0,i));
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	astring.put (i, str);
     }
 }
@@ -137,7 +137,7 @@ void b()
         *adouble = i;
         *acomplex = Complex(i,0);
         *adcomplex = DComplex(0,i);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
         *astring = str;
         AlwaysAssertExit ( (colInx1.getRowNumber(found) == i  && found));
         AlwaysAssertExit ( (colInx2.getRowNumber(found) == i  && found));

--- a/tables/Tables/test/tConcatTable.cc
+++ b/tables/Tables/test/tConcatTable.cc
@@ -135,7 +135,7 @@ void doIt (const Table& tab)
     ae.get (i, aeval);
     af.get (i, afval);
     ag.get (i, agval);
-    sprintf (str, "V%i", i);
+    snprintf (str, sizeof(str), "V%i", i);
     if (abval != Int(i)  ||  acval != Int(i+1)  ||  adval != i+2
         ||  aeval != i+3  ||  afval != str  ||  agval != DComplex(i+2)) {
       cout << "error in row " << i << ": " << abval

--- a/tables/Tables/test/tConcatTable2.cc
+++ b/tables/Tables/test/tConcatTable2.cc
@@ -101,7 +101,7 @@ void fill(const String& name, const String& name2, Int stval)
     adouble.put (i, stval);
     acomplex.put (i, Complex(stval,0));
     adcomplex.put (i, DComplex(0,stval));
-    sprintf (str, "V%i", stval);
+    snprintf (str, sizeof(str), "V%i", stval);
     astring.put (i, str);
     ++stval;
   }
@@ -164,7 +164,7 @@ void checkTable (const Table& tab, uInt nkey, uInt nsubrow, Int stval,
     AlwaysAssertExit (adouble(row) == stval);
     AlwaysAssertExit (acomplex(row) == Complex(stval,0));
     AlwaysAssertExit (adcomplex(row) == DComplex(0,stval));
-    sprintf (str, "V%i", stval);
+    snprintf (str, sizeof(str), "V%i", stval);
     AlwaysAssertExit (astring(row) == str);
     ++stval;
   }

--- a/tables/Tables/test/tTable.cc
+++ b/tables/Tables/test/tTable.cc
@@ -201,7 +201,7 @@ void a (const StorageOption& stopt, Bool doExcp)
     for (i=0; i<tab.nrow(); i++) {
 	ac.put (i, i+1);
 	ae.put (i, i+3);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	af.put (i, str);
     }
     Vector<float> vec2;
@@ -317,7 +317,7 @@ void b (Bool doExcp)
 	ae.get (i, aeval);
 	af.get (i, afval);
 	ag.get (i, agval);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	if (abval != Int(i)  ||  acval != Int(i+1)
         ||  adval != i+2  ||  aeval != i+3
 	||  afval != str  ||  agval != DComplex(i+2)) {
@@ -665,7 +665,7 @@ void c (const StorageOption& stopt, Bool doExcp)
 	ac.put (i, i+1);
 	ad.put (i, i+2);
 	ae.put (i, i+3);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	af.put (i, str);
 	arr1.put(i,arrf);
 	arr2.put(i,arrf);

--- a/tables/Tables/test/tTable_2.cc
+++ b/tables/Tables/test/tTable_2.cc
@@ -111,7 +111,7 @@ void doIt (const String& tableName)
 	ae.get (i, aeval);
 	af.get (i, afval);
 	ag.get (i, agval);
-	sprintf (str, "V%i", i);
+	snprintf (str, sizeof(str), "V%i", i);
 	if (abval != Int(i)  ||  acval != Int(i+1)  ||  adval != i+2
         ||  aeval != i+3  ||  afval != str  ||  agval != DComplex(i+2)) {
 	    cout << "error in row " << i << ": " << abval


### PR DESCRIPTION
clang warned that the insecure sprintf should be replaced by snprintf.
It was easy to do; only fits.h/cc required a bit more work.