### PR TITLE
updated AdiosStMan for API update in ADIOS2

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -454,11 +454,11 @@ void Adios2StMan::impl::create64(rownr_t  aNrRows)
     itsRows = aNrRows;
     itsAdiosEngine = std::make_shared<adios2::Engine>(
         itsAdiosIO->Open(fileName() + ".bp", adios2::Mode::Write));
+    itsAdiosEngine->BeginStep();
     for (uInt i = 0; i < ncolumn(); ++i)
     {
         itsColumnPtrBlk[i]->create(itsAdiosEngine, 'w');
     }
-    itsAdiosEngine->BeginStep();
 }
 
 rownr_t Adios2StMan::impl::open64(rownr_t aNrRows, AipsIO &ios)
@@ -466,11 +466,11 @@ rownr_t Adios2StMan::impl::open64(rownr_t aNrRows, AipsIO &ios)
     itsRows = aNrRows;
     itsAdiosEngine = std::make_shared<adios2::Engine>(
         itsAdiosIO->Open(fileName() + ".bp", adios2::Mode::Read));
+    itsAdiosEngine->BeginStep();
     for (uInt i = 0; i < ncolumn(); ++i)
     {
         itsColumnPtrBlk[i]->create(itsAdiosEngine, 'r');
     }
-    itsAdiosEngine->BeginStep();
 
     ios.getstart(DATA_MANAGER_TYPE);
     ios >> itsDataManName;


### PR DESCRIPTION
A change in the most recent ADIOS2 (2.10) API requires the BeginStep call to be earlier in the column creation/ data writing process.