### PR TITLE
Install newer numpy for python wheels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 3.6.1
+
+ - Use the latest numpy for dockers; this should make python-casacore compatible with numpy 2.0.
+
+
 # 3.6.0
 
 ## General

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.3.0)
 
-project(casacore VERSION 3.6.0)
+project(casacore VERSION 3.6.1)
 
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)

--- a/docker/py_wheel.docker
+++ b/docker/py_wheel.docker
@@ -55,8 +55,8 @@ RUN ./b2 -j${THREADS} \
     cxxflags="-fPIC -I/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}${PYUNICODE}/" \
     link=static,shared install
 
-# casacore wants numpy
-RUN /opt/python/${TARGET}/bin/pip install oldest_supported_numpy
+# casacore wants numpy. Do not take oldest_supported_numpy, because we want numpy 2.0 compatibility
+RUN /opt/python/${TARGET}/bin/pip install numpy
 
 # set up casacore
 ADD . /code


### PR DESCRIPTION
When compiling with `oldest_supported_numpy`, the resulting package is incompatible with numpy 2.0. Using the latest numpy should get us numpy 2.0 compatibility.