### PR TITLE
Fix Dysco test compilation issue with older Boost versions

### DIFF
--- a/tables/Dysco/CMakeLists.txt
+++ b/tables/Dysco/CMakeLists.txt
@@ -43,19 +43,20 @@ set_property(TARGET dyscostman-object PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 set(DYSCOSTMAN_SOURCES $<TARGET_OBJECTS:dyscostman-object> PARENT_SCOPE)
 set(DYSCOSTMAN_LIBRARIES ${GSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} PARENT_SCOPE)
-find_package(Boost COMPONENTS system filesystem unit_test_framework)
-if(Boost_FOUND)
-	include_directories(${Boost_INCLUDE_DIR})
-  add_executable(tDysco
-    $<TARGET_OBJECTS:dyscostman-object>
-    tests/runtests.cc 
-    tests/testbytepacking.cc
-    tests/testdyscostman.cc
-    tests/testtimeblockencoder.cc
-    )
-  target_link_libraries(tDysco ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} casa_tables casa_casa)
-  add_test(tDysco tDysco)
-else()
-  message("Boost testing framework not found.")
+if(BUILD_TESTING)
+  find_package(Boost 1.72 COMPONENTS system filesystem unit_test_framework)
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIR})
+    add_executable(tDysco
+      $<TARGET_OBJECTS:dyscostman-object>
+      tests/runtests.cc
+      tests/testbytepacking.cc
+      tests/testdyscostman.cc
+      tests/testtimeblockencoder.cc
+      )
+    target_link_libraries(tDysco ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} casa_tables casa_casa)
+    add_test(tDysco tDysco)
+  else()
+    message("Boost testing framework not found.")
+  endif()
 endif()
-


### PR DESCRIPTION
The tests for Dysco were compiled unconditionally (i.e., irrespective of whether `BUILD_TESTING` was set to `ON` or `OFF`), which triggered an issue on systems with older Boost libraries (<1.72). This has been fixed.