### PR TITLE
Fix library name in FindSOFA.cmake

### DIFF
--- a/cmake/FindSOFA.cmake
+++ b/cmake/FindSOFA.cmake
@@ -9,7 +9,7 @@
 
 if(NOT SOFA_FOUND)
 
-  find_library(SOFA_LIBRARY sofa
+  find_library(SOFA_LIBRARY NAMES sofa_c sofa
     HINTS ${SOFA_ROOT_DIR} PATH_SUFFIXES lib)
   mark_as_advanced(SOFA_LIBRARY)
 


### PR DESCRIPTION
The installed SOFA library is normally named `libsofa_c.a`. The alternative name is retained to allow backwards compatibility (if in fact the other name ever worked -- I have not searched SOFA archives to determine if the other name was valid at some point in the past.)