### PR TITLE
Only look for SOFA with testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,11 @@ find_package (DL)
 if (USE_READLINE)
     find_package (Readline REQUIRED)
 endif (USE_READLINE)
-find_package (SOFA)
+
+if (BUILD_TESTING)
+    find_package (SOFA)
+endif()
+
 if (USE_ADIOS2)
     find_package (ADIOS2 2.6.0 CONFIG REQUIRED)
     if(NOT USE_MPI)


### PR DESCRIPTION
SOFA is only used for testing, so we don't need to look for it when not building testing. This will suppress the warning "SOFA not found" for most users, possibly reducing confusion.