### PR TITLE
Properly reset class variables in FITS-IDI filler

### DIFF
--- a/msfits/MSFits/FitsIDItoMS.cc
+++ b/msfits/MSFits/FitsIDItoMS.cc
@@ -202,11 +202,13 @@ FITSIDItoMS1::FITSIDItoMS1(FitsInput& fitsin, const String& correlat,
       firstWeather = True;
       firstGainCurve = True;
       firstPhaseCal = True;
+      firstEOP = True;
       weather_hasWater_p = False;
       weather_hasElectron_p = False;
       antIdFromNo.clear();
       digiLevels.clear();
       rdate = 0.;
+      array_p = "";
   }
   
   //
@@ -2584,7 +2586,7 @@ void FITSIDItoMS1::fillAntennaTable()
      }
      else{
        if(array_p != arrnam){
-	 *itsLog << LogIO::WARN << "Conflicting observatory names: found "
+	 *itsLog << LogIO::SEVERE << "Conflicting observatory names: found "
 		 << arrnam << " and " << array_p << LogIO::POST;
        }
      }


### PR DESCRIPTION
In particular, clear the array name when processing the primary HDU. This makes sure converting multiple FITS-IDI files from different arrays will correctly identify the array and make the appropriate digital corrections for the various array/correlator combinations. Change the warning about conflicting observatory names to SEVERE as this now only applies to conflicting names within a single FITS-IDI file, which would be serious trouble as the wrong digital corrections would probably be applied.  This should not happen in real life.