### PR TITLE
Support compilation with c++23 turned on

### DIFF
--- a/casa/Logging/LogMessage.cc
+++ b/casa/Logging/LogMessage.cc
@@ -182,7 +182,7 @@ String LogMessage::toString() const
 
   ostringstream os;
   os << header << "\t" << message;
-  return os;
+  return String(os);
 }
 
 String LogMessage::toTermString() const
@@ -208,7 +208,7 @@ String LogMessage::toTermString() const
   os << header << "\n" << message;
   //String pr = toString(priority());
   //os << pr.resize(6, ' ') << "   " << message;
-  return os;
+  return String(os);
 }
 
 ostream &operator<<(ostream &os, const LogMessage &message)

--- a/casa/Logging/LogOrigin.cc
+++ b/casa/Logging/LogOrigin.cc
@@ -198,7 +198,7 @@ String LogOrigin::location() const
 	}
 	os << ")";
     }
-    return os;
+    return String(os);
 }
 
 String LogOrigin::toString() const

--- a/casa/OS/Time.cc
+++ b/casa/OS/Time.cc
@@ -296,7 +296,7 @@ String Time::toString(const Bool iso) const
       out<<year;
   }
 
-  return out;
+  return String(out);
 }
 
 istream& operator>>(istream& in, Time& other) {

--- a/casa/Quanta/MVAngle.cc
+++ b/casa/Quanta/MVAngle.cc
@@ -199,7 +199,7 @@ String MVAngle::string(uInt intyp, uInt inprec) const {
 String MVAngle::string(const MVAngle::Format &form) const {
     ostringstream oss;
     print (oss, form);
-    return oss;
+    return String(oss);
 }
 
 Double MVAngle::timeZone() {

--- a/casa/Quanta/MVTime.cc
+++ b/casa/Quanta/MVTime.cc
@@ -357,7 +357,7 @@ String MVTime::string(uInt intyp, uInt inprec) const {
 String MVTime::string(const MVTime::Format &form) const {
     ostringstream oss;
     print (oss, form);
-    return oss;
+    return String(oss);
 }
 
 Double MVTime::timeZone() {


### PR DESCRIPTION
Due to change of rules in implicit move in C++23, at least with GCC (14) there are a few lines that no longer compiled. This has to do with the move-only class ostringstream, which seem to hide the conversion constructor of String.

The changes are of course backward compatible, so that c++23 is not required.