### PR TITLE
Use new Python find strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ if (POLICY CMP0074)
     cmake_policy (SET CMP0074 NEW)
 endif()
 
+# Use LOCATION as Python find strategy.
+if (POLICY CMP0094)
+    cmake_policy (SET CMP0094 NEW)
+endif()
+
 # Increment the PROJECT_SOVERSION every time you update VERSION_MINOR!
 SET(PROJECT_SOVERSION 8)
 

--- a/python3/CMakeLists-cmake3.14.txt
+++ b/python3/CMakeLists-cmake3.14.txt
@@ -80,4 +80,3 @@ if (NOT BUILD_PYTHON)
     DESTINATION include/casacore/python
     )
 endif (NOT BUILD_PYTHON)
-


### PR DESCRIPTION
Ensure that CasaCore uses the new "LOCATION" strategy for finding Python, which will become the default in the future.

With the old strategy, CasaCore will not build if a system has for example both Python 3.10 and 3.12, while only 3.10 has all required development features.