### PR TITLE
Add SimpleColumnarFile class for use in Stokes I stman

### DIFF
--- a/tables/AlternateMans/BitPacking.h
+++ b/tables/AlternateMans/BitPacking.h
@@ -1,0 +1,48 @@
+#ifndef CASACORE_TABLES_BITPACKING_H_
+#define CASACORE_TABLES_BITPACKING_H_
+
+#include <cstring>
+
+inline void PackBoolArray(unsigned char* packed_buffer, const bool* input,
+                          size_t n) {
+  const size_t limit = n / 8;
+  const bool* end = input + n;
+  for (size_t i = 0; i != limit; ++i) {
+    *packed_buffer = 0;
+    for (size_t b = 0; b != 8; ++b) {
+      *packed_buffer |= (*input) << b;
+      ++input;
+    }
+    ++packed_buffer;
+  }
+  size_t b = 0;
+  if (input != end) {
+    *packed_buffer = 0;
+    do {
+      *packed_buffer |= (*input) << b;
+      ++input;
+      ++b;
+    } while (input != end);
+  }
+}
+
+inline void UnpackBoolArray(bool* output, const unsigned char* packed_input,
+                            size_t n) {
+  bool* end = output + n;
+  const size_t limit = n / 8;
+  for (size_t i = 0; i != limit; i++) {
+    for (size_t b = 0; b != 8; ++b) {
+      *output = (*packed_input >> b) & 0x1;
+      ++output;
+    }
+    ++packed_input;
+  }
+  size_t b = 0;
+  while (output != end) {
+    *output = (*packed_input >> b) & 0x1;
+    ++output;
+    ++b;
+  }
+}
+
+#endif

--- a/tables/AlternateMans/RowBasedFile.h
+++ b/tables/AlternateMans/RowBasedFile.h
@@ -27,7 +27,9 @@ class RowBasedFile {
     rhs.filename_ = "";
   }
 
-  // Create or overwrite a new columnar file on disk
+  /**
+   * Create or overwrite a new columnar file on disk
+   */
   RowBasedFile(const std::string& filename, uint64_t header_size,
                uint64_t stride)
       : stride_(stride), filename_(filename) {
@@ -40,7 +42,9 @@ class RowBasedFile {
     data_location_ = header_size + kPrivateHeaderSize;
   }
 
-  // Open an existing columnar file
+  /**
+   * Open an existing columnar file
+   */
   RowBasedFile(const std::string& filename, size_t header_size)
       : filename_(filename) {
     file_ = open(filename.c_str(), O_RDWR);
@@ -67,7 +71,7 @@ class RowBasedFile {
 
   /**
    * Close the file. After closing, all calls to I/O functions
-   * cause undefined behaviour, untill the class is assigned to
+   * cause undefined behaviour, until the class is assigned to
    * a new instance.
    */
   void Close() {
@@ -124,7 +128,7 @@ class RowBasedFile {
   /**
    * Number of bytes reserved for an optional header.
    */
-  uint64_t HeaderSize() const { return data_location_ - sizeof(stride_); }
+  uint64_t HeaderSize() const { return data_location_ - kPrivateHeaderSize; }
   /**
    * Write an optional extra header to the file. When creating the file,
    * the requested space is saved to store this header.

--- a/tables/AlternateMans/RowBasedFile.h
+++ b/tables/AlternateMans/RowBasedFile.h
@@ -78,9 +78,9 @@ class RowBasedFile {
     if (IsOpen()) {
       Truncate(NRows());
       int result = close(file_);
+      file_ = -1;
       if (result < 0)
         throw std::runtime_error("Could not close file " + filename_);
-      file_ = -1;
       n_rows_ = 0;
       stride_ = 0;
       filename_ = "";

--- a/tables/AlternateMans/RowBasedFile.h
+++ b/tables/AlternateMans/RowBasedFile.h
@@ -1,0 +1,194 @@
+#ifndef CASACORE_ROW_BASED_FILE_H_
+#define CASACORE_ROW_BASED_FILE_H_
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace casacore {
+
+class RowBasedFile {
+ public:
+  RowBasedFile() = default;
+  RowBasedFile(const RowBasedFile& rhs) = delete;
+  RowBasedFile(RowBasedFile&& rhs) noexcept
+      : file_(rhs.file_),
+        n_rows_(rhs.n_rows_),
+        stride_(rhs.stride_),
+        data_location_(rhs.data_location_),
+        filename_(rhs.filename_) {
+    rhs.file_ = -1;
+    rhs.n_rows_ = 0;
+    rhs.stride_ = 0;
+    rhs.data_location_ = kPrivateHeaderSize;
+    rhs.filename_ = "";
+  }
+
+  // Create or overwrite a new columnar file on disk
+  RowBasedFile(const std::string& filename, uint64_t header_size,
+               uint64_t stride)
+      : stride_(stride), filename_(filename) {
+    file_ = open(filename.c_str(), O_CREAT | O_RDWR | O_TRUNC,
+                 S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (file_ < 0)
+      throw std::runtime_error("I/O error: could not create new file '" +
+                               filename + "'");
+    WriteData(reinterpret_cast<unsigned char*>(&stride_), sizeof(stride_));
+    data_location_ = header_size + kPrivateHeaderSize;
+  }
+
+  // Open an existing columnar file
+  RowBasedFile(const std::string& filename, size_t header_size)
+      : filename_(filename) {
+    file_ = open(filename.c_str(), O_RDWR);
+    if (file_ < 0)
+      throw std::runtime_error("I/O error: could not open file '" + filename +
+                               "'");
+    ReadData(reinterpret_cast<unsigned char*>(&stride_), kPrivateHeaderSize);
+    data_location_ = header_size + kPrivateHeaderSize;
+    const uint64_t pos = lseek(file_, 0, SEEK_END);
+    n_rows_ = stride_ == 0 ? 0 : (pos - data_location_) / stride_;
+  }
+  ~RowBasedFile() noexcept {
+    if (IsOpen()) close(file_);
+  }
+  RowBasedFile& operator=(RowBasedFile&& rhs) {
+    Close();
+    std::swap(file_, rhs.file_);
+    std::swap(n_rows_, rhs.n_rows_);
+    std::swap(stride_, rhs.stride_);
+    std::swap(data_location_, rhs.data_location_);
+    std::swap(filename_, rhs.filename_);
+    return *this;
+  }
+
+  /**
+   * Close the file. After closing, all calls to I/O functions
+   * cause undefined behaviour, untill the class is assigned to
+   * a new instance.
+   */
+  void Close() {
+    if (IsOpen()) {
+      Truncate(NRows());
+      int result = close(file_);
+      if (result < 0)
+        throw std::runtime_error("Could not close file " + filename_);
+      file_ = -1;
+      n_rows_ = 0;
+      stride_ = 0;
+      filename_ = "";
+    }
+  }
+
+  void Truncate(uint64_t n_rows) {
+    const int result = ftruncate(file_, n_rows_ * stride_ + data_location_);
+    if (result < 0) {
+      char errstr[128];
+      char* msg = strerror_r(errno, errstr, 128);
+      throw std::runtime_error("I/O error: could not truncate file '" +
+                               filename_ + "' to have " +
+                               std::to_string(n_rows) + " rows: " + msg);
+    }
+  }
+
+  void Seek(off_t pos, int seek_direction) {
+    const off_t result = lseek(file_, pos, seek_direction);
+    if (result < 0)
+      throw std::runtime_error("I/O error: could not seek through file '" +
+                               filename_ + "'");
+  }
+
+  void ReadData(unsigned char* data, uint64_t size) {
+    const int result = ::read(file_, data, size);
+    if (result < 0)
+      throw std::runtime_error("I/O error: could not read from file '" +
+                               filename_ + "'");
+  }
+
+  void WriteData(const unsigned char* data, uint64_t size) {
+    const int result = write(file_, data, size);
+    if (result < 0)
+      throw std::runtime_error("I/O error: could not write to file '" +
+                               filename_ + "'");
+  }
+  bool IsOpen() const { return file_ >= 0; }
+  /**
+   * Offset of the first row in the file. When using Seek() to move to
+   * a row, this number should be added to the offset.
+   */
+  uint64_t DataLocation() const { return data_location_; }
+  const std::string& Filename() const { return filename_; }
+  /**
+   * Number of bytes reserved for an optional header.
+   */
+  uint64_t HeaderSize() const { return data_location_ - sizeof(stride_); }
+  /**
+   * Write an optional extra header to the file. When creating the file,
+   * the requested space is saved to store this header.
+   * @param data An array equal to the size of the header given
+   * in the @ref CreateNew() and @ref OpenExisting() calls.
+   */
+  void WriteHeader(const unsigned char* data) {
+    Seek(kPrivateHeaderSize, SEEK_SET);
+    WriteData(data, data_location_ - kPrivateHeaderSize);
+  }
+  /**
+   * Read an optional extra header to the file. @see WriteHeader().
+   */
+  void ReadHeader(unsigned char* data) {
+    Seek(kPrivateHeaderSize, SEEK_SET);
+    ReadData(data, data_location_ - kPrivateHeaderSize);
+  }
+  /**
+   * Total number of rows stored in this file.
+   */
+  uint64_t NRows() const { return n_rows_; }
+  void SetNRows(uint64_t new_n_rows) { n_rows_ = new_n_rows; }
+  /**
+   * Total number of bytes in one row. This value is also stored in the file,
+   * and is read from the file in @ref OpenExisting().
+   */
+  uint64_t Stride() const { return stride_; }
+  /**
+   * Set the number of bytes per row for this file. This changes the format
+   * of the file, and because of this the file is emptied.
+   */
+  void SetStride(uint64_t new_stride) {
+    Truncate(0);
+    n_rows_ = 0;
+    stride_ = new_stride;
+    Seek(0, SEEK_SET);
+    WriteData(reinterpret_cast<unsigned char*>(&stride_), sizeof(stride_));
+  }
+
+  /**
+   * Adds a given number of rows to the back of the file.
+   */
+  void AddRows(uint64_t n_rows) { SetNRows(NRows() + n_rows); }
+
+  /**
+   * Deletes the last row.
+   */
+  void DeleteRow() {
+    if (NRows() > 0) {
+      SetNRows(NRows() - 1);
+    }
+  }
+
+ private:
+  // The "C" file API is used because we need to use (f)truncate, which is not
+  // available from the C++ fstream API.
+  int file_ = -1;
+  uint64_t n_rows_ = 0;
+  uint64_t stride_ = 0;
+  static constexpr uint64_t kPrivateHeaderSize = sizeof(stride_);
+  uint64_t data_location_ = kPrivateHeaderSize;
+  std::string filename_;
+};
+
+}  // namespace casacore
+
+#endif

--- a/tables/AlternateMans/SimpleColumnarFile.h
+++ b/tables/AlternateMans/SimpleColumnarFile.h
@@ -1,0 +1,153 @@
+#ifndef CASACORE_COLUMNAR_FILE_H_
+#define CASACORE_COLUMNAR_FILE_H_
+
+#include <cassert>
+#include <complex>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "BitPacking.h"
+#include "RowBasedFile.h"
+
+namespace casacore {
+
+/**
+ * Class that provides binary table I/O. It is similar to
+ * @ref BufferedColumnarFile, but is a simple implementation to demonstrate the
+ * interface and to test the base class @ref RowBasedFile. For documentation,
+ * see @ref BufferedColumnarFile.
+ *
+ * This class writes the data in a cell directly to file when @ref Write() is
+ * called, and always reads it back when @ref Read() is called.
+ */
+class SimpleColumnarFile : private RowBasedFile {
+ public:
+  using RowBasedFile::AddRows;
+  using RowBasedFile::Close;
+  using RowBasedFile::DeleteRow;
+  using RowBasedFile::Filename;
+  using RowBasedFile::IsOpen;
+  using RowBasedFile::NRows;
+  using RowBasedFile::ReadHeader;
+  using RowBasedFile::Stride;
+  using RowBasedFile::WriteHeader;
+
+  SimpleColumnarFile() noexcept = default;
+
+  SimpleColumnarFile(const SimpleColumnarFile& rhs) = delete;
+  SimpleColumnarFile(SimpleColumnarFile&& rhs) noexcept
+      : packed_buffer_(std::move(rhs.packed_buffer_)) {}
+
+  ~SimpleColumnarFile() noexcept = default;
+
+  SimpleColumnarFile& operator=(SimpleColumnarFile&& rhs) {
+    RowBasedFile::operator=(std::move(rhs));
+    std::swap(packed_buffer_, rhs.packed_buffer_);
+    return *this;
+  }
+
+  static SimpleColumnarFile CreateNew(const std::string& filename,
+                                      uint64_t header_size, uint64_t stride) {
+    return SimpleColumnarFile(filename, header_size, stride);
+  }
+
+  static SimpleColumnarFile OpenExisting(const std::string& filename,
+                                         size_t header_size) {
+    return SimpleColumnarFile(filename, header_size);
+  }
+
+  void Read(uint64_t row, uint64_t column_offset, std::complex<float>* data,
+            uint64_t n) {
+    ReadImplementation(row, column_offset, data, n);
+  }
+  void Read(uint64_t row, uint64_t column_offset, float* data, uint64_t n) {
+    ReadImplementation(row, column_offset, data, n);
+  }
+  void Read(uint64_t row, uint64_t column_offset, double* data, uint64_t n) {
+    ReadImplementation(row, column_offset, data, n);
+  }
+  void Read(uint64_t row, uint64_t column_offset, bool* data, uint64_t n) {
+    const size_t byte_size = (n + 7) / 8;
+    assert(column_offset + byte_size <= Stride());
+    if (row >= NRows()) {
+      std::fill_n(data, n, false);
+    } else {
+      Seek(row * Stride() + column_offset + DataLocation(), SEEK_SET);
+      ReadData(packed_buffer_.data(), byte_size);
+      UnpackBoolArray(data, packed_buffer_.data(), n);
+    }
+  }
+  void Write(uint64_t row, uint64_t column_offset,
+             const std::complex<float>* data, uint64_t n) {
+    WriteImplementation(row, column_offset, data, n);
+  }
+  void Write(uint64_t row, uint64_t column_offset,
+             const std::complex<double>* data, uint64_t n) {
+    WriteImplementation(row, column_offset, data, n);
+  }
+  void Write(uint64_t row, uint64_t column_offset, float* data, uint64_t n) {
+    WriteImplementation(row, column_offset, data, n);
+  }
+  void Write(uint64_t row, uint64_t column_offset, double* data, uint64_t n) {
+    WriteImplementation(row, column_offset, data, n);
+  }
+  void Write(uint64_t row, uint64_t column_offset, const bool* data,
+             uint64_t n) {
+    assert(column_offset + n <= Stride());
+    PackBoolArray(packed_buffer_.data(), data, n);
+    Seek(row * Stride() + column_offset + DataLocation(), SEEK_SET);
+    WriteData(packed_buffer_.data(), n);
+    SetNRows(std::max(row + 1, NRows()));
+  }
+
+  /**
+   * Set the number of bytes per row for this file. This changes the format
+   * of the file, and because of this the file is emptied.
+   */
+  void SetStride(uint64_t new_stride) {
+    RowBasedFile::SetStride(new_stride);
+    packed_buffer_.resize((new_stride + 7) / 8);
+  }
+
+ private:
+  // Create or overwrite a new columnar file on disk
+  SimpleColumnarFile(const std::string& filename, uint64_t header_size,
+                     uint64_t stride)
+      : RowBasedFile(filename, header_size, stride),
+        packed_buffer_((stride + 7) / 8) {}
+
+  // Open an existing columnar file
+  SimpleColumnarFile(const std::string& filename, size_t header_size)
+      : RowBasedFile(filename, header_size) {
+    packed_buffer_.resize((Stride() + 7) / 8);
+  }
+
+  template <typename ValueType>
+  void ReadImplementation(uint64_t row, uint64_t column_offset, ValueType* data,
+                          uint64_t n) {
+    assert(column_offset + n * sizeof(ValueType) <= Stride());
+    if (row >= NRows()) {
+      std::fill_n(data, n, ValueType());
+    } else {
+      Seek(row * Stride() + column_offset + DataLocation(), SEEK_SET);
+      ReadData(reinterpret_cast<unsigned char*>(data), n * sizeof(ValueType));
+    }
+  }
+
+  template <typename ValueType>
+  void WriteImplementation(uint64_t row, uint64_t column_offset,
+                           const ValueType* data, uint64_t n) {
+    assert(column_offset + n * sizeof(ValueType) <= Stride());
+    Seek(row * Stride() + column_offset + DataLocation(), SEEK_SET);
+    WriteData(reinterpret_cast<const unsigned char*>(data),
+              n * sizeof(ValueType));
+    SetNRows(std::max(row + 1, NRows()));
+  }
+
+  std::vector<unsigned char> packed_buffer_;
+};
+
+}  // namespace casacore
+
+#endif


### PR DESCRIPTION
This PR merges towards the stokes--storage-manager and is part of several PRs that together will add this stman. The work is split in several PRs to allow easier reviewing.

The tests for these classes are here: https://github.com/casacore/casacore/pull/1381

The idea of the low-level class added in this PR is that it can be reused for further storage managers, like specialized antenna and uvw-column storage managers.