### PR TITLE
Verify files are proper FITS-IDI before conversion

### DIFF
--- a/msfits/MSFits/MSFitsIDI.cc
+++ b/msfits/MSFits/MSFitsIDI.cc
@@ -276,6 +276,12 @@ void MSFitsIDI::readFITSFile(Bool& atEnd)
     os << LogIO::SEVERE << "Error reading FITS input" << LogIO::EXCEPTION;
   }
 
+  // Make sure this is a FITS-IDI file; the Astropy FITS code may
+  // inadvertedly turn an valid FITS-IDI into a random groups FITS file.
+  if (infits.hdutype() != FITS::PrimaryArrayHDU) {
+    os << LogIO::SEVERE << "Not a FITS-IDI file" << LogIO::EXCEPTION;
+  }
+
   // Regular expression for trailing blanks
   Regex trailing(" *$");
 


### PR DESCRIPTION
The astropy.io.fits module inadvertedly converts FITS-IDI files into random group structure FITS.  Since casacore interprets FITS keywords differently for such files this results in misinterpretation of the origin of the FITS-IDI and therefore the digital corrections aren't applied correctly.  Prevent this by generating an error if the user tries to convert random groups FITS using the FITS-IDI conversion code.