### PR TITLE
Fix and perform boolean Stokes I checking

### DIFF
--- a/tables/AlternateMans/RowBasedFile.h
+++ b/tables/AlternateMans/RowBasedFile.h
@@ -232,7 +232,7 @@ class RowBasedFile {
 
     WriteData(private_header_buffer.data(), private_header_buffer.size());
   }
-  
+
   /**
    * The size of the private header that the writer creates for the current file
    * format. This number is written into the file. Whenever a file is read, the
@@ -277,12 +277,12 @@ class RowBasedFile {
     else
       return "Unknown error";
   }
-  
+
   static std::string ErrorStringHelper(char* returned_buffer,
                                        char* /*supplied_buffer*/) {
     return std::string(returned_buffer);
   }
-  
+
   static std::string ErrorString() {
     char errstr[128];
     // This is a small trick to allow both versions of strerror_r: by using


### PR DESCRIPTION
This performs two things:
- It adds a check to make sure all correlations have the same boolean values (~flags)
- It returns that boolean to all correlations, instead of returning false for the 2nd and 3rd correlation.