### PR TITLE
Various finishing touches for the compressing storage managers

### DIFF
--- a/docker/ubuntu2204_clang.docker
+++ b/docker/ubuntu2204_clang.docker
@@ -12,6 +12,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     wcslib-dev \
     libfftw3-dev \
     gfortran \
+    libc++-dev \
+    libc++abi-dev \
     libncurses5-dev \
     libreadline6-dev \
     libhdf5-serial-dev \
@@ -37,6 +39,7 @@ RUN useradd -ms /bin/bash casacore \
 USER casacore
 RUN mkdir /code/build
 WORKDIR /code/build
+ENV CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
 RUN cmake .. \
     -DBUILD_TESTING=ON \
     -DUSE_OPENMP=OFF \

--- a/docker/ubuntu2404_gcc.docker
+++ b/docker/ubuntu2404_gcc.docker
@@ -17,7 +17,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libreadline6-dev \
     libhdf5-serial-dev \
     libboost-dev \
+    libboost-filesystem-dev \
     libboost-python-dev \
+    libboost-system-dev \
     libboost-test-dev \
     libgsl-dev \
     python-is-python3 \

--- a/docker/ubuntu2404_gcc.docker
+++ b/docker/ubuntu2404_gcc.docker
@@ -17,9 +17,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libreadline6-dev \
     libhdf5-serial-dev \
     libboost-dev \
-    libboost-filesystem-dev \
     libboost-python-dev \
-    libboost-system-dev \
     libboost-test-dev \
     libgsl-dev \
     python-is-python3 \

--- a/tables/AlternateMans/SimpleColumnarFile.h
+++ b/tables/AlternateMans/SimpleColumnarFile.h
@@ -67,6 +67,9 @@ class SimpleColumnarFile : private RowBasedFile {
   void Read(uint64_t row, uint64_t column_offset, double* data, uint64_t n) {
     ReadImplementation(row, column_offset, data, n);
   }
+  void Read(uint64_t row, uint64_t column_offset, int32_t* data, uint64_t n) {
+    ReadImplementation(row, column_offset, data, n);
+  }
   void Read(uint64_t row, uint64_t column_offset, bool* data, uint64_t n) {
     const size_t byte_size = (n + 7) / 8;
     assert(column_offset + byte_size <= Stride());
@@ -86,10 +89,16 @@ class SimpleColumnarFile : private RowBasedFile {
              const std::complex<double>* data, uint64_t n) {
     WriteImplementation(row, column_offset, data, n);
   }
-  void Write(uint64_t row, uint64_t column_offset, float* data, uint64_t n) {
+  void Write(uint64_t row, uint64_t column_offset, const float* data,
+             uint64_t n) {
     WriteImplementation(row, column_offset, data, n);
   }
-  void Write(uint64_t row, uint64_t column_offset, double* data, uint64_t n) {
+  void Write(uint64_t row, uint64_t column_offset, const double* data,
+             uint64_t n) {
+    WriteImplementation(row, column_offset, data, n);
+  }
+  void Write(uint64_t row, uint64_t column_offset, const int32_t* data,
+             uint64_t n) {
     WriteImplementation(row, column_offset, data, n);
   }
   void Write(uint64_t row, uint64_t column_offset, const bool* data,

--- a/tables/AlternateMans/StokesIStMan.h
+++ b/tables/AlternateMans/StokesIStMan.h
@@ -147,6 +147,8 @@ class StokesIStMan final : public casacore::DataManager {
   // does not have move construct/assignment.
   std::vector<std::unique_ptr<StokesIStManColumn>> columns_;
   BufferedColumnarFile file_;
+  constexpr static size_t kHeaderSize = 8;
+  constexpr static const char kMagicHeaderTag[8] = "StkIcol";
 };
 
 }  // namespace casacore

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -3,6 +3,7 @@ if(Boost_FOUND)
 include_directories(${Boost_INCLUDE_DIR})
 
   set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
   
   set (testfiles
     tAntennaPairFile.cc

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -1,21 +1,17 @@
-find_package(Boost COMPONENTS unit_test_framework system)
-if(Boost_FOUND)
-include_directories(${Boost_INCLUDE_DIR})
+set (testfiles
+  tAntennaPairFile.cc
+  tBitPacking.cc
+  tColumnarFile.cc
+  tUvwFile.cc
+)
 
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  
-  set (testfiles
-    tAntennaPairFile.cc
-    tBitPacking.cc
-    tColumnarFile.cc
-    tStokesIStMan.cc
-    tUvwFile.cc
-  )
+find_package(Boost COMPONENTS unit_test_framework)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIR})
 
   add_executable (altmantest ${testfiles})
   add_pch_support(altmantest)
-  target_link_libraries(altmantest casa_tables ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+  target_link_libraries(altmantest casa_tables ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
   add_test (altmantest ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./altmantest)
   add_dependencies(check altmantest)
 endif(Boost_FOUND)

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -1,14 +1,16 @@
-set (testfiles
-  tAntennaPairFile.cc
-  tBitPacking.cc
-  tColumnarFile.cc
-  tStokesIStMan.cc
-  tUvwFile.cc
-)
-
 find_package(Boost COMPONENTS unit_test_framework system)
 if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIR})
+
+  set(CMAKE_CXX_STANDARD 17)
+  
+  set (testfiles
+    tAntennaPairFile.cc
+    tBitPacking.cc
+    tColumnarFile.cc
+    tStokesIStMan.cc
+    tUvwFile.cc
+  )
 
   add_executable (altmantest ${testfiles})
   add_pch_support(altmantest)

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set (testfiles
   tAntennaPairFile.cc
   tBitPacking.cc
   tColumnarFile.cc
+  tStokesIStMan.cc
   tUvwFile.cc
 )
 

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -6,13 +6,13 @@ set (testfiles
   tUvwFile.cc
 )
 
-find_package(Boost COMPONENTS unit_test_framework)
+find_package(Boost COMPONENTS unit_test_framework system)
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIR})
 
   add_executable (altmantest ${testfiles})
   add_pch_support(altmantest)
-  target_link_libraries(altmantest casa_tables ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+  target_link_libraries(altmantest casa_tables ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_SYSTEM_LIBRARY})
   add_test (altmantest ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./altmantest)
   add_dependencies(check altmantest)
 endif(Boost_FOUND)

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -5,7 +5,7 @@ set (testfiles
   tUvwFile.cc
 )
 
-find_package(Boost COMPONENTS unit_test_framework)
+find_package(Boost COMPONENTS unit_test_framework system)
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIR})
 

--- a/tables/AlternateMans/test/tStokesIStMan.cc
+++ b/tables/AlternateMans/test/tStokesIStMan.cc
@@ -1,0 +1,54 @@
+#include <boost/test/unit_test.hpp>
+
+#include <casacore/tables/AlternateMans/StokesIStManColumn.h>
+
+BOOST_AUTO_TEST_SUITE(stokes_i_st_man_column)
+
+BOOST_AUTO_TEST_CASE(expand_from_stokes_i) {
+  casacore::ExpandFromStokesI<int>(nullptr, 0);
+
+  double test_data_a[4] = {1.0, -1.0, -1.0, -1.0};
+  casacore::ExpandFromStokesI(test_data_a, 1);
+  BOOST_CHECK_EQUAL(test_data_a[0], 1.0);
+  BOOST_CHECK_EQUAL(test_data_a[1], 0.0);
+  BOOST_CHECK_EQUAL(test_data_a[2], 0.0);
+  BOOST_CHECK_EQUAL(test_data_a[3], 1.0);
+
+  const std::complex<float> u = {8.8, 8.8};
+  std::complex<float> test_data_b[12] = {{-3.7, 2.0}, {5.2, 0.0}, {std::numeric_limits<float>::quiet_NaN(), -2.1}, u,u,u,u,u,u,u,u,u};
+  casacore::ExpandFromStokesI(test_data_b, 3);
+  const std::complex<float> reference_b[8] = {
+    {-3.7, 2.0}, {0.0}, {0.0}, {-3.7, 2.0}, // 1
+    {5.2, 0.0}, {0.0}, {0.0}, {5.2, 0.0} // 2
+  };
+  BOOST_CHECK_EQUAL_COLLECTIONS(test_data_b, test_data_b+8, reference_b, reference_b+8);
+  BOOST_CHECK(std::isnan(test_data_b[8].real()));
+  BOOST_CHECK_EQUAL(test_data_b[8].imag(), -2.1f);
+  BOOST_CHECK_EQUAL(test_data_b[9], 0.0f);
+  BOOST_CHECK_EQUAL(test_data_b[10], 0.0f);
+  BOOST_CHECK(std::isnan(test_data_b[11].real()));
+  BOOST_CHECK_EQUAL(test_data_b[11].imag(), -2.1f);
+}
+
+BOOST_AUTO_TEST_CASE(transform_to_stokes_i) {
+  casacore::TransformToStokesI<int>(nullptr, nullptr, 0);
+
+  constexpr size_t data_a_size = 12;
+  const bool test_data_a[data_a_size] = {false, false, false, false, true, true, true, true, false, false, false, false};
+  char buffer_a[data_a_size * sizeof(bool)];
+  const bool* result_a = casacore::TransformToStokesI(test_data_a, buffer_a, data_a_size/4);
+  BOOST_CHECK(!result_a[0]);
+  BOOST_CHECK(result_a[1]);
+  BOOST_CHECK(!result_a[2]);
+
+  constexpr size_t data_b_size = 16;
+  const double test_data_b[data_b_size] = {3.0, 0.0, 0.0, 3.0, 20.0,  0.0,  0.0, 24.0, 0.0,  0.0,   0.0, 1000.0, std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, 0.0};
+  char buffer_b[data_b_size * sizeof(double)];
+  const double* result_b = casacore::TransformToStokesI(test_data_b, buffer_b, data_b_size/4);
+  BOOST_CHECK_CLOSE_FRACTION(result_b[0], 3.0, 1e-11);
+  BOOST_CHECK_CLOSE_FRACTION(result_b[1], 22.0, 1e-11);
+  BOOST_CHECK_CLOSE_FRACTION(result_b[2], 500.0, 1e-11);
+  BOOST_CHECK(std::isnan(result_b[3]));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These changes add support for opening a read-only file, and make sure that no writing or truncation is performed when no changes are made. This is e.g. important for supporting MS-es as input in e.g. CWL tasks.

It also adds a magic header mark to the Stokes I data column, such that Stokes I, UVW and Antenna cols can be distinguished from each other already from the header. This changes the format of the Stokes I columns, but since it is not used yet, now is the time (and it should be the last change). This makes the Stokes I stman in line with the other compressing storage managers.

A test set is added for the operations done in the Stokes I stman.

Finally there are some fixes to make sure everything remains robust when failures occur. The RO changes showed that e.g. if a close fails but the state of the file is not updated accurate, the destructor might then also throw, thereby causing a terminate instead of an exception. This should be all fixed now.