### PR TITLE
Fix a compilation issue for some gcc versions

### DIFF
--- a/docker/ubuntu2404_gcc.docker
+++ b/docker/ubuntu2404_gcc.docker
@@ -17,7 +17,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libreadline6-dev \
     libhdf5-serial-dev \
     libboost-dev \
+    libboost-filesystem-dev \
     libboost-python-dev \
+    libboost-system-dev \
     libboost-test-dev \
     libgsl-dev \
     python-is-python3 \

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -2,16 +2,17 @@ set (testfiles
   tAntennaPairFile.cc
   tBitPacking.cc
   tColumnarFile.cc
+  tStokesIStMan.cc
   tUvwFile.cc
 )
 
-find_package(Boost COMPONENTS unit_test_framework system)
+find_package(Boost COMPONENTS filesystem system unit_test_framework)
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIR})
 
   add_executable (altmantest ${testfiles})
   add_pch_support(altmantest)
-  target_link_libraries(altmantest casa_tables ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+  target_link_libraries(altmantest casa_tables ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
   add_test (altmantest ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./altmantest)
   add_dependencies(check altmantest)
 endif(Boost_FOUND)


### PR DESCRIPTION
Not all gcc versions in use correctly implement std::filesystem::permissions, so this MR uses boost instead.