### PR TITLE
Fix memory leak in TaQLNode

### DIFF
--- a/tables/TaQL/TaQLNode.h
+++ b/tables/TaQL/TaQLNode.h
@@ -105,9 +105,7 @@ public:
   const TaQLStyle& style() const
     { return itsRep->style(); }
 
-  // Destructor deletes the letter if no more references.
-  ~TaQLNode()
-    {}
+  virtual ~TaQLNode() noexcept = default;
 
   // Parse a TaQL command and return the result.
   // An exception is thrown in case of parse errors.


### PR DESCRIPTION
Because the destructor of TaQLNode was not virtual, but is used as base class, deleting it through a pointer to base class causes a memory leak. Because TaQLNode has a mutex, it also leaks resources, which at least is somewhat serious.

This was found by the address sanitizer.