### PR TITLE
Fix hyperlinks in documentation

### DIFF
--- a/mainpage.dox
+++ b/mainpage.dox
@@ -231,10 +231,10 @@ namespace casacore {
 ///   <td>casa boost-python python numpy</td>
 ///   </tr>
 ///   </table>
-///   <a href="http://www.atnf.csiro.au/computing/software/miriad">mirlib</a>
+///   <a href="https://www.atnf.csiro.au/computing/software/miriad">mirlib</a>
 ///   is distributed and built as part of Casacore.
-///   <a href="http://www.atnf.csiro.au/~mcalabre/WCS">wcslib</a> and
-///   <a href="http://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html">cfitsio</a>
+///   <a href="https://www.atnf.csiro.au/computing/software/wcs/index.html">wcslib</a> and
+///   <a href="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html">cfitsio</a>
 ///   are external packages that have to be installed before building all of Casacore.
 ///   <a href="http://www.boost.org/doc/libs/1_57_0/libs/python/doc">Boost-Python</a>
 ///   is required when building libcasa_python.


### PR DESCRIPTION
Fixed the hyperlinks in the main page of the documentation. The link to WCSLib was wrong, all links now use https.