### PR TITLE
Fix inconsistent pinning of Boost

### DIFF
--- a/casa/Arrays/test/CMakeLists.txt
+++ b/casa/Arrays/test/CMakeLists.txt
@@ -51,7 +51,7 @@ set (testfiles
   tVectorSTLIterator.cc
 )
 
-find_package(Boost COMPONENTS filesystem unit_test_framework system)
+find_package(Boost 1.72 COMPONENTS filesystem unit_test_framework system)
 if(Boost_FOUND)
 	include_directories(${Boost_INCLUDE_DIR})
 

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -6,7 +6,7 @@ set (testfiles
   tUvwFile.cc
 )
 
-find_package(Boost COMPONENTS filesystem system unit_test_framework)
+find_package(Boost 1.72 COMPONENTS filesystem system unit_test_framework)
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIR})
 


### PR DESCRIPTION
Building Casacore on a system that has a Boost version less than 1.72 fails due to the Boost pinning being inconsistent. 

Some of the "find_package(Boost" calls do find a Boost library and some don't. For example:

--------------------
-- Found Boost: /usr/include (found version "1.66.0") found components: filesystem unit_test_framework system
-- Found GSL: /usr/include (found version "2.5")
-- Could NOT find Boost: Found unsuitable version "1.66.0", but required is at least "1.72" (found /usr/include, found components: system filesystem unit_test_framework)
Boost testing framework not found.
-- Found Boost: /usr/include (found version "1.66.0") found components: filesystem system unit_test_framework
-------------------

This PR adds the missing version requirements to casa/Arrays/test and tables/AlternateMans/test .

