### PR TITLE
Fix thread safety issues in "rc" functions

### DIFF
--- a/casa/Containers/Allocator.h
+++ b/casa/Containers/Allocator.h
@@ -92,19 +92,14 @@ struct casacore_allocator: public std11_allocator<T> {
   struct rebind {
     typedef casacore_allocator<TOther> other;
   };
-  casacore_allocator() throw () {
-  }
+  casacore_allocator() noexcept = default;
 
-  casacore_allocator(const casacore_allocator&other) noexcept
-  :Super(other) {
-  }
+  casacore_allocator(const casacore_allocator&other) noexcept = default;
 
   template<typename TOther>
-  casacore_allocator(const casacore_allocator<TOther>&) noexcept {
-  }
+  casacore_allocator(const casacore_allocator<TOther>&) noexcept {}
 
-  ~casacore_allocator() noexcept {
-  }
+  ~casacore_allocator() noexcept = default;
 
   pointer allocate(size_type elements, const void* = 0) {
     if (elements > std::allocator_traits<casacore_allocator>::max_size(*this)) {

--- a/casa/System/Aipsrc.cc
+++ b/casa/System/Aipsrc.cc
@@ -268,13 +268,13 @@ const String &Aipsrc::aipsHome() {
   return home;
 }
 
-uInt Aipsrc::registerRC(const String &keyword, Block<String> &nlst) {
+uInt Aipsrc::registerRC(const String &keyword, std::vector<String> &nlst) {
   uInt n;
-  for (n=0; n<nlst.nelements(); n++) {
+  for (n=0; n<nlst.size(); n++) {
     if (nlst[n] == keyword) break;
   }
   n++;
-  if (n>nlst.nelements()) {
+  if (n>nlst.size()) {
     nlst.resize(n);
   }
   nlst[n-1] = keyword;
@@ -307,45 +307,45 @@ uInt Aipsrc::registerRC(const String &keyword,
 }
 
 const String &Aipsrc::get(uInt keyword) {
-  AlwaysAssert(keyword>0 && keyword<=strlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=strlst.size(), AipsError);
   return strlst[keyword-1];
 }
 
 const uInt &Aipsrc::get(uInt &code, uInt keyword) {
-  AlwaysAssert(keyword>0 && keyword<=codlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=codlst.size(), AipsError);
   code = codlst[keyword-1];
   return codlst[keyword-1];
 }
 
 void Aipsrc::set(uInt keyword, const String &deflt) {
-  AlwaysAssert(keyword>0 && keyword<=strlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=strlst.size(), AipsError);
   strlst[keyword-1] = deflt;
 }
 	       
 void Aipsrc::set(uInt keyword,
 		 Int Nname, const String tname[], const String &deflt) {
-  AlwaysAssert(keyword>0 && keyword<=codlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=codlst.size(), AipsError);
   find (codlst[keyword-1], String::toString(keyword), Nname, tname, deflt);
 }
 
 void Aipsrc::set(uInt keyword,
 		 const Vector<String> &tname, const String &deflt) {
-  AlwaysAssert(keyword>0 && keyword<=codlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=codlst.size(), AipsError);
   find (codlst[keyword-1], String::toString(keyword), tname, deflt);
 }
 
 void Aipsrc::save(uInt keyword) {
-  AlwaysAssert(keyword>0 && keyword<=strlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=strlst.size(), AipsError);
   Aipsrc::save(nstrlst[keyword-1], strlst[keyword-1]);
 }
 
 void Aipsrc::save(uInt keyword, const String tname[]) {
-  AlwaysAssert(keyword>0 && keyword<=codlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=codlst.size(), AipsError);
   Aipsrc::save(ncodlst[keyword-1], tname[codlst[keyword-1]]);
 }
 
 void Aipsrc::save(uInt keyword, const Vector<String> &tname) {
-  AlwaysAssert(keyword>0 && keyword<=codlst.nelements(), AipsError);
+  AlwaysAssert(keyword>0 && keyword<=codlst.size(), AipsError);
   Aipsrc::save(ncodlst[keyword-1], tname(codlst[keyword-1]));
 }
 
@@ -549,10 +549,8 @@ uInt Aipsrc::genRestore(Vector<String> &namlst, Vector<String> &vallst,
   Block<String> nl;
   Block<String> vl;
   Int nkw = Aipsrc::genParse(nl, vl, ef, fileList);
-  Block<String> nla;
-  Block<String> vla;
-  nla.resize(0);
-  vla.resize(0);
+  std::vector<String> nla;
+  std::vector<String> vla;
   uInt n;
   for (Int i=nkw-1; i>=0; i--) {	// reverse order to do aipsrc like
     if (!nl[i].contains('*')) {		// no wild cards
@@ -587,7 +585,7 @@ void Aipsrc::genSave(Vector<String> &namlst, Vector<String> &vallst,
 
 void Aipsrc::genSet(Vector<String> &namlst, Vector<String> &vallst,
 		    const String &nam, const String &val) {
-  Block<String> nl = makeBlock(namlst);
+  std::vector<String> nl(namlst.begin(), namlst.end());
   uInt n = Aipsrc::registerRC(nam, nl);
   if (n > vallst.nelements()) vallst.resize(n, True);
   vallst(n-1) = val;
@@ -641,10 +639,10 @@ Bool Aipsrc::genGet(String &val, Vector<String> &namlst, Vector<String> &vallst,
   String Aipsrc::home = String();
   String Aipsrc::uhome= String();
   Bool Aipsrc::filled = False;
-  Block<String> Aipsrc::strlst(0);
-  Block<String> Aipsrc::nstrlst(0);
-  Block<uInt> Aipsrc::codlst(0);
-  Block<String> Aipsrc::ncodlst(0);
+  std::vector<String> Aipsrc::strlst;
+  std::vector<String> Aipsrc::nstrlst;
+  std::vector<uInt> Aipsrc::codlst;
+  std::vector<String> Aipsrc::ncodlst;
 
 } //# NAMESPACE CASACORE - END
 

--- a/casa/System/Aipsrc.h
+++ b/casa/System/Aipsrc.h
@@ -376,7 +376,7 @@ protected:
   // Actual find function to use during parse() without recursing into parse()
   static Bool findNoParse(String &value, const String &keyword, uInt start);
   // The registration function
-  static uInt registerRC(const String &keyword, Block<String> &nlst);
+  static uInt registerRC(const String &keyword, std::vector<String> &nlst);
   // Actual saving
   static void save(const String keyword, const String val);
   
@@ -410,11 +410,14 @@ private:
   static Bool filled;
   // String register list
   // <group>
-  static Block<String> strlst;
-  static Block<String> nstrlst;
-  static Block<uInt> codlst;
-  static Block<String> ncodlst;
+  static std::vector<String> strlst;
+  static std::vector<String> nstrlst;
+  static std::vector<uInt> codlst;
+  static std::vector<String> ncodlst;
   // </group>
+
+  Aipsrc() = delete;
+  ~Aipsrc() = delete;
 
   //# General member functions
   // Read in the aipsrc files. Always called using theirCallOnce (except for reRead()).

--- a/casa/System/AipsrcBool.cc
+++ b/casa/System/AipsrcBool.cc
@@ -31,17 +31,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# Data
-AipsrcValue<Bool> AipsrcValue<Bool>::myp_p;
-std::mutex AipsrcValue<Bool>::theirMutex;
-
-//# Constructor
-AipsrcValue<Bool>::AipsrcValue() :
-  tlst(0), ntlst(0) {}
-
-//# Destructor
-AipsrcValue<Bool>::~AipsrcValue() {}
-
 Bool AipsrcValue<Bool>::find(Bool &value, const String &keyword) {
   String res;
   Bool x = Aipsrc::find(res, keyword, 0);
@@ -58,34 +47,34 @@ Bool AipsrcValue<Bool>::find(Bool &value, const String &keyword,
 uInt AipsrcValue<Bool>::registerRC(const String &keyword,
 				   const Bool &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find (reinterpret_cast<bool&>(tlst[n-1]), keyword, deflt);
   return n;
 }
 
-const Bool &AipsrcValue<Bool>::get(uInt keyword) {
+const Bool AipsrcValue<Bool>::get(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  return (myp_p.tlst)[keyword-1];
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  return tlst[keyword-1];
 }
 
 void AipsrcValue<Bool>::set(uInt keyword, const Bool &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  (myp_p.tlst)[keyword-1] = deflt;
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  tlst[keyword-1] = deflt;
 }
 
 void AipsrcValue<Bool>::save(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
   ostringstream oss;
-  if ((myp_p.tlst)[keyword-1]) {
+  if (tlst[keyword-1]) {
     oss << "true";
   } else {
     oss << "false";
   }
-  Aipsrc::save((myp_p.ntlst)[keyword-1], String(oss));
+  Aipsrc::save((ntlst)[keyword-1], String(oss));
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/System/AipsrcVBool.cc
+++ b/casa/System/AipsrcVBool.cc
@@ -33,17 +33,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# Data
-AipsrcVector<Bool> AipsrcVector<Bool>::myp_p;
-std::mutex AipsrcVector<Bool>::theirMutex;
-
-//# Constructor
-AipsrcVector<Bool>::AipsrcVector() : 
-  tlst(0), ntlst(0) {}
-
-//# Destructor
-AipsrcVector<Bool>::~AipsrcVector() {}
-
 Bool AipsrcVector<Bool>::find(Vector<Bool> &value,
 			      const String &keyword) {
   String res;
@@ -73,39 +62,39 @@ Bool AipsrcVector<Bool>::find(Vector<Bool> &value,
 uInt AipsrcVector<Bool>::registerRC(const String &keyword,
 				    const Vector<Bool> &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find (tlst[n-1], keyword, deflt);
   return n;
 }
 
-const Vector<Bool> &AipsrcVector<Bool>::get(uInt keyword) {
+const Vector<Bool> AipsrcVector<Bool>::get(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  return (myp_p.tlst)[keyword-1];
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  return tlst[keyword-1];
 }
 
 void AipsrcVector<Bool>::set(uInt keyword,
 			     const Vector<Bool> &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  (myp_p.tlst)[keyword-1].resize(deflt.nelements());
-  (myp_p.tlst)[keyword-1] = deflt;
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  tlst[keyword-1].resize(deflt.nelements());
+  tlst[keyword-1] = deflt;
 }
 
 void AipsrcVector<Bool>::save(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
   ostringstream oss;
-  Int n = ((myp_p.tlst)[keyword-1]).nelements();
+  Int n = (tlst[keyword-1]).nelements();
   for (Int i=0; i<n; i++) {
-    if (((myp_p.tlst)[keyword-1])(i)) {
+    if ((tlst[keyword-1])(i)) {
       oss << " true";
     } else {
       oss << " false";
     }
   }
-  Aipsrc::save((myp_p.ntlst)[keyword-1], String(oss));
+  Aipsrc::save((ntlst)[keyword-1], String(oss));
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/System/AipsrcVString.cc
+++ b/casa/System/AipsrcVString.cc
@@ -33,17 +33,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# Data
-AipsrcVector<String> AipsrcVector<String>::myp_p;
-std::mutex AipsrcVector<String>::theirMutex;
-
-//# Constructor
-AipsrcVector<String>::AipsrcVector() : 
-  tlst(0), ntlst(0) {}
-
-//# Destructor
-AipsrcVector<String>::~AipsrcVector() {}
-
 Bool AipsrcVector<String>::find(Vector<String> &value,
 					    const String &keyword) {
   String res;
@@ -73,33 +62,33 @@ uInt AipsrcVector<String>::registerRC(const String &keyword,
 						  const Vector<String> 
 						  &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find (tlst[n-1], keyword, deflt);
   return n;
 }
 
-const Vector<String> &AipsrcVector<String>::get(uInt keyword) {
+const Vector<String> AipsrcVector<String>::get(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  return (myp_p.tlst)[keyword-1];
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  return tlst[keyword-1];
 }
 
 void AipsrcVector<String>::set(uInt keyword,
 					   const Vector<String> &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  (myp_p.tlst)[keyword-1].resize(deflt.nelements());
-  (myp_p.tlst)[keyword-1] = deflt;
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  tlst[keyword-1].resize(deflt.nelements());
+  tlst[keyword-1] = deflt;
 }
 
 void AipsrcVector<String>::save(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
   ostringstream oss;
-  Int n = ((myp_p.tlst)[keyword-1]).nelements();
-  for (Int i=0; i<n; i++) oss << " " << ((myp_p.tlst)[keyword-1])(i);
-  Aipsrc::save((myp_p.ntlst)[keyword-1], String(oss));
+  Int n = (tlst[keyword-1]).nelements();
+  for (Int i=0; i<n; i++) oss << " " << (tlst[keyword-1])(i);
+  Aipsrc::save((ntlst)[keyword-1], String(oss));
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/System/AipsrcValue.tcc
+++ b/casa/System/AipsrcValue.tcc
@@ -35,21 +35,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# Data
-template <class T>
-AipsrcValue<T> AipsrcValue<T>::myp_p;
-template <class T>
-std::mutex AipsrcValue<T>::theirMutex;
-
-//# Constructor
-template <class T>
-AipsrcValue<T>::AipsrcValue() : 
-  tlst(0), ntlst(0) {}
-
-//# Destructor
-template <class T>
-AipsrcValue<T>::~AipsrcValue() {}
-
 template <class T>
 Bool AipsrcValue<T>::find(T &value, const String &keyword) {
   String res;
@@ -95,9 +80,9 @@ template <class T>
 uInt AipsrcValue<T>::registerRC(const String &keyword,
 				const T &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find (tlst[n-1], keyword, deflt);
   return n;
 }
 
@@ -106,24 +91,24 @@ uInt AipsrcValue<T>::registerRC(const String &keyword,
 				const Unit &defun, const Unit &resun,
 				const T &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, defun, resun, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find ((tlst)[n-1], keyword, defun, resun, deflt);
   return n;
 }
 
 template <class T>
-const T &AipsrcValue<T>::get(uInt keyword) {
+const T AipsrcValue<T>::get(uInt keyword) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  return (myp_p.tlst)[keyword-1];
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  return (tlst)[keyword-1];
 }
 
 template <class T>
 void AipsrcValue<T>::set(uInt keyword, const T &deflt) {
   std::lock_guard<std::mutex> lock(theirMutex);
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  (myp_p.tlst)[keyword-1] = deflt;
+  AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+  (tlst)[keyword-1] = deflt;
 }
 
 template <class T>
@@ -131,11 +116,11 @@ void AipsrcValue<T>::save(uInt keyword) {
   ostringstream oss;
   {
     std::lock_guard<std::mutex> lock(theirMutex);
-    AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-    oss << (myp_p.tlst)[keyword-1];
+    AlwaysAssert(keyword > 0 && keyword <= tlst.size(), AipsError);
+    oss << (tlst)[keyword-1];
   }
   // Unlock has to be done before save, because MVTime uses AipsrcValue.
-  Aipsrc::save((myp_p.ntlst)[keyword-1], String(oss));
+  Aipsrc::save((ntlst)[keyword-1], String(oss));
 }
 
 } //# NAMESPACE CASACORE - END

--- a/casa/System/AipsrcVector.h
+++ b/casa/System/AipsrcVector.h
@@ -29,8 +29,10 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/ArrayFwd.h>
 #include <casacore/casa/BasicSL/String.h>
-#include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/System/Aipsrc.h>
+
+#include <mutex>
+#include <vector>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -83,13 +85,6 @@ class Unit;
 template <class T> class AipsrcVector : public Aipsrc {
 
 public:
-  //# Constructors
-  // Default constructor
-  // See a note in <linkto class=AipsrcValue>AipsrcValue</linkto>.
-  AipsrcVector();
-  //# Destructor
-  ~AipsrcVector();
-
   //# Member functions
   // The <src>find()</src> functions will, given a keyword, return the value
   // of a matched keyword found in the files. If no match found the
@@ -123,7 +118,7 @@ public:
   
   // Gets are like find, but using registered integers rather than names.
   // <group>
-  static const Vector<T> &get(uInt keyword);
+  static const Vector<T> get(uInt keyword);
   // </group>
   
   // Sets allow registered values to be set
@@ -136,22 +131,12 @@ public:
 
 private:
   //# Data
-  static AipsrcVector myp_p;
-  static std::mutex theirMutex;
+  inline static std::mutex theirMutex;
   // register list
   // <group>
-  Block<Vector<T> > tlst;
-  Block<String> ntlst;
+  inline static std::vector<Vector<T> > tlst;
+  inline static std::vector<String> ntlst;
   // </group>
-  
-  //# Constructors
-  // Copy constructor (not implemented)
-  AipsrcVector<T> &operator=(const AipsrcVector<T> &other);
-  
-  //# Copy assignment (not implemented)
-  AipsrcVector(const AipsrcVector<T> &other);
-  
-  //# General member functions
 };
 
 #define AipsrcVector_String AipsrcVector
@@ -166,24 +151,18 @@ private:
 
 template <> class AipsrcVector_String<String> : public Aipsrc {
  public:
-  AipsrcVector_String();
-  ~AipsrcVector_String();
   static Bool find(Vector<String> &value, const String &keyword);
   static Bool find(Vector<String> &value, const String &keyword, 
 		   const Vector<String> &deflt);
   static uInt registerRC(const String &keyword, const Vector<String> &deflt);
-  static const Vector<String> &get(uInt keyword);
+  static const Vector<String> get(uInt keyword);
   static void set(uInt keyword, const Vector<String> &deflt);
   static void save(uInt keyword);
 
 private:
-  static AipsrcVector_String myp_p;
-  static std::mutex theirMutex;
-  Block<Vector<String> > tlst;
-  Block<String> ntlst;
-  AipsrcVector_String<String>
-    &operator=(const AipsrcVector_String<String> &other);
-  AipsrcVector_String(const AipsrcVector_String<String> &other);
+  inline static std::mutex theirMutex;
+  inline static std::vector<Vector<String> > tlst;
+  inline static std::vector<String> ntlst;
 };
 
 #undef AipsrcVector_String
@@ -200,24 +179,18 @@ private:
 
 template <> class AipsrcVector_Bool<Bool> : public Aipsrc {
  public:
-  AipsrcVector_Bool();
-  ~AipsrcVector_Bool();
   static Bool find(Vector<Bool> &value, const String &keyword);
   static Bool find(Vector<Bool> &value, const String &keyword, 
 		   const Vector<Bool> &deflt);
   static uInt registerRC(const String &keyword, const Vector<Bool> &deflt);
-  static const Vector<Bool> &get(uInt keyword);
+  static const Vector<Bool> get(uInt keyword);
   static void set(uInt keyword, const Vector<Bool> &deflt);
   static void save(uInt keyword);
 
 private:
-  static AipsrcVector_Bool myp_p;
-  static std::mutex theirMutex;
-  Block<Vector<Bool> > tlst;
-  Block<String> ntlst;
-  AipsrcVector_Bool<Bool>
-    &operator=(const AipsrcVector_Bool<Bool> &other);
-  AipsrcVector_Bool(const AipsrcVector_Bool<Bool> &other);
+  inline static std::mutex theirMutex;
+  inline static std::vector<Vector<Bool> > tlst;
+  inline static std::vector<String> ntlst;
 };
 
 #undef AipsrcVector_Bool

--- a/casa/System/AipsrcVector.tcc
+++ b/casa/System/AipsrcVector.tcc
@@ -37,19 +37,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-//# Data
-template <class T>
-AipsrcVector<T> AipsrcVector<T>::myp_p;
-
-//# Constructor
-template <class T>
-AipsrcVector<T>::AipsrcVector() : 
-  tlst(0), ntlst(0) {}
-
-//# Destructor
-template <class T>
-AipsrcVector<T>::~AipsrcVector() {}
-
 template <class T>
 Bool AipsrcVector<T>::find(Vector<T> &value,
 			   const String &keyword) {
@@ -112,9 +99,9 @@ Bool AipsrcVector<T>::find(Vector<T> &value, const String &keyword,
 template <class T>
 uInt AipsrcVector<T>::registerRC(const String &keyword,
 				 const Vector<T> &deflt) {
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find ((tlst)[n-1], keyword, deflt);
   return n;
 }
 
@@ -122,32 +109,32 @@ template <class T>
 uInt AipsrcVector<T>::registerRC(const String &keyword,
 				 const Unit &defun, const Unit &resun,
 				 const Vector<T> &deflt) {
-  uInt n = Aipsrc::registerRC(keyword, myp_p.ntlst);
-  myp_p.tlst.resize(n);
-  find ((myp_p.tlst)[n-1], keyword, defun, resun, deflt);
+  uInt n = Aipsrc::registerRC(keyword, ntlst);
+  tlst.resize(n);
+  find ((tlst)[n-1], keyword, defun, resun, deflt);
   return n;
 }
 
 template <class T>
-const Vector<T> &AipsrcVector<T>::get(uInt keyword) {
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  return (myp_p.tlst)[keyword-1];
+const Vector<T> AipsrcVector<T>::get(uInt keyword) {
+  AlwaysAssert(keyword > 0 && keyword <= tlst.nelements(), AipsError);
+  return (tlst)[keyword-1];
 }
 
 template <class T>
 void AipsrcVector<T>::set(uInt keyword, const Vector<T> &deflt) {
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
-  (myp_p.tlst)[keyword-1].resize(deflt.nelements());
-  (myp_p.tlst)[keyword-1] = deflt;
+  AlwaysAssert(keyword > 0 && keyword <= tlst.nelements(), AipsError);
+  (tlst)[keyword-1].resize(deflt.nelements());
+  (tlst)[keyword-1] = deflt;
 }
 
 template <class T>
 void AipsrcVector<T>::save(uInt keyword) {
-  AlwaysAssert(keyword > 0 && keyword <= myp_p.tlst.nelements(), AipsError);
+  AlwaysAssert(keyword > 0 && keyword <= tlst.nelements(), AipsError);
   ostringstream oss;
-  Int n = ((myp_p.tlst)[keyword-1]).nelements();
-  for (Int i=0; i<n; i++) oss << " " << ((myp_p.tlst)[keyword-1])(i);
-  Aipsrc::save((myp_p.ntlst)[keyword-1], String(oss));
+  Int n = ((tlst)[keyword-1]).nelements();
+  for (Int i=0; i<n; i++) oss << " " << ((tlst)[keyword-1])(i);
+  Aipsrc::save((ntlst)[keyword-1], String(oss));
 }
 
 } //# NAMESPACE CASACORE - END


### PR DESCRIPTION
In order to find the culprit, the functions were also simplified and improved somewhat. The real issue turned out to be to return a reference to a value inside a (Block) container, while that container could be modified by a separate thread.

The thread sanitizer pointer at first to the allocator used by the Block class, which made me suspect that the allocator wasn't thread safe. Hence I replaced the Block by std::vector, which in the end didn't solve the race issue (it was the returned reference), but which I think is cleaner anyway, so I kept the change.