### PR TITLE
Refactor MCFrame to remove ref to MeasFrame and use pimpl pattern

### DIFF
--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -145,10 +145,10 @@ void MCFrame::resetRadialVelocity() {
 void MCFrame::resetComet() {
 }
 
-Bool MCFrame::getTDB(Double &tdb, const MeasFrame& myf) {
-  if (myf.epoch()) {
+Bool MCFrame::getTDB(Double &tdb, const MeasFrame& frame) {
+  if (frame.epoch()) {
     if (!impl_->epTDBp) {
-      impl_->epTDBp = impl_->epConvTDB(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epTDBp = impl_->epConvTDB(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epTDBp;
@@ -158,10 +158,10 @@ Bool MCFrame::getTDB(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getUT1(Double &tdb, const MeasFrame& myf) {
-  if (myf.epoch()) {
+Bool MCFrame::getUT1(Double &tdb, const MeasFrame& frame) {
+  if (frame.epoch()) {
     if (!impl_->epUT1p) {
-      impl_->epUT1p = impl_->epConvUT1(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epUT1p = impl_->epConvUT1(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epUT1p;
@@ -171,10 +171,10 @@ Bool MCFrame::getUT1(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getTT(Double &tdb, const MeasFrame& myf) {
-  if (myf.epoch()) {
+Bool MCFrame::getTT(Double &tdb, const MeasFrame& frame) {
+  if (frame.epoch()) {
     if (!impl_->epTTp) {
-      impl_->epTTp = impl_->epConvTT(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epTTp = impl_->epConvTT(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epTTp;
@@ -184,10 +184,10 @@ Bool MCFrame::getTT(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getLong(Double &tdb, const MeasFrame& myf) {
-  if (myf.position()) {
+Bool MCFrame::getLong(Double &tdb, const MeasFrame& frame) {
+  if (frame.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp.get();
     }
@@ -198,10 +198,10 @@ Bool MCFrame::getLong(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getLat(Double &tdb, const MeasFrame& myf) {
-  if (myf.position()) {
+Bool MCFrame::getLat(Double &tdb, const MeasFrame& frame) {
+  if (frame.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp.get();
     }
@@ -212,10 +212,10 @@ Bool MCFrame::getLat(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& myf) {
-  if (myf.position()) {
+Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& frame) {
+  if (frame.position()) {
     if (impl_->posLongGeop.empty()) {
-      impl_->posGeop = impl_->posConvLongGeo(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posGeop = impl_->posConvLongGeo(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
         getValue();
       impl_->posLongGeop = impl_->posGeop.get();
     }
@@ -226,10 +226,10 @@ Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& myf) {
-  if (myf.position()) {
+Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& frame) {
+  if (frame.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp.get();
     }
@@ -240,10 +240,10 @@ Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getRadius(Double &tdb, const MeasFrame& myf) {
-  if (myf.position()) {
+Bool MCFrame::getRadius(Double &tdb, const MeasFrame& frame) {
+  if (frame.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp.get();
     }
@@ -254,10 +254,10 @@ Bool MCFrame::getRadius(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getLAST(Double &tdb, const MeasFrame& myf) {
-  if (myf.epoch()) {
+Bool MCFrame::getLAST(Double &tdb, const MeasFrame& frame) {
+  if (frame.epoch()) {
     if (!impl_->epLASTp) {
-      impl_->epLASTp = impl_->epConvLAST(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epLASTp = impl_->epConvLAST(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = fmod(*impl_->epLASTp, 1.0);
@@ -267,16 +267,16 @@ Bool MCFrame::getLAST(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getLASTr(Double &tdb, const MeasFrame& myf) {
-  Bool tmp = MCFrame::getLAST(tdb, myf);
+Bool MCFrame::getLASTr(Double &tdb, const MeasFrame& frame) {
+  Bool tmp = MCFrame::getLAST(tdb, frame);
   tdb *= C::circle;
   return tmp;
 }
 
-Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->j2000Longp = impl_->dirJ2000p.get();
     }
@@ -287,10 +287,10 @@ Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->j2000Longp = impl_->dirJ2000p.get();
     }
@@ -301,10 +301,10 @@ Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->j2000Longp = impl_->dirJ2000p.get();
     }
@@ -315,10 +315,10 @@ Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->b1950Longp = impl_->dirB1950p.get();
     }
@@ -329,10 +329,10 @@ Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->b1950Longp = impl_->dirB1950p.get();
     }
@@ -343,10 +343,10 @@ Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->b1950Longp = impl_->dirB1950p.get();
     }
@@ -357,10 +357,10 @@ Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->appLongp = impl_->dirAppp.get();
     }
@@ -371,10 +371,10 @@ Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->appLongp = impl_->dirAppp.get();
     }
@@ -385,10 +385,10 @@ Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& myf) {
-  if (myf.direction()) {
+Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& frame) {
+  if (frame.direction()) {
     if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
       impl_->appLongp = impl_->dirAppp.get();
     }
@@ -399,10 +399,10 @@ Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getLSR(Double &tdb, const MeasFrame& myf) {
-  if (myf.radialVelocity()) {
+Bool MCFrame::getLSR(Double &tdb, const MeasFrame& frame) {
+  if (frame.radialVelocity()) {
     if (!impl_->radLSRp) {
-      impl_->radLSRp = impl_->radConvLSR(*dynamic_cast<const MVRadialVelocity *const>(myf.radialVelocity()->
+      impl_->radLSRp = impl_->radConvLSR(*dynamic_cast<const MVRadialVelocity *>(frame.radialVelocity()->
 						      getData())).
 	getValue();
     }
@@ -413,46 +413,46 @@ Bool MCFrame::getLSR(Double &tdb, const MeasFrame& myf) {
   return False;
 }
 
-Bool MCFrame::getCometType(uInt &tdb, const MeasFrame& myf) {
-  if (myf.comet()) {
-    tdb = static_cast<uInt>(myf.comet()->getType());
+Bool MCFrame::getCometType(uInt &tdb, const MeasFrame& frame) {
+  if (frame.comet()) {
+    tdb = static_cast<uInt>(frame.comet()->getType());
     return True;
   }
   tdb = 0;
   return False;
 }
 
-Bool MCFrame::getComet(MVPosition &tdb, const MeasFrame& myf) {
-  if (myf.comet()) {
+Bool MCFrame::getComet(MVPosition &tdb, const MeasFrame& frame) {
+  if (frame.comet()) {
     Double x(0);
-    if (getTDB(x, myf) && myf.comet()->get(tdb, x)) return True;
+    if (getTDB(x, frame) && frame.comet()->get(tdb, x)) return True;
   }
   tdb = MVPosition(0.0);
   return False;
 }
 
-void MCFrame::makeEpoch(const MeasFrame& myf) {
+void MCFrame::makeEpoch(const MeasFrame& frame) {
   const MEpoch::Ref REFTDB = MEpoch::Ref(MEpoch::TDB);
   const MEpoch::Ref REFUT1 = MEpoch::Ref(MEpoch::UT1);
   const MEpoch::Ref REFTT  = MEpoch::Ref(MEpoch::TT);
-  impl_->epConvTDB = MEpoch::Convert(*(myf.epoch()), REFTDB);
-  impl_->epConvUT1 = MEpoch::Convert(*(myf.epoch()), REFUT1);
-  impl_->epConvTT  = MEpoch::Convert(*(myf.epoch()), REFTT);
+  impl_->epConvTDB = MEpoch::Convert(*(frame.epoch()), REFTDB);
+  impl_->epConvUT1 = MEpoch::Convert(*(frame.epoch()), REFUT1);
+  impl_->epConvTT  = MEpoch::Convert(*(frame.epoch()), REFTT);
   impl_->epTDBp.reset();
   impl_->epUT1p.reset();
   impl_->epTTp.reset();
-  impl_->epConvLAST = MEpoch::Convert(*(myf.epoch()),
-				   MEpoch::Ref(MEpoch::LAST, myf));
+  impl_->epConvLAST = MEpoch::Convert(*(frame.epoch()),
+				   MEpoch::Ref(MEpoch::LAST, frame));
   impl_->epLASTp.reset();
   impl_->appLongp = casacore::Vector<Double>();
   impl_->dirAppp = MVDirection();
   impl_->radLSRp.reset();
 }
 
-void MCFrame::makePosition(const MeasFrame& myf) {
+void MCFrame::makePosition(const MeasFrame& frame) {
   static const MPosition::Ref REFLONG 
     = MPosition::Ref(MPosition::ITRF);
-  impl_->posConvLong = MPosition::Convert(*myf.position(),
+  impl_->posConvLong = MPosition::Convert(*frame.position(),
 				       REFLONG);
   impl_->posLongp = casacore::Vector<Double>();
   impl_->posITRFp = MVPosition();
@@ -460,25 +460,25 @@ void MCFrame::makePosition(const MeasFrame& myf) {
   impl_->radLSRp.reset();
   static const MPosition::Ref REFGEO
     = MPosition::Ref(MPosition::WGS84);
-  impl_->posConvLongGeo = MPosition::Convert(*myf.position(),
+  impl_->posConvLongGeo = MPosition::Convert(*frame.position(),
 					  REFGEO);
   impl_->posLongGeop = casacore::Vector<Double>();
   impl_->posGeop = MVPosition();
 }
 
-void MCFrame::makeDirection(const MeasFrame& myf) {
+void MCFrame::makeDirection(const MeasFrame& frame) {
   static const MDirection::Ref REFJ2000 = MDirection::Ref(MDirection::J2000);
-  impl_->dirConvJ2000 = MDirection::Convert(*myf.direction(),
+  impl_->dirConvJ2000 = MDirection::Convert(*frame.direction(),
 					 MDirection::Ref(MDirection::J2000,
-							 myf));
+							 frame));
 
   static const MDirection::Ref REFB1950 = MDirection::Ref(MDirection::B1950);
-  impl_->dirConvB1950 = MDirection::Convert(*myf.direction(),
+  impl_->dirConvB1950 = MDirection::Convert(*frame.direction(),
 					 MDirection::Ref(MDirection::B1950,
-							 myf));
-  impl_->dirConvApp = MDirection::Convert(*myf.direction(),
+							 frame));
+  impl_->dirConvApp = MDirection::Convert(*frame.direction(),
 				       MDirection::Ref(MDirection::APP,
-						       myf));
+						       frame));
   impl_->j2000Longp = casacore::Vector<Double>();
   impl_->dirJ2000p = MVDirection();
   impl_->b1950Longp = casacore::Vector<Double>();
@@ -488,10 +488,10 @@ void MCFrame::makeDirection(const MeasFrame& myf) {
   impl_->radLSRp.reset();
 }
 
-void MCFrame::makeRadialVelocity(const MeasFrame& myf) {
+void MCFrame::makeRadialVelocity(const MeasFrame& frame) {
   static const MRadialVelocity::Ref REFLSR 
     = MRadialVelocity::Ref(MRadialVelocity::LSRK);
-  impl_->radConvLSR = MRadialVelocity::Convert(*myf.radialVelocity(),
+  impl_->radConvLSR = MRadialVelocity::Convert(*frame.radialVelocity(),
 					    REFLSR);
   impl_->radLSRp.reset();
 }

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -49,53 +49,53 @@ struct MCFrameImplementation {
   // Conversion to TDB time (due to some (for me) unsolvable dependency
   // errors)
   // not the proper MeasConvert* here)
-  std::optional<MeasConvert<MEpoch>> epConvTDB;
+  MeasConvert<MEpoch> epConvTDB;
   // TDB time
   std::optional<Double> epTDBp;
   // Conversion to UT1 time
-  std::optional<MeasConvert<MEpoch>> epConvUT1;
+  MeasConvert<MEpoch> epConvUT1;
   // UT1 time
   std::optional<Double> epUT1p;
   // Conversion to TT time
-  std::optional<MeasConvert<MEpoch>> epConvTT;
+  MeasConvert<MEpoch> epConvTT;
   // TT time
   std::optional<Double> epTTp;
   // Conversion to LAST time
-  std::optional<MeasConvert<MEpoch>> epConvLAST;
+  MeasConvert<MEpoch> epConvLAST;
   // LAST time
   std::optional<Double> epLASTp;
   // Conversion to ITRF longitude/latitude
-  std::optional<MeasConvert<MPosition>> posConvLong;
+  MeasConvert<MPosition> posConvLong;
   // Longitude
   Vector<Double> posLongp;
   // Position
   std::optional<MVPosition> posITRFp;
   // Conversion to geodetic longitude/latitude
-  std::optional<MeasConvert<MPosition>> posConvLongGeo;
+  MeasConvert<MPosition> posConvLongGeo;
   // Latitude
   Vector<Double> posLongGeop;
   // Position
   std::optional<MVPosition> posGeop;
   // Conversion to J2000
-  std::optional<MeasConvert<MDirection>> dirConvJ2000;
+  MeasConvert<MDirection> dirConvJ2000;
   // Longitude
   Vector<Double> j2000Longp;
   // J2000 coordinates
   std::optional<MVDirection> dirJ2000p;
   // Conversion to B1950
-  std::optional<MeasConvert<MDirection>> dirConvB1950;
+  MeasConvert<MDirection> dirConvB1950;
   // Longitude
   Vector<Double> b1950Longp;
   // B1950 coordinates
   std::optional<MVDirection> dirB1950p;
   // Conversion to apparent coordinates
-  std::optional<MeasConvert<MDirection>> dirConvApp;
+  MeasConvert<MDirection> dirConvApp;
   // Longitude
   Vector<Double> appLongp;
   // Apparent coordinates
   std::optional<MVDirection> dirAppp;
   // Conversion to LSR radial velocity
-  std::optional<MeasConvert<MRadialVelocity>> radConvLSR;
+  MeasConvert<MRadialVelocity> radConvLSR;
   // Radial velocity
   std::optional<Double> radLSRp;
 };
@@ -150,8 +150,7 @@ void MCFrame::resetComet() {
 Bool MCFrame::getTDB(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
     if (!impl_->epTDBp) {
-      impl_->epTDBp = impl_->epConvTDB->operator()
-	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epTDBp = impl_->epConvTDB(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epTDBp;
@@ -164,8 +163,7 @@ Bool MCFrame::getTDB(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getUT1(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
     if (!impl_->epUT1p) {
-      impl_->epUT1p = impl_->epConvUT1->operator()
-	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epUT1p = impl_->epConvUT1(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epUT1p;
@@ -178,8 +176,7 @@ Bool MCFrame::getUT1(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getTT(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
     if (!impl_->epTTp) {
-      impl_->epTTp = impl_->epConvTT->operator()
-	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epTTp = impl_->epConvTT(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epTTp;
@@ -192,8 +189,7 @@ Bool MCFrame::getTT(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getLong(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong->operator()
-	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp->get();
     }
@@ -207,8 +203,7 @@ Bool MCFrame::getLong(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getLat(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong->operator()
-	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp->get();
     }
@@ -222,8 +217,7 @@ Bool MCFrame::getLat(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
     if (impl_->posLongGeop.empty()) {
-      impl_->posGeop = impl_->posConvLongGeo->operator()
-        (*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posGeop = impl_->posConvLongGeo(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
         getValue();
       impl_->posLongGeop = impl_->posGeop->get();
     }
@@ -237,8 +231,7 @@ Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& myf) {
   if (myf.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong->operator()
-	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp->get();
     }
@@ -252,8 +245,7 @@ Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& myf) {
 Bool MCFrame::getRadius(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
     if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong->operator()
-	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
+      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
       impl_->posLongp = impl_->posITRFp->get();
     }
@@ -267,8 +259,7 @@ Bool MCFrame::getRadius(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getLAST(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
     if (!impl_->epLASTp) {
-      impl_->epLASTp = impl_->epConvLAST->operator()
-	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
+      impl_->epLASTp = impl_->epConvLAST(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
     tdb = fmod(*impl_->epLASTp, 1.0);
@@ -287,8 +278,7 @@ Bool MCFrame::getLASTr(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->j2000Longp = impl_->dirJ2000p->get();
     }
@@ -302,8 +292,7 @@ Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->j2000Longp = impl_->dirJ2000p->get();
     }
@@ -317,8 +306,7 @@ Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->j2000Longp = impl_->dirJ2000p->get();
     }
@@ -332,8 +320,7 @@ Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& myf) {
 Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->b1950Longp = impl_->dirB1950p->get();
     }
@@ -347,8 +334,7 @@ Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->b1950Longp = impl_->dirB1950p->get();
     }
@@ -362,8 +348,7 @@ Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->b1950Longp = impl_->dirB1950p->get();
     }
@@ -377,8 +362,7 @@ Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& myf) {
 Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->appLongp = impl_->dirAppp->get();
     }
@@ -392,8 +376,7 @@ Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->appLongp = impl_->dirAppp->get();
     }
@@ -407,8 +390,7 @@ Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& myf) {
 Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
     if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp->operator()
-	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
+      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
       impl_->appLongp = impl_->dirAppp->get();
     }
@@ -422,8 +404,7 @@ Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& myf) {
 Bool MCFrame::getLSR(Double &tdb, const MeasFrame& myf) {
   if (myf.radialVelocity()) {
     if (!impl_->radLSRp) {
-      impl_->radLSRp = impl_->radConvLSR->operator()
-	(*dynamic_cast<const MVRadialVelocity *const>(myf.radialVelocity()->
+      impl_->radLSRp = impl_->radConvLSR(*dynamic_cast<const MVRadialVelocity *const>(myf.radialVelocity()->
 						      getData())).
 	getValue();
     }
@@ -462,7 +443,6 @@ void MCFrame::makeEpoch(const MeasFrame& myf) {
   impl_->epTDBp.reset();
   impl_->epUT1p.reset();
   impl_->epTTp.reset();
-  impl_->epConvLAST.reset();
   impl_->epConvLAST = MEpoch::Convert(*(myf.epoch()),
 				   MEpoch::Ref(MEpoch::LAST, myf));
   impl_->epLASTp.reset();
@@ -474,7 +454,7 @@ void MCFrame::makeEpoch(const MeasFrame& myf) {
 void MCFrame::makePosition(const MeasFrame& myf) {
   static const MPosition::Ref REFLONG 
     = MPosition::Ref(MPosition::ITRF);
-  impl_->posConvLong = MPosition::Convert(*(myf.position()),
+  impl_->posConvLong = MPosition::Convert(*myf.position(),
 				       REFLONG);
   impl_->posLongp = casacore::Vector<Double>();
   impl_->posITRFp.reset();
@@ -482,7 +462,7 @@ void MCFrame::makePosition(const MeasFrame& myf) {
   impl_->radLSRp.reset();
   static const MPosition::Ref REFGEO
     = MPosition::Ref(MPosition::WGS84);
-  impl_->posConvLongGeo = MPosition::Convert(*(myf.position()),
+  impl_->posConvLongGeo = MPosition::Convert(*myf.position(),
 					  REFGEO);
   impl_->posLongGeop = casacore::Vector<Double>();
   impl_->posGeop.reset();
@@ -490,15 +470,15 @@ void MCFrame::makePosition(const MeasFrame& myf) {
 
 void MCFrame::makeDirection(const MeasFrame& myf) {
   static const MDirection::Ref REFJ2000 = MDirection::Ref(MDirection::J2000);
-  impl_->dirConvJ2000 = MDirection::Convert(*(myf.direction()),
+  impl_->dirConvJ2000 = MDirection::Convert(*myf.direction(),
 					 MDirection::Ref(MDirection::J2000,
 							 myf));
 
   static const MDirection::Ref REFB1950 = MDirection::Ref(MDirection::B1950);
-  impl_->dirConvB1950 = MDirection::Convert(*(myf.direction()),
+  impl_->dirConvB1950 = MDirection::Convert(*myf.direction(),
 					 MDirection::Ref(MDirection::B1950,
 							 myf));
-  impl_->dirConvApp = MDirection::Convert(*(myf.direction()),
+  impl_->dirConvApp = MDirection::Convert(*myf.direction(),
 				       MDirection::Ref(MDirection::APP,
 						       myf));
   impl_->j2000Longp = casacore::Vector<Double>();
@@ -513,7 +493,7 @@ void MCFrame::makeDirection(const MeasFrame& myf) {
 void MCFrame::makeRadialVelocity(const MeasFrame& myf) {
   static const MRadialVelocity::Ref REFLSR 
     = MRadialVelocity::Ref(MRadialVelocity::LSRK);
-  impl_->radConvLSR = MRadialVelocity::Convert(*(myf.radialVelocity()),
+  impl_->radConvLSR = MRadialVelocity::Convert(*myf.radialVelocity(),
 					    REFLSR);
   impl_->radLSRp.reset();
 }

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -123,7 +123,7 @@ void MCFrame::resetEpoch() {
 }
 
 void MCFrame::resetPosition() {
-  if (impl_->posLongp.empty()) {
+  if (!impl_->posLongp.empty()) {
     impl_->posLongp = casacore::Vector<Double>();
     impl_->posITRFp.reset();
     impl_->posLongGeop = casacore::Vector<Double>();
@@ -135,15 +135,15 @@ void MCFrame::resetPosition() {
 }
 
 void MCFrame::resetDirection() {
-  if (impl_->j2000Longp.empty()) {
+  if (!impl_->j2000Longp.empty()) {
     impl_->j2000Longp = casacore::Vector<Double>();
     impl_->dirJ2000p.reset();
   }
-  if (impl_->b1950Longp.empty()) {
+  if (!impl_->b1950Longp.empty()) {
     impl_->b1950Longp = casacore::Vector<Double>();
     impl_->dirB1950p.reset();
   }
-  if (impl_->appLongp.empty()) {
+  if (!impl_->appLongp.empty()) {
     impl_->appLongp = casacore::Vector<Double>();
     impl_->dirAppp.reset();
   }

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -46,11 +46,6 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 struct MCFrameImplementation {
-  //# Data
-  // The belonging frame pointer
-  // MeasFrame myf;
-  // The actual measure conversion values
-  // <group>
   // Conversion to TDB time (due to some (for me) unsolvable dependency
   // errors)
   // not the proper MeasConvert* here)
@@ -103,7 +98,6 @@ struct MCFrameImplementation {
   std::optional<MeasConvert<MRadialVelocity>> radConvLSR;
   // Radial velocity
   std::optional<Double> radLSRp;
-  // </group>
 };
   
 MCFrame::MCFrame() :

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -46,9 +46,7 @@
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 struct MCFrameImplementation {
-  // Conversion to TDB time (due to some (for me) unsolvable dependency
-  // errors)
-  // not the proper MeasConvert* here)
+  // Conversion to TDB time
   MeasConvert<MEpoch> epConvTDB;
   // TDB time
   std::optional<Double> epTDBp;

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -24,6 +24,9 @@
 //#                        Charlottesville, VA 22903-2475 USA
 
 //# Includes
+#include <optional>
+
+#include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/BasicMath/Math.h>
 #include <casacore/casa/BasicSL/Constants.h>
@@ -42,425 +45,412 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-// MCFrame class
- 
-//# Constructors
-MCFrame::MCFrame(MeasFrame &inf) :
-  myf(inf),
-  epConvTDB(0), epTDBp(0), 
-  epConvUT1(0), epUT1p(0), 
-  epConvTT(0), epTTp(0), 
-  epConvLAST(0), epLASTp(0), 
-  posConvLong(0), posLongp(0), posITRFp(0),
-  posConvLongGeo(0), posLongGeop(0), posGeop(0),
-  dirConvJ2000(0), j2000Longp(0), dirJ2000p(0),
-  dirConvB1950(0), b1950Longp(0), dirB1950p(0),
-  dirConvApp(0), appLongp(0), dirAppp(0),
-  radConvLSR(0), radLSRp(0) {;}
-
-// Destructor
-MCFrame::~MCFrame() {
-  delete static_cast<MEpoch::Convert *>(epConvTDB);
-  delete epTDBp;
-  delete static_cast<MEpoch::Convert *>(epConvUT1);
-  delete epUT1p;
-  delete static_cast<MEpoch::Convert *>(epConvTT);
-  delete epTTp;
-  delete static_cast<MEpoch::Convert *>(epConvLAST);
-  delete epLASTp;
-  delete static_cast<MPosition::Convert *>(posConvLong);
-  delete posLongp;
-  delete posITRFp;
-  delete static_cast<MPosition::Convert *>(posConvLongGeo);
-  delete posLongGeop;
-  delete posGeop;
-  delete static_cast<MDirection::Convert *>(dirConvJ2000);
-  delete j2000Longp;
-  delete dirJ2000p;
-  delete static_cast<MDirection::Convert *>(dirConvB1950);
-  delete b1950Longp;
-  delete dirB1950p;
-  delete static_cast<MDirection::Convert *>(dirConvApp);
-  delete appLongp;
-  delete dirAppp;
-  delete static_cast<MRadialVelocity::Convert *>(radConvLSR);
-  delete radLSRp;
+struct MCFrameImplementation {
+  //# Data
+  // The belonging frame pointer
+  // MeasFrame myf;
+  // The actual measure conversion values
+  // <group>
+  // Conversion to TDB time (due to some (for me) unsolvable dependency
+  // errors)
+  // not the proper MeasConvert* here)
+  std::optional<MeasConvert<MEpoch>> epConvTDB;
+  // TDB time
+  std::optional<Double> epTDBp;
+  // Conversion to UT1 time
+  std::optional<MeasConvert<MEpoch>> epConvUT1;
+  // UT1 time
+  std::optional<Double> epUT1p;
+  // Conversion to TT time
+  std::optional<MeasConvert<MEpoch>> epConvTT;
+  // TT time
+  std::optional<Double> epTTp;
+  // Conversion to LAST time
+  std::optional<MeasConvert<MEpoch>> epConvLAST;
+  // LAST time
+  std::optional<Double> epLASTp;
+  // Conversion to ITRF longitude/latitude
+  std::optional<MeasConvert<MPosition>> posConvLong;
+  // Longitude
+  Vector<Double> posLongp;
+  // Position
+  std::optional<MVPosition> posITRFp;
+  // Conversion to geodetic longitude/latitude
+  std::optional<MeasConvert<MPosition>> posConvLongGeo;
+  // Latitude
+  Vector<Double> posLongGeop;
+  // Position
+  std::optional<MVPosition> posGeop;
+  // Conversion to J2000
+  std::optional<MeasConvert<MDirection>> dirConvJ2000;
+  // Longitude
+  Vector<Double> j2000Longp;
+  // J2000 coordinates
+  std::optional<MVDirection> dirJ2000p;
+  // Conversion to B1950
+  std::optional<MeasConvert<MDirection>> dirConvB1950;
+  // Longitude
+  Vector<Double> b1950Longp;
+  // B1950 coordinates
+  std::optional<MVDirection> dirB1950p;
+  // Conversion to apparent coordinates
+  std::optional<MeasConvert<MDirection>> dirConvApp;
+  // Longitude
+  Vector<Double> appLongp;
+  // Apparent coordinates
+  std::optional<MVDirection> dirAppp;
+  // Conversion to LSR radial velocity
+  std::optional<MeasConvert<MRadialVelocity>> radConvLSR;
+  // Radial velocity
+  std::optional<Double> radLSRp;
+  // </group>
+};
+  
+MCFrame::MCFrame() :
+  impl_(std::make_unique<MCFrameImplementation>()) {
 }
 
-// Operators
+MCFrame::MCFrame(const MCFrame &other) :
+  impl_(std::make_unique<MCFrameImplementation>(*other.impl_))
+{
+}
 
-// General member functions
+MCFrame::MCFrame(MCFrame &&other) = default;
+MCFrame::~MCFrame() = default;
 
 void MCFrame::resetEpoch() {
-    delete epTDBp; epTDBp = 0;
-    delete epUT1p; epUT1p = 0;
-    delete epTTp; epTTp = 0;
-    delete epLASTp; epLASTp = 0;
-    delete appLongp; appLongp = 0;
-    delete dirAppp; dirAppp = 0;
-    delete radLSRp; radLSRp = 0;
+  impl_->epTDBp.reset();
+  impl_->epUT1p.reset();
+  impl_->epTTp.reset();
+  impl_->epLASTp.reset();
+  impl_->appLongp = casacore::Vector<Double>();
+  impl_->dirAppp.reset();
+  impl_->radLSRp.reset();
 }
 
 void MCFrame::resetPosition() {
-  if (posLongp) {
-    delete posLongp; posLongp = 0;
-    delete posITRFp; posITRFp = 0;
-    delete posLongGeop; posLongGeop = 0;
-    delete posGeop; posGeop = 0;
+  if (impl_->posLongp.empty()) {
+    impl_->posLongp = casacore::Vector<Double>();
+    impl_->posITRFp.reset();
+    impl_->posLongGeop = casacore::Vector<Double>();
+    impl_->posGeop.reset();
   }
-  if (epLASTp) {
-    delete epLASTp; epLASTp = 0;
+  if (impl_->epLASTp) {
+    impl_->epLASTp.reset();
   }
 }
 
 void MCFrame::resetDirection() {
-  if (j2000Longp) {
-    delete j2000Longp; j2000Longp = 0;
-    delete dirJ2000p; dirJ2000p = 0;
+  if (impl_->j2000Longp.empty()) {
+    impl_->j2000Longp = casacore::Vector<Double>();
+    impl_->dirJ2000p.reset();
   }
-  if (b1950Longp) {
-    delete b1950Longp; b1950Longp = 0;
-    delete dirB1950p; dirB1950p = 0;
+  if (impl_->b1950Longp.empty()) {
+    impl_->b1950Longp = casacore::Vector<Double>();
+    impl_->dirB1950p.reset();
   }
-  if (appLongp) {
-    delete appLongp; appLongp = 0;
-    delete dirAppp; dirAppp = 0;
+  if (impl_->appLongp.empty()) {
+    impl_->appLongp = casacore::Vector<Double>();
+    impl_->dirAppp.reset();
   }
-  if (radLSRp) {
-    delete radLSRp; radLSRp = 0;
-  }
+  impl_->radLSRp.reset();
 }
 
 void MCFrame::resetRadialVelocity() {
-  if (radLSRp) {
-    delete radLSRp; radLSRp = 0;
-  }
+  impl_->radLSRp.reset();
 }
 
 void MCFrame::resetComet() {
 }
 
-Bool MCFrame::getTDB(Double &tdb) {
+Bool MCFrame::getTDB(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
-    if (!epTDBp) {
-      epTDBp = new Double;
-      *epTDBp = static_cast<MEpoch::Convert *>(epConvTDB)->operator()
+    if (!impl_->epTDBp) {
+      impl_->epTDBp = impl_->epConvTDB->operator()
 	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
-    tdb = *epTDBp;
+    tdb = *impl_->epTDBp;
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getUT1(Double &tdb) {
+Bool MCFrame::getUT1(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
-    if (!epUT1p) {
-      epUT1p = new Double;
-      *epUT1p = static_cast<MEpoch::Convert *>(epConvUT1)->operator()
+    if (!impl_->epUT1p) {
+      impl_->epUT1p = impl_->epConvUT1->operator()
 	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
-    tdb = *epUT1p;
+    tdb = *impl_->epUT1p;
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getTT(Double &tdb) {
+Bool MCFrame::getTT(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
-    if (!epTTp) {
-      epTTp = new Double;
-      *epTTp = static_cast<MEpoch::Convert *>(epConvTT)->operator()
+    if (!impl_->epTTp) {
+      impl_->epTTp = impl_->epConvTT->operator()
 	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
-    tdb = *epTTp;
+    tdb = *impl_->epTTp;
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getLong(Double &tdb) {
+Bool MCFrame::getLong(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
-    if (!posLongp) {
-      posLongp = new Vector<Double>(3);
-      posITRFp = new MVPosition;
-      *posITRFp = static_cast<MPosition::Convert *>(posConvLong)->operator()
+    if (impl_->posLongp.empty()) {
+      impl_->posITRFp = impl_->posConvLong->operator()
 	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      *posLongp = posITRFp->get();
+      impl_->posLongp = impl_->posITRFp->get();
     }
-    tdb = MVAngle(posLongp->operator()(1))(-0.5);
+    tdb = MVAngle(impl_->posLongp(1))(-0.5);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getLat(Double &tdb) {
+Bool MCFrame::getLat(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
-    if (!posLongp) {
-      posLongp = new Vector<Double>(3);
-      posITRFp = new MVPosition;
-      *posITRFp = static_cast<MPosition::Convert *>(posConvLong)->operator()
+    if (impl_->posLongp.empty()) {
+      impl_->posITRFp = impl_->posConvLong->operator()
 	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      *posLongp = posITRFp->get();
+      impl_->posLongp = impl_->posITRFp->get();
     }
-    tdb = posLongp->operator()(2);
+    tdb = impl_->posLongp(2);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getLatGeo(Double &tdb) {
+Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
-    if (!posLongGeop) {
-      posLongGeop = new Vector<Double>(3);
-      posGeop = new MVPosition;
-      *posGeop = static_cast<MPosition::Convert *>(posConvLongGeo)->operator()
+    if (impl_->posLongGeop.empty()) {
+      impl_->posGeop = impl_->posConvLongGeo->operator()
         (*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
         getValue();
-      *posLongGeop = posGeop->get();
+      impl_->posLongGeop = impl_->posGeop->get();
     }
-    tdb = posLongGeop->operator()(2);
+    tdb = impl_->posLongGeop(2);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getITRF(MVPosition &tdb) {
+Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& myf) {
   if (myf.position()) {
-    if (!posLongp) {
-      posLongp = new Vector<Double>(3);
-      posITRFp = new MVPosition;
-      *posITRFp = static_cast<MPosition::Convert *>(posConvLong)->operator()
+    if (impl_->posLongp.empty()) {
+      impl_->posITRFp = impl_->posConvLong->operator()
 	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      *posLongp = posITRFp->get();
+      impl_->posLongp = impl_->posITRFp->get();
     }
-    tdb = *posITRFp;
+    tdb = *impl_->posITRFp;
     return True;
   }
   tdb = MVPosition(0.0);
   return False;
 }
 
-Bool MCFrame::getRadius(Double &tdb) {
+Bool MCFrame::getRadius(Double &tdb, const MeasFrame& myf) {
   if (myf.position()) {
-    if (!posLongp) {
-      posLongp = new Vector<Double>(3);
-      posITRFp = new MVPosition;
-      *posITRFp = static_cast<MPosition::Convert *>(posConvLong)->operator()
+    if (impl_->posLongp.empty()) {
+      impl_->posITRFp = impl_->posConvLong->operator()
 	(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      *posLongp = posITRFp->get();
+      impl_->posLongp = impl_->posITRFp->get();
     }
-    tdb = posLongp->operator()(0);
+    tdb = impl_->posLongp(0);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getLAST(Double &tdb) {
+Bool MCFrame::getLAST(Double &tdb, const MeasFrame& myf) {
   if (myf.epoch()) {
-    if (!epLASTp) {
-      epLASTp = new Double;
-      *epLASTp = static_cast<MEpoch::Convert *>(epConvLAST)->operator()
+    if (!impl_->epLASTp) {
+      impl_->epLASTp = impl_->epConvLAST->operator()
 	(*dynamic_cast<const MVEpoch *const>(myf.epoch()->getData())).
 	getValue().get();
     }
-    tdb = fmod(*epLASTp, 1.0);
+    tdb = fmod(*impl_->epLASTp, 1.0);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getLASTr(Double &tdb) {
-  Bool tmp = MCFrame::getLAST(tdb);
+Bool MCFrame::getLASTr(Double &tdb, const MeasFrame& myf) {
+  Bool tmp = MCFrame::getLAST(tdb, myf);
   tdb *= C::circle;
   return tmp;
 }
 
-Bool MCFrame::getJ2000Long(Double &tdb) {
+Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!j2000Longp) {
-      j2000Longp = new Vector<Double>(2);
-      dirJ2000p = new MVDirection;
-      *dirJ2000p = static_cast<MDirection::Convert *>(dirConvJ2000)->operator()
+    if (impl_->j2000Longp.empty()) {
+      impl_->dirJ2000p = impl_->dirConvJ2000->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *j2000Longp = dirJ2000p->get();
+      impl_->j2000Longp = impl_->dirJ2000p->get();
     }
-    tdb = j2000Longp->operator()(0);
+    tdb = impl_->j2000Longp(0);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getJ2000Lat(Double &tdb) {
+Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!j2000Longp) {
-      j2000Longp = new Vector<Double>(2);
-      dirJ2000p = new MVDirection;
-      *dirJ2000p = static_cast<MDirection::Convert *>(dirConvJ2000)->operator()
+    if (impl_->j2000Longp.empty()) {
+      impl_->dirJ2000p = impl_->dirConvJ2000->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *j2000Longp = dirJ2000p->get();
+      impl_->j2000Longp = impl_->dirJ2000p->get();
     }
-    tdb = j2000Longp->operator()(1);
+    tdb = impl_->j2000Longp(1);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getJ2000(MVDirection &tdb) {
+Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!j2000Longp) {
-      j2000Longp = new Vector<Double>(2);
-      dirJ2000p = new MVDirection;
-      *dirJ2000p = static_cast<MDirection::Convert *>(dirConvJ2000)->operator()
+    if (impl_->j2000Longp.empty()) {
+      impl_->dirJ2000p = impl_->dirConvJ2000->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *j2000Longp = dirJ2000p->get();
+      impl_->j2000Longp = impl_->dirJ2000p->get();
     }
-    tdb = *dirJ2000p;
+    tdb = *impl_->dirJ2000p;
     return True;
   }
   tdb = MVDirection(0.0);
   return False;
 }
 
-Bool MCFrame::getB1950Long(Double &tdb) {
+Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!b1950Longp) {
-      b1950Longp = new Vector<Double>(2);
-      dirB1950p = new MVDirection;
-      *dirB1950p = static_cast<MDirection::Convert *>(dirConvB1950)->operator()
+    if (impl_->b1950Longp.empty()) {
+      impl_->dirB1950p = impl_->dirConvB1950->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *b1950Longp = dirB1950p->get();
+      impl_->b1950Longp = impl_->dirB1950p->get();
     }
-    tdb = b1950Longp->operator()(0);
+    tdb = impl_->b1950Longp(0);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getB1950Lat(Double &tdb) {
+Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!b1950Longp) {
-      b1950Longp = new Vector<Double>(2);
-      dirB1950p = new MVDirection;
-      *dirB1950p = static_cast<MDirection::Convert *>(dirConvB1950)->operator()
+    if (impl_->b1950Longp.empty()) {
+      impl_->dirB1950p = impl_->dirConvB1950->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *b1950Longp = dirB1950p->get();
+      impl_->b1950Longp = impl_->dirB1950p->get();
     }
-    tdb = b1950Longp->operator()(1);
+    tdb = impl_->b1950Longp(1);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getB1950(MVDirection &tdb) {
+Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!b1950Longp) {
-      b1950Longp = new Vector<Double>(2);
-      dirB1950p = new MVDirection;
-      *dirB1950p = static_cast<MDirection::Convert *>(dirConvB1950)->operator()
+    if (impl_->b1950Longp.empty()) {
+      impl_->dirB1950p = impl_->dirConvB1950->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *b1950Longp = dirB1950p->get();
+      impl_->b1950Longp = impl_->dirB1950p->get();
     }
-    tdb = *dirB1950p;
+    tdb = *impl_->dirB1950p;
     return True;
   }
   tdb = MVDirection(0.0);
   return False;
 }
 
-Bool MCFrame::getAppLong(Double &tdb) {
+Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!appLongp) {
-      appLongp = new Vector<Double>(2);
-      dirAppp = new MVDirection;
-      *dirAppp = static_cast<MDirection::Convert *>(dirConvApp)->operator()
+    if (impl_->appLongp.empty()) {
+      impl_->dirAppp = impl_->dirConvApp->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *appLongp = dirAppp->get();
+      impl_->appLongp = impl_->dirAppp->get();
     }
-    tdb = appLongp->operator()(0);
+    tdb = impl_->appLongp(0);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getAppLat(Double &tdb) {
+Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!appLongp) {
-      appLongp = new Vector<Double>(2);
-      dirAppp = new MVDirection;
-      *dirAppp = static_cast<MDirection::Convert *>(dirConvApp)->operator()
+    if (impl_->appLongp.empty()) {
+      impl_->dirAppp = impl_->dirConvApp->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *appLongp = dirAppp->get();
+      impl_->appLongp = impl_->dirAppp->get();
     }
-    tdb = appLongp->operator()(1);
+    tdb = impl_->appLongp(1);
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getApp(MVDirection &tdb) {
+Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& myf) {
   if (myf.direction()) {
-    if (!appLongp) {
-      appLongp = new Vector<Double>(2);
-      dirAppp = new MVDirection;
-      *dirAppp = static_cast<MDirection::Convert *>(dirConvApp)->operator()
+    if (impl_->appLongp.empty()) {
+      impl_->dirAppp = impl_->dirConvApp->operator()
 	(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      *appLongp = dirAppp->get();
+      impl_->appLongp = impl_->dirAppp->get();
     }
-    tdb = *dirAppp;
+    tdb = *impl_->dirAppp;
     return True;
   }
   tdb = MVDirection(0.0);
   return False;
 }
 
-Bool MCFrame::getLSR(Double &tdb) {
+Bool MCFrame::getLSR(Double &tdb, const MeasFrame& myf) {
   if (myf.radialVelocity()) {
-    if (!radLSRp) {
-      radLSRp = new Double;
-      *radLSRp = static_cast<MRadialVelocity::Convert *>(radConvLSR)->operator()
+    if (!impl_->radLSRp) {
+      impl_->radLSRp = impl_->radConvLSR->operator()
 	(*dynamic_cast<const MVRadialVelocity *const>(myf.radialVelocity()->
 						      getData())).
 	getValue();
     }
-    tdb = *radLSRp;
+    tdb = *impl_->radLSRp;
     return True;
   }
   tdb = 0.0;
   return False;
 }
 
-Bool MCFrame::getCometType(uInt &tdb) {
+Bool MCFrame::getCometType(uInt &tdb, const MeasFrame& myf) {
   if (myf.comet()) {
     tdb = static_cast<uInt>(myf.comet()->getType());
     return True;
@@ -469,143 +459,96 @@ Bool MCFrame::getCometType(uInt &tdb) {
   return False;
 }
 
-Bool MCFrame::getComet(MVPosition &tdb) {
+Bool MCFrame::getComet(MVPosition &tdb, const MeasFrame& myf) {
   if (myf.comet()) {
     Double x(0);
-    if (getTDB(x) && myf.comet()->get(tdb, x)) return True;
+    if (getTDB(x, myf) && myf.comet()->get(tdb, x)) return True;
   }
   tdb = MVPosition(0.0);
   return False;
 }
 
-void MCFrame::makeEpoch() {
-  static const MEpoch::Ref REFTDB = MEpoch::Ref(MEpoch::TDB);
-  static const MEpoch::Ref REFUT1 = MEpoch::Ref(MEpoch::UT1);
-  static const MEpoch::Ref REFTT  = MEpoch::Ref(MEpoch::TT);
-  delete static_cast<MEpoch::Convert *>(epConvTDB);
-  delete static_cast<MEpoch::Convert *>(epConvUT1);
-  delete static_cast<MEpoch::Convert *>(epConvTT);
-  epConvTDB = new MEpoch::Convert(*(myf.epoch()), REFTDB);
-  epConvUT1 = new MEpoch::Convert(*(myf.epoch()), REFUT1);
-  epConvTT  = new MEpoch::Convert(*(myf.epoch()), REFTT);
-  uInt locker = 0;			// locking assurance
-  if (epTDBp) {
-    delete epTDBp; epTDBp = 0;
+void MCFrame::makeEpoch(const MeasFrame& myf) {
+  const MEpoch::Ref REFTDB = MEpoch::Ref(MEpoch::TDB);
+  const MEpoch::Ref REFUT1 = MEpoch::Ref(MEpoch::UT1);
+  const MEpoch::Ref REFTT  = MEpoch::Ref(MEpoch::TT);
+  impl_->epConvTDB = MEpoch::Convert(*(myf.epoch()), REFTDB);
+  impl_->epConvUT1 = MEpoch::Convert(*(myf.epoch()), REFUT1);
+  impl_->epConvTT  = MEpoch::Convert(*(myf.epoch()), REFTT);
+  impl_->epTDBp.reset();
+  impl_->epUT1p.reset();
+  impl_->epTTp.reset();
+  impl_->epConvLAST.reset();
+  impl_->epConvLAST = MEpoch::Convert(*(myf.epoch()),
+				   MEpoch::Ref(MEpoch::LAST, myf));
+  impl_->epLASTp.reset();
+  if (!impl_->appLongp.empty()) {
+    impl_->appLongp = casacore::Vector<Double>();
+    impl_->dirAppp.reset();
   }
-  if (epUT1p) {
-    delete epUT1p; epUT1p = 0;
-  }
-  if (epTTp) {
-    delete epTTp; epTTp = 0;
-  }
-  myf.lock(locker);
-  if (epConvLAST) {
-    delete static_cast<MEpoch::Convert *>(epConvLAST);
-    epConvLAST = 0;
-  }
-  epConvLAST = new MEpoch::Convert(*(myf.epoch()),
-				   MEpoch::Ref(MEpoch::LAST, this->myf));
-  myf.unlock(locker);
-  if (epLASTp) {
-    delete epLASTp; epLASTp = 0;
-  }
-  if (appLongp) {
-    delete appLongp; appLongp = 0;
-    delete dirAppp; dirAppp = 0;
-  }
-  if (radLSRp) {
-    delete radLSRp; radLSRp = 0;
-  }
+  impl_->radLSRp.reset();
 }
 
-void MCFrame::makePosition() {
+void MCFrame::makePosition(const MeasFrame& myf) {
   static const MPosition::Ref REFLONG 
     = MPosition::Ref(MPosition::ITRF);
-  delete static_cast<MPosition::Convert *>(posConvLong);
-  posConvLong = new MPosition::Convert(*(myf.position()),
+  impl_->posConvLong = MPosition::Convert(*(myf.position()),
 				       REFLONG);
-  if (posLongp) {
-    delete posLongp; posLongp = 0;
-    delete posITRFp; posITRFp = 0;
+  if (!impl_->posLongp.empty()) {
+    impl_->posLongp = casacore::Vector<Double>();
+    impl_->posITRFp.reset();
   }
-  if (epLASTp) {
-    delete epLASTp; epLASTp = 0;
-  }
-  if (radLSRp) {
-    delete radLSRp; radLSRp = 0;
-  }
+  impl_->epLASTp.reset();
+  impl_->radLSRp.reset();
   static const MPosition::Ref REFGEO
     = MPosition::Ref(MPosition::WGS84);
-  delete static_cast<MPosition::Convert *>(posConvLongGeo);
-  posConvLongGeo = new MPosition::Convert(*(myf.position()),
+  impl_->posConvLongGeo = MPosition::Convert(*(myf.position()),
 					  REFGEO);
-  if (posLongGeop) {
-    delete posLongGeop; posLongGeop = 0;
-    delete posGeop; posGeop = 0;
+  if (!impl_->posLongGeop.empty()) {
+    impl_->posLongGeop = casacore::Vector<Double>();
+    impl_->posGeop.reset();
   }
 }
 
-void MCFrame::makeDirection() {
+void MCFrame::makeDirection(const MeasFrame& myf) {
   static const MDirection::Ref REFJ2000 = MDirection::Ref(MDirection::J2000);
-  uInt locker =0;
-  myf.lock(locker);
-  if (dirConvJ2000) {
-    delete static_cast<MDirection::Convert *>(dirConvJ2000);
-    dirConvJ2000 = 0;
-  }
-  dirConvJ2000 = new MDirection::Convert(*(myf.direction()),
+  impl_->dirConvJ2000 = MDirection::Convert(*(myf.direction()),
 					 MDirection::Ref(MDirection::J2000,
-							 this->myf));
-  myf.unlock(locker);
+							 myf));
 
   static const MDirection::Ref REFB1950 = MDirection::Ref(MDirection::B1950);
-  myf.lock(locker);
-  if (dirConvB1950) {
-    delete static_cast<MDirection::Convert *>(dirConvB1950);
-    dirConvB1950 = 0;
-  }
-  dirConvB1950 = new MDirection::Convert(*(myf.direction()),
+  impl_->dirConvB1950 = MDirection::Convert(*(myf.direction()),
 					 MDirection::Ref(MDirection::B1950,
-							 this->myf));
-  myf.unlock(locker);
-  myf.lock(locker);
-  if (dirConvApp) {
-    delete static_cast<MDirection::Convert *>(dirConvApp);
-    dirConvApp = 0;
-  }
-  dirConvApp = new MDirection::Convert(*(myf.direction()),
+							 myf));
+  impl_->dirConvApp = MDirection::Convert(*(myf.direction()),
 				       MDirection::Ref(MDirection::APP,
-						       this->myf));
-  myf.unlock(locker);
-  if (j2000Longp) {
-    delete j2000Longp; j2000Longp = 0;
-    delete dirJ2000p; dirJ2000p = 0;
+						       myf));
+  if (!impl_->j2000Longp.empty()) {
+    impl_->j2000Longp = casacore::Vector<Double>();
+    impl_->dirJ2000p.reset();
   }
-  if (b1950Longp) {
-    delete b1950Longp; b1950Longp = 0;
-    delete dirB1950p; dirB1950p = 0;
+  if (!impl_->b1950Longp.empty()) {
+    impl_->b1950Longp = casacore::Vector<Double>();
+    impl_->dirB1950p.reset();
   }
-  if (appLongp) {
-    delete appLongp; appLongp = 0;
-    delete dirAppp; dirAppp = 0;
+  if (!impl_->appLongp.empty()) {
+    impl_->appLongp = casacore::Vector<Double>();
+    impl_->dirAppp.reset();
   }
-  if (radLSRp) {
-    delete radLSRp; radLSRp = 0;
+  if (impl_->radLSRp) {
+    impl_->radLSRp.reset();
   }
 }
 
-void MCFrame::makeRadialVelocity() {
+void MCFrame::makeRadialVelocity(const MeasFrame& myf) {
   static const MRadialVelocity::Ref REFLSR 
     = MRadialVelocity::Ref(MRadialVelocity::LSRK);
-  delete static_cast<MRadialVelocity::Convert *>(radConvLSR);
-  radConvLSR = new MRadialVelocity::Convert(*(myf.radialVelocity()),
+  impl_->radConvLSR = MRadialVelocity::Convert(*(myf.radialVelocity()),
 					    REFLSR);
-  if (radLSRp) {
-    delete radLSRp; radLSRp = 0;
-  }
+  impl_->radLSRp.reset();
 }
 
-void MCFrame::makeComet() {;}
+void MCFrame::makeComet() {}
 
 } //# NAMESPACE CASACORE - END
 

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -123,30 +123,20 @@ void MCFrame::resetEpoch() {
 }
 
 void MCFrame::resetPosition() {
-  if (!impl_->posLongp.empty()) {
-    impl_->posLongp = casacore::Vector<Double>();
-    impl_->posITRFp.reset();
-    impl_->posLongGeop = casacore::Vector<Double>();
-    impl_->posGeop.reset();
-  }
-  if (impl_->epLASTp) {
-    impl_->epLASTp.reset();
-  }
+  impl_->posLongp = casacore::Vector<Double>();
+  impl_->posITRFp.reset();
+  impl_->posLongGeop = casacore::Vector<Double>();
+  impl_->posGeop.reset();
+  impl_->epLASTp.reset();
 }
 
 void MCFrame::resetDirection() {
-  if (!impl_->j2000Longp.empty()) {
-    impl_->j2000Longp = casacore::Vector<Double>();
-    impl_->dirJ2000p.reset();
-  }
-  if (!impl_->b1950Longp.empty()) {
-    impl_->b1950Longp = casacore::Vector<Double>();
-    impl_->dirB1950p.reset();
-  }
-  if (!impl_->appLongp.empty()) {
-    impl_->appLongp = casacore::Vector<Double>();
-    impl_->dirAppp.reset();
-  }
+  impl_->j2000Longp = casacore::Vector<Double>();
+  impl_->dirJ2000p.reset();
+  impl_->b1950Longp = casacore::Vector<Double>();
+  impl_->dirB1950p.reset();
+  impl_->appLongp = casacore::Vector<Double>();
+  impl_->dirAppp.reset();
   impl_->radLSRp.reset();
 }
 
@@ -476,10 +466,8 @@ void MCFrame::makeEpoch(const MeasFrame& myf) {
   impl_->epConvLAST = MEpoch::Convert(*(myf.epoch()),
 				   MEpoch::Ref(MEpoch::LAST, myf));
   impl_->epLASTp.reset();
-  if (!impl_->appLongp.empty()) {
-    impl_->appLongp = casacore::Vector<Double>();
-    impl_->dirAppp.reset();
-  }
+  impl_->appLongp = casacore::Vector<Double>();
+  impl_->dirAppp.reset();
   impl_->radLSRp.reset();
 }
 
@@ -488,20 +476,16 @@ void MCFrame::makePosition(const MeasFrame& myf) {
     = MPosition::Ref(MPosition::ITRF);
   impl_->posConvLong = MPosition::Convert(*(myf.position()),
 				       REFLONG);
-  if (!impl_->posLongp.empty()) {
-    impl_->posLongp = casacore::Vector<Double>();
-    impl_->posITRFp.reset();
-  }
+  impl_->posLongp = casacore::Vector<Double>();
+  impl_->posITRFp.reset();
   impl_->epLASTp.reset();
   impl_->radLSRp.reset();
   static const MPosition::Ref REFGEO
     = MPosition::Ref(MPosition::WGS84);
   impl_->posConvLongGeo = MPosition::Convert(*(myf.position()),
 					  REFGEO);
-  if (!impl_->posLongGeop.empty()) {
-    impl_->posLongGeop = casacore::Vector<Double>();
-    impl_->posGeop.reset();
-  }
+  impl_->posLongGeop = casacore::Vector<Double>();
+  impl_->posGeop.reset();
 }
 
 void MCFrame::makeDirection(const MeasFrame& myf) {
@@ -517,21 +501,13 @@ void MCFrame::makeDirection(const MeasFrame& myf) {
   impl_->dirConvApp = MDirection::Convert(*(myf.direction()),
 				       MDirection::Ref(MDirection::APP,
 						       myf));
-  if (!impl_->j2000Longp.empty()) {
-    impl_->j2000Longp = casacore::Vector<Double>();
-    impl_->dirJ2000p.reset();
-  }
-  if (!impl_->b1950Longp.empty()) {
-    impl_->b1950Longp = casacore::Vector<Double>();
-    impl_->dirB1950p.reset();
-  }
-  if (!impl_->appLongp.empty()) {
-    impl_->appLongp = casacore::Vector<Double>();
-    impl_->dirAppp.reset();
-  }
-  if (impl_->radLSRp) {
-    impl_->radLSRp.reset();
-  }
+  impl_->j2000Longp = casacore::Vector<Double>();
+  impl_->dirJ2000p.reset();
+  impl_->b1950Longp = casacore::Vector<Double>();
+  impl_->dirB1950p.reset();
+  impl_->appLongp = casacore::Vector<Double>();
+  impl_->dirAppp.reset();
+  impl_->radLSRp.reset();
 }
 
 void MCFrame::makeRadialVelocity(const MeasFrame& myf) {

--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -67,31 +67,31 @@ struct MCFrameImplementation {
   // Longitude
   Vector<Double> posLongp;
   // Position
-  std::optional<MVPosition> posITRFp;
+  MVPosition posITRFp;
   // Conversion to geodetic longitude/latitude
   MeasConvert<MPosition> posConvLongGeo;
   // Latitude
   Vector<Double> posLongGeop;
   // Position
-  std::optional<MVPosition> posGeop;
+  MVPosition posGeop;
   // Conversion to J2000
   MeasConvert<MDirection> dirConvJ2000;
   // Longitude
   Vector<Double> j2000Longp;
   // J2000 coordinates
-  std::optional<MVDirection> dirJ2000p;
+  MVDirection dirJ2000p;
   // Conversion to B1950
   MeasConvert<MDirection> dirConvB1950;
   // Longitude
   Vector<Double> b1950Longp;
   // B1950 coordinates
-  std::optional<MVDirection> dirB1950p;
+  MVDirection dirB1950p;
   // Conversion to apparent coordinates
   MeasConvert<MDirection> dirConvApp;
   // Longitude
   Vector<Double> appLongp;
   // Apparent coordinates
-  std::optional<MVDirection> dirAppp;
+  MVDirection dirAppp;
   // Conversion to LSR radial velocity
   MeasConvert<MRadialVelocity> radConvLSR;
   // Radial velocity
@@ -116,25 +116,25 @@ void MCFrame::resetEpoch() {
   impl_->epTTp.reset();
   impl_->epLASTp.reset();
   impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp.reset();
+  impl_->dirAppp = MVDirection();
   impl_->radLSRp.reset();
 }
 
 void MCFrame::resetPosition() {
   impl_->posLongp = casacore::Vector<Double>();
-  impl_->posITRFp.reset();
+  impl_->posITRFp = MVPosition();
   impl_->posLongGeop = casacore::Vector<Double>();
-  impl_->posGeop.reset();
+  impl_->posGeop = MVPosition();
   impl_->epLASTp.reset();
 }
 
 void MCFrame::resetDirection() {
   impl_->j2000Longp = casacore::Vector<Double>();
-  impl_->dirJ2000p.reset();
+  impl_->dirJ2000p = MVDirection();
   impl_->b1950Longp = casacore::Vector<Double>();
-  impl_->dirB1950p.reset();
+  impl_->dirB1950p = MVDirection();
   impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp.reset();
+  impl_->dirAppp = MVDirection();
   impl_->radLSRp.reset();
 }
 
@@ -189,7 +189,7 @@ Bool MCFrame::getLong(Double &tdb, const MeasFrame& myf) {
     if (impl_->posLongp.empty()) {
       impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp->get();
+      impl_->posLongp = impl_->posITRFp.get();
     }
     tdb = MVAngle(impl_->posLongp(1))(-0.5);
     return True;
@@ -203,7 +203,7 @@ Bool MCFrame::getLat(Double &tdb, const MeasFrame& myf) {
     if (impl_->posLongp.empty()) {
       impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp->get();
+      impl_->posLongp = impl_->posITRFp.get();
     }
     tdb = impl_->posLongp(2);
     return True;
@@ -217,7 +217,7 @@ Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& myf) {
     if (impl_->posLongGeop.empty()) {
       impl_->posGeop = impl_->posConvLongGeo(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
         getValue();
-      impl_->posLongGeop = impl_->posGeop->get();
+      impl_->posLongGeop = impl_->posGeop.get();
     }
     tdb = impl_->posLongGeop(2);
     return True;
@@ -231,9 +231,9 @@ Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& myf) {
     if (impl_->posLongp.empty()) {
       impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp->get();
+      impl_->posLongp = impl_->posITRFp.get();
     }
-    tdb = *impl_->posITRFp;
+    tdb = impl_->posITRFp;
     return True;
   }
   tdb = MVPosition(0.0);
@@ -245,7 +245,7 @@ Bool MCFrame::getRadius(Double &tdb, const MeasFrame& myf) {
     if (impl_->posLongp.empty()) {
       impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *const>(myf.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp->get();
+      impl_->posLongp = impl_->posITRFp.get();
     }
     tdb = impl_->posLongp(0);
     return True;
@@ -278,7 +278,7 @@ Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& myf) {
     if (impl_->j2000Longp.empty()) {
       impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->j2000Longp = impl_->dirJ2000p->get();
+      impl_->j2000Longp = impl_->dirJ2000p.get();
     }
     tdb = impl_->j2000Longp(0);
     return True;
@@ -292,7 +292,7 @@ Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& myf) {
     if (impl_->j2000Longp.empty()) {
       impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->j2000Longp = impl_->dirJ2000p->get();
+      impl_->j2000Longp = impl_->dirJ2000p.get();
     }
     tdb = impl_->j2000Longp(1);
     return True;
@@ -306,9 +306,9 @@ Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& myf) {
     if (impl_->j2000Longp.empty()) {
       impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->j2000Longp = impl_->dirJ2000p->get();
+      impl_->j2000Longp = impl_->dirJ2000p.get();
     }
-    tdb = *impl_->dirJ2000p;
+    tdb = impl_->dirJ2000p;
     return True;
   }
   tdb = MVDirection(0.0);
@@ -320,7 +320,7 @@ Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& myf) {
     if (impl_->b1950Longp.empty()) {
       impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->b1950Longp = impl_->dirB1950p->get();
+      impl_->b1950Longp = impl_->dirB1950p.get();
     }
     tdb = impl_->b1950Longp(0);
     return True;
@@ -334,7 +334,7 @@ Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& myf) {
     if (impl_->b1950Longp.empty()) {
       impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->b1950Longp = impl_->dirB1950p->get();
+      impl_->b1950Longp = impl_->dirB1950p.get();
     }
     tdb = impl_->b1950Longp(1);
     return True;
@@ -348,9 +348,9 @@ Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& myf) {
     if (impl_->b1950Longp.empty()) {
       impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->b1950Longp = impl_->dirB1950p->get();
+      impl_->b1950Longp = impl_->dirB1950p.get();
     }
-    tdb = *impl_->dirB1950p;
+    tdb = impl_->dirB1950p;
     return True;
   }
   tdb = MVDirection(0.0);
@@ -362,7 +362,7 @@ Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& myf) {
     if (impl_->appLongp.empty()) {
       impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->appLongp = impl_->dirAppp->get();
+      impl_->appLongp = impl_->dirAppp.get();
     }
     tdb = impl_->appLongp(0);
     return True;
@@ -376,7 +376,7 @@ Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& myf) {
     if (impl_->appLongp.empty()) {
       impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->appLongp = impl_->dirAppp->get();
+      impl_->appLongp = impl_->dirAppp.get();
     }
     tdb = impl_->appLongp(1);
     return True;
@@ -390,9 +390,9 @@ Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& myf) {
     if (impl_->appLongp.empty()) {
       impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *const>(myf.direction()->getData())).
 	getValue();
-      impl_->appLongp = impl_->dirAppp->get();
+      impl_->appLongp = impl_->dirAppp.get();
     }
-    tdb = *impl_->dirAppp;
+    tdb = impl_->dirAppp;
     return True;
   }
   tdb = MVDirection(0.0);
@@ -445,7 +445,7 @@ void MCFrame::makeEpoch(const MeasFrame& myf) {
 				   MEpoch::Ref(MEpoch::LAST, myf));
   impl_->epLASTp.reset();
   impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp.reset();
+  impl_->dirAppp = MVDirection();
   impl_->radLSRp.reset();
 }
 
@@ -455,7 +455,7 @@ void MCFrame::makePosition(const MeasFrame& myf) {
   impl_->posConvLong = MPosition::Convert(*myf.position(),
 				       REFLONG);
   impl_->posLongp = casacore::Vector<Double>();
-  impl_->posITRFp.reset();
+  impl_->posITRFp = MVPosition();
   impl_->epLASTp.reset();
   impl_->radLSRp.reset();
   static const MPosition::Ref REFGEO
@@ -463,7 +463,7 @@ void MCFrame::makePosition(const MeasFrame& myf) {
   impl_->posConvLongGeo = MPosition::Convert(*myf.position(),
 					  REFGEO);
   impl_->posLongGeop = casacore::Vector<Double>();
-  impl_->posGeop.reset();
+  impl_->posGeop = MVPosition();
 }
 
 void MCFrame::makeDirection(const MeasFrame& myf) {
@@ -480,11 +480,11 @@ void MCFrame::makeDirection(const MeasFrame& myf) {
 				       MDirection::Ref(MDirection::APP,
 						       myf));
   impl_->j2000Longp = casacore::Vector<Double>();
-  impl_->dirJ2000p.reset();
+  impl_->dirJ2000p = MVDirection();
   impl_->b1950Longp = casacore::Vector<Double>();
-  impl_->dirB1950p.reset();
+  impl_->dirB1950p = MVDirection();
   impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp.reset();
+  impl_->dirAppp = MVDirection();
   impl_->radLSRp.reset();
 }
 

--- a/measures/Measures/MCFrame.h
+++ b/measures/Measures/MCFrame.h
@@ -113,60 +113,60 @@ public:
   // Reset Comet
   void resetComet();
   // Make full Epoch
-  void makeEpoch(const MeasFrame& myf);
+  void makeEpoch(const MeasFrame& frame);
   // Make full Position
-  void makePosition(const MeasFrame& myf);
+  void makePosition(const MeasFrame& frame);
   // Make full Direction
-  void makeDirection(const MeasFrame& myf);
+  void makeDirection(const MeasFrame& frame);
   // Make full RadialVelocity
-  void makeRadialVelocity(const MeasFrame& myf);
+  void makeRadialVelocity(const MeasFrame& frame);
   // Make full Comet
   void makeComet();
 
-  // Get TDB in days
-  Bool getTDB(Double &tdb, const MeasFrame& myf);
+  // Get time as Temps Dynamique Barycentrique (TDB, or Barycentric Dynamical Time) in days
+  Bool getTDB(Double &tdb, const MeasFrame& frame);
   // Get UT1 in days
-  Bool getUT1(Double &tdb, const MeasFrame& myf);
+  Bool getUT1(Double &tdb, const MeasFrame& frame);
   // Get TT in days
-  Bool getTT(Double &tdb, const MeasFrame& myf);
+  Bool getTT(Double &tdb, const MeasFrame& frame);
   // Get the longitude (in rad)
-  Bool getLong(Double &tdb, const MeasFrame& myf);
+  Bool getLong(Double &tdb, const MeasFrame& frame);
   // Get the latitude (ITRF) (in rad)
-  Bool getLat(Double &tdb, const MeasFrame& myf);
+  Bool getLat(Double &tdb, const MeasFrame& frame);
   // Get the position
-  Bool getITRF(MVPosition &tdb, const MeasFrame& myf);
+  Bool getITRF(MVPosition &tdb, const MeasFrame& frame);
   // Get the geocentric position (in m)
-  Bool getRadius(Double &tdb, const MeasFrame& myf);
+  Bool getRadius(Double &tdb, const MeasFrame& frame);
   // Get the geodetic latitude
-  Bool getLatGeo(Double &tdb, const MeasFrame& myf);
+  Bool getLatGeo(Double &tdb, const MeasFrame& frame);
   // Get the LAST (in days)
-  Bool getLAST(Double &tdb, const MeasFrame& myf);
+  Bool getLAST(Double &tdb, const MeasFrame& frame);
   // Get the LAST (in rad)
-  Bool getLASTr(Double &tdb, const MeasFrame& myf);
+  Bool getLASTr(Double &tdb, const MeasFrame& frame);
   // Get J2000 coordinates (direction cosines) and long/lat (rad)
   // <group>
-  Bool getJ2000(MVDirection &tdb, const MeasFrame& myf);
-  Bool getJ2000Long(Double &tdb, const MeasFrame& myf);
-  Bool getJ2000Lat(Double &tdb, const MeasFrame& myf);
+  Bool getJ2000(MVDirection &tdb, const MeasFrame& frame);
+  Bool getJ2000Long(Double &tdb, const MeasFrame& frame);
+  Bool getJ2000Lat(Double &tdb, const MeasFrame& frame);
   // </group>
   // Get B1950 coordinates (direction cosines) and long/lat (rad)
   // <group>
-  Bool getB1950(MVDirection &tdb, const MeasFrame& myf);
-  Bool getB1950Long(Double &tdb, const MeasFrame& myf);
-  Bool getB1950Lat(Double &tdb, const MeasFrame& myf);
+  Bool getB1950(MVDirection &tdb, const MeasFrame& frame);
+  Bool getB1950Long(Double &tdb, const MeasFrame& frame);
+  Bool getB1950Lat(Double &tdb, const MeasFrame& frame);
   // </group>
   // Get apparent coordinates (direction cosines) and long/lat (rad)
   // <group>
-  Bool getApp(MVDirection &tdb, const MeasFrame& myf);
-  Bool getAppLong(Double &tdb, const MeasFrame& myf);
-  Bool getAppLat(Double &tdb, const MeasFrame& myf);
+  Bool getApp(MVDirection &tdb, const MeasFrame& frame);
+  Bool getAppLong(Double &tdb, const MeasFrame& frame);
+  Bool getAppLat(Double &tdb, const MeasFrame& frame);
   // </group>
   // Get LSR radial velocity (m/s)
-  Bool getLSR(Double &tdb, const MeasFrame& myf);
+  Bool getLSR(Double &tdb, const MeasFrame& frame);
   // Get Comet type
-  Bool getCometType(uInt &tdb, const MeasFrame& myf);
+  Bool getCometType(uInt &tdb, const MeasFrame& frame);
   // Get Comet position
-  Bool getComet(MVPosition &tdb, const MeasFrame& myf);
+  Bool getComet(MVPosition &tdb, const MeasFrame& frame);
   
 private:
   MCFrame &operator=(const MCFrame &other) = delete;

--- a/measures/Measures/MCFrame.h
+++ b/measures/Measures/MCFrame.h
@@ -28,15 +28,13 @@
 
 //# Includes
 #include <casacore/casa/aips.h>
-#include <casacore/casa/Arrays/Vector.h>
 #include <casacore/measures/Measures/Measure.h>
-#include <casacore/measures/Measures/MeasFrame.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
-class MVDirection;
-class MVPosition;
+class MeasFrame;
+struct MCFrameImplementation;
 
 // <summary>
 // Measure frame calculations proxy
@@ -94,7 +92,9 @@ public:
   
   //# Constructors
   // Construct using the MeasFrame parent
-  MCFrame(MeasFrame &inf);
+  MCFrame();
+  MCFrame(const MCFrame &other);
+  MCFrame(MCFrame &&other);
 
   // Destructor
   ~MCFrame();
@@ -113,128 +113,67 @@ public:
   // Reset Comet
   void resetComet();
   // Make full Epoch
-  void makeEpoch();
+  void makeEpoch(const MeasFrame& myf);
   // Make full Position
-  void makePosition();
+  void makePosition(const MeasFrame& myf);
   // Make full Direction
-  void makeDirection();
+  void makeDirection(const MeasFrame& myf);
   // Make full RadialVelocity
-  void makeRadialVelocity();
+  void makeRadialVelocity(const MeasFrame& myf);
   // Make full Comet
   void makeComet();
 
   // Get TDB in days
-  Bool getTDB(Double &tdb);
+  Bool getTDB(Double &tdb, const MeasFrame& myf);
   // Get UT1 in days
-  Bool getUT1(Double &tdb);
+  Bool getUT1(Double &tdb, const MeasFrame& myf);
   // Get TT in days
-  Bool getTT(Double &tdb);
+  Bool getTT(Double &tdb, const MeasFrame& myf);
   // Get the longitude (in rad)
-  Bool getLong(Double &tdb);
+  Bool getLong(Double &tdb, const MeasFrame& myf);
   // Get the latitude (ITRF) (in rad)
-  Bool getLat(Double &tdb);
+  Bool getLat(Double &tdb, const MeasFrame& myf);
   // Get the position
-  Bool getITRF(MVPosition &tdb);
+  Bool getITRF(MVPosition &tdb, const MeasFrame& myf);
   // Get the geocentric position (in m)
-  Bool getRadius(Double &tdb);
+  Bool getRadius(Double &tdb, const MeasFrame& myf);
   // Get the geodetic latitude
-  Bool getLatGeo(Double &tdb);
+  Bool getLatGeo(Double &tdb, const MeasFrame& myf);
   // Get the LAST (in days)
-  Bool getLAST(Double &tdb);
+  Bool getLAST(Double &tdb, const MeasFrame& myf);
   // Get the LAST (in rad)
-  Bool getLASTr(Double &tdb);
+  Bool getLASTr(Double &tdb, const MeasFrame& myf);
   // Get J2000 coordinates (direction cosines) and long/lat (rad)
   // <group>
-  Bool getJ2000(MVDirection &tdb);
-  Bool getJ2000Long(Double &tdb);
-  Bool getJ2000Lat(Double &tdb);
+  Bool getJ2000(MVDirection &tdb, const MeasFrame& myf);
+  Bool getJ2000Long(Double &tdb, const MeasFrame& myf);
+  Bool getJ2000Lat(Double &tdb, const MeasFrame& myf);
   // </group>
   // Get B1950 coordinates (direction cosines) and long/lat (rad)
   // <group>
-  Bool getB1950(MVDirection &tdb);
-  Bool getB1950Long(Double &tdb);
-  Bool getB1950Lat(Double &tdb);
+  Bool getB1950(MVDirection &tdb, const MeasFrame& myf);
+  Bool getB1950Long(Double &tdb, const MeasFrame& myf);
+  Bool getB1950Lat(Double &tdb, const MeasFrame& myf);
   // </group>
   // Get apparent coordinates (direction cosines) and long/lat (rad)
   // <group>
-  Bool getApp(MVDirection &tdb);
-  Bool getAppLong(Double &tdb);
-  Bool getAppLat(Double &tdb);
+  Bool getApp(MVDirection &tdb, const MeasFrame& myf);
+  Bool getAppLong(Double &tdb, const MeasFrame& myf);
+  Bool getAppLat(Double &tdb, const MeasFrame& myf);
   // </group>
   // Get LSR radial velocity (m/s)
-  Bool getLSR(Double &tdb);
+  Bool getLSR(Double &tdb, const MeasFrame& myf);
   // Get Comet type
-  Bool getCometType(uInt &tdb);
+  Bool getCometType(uInt &tdb, const MeasFrame& myf);
   // Get Comet position
-  Bool getComet(MVPosition &tdb);
+  Bool getComet(MVPosition &tdb, const MeasFrame& myf);
   
 private:
-  //# Data
-  // The belonging frame pointer
-  MeasFrame myf;
-  // The actual measure conversion values
-  // <group>
-  // Conversion to TDB time (due to some (for me) unsolvable dependency
-  // errors)
-  // not the proper MeasConvert* here)
-  void *epConvTDB;
-  // TDB time
-  Double *epTDBp;
-  // Conversion to UT1 time
-  void *epConvUT1;
-  // UT1 time
-  Double *epUT1p;
-  // Conversion to TT time
-  void *epConvTT;
-  // TT time
-  Double *epTTp;
-  // Conversion to LAST time
-  void *epConvLAST;
-  // LAST time
-  Double *epLASTp;
-  // Conversion to ITRF longitude/latitude
-  void *posConvLong;
-  // Longitude
-  Vector<Double> *posLongp;
-  // Position
-  MVPosition *posITRFp;
-  // Conversion to geodetic longitude/latitude
-  void *posConvLongGeo;
-  // Latitude
-  Vector<Double> *posLongGeop;
-  // Position
-  MVPosition *posGeop;
-  // Conversion to J2000
-  void *dirConvJ2000;
-  // Longitude
-  Vector<Double> *j2000Longp;
-  // J2000 coordinates
-  MVDirection *dirJ2000p;
-  // Conversion to B1950
-  void *dirConvB1950;
-  // Longitude
-  Vector<Double> *b1950Longp;
-  // B1950 coordinates
-  MVDirection *dirB1950p;
-  // Conversion to apparent coordinates
-  void *dirConvApp;
-  // Longitude
-  Vector<Double> *appLongp;
-  // Apparent coordinates
-  MVDirection *dirAppp;
-  // Conversion to LSR radial velocity
-  void *radConvLSR;
-  // Radial velocity
-  Double *radLSRp;
-  // </group>
+  MCFrame &operator=(const MCFrame &other) = delete;
   
-  //# Member functions
-  // Default constructor (not implemented)
-  MCFrame();
-  // Copy constructor (not implemented)
-  MCFrame(const MCFrame &other);
-  // Copy assignment (not implemented)
-  MCFrame &operator=(const MCFrame &other);
+  // pointer-to-implementation (pimpl) pattern is used to avoid a large number of
+  // dependencies in the header file.
+  std::unique_ptr<MCFrameImplementation> impl_;
 };
 
 

--- a/measures/Measures/MeasFrame.cc
+++ b/measures/Measures/MeasFrame.cc
@@ -324,133 +324,133 @@ void MeasFrame::unlock(const uInt locker) {
 }
 
 Bool MeasFrame::getTDB(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getTDB(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getTDB(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getUT1(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getUT1(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getUT1(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getTT(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getTT(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getTT(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getLong(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getLong(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getLong(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getLat(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getLat(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getLat(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getITRF(MVPosition &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getITRF(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getITRF(tdb, *this));
   tdb = MVPosition(0.0);
   return False; 
 }
 
 Bool MeasFrame::getRadius(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getRadius(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getRadius(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getLatGeo(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getLatGeo(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getLatGeo(tdb, *this));
   tdb = 0;
   return False;
 }
 
 Bool MeasFrame::getLAST(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getLAST(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getLAST(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getLASTr(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getLASTr(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getLASTr(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getJ2000(MVDirection &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getJ2000(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getJ2000(tdb, *this));
   tdb = Double(0.0);
   return False; 
 }
 
 Bool MeasFrame::getJ2000Long(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getJ2000Long(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getJ2000Long(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getJ2000Lat(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getJ2000Lat(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getJ2000Lat(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getB1950(MVDirection &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getB1950(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getB1950(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getB1950Long(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getB1950Long(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getB1950Long(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getB1950Lat(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getB1950Lat(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getB1950Lat(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getApp(MVDirection &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getApp(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getApp(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getAppLong(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getAppLong(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getAppLong(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getAppLat(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getAppLat(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getAppLat(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getLSR(Double &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getLSR(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getLSR(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getCometType(uInt &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getCometType(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getCometType(tdb, *this));
   tdb = 0;
   return False; 
 }
 
 Bool MeasFrame::getComet(MVPosition &tdb) const {
-  if (rep && rep->mymcf) return (rep->mymcf->getComet(tdb));
+  if (rep && rep->mymcf) return (rep->mymcf->getComet(tdb, *this));
   tdb = MVPosition(0.0);
   return False; 
 }
@@ -460,7 +460,7 @@ void MeasFrame::create() {
     rep = new FrameRep();
     uInt locker = 0;
     lock(locker);
-    rep->mymcf = new MCFrame(*this);
+    rep->mymcf = new MCFrame();
     unlock(locker);
   }
 }
@@ -517,19 +517,19 @@ void MeasFrame::fill(const MeasComet *in) {
 }
 
 void MeasFrame::makeEpoch() {
-  rep->mymcf->makeEpoch();
+  rep->mymcf->makeEpoch(*this);
 }
 
 void MeasFrame::makePosition() {
-  rep->mymcf->makePosition();
+  rep->mymcf->makePosition(*this);
 }
 
 void MeasFrame::makeDirection() {
-  rep->mymcf->makeDirection();
+  rep->mymcf->makeDirection(*this);
 }
 
 void MeasFrame::makeRadialVelocity() {
-  rep->mymcf->makeRadialVelocity();
+  rep->mymcf->makeRadialVelocity(*this);
 }
 
 void MeasFrame::makeComet() {


### PR DESCRIPTION
This removes an unnecessary MeasFrame field from MCFrame. Since that field keeps a reference, it makes it hard to reason about thread safety.

It also refactors the MCFrame class; the internal fields are moved to the unit file by using the pimpl pattern. This also allows the use of std::optional instead of (smart) pointers, which avoids manual copying (and saves some allocations).