### PR TITLE
Download WSRT Measures from https URL

### DIFF
--- a/docker/py_wheel.docker
+++ b/docker/py_wheel.docker
@@ -24,7 +24,7 @@ RUN yum install -y flex cfitsio-devel blas-devel lapack-devel ncurses-devel read
 # download other source code
 WORKDIR /tmp
 RUN curl -L http://www.iausofa.org/2015_0209_F/sofa_f-20150209_a.tar.gz --output /tmp/sofa.tgz
-RUN curl -L ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar --output /tmp/measures.tgz
+RUN curl -L https://www.astron.nl/iers/WSRT_Measures.ztar --output /tmp/measures.tgz
 RUN curl -L https://downloads.sourceforge.net/project/boost/boost/${BOOST}/boost_${BOOST_}.tar.bz2 --output /tmp/boost.tar.bz2
 
 RUN mkdir /build

--- a/docker/ubuntu2004_clang.docker
+++ b/docker/ubuntu2004_clang.docker
@@ -26,7 +26,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install WSRT Measures (extra casacore data, for tests)
 # Note: The file on the ftp site is updated daily. When warnings regarding leap
 # seconds appear, ignore them or regenerate the docker image.
-    && wget -nv -O /WSRT_Measures.ztar ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+    && wget -nv -O /WSRT_Measures.ztar https://www.astron.nl/iers/WSRT_Measures.ztar \
     && mkdir -p /usr/local/share/casacore/data \
     && cd /usr/local/share/casacore/data \
     && tar xfz /WSRT_Measures.ztar \

--- a/docker/ubuntu2004_gcc.docker
+++ b/docker/ubuntu2004_gcc.docker
@@ -27,7 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install WSRT Measures (extra casacore data, for tests)
 # Note: The file on the ftp site is updated daily. When warnings regarding leap
 # seconds appear, ignore them or regenerate the docker image.
-    && wget -nv -O /WSRT_Measures.ztar ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+    && wget -nv -O /WSRT_Measures.ztar https://www.astron.nl/iers/WSRT_Measures.ztar \
     && mkdir -p /usr/local/share/casacore/data \
     && cd /usr/local/share/casacore/data \
     && tar xfz /WSRT_Measures.ztar \

--- a/docker/ubuntu2204_clang.docker
+++ b/docker/ubuntu2204_clang.docker
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install WSRT Measures (extra casacore data, for tests)
 # Note: The file on the ftp site is updated daily. When warnings regarding leap
 # seconds appear, ignore them or regenerate the docker image.
-    && wget -nv -O /WSRT_Measures.ztar ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+    && wget -nv -O /WSRT_Measures.ztar https://www.astron.nl/iers/WSRT_Measures.ztar \
     && mkdir -p /usr/local/share/casacore/data \
     && cd /usr/local/share/casacore/data \
     && tar xfz /WSRT_Measures.ztar \

--- a/docker/ubuntu2204_gcc.docker
+++ b/docker/ubuntu2204_gcc.docker
@@ -27,7 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install WSRT Measures (extra casacore data, for tests)
 # Note: The file on the ftp site is updated daily. When warnings regarding leap
 # seconds appear, ignore them or regenerate the docker image.
-    && wget -nv -O /WSRT_Measures.ztar ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+    && wget -nv -O /WSRT_Measures.ztar https://www.astron.nl/iers/WSRT_Measures.ztar \
     && mkdir -p /usr/local/share/casacore/data \
     && cd /usr/local/share/casacore/data \
     && tar xfz /WSRT_Measures.ztar \

--- a/docker/ubuntu2404_clang.docker
+++ b/docker/ubuntu2404_clang.docker
@@ -26,7 +26,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install WSRT Measures (extra casacore data, for tests)
 # Note: The file on the ftp site is updated daily. When warnings regarding leap
 # seconds appear, ignore them or regenerate the docker image.
-    && wget -nv -O /WSRT_Measures.ztar ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+    && wget -nv -O /WSRT_Measures.ztar https://www.astron.nl/iers/WSRT_Measures.ztar \
     && mkdir -p /usr/local/share/casacore/data \
     && cd /usr/local/share/casacore/data \
     && tar xfz /WSRT_Measures.ztar \

--- a/docker/ubuntu2404_gcc.docker
+++ b/docker/ubuntu2404_gcc.docker
@@ -29,7 +29,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install WSRT Measures (extra casacore data, for tests)
 # Note: The file on the ftp site is updated daily. When warnings regarding leap
 # seconds appear, ignore them or regenerate the docker image.
-    && wget -nv -O /WSRT_Measures.ztar ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+    && wget -nv -O /WSRT_Measures.ztar https://www.astron.nl/iers/WSRT_Measures.ztar \
     && mkdir -p /usr/local/share/casacore/data \
     && cd /usr/local/share/casacore/data \
     && tar xfz /WSRT_Measures.ztar \


### PR DESCRIPTION
The FTP site is currently down, and in the meantime the file has been additionally hosted under this new https URL. See #1427 for details.