### PR TITLE
Fix read/write of Adios2StMan by row chunks

### DIFF
--- a/tables/DataMan/Adios2StMan.cc
+++ b/tables/DataMan/Adios2StMan.cc
@@ -489,7 +489,6 @@ rownr_t Adios2StMan::impl::open64(rownr_t aNrRows, AipsIO &ios)
       ios >> dummy;
     }
     ios.getend();
-    itsRows = aNrRows;
     return itsRows;
 }
 

--- a/tables/DataMan/Adios2StManColumn.h
+++ b/tables/DataMan/Adios2StManColumn.h
@@ -119,6 +119,30 @@ private:
 
 
 protected:
+
+    /// Iterates over a RefRows object, adjusting an Adios2StManColumn's
+    /// adios variable selection to cover the required table rows (and the full cell)
+    /// while also calculating the offset into a given user-provided array where data
+    /// corresponding to such rows should be written into or read from.
+    class ArrayColumnCellsVIter
+    {
+    public:
+        ArrayColumnCellsVIter(Adios2StManColumn &column, const RefRows &rownrs);
+
+        /// Whether there are more rows to go through
+        bool finished() const;
+
+        /// Adjusts the Adios2StManColumn's adios variable selection to cover the next
+        /// set of rows, returning the offset into the user-provided array that corresponds
+        /// to that selection.
+        std::size_t next_offset();
+
+    private:
+        Adios2StManColumn &itsColumn;
+        RefRowsSliceIter itsRowsSliceIter;
+        std::size_t itsOffset {0};
+    };
+
     void scalarToSelection(rownr_t rownr);
     void scalarColumnVToSelection();
     void scalarColumnCellsVToSelection(const RefRows &rownrs);

--- a/tables/DataMan/test/tAdios2StMan.cc
+++ b/tables/DataMan/test/tAdios2StMan.cc
@@ -279,7 +279,7 @@ void doReadCopiedTable(std::string filename, std::string column, uInt rows, IPos
     VerifyArrayColumn<Complex>(tab, column, rows, array_pos);
 }
 
-int main() {
+int main(int argc, char **argv){
 
 #ifdef HAVE_MPI
     MPI_Init(&argc,&argv);


### PR DESCRIPTION
This PR fixes the `{get,put}ArrayColumnCellsV` implementation for the Adios2StMan. It previously was broken in subtle ways, which became evident during further testing. The PR adds a new class that iterates over the row slices in a `RefRows` object, adjusting the start/offsets of the underlying adios Variable, and returning the corresponding offset into the user-provided buffer. This is then used to correctly read/write consecutive row slices from/to the adios variable to/from the user-provided buffer.

No tests have been added at this stage, but this has been tested at a higher level externally via python-casacore's `table.{get,put}col(nrow=..., startrow=...)`.