### PR TITLE
perf: avoid/defer construction of instances in MCFrame

### DIFF
--- a/measures/Measures/MCFrame.cc
+++ b/measures/Measures/MCFrame.cc
@@ -47,57 +47,57 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 struct MCFrameImplementation {
   // Conversion to TDB time
-  MeasConvert<MEpoch> epConvTDB;
+  std::optional< MeasConvert<MEpoch> > epConvTDB;
   // TDB time
   std::optional<Double> epTDBp;
   // Conversion to UT1 time
-  MeasConvert<MEpoch> epConvUT1;
+  std::optional< MeasConvert<MEpoch> > epConvUT1;
   // UT1 time
   std::optional<Double> epUT1p;
   // Conversion to TT time
-  MeasConvert<MEpoch> epConvTT;
+  std::optional< MeasConvert<MEpoch> > epConvTT;
   // TT time
   std::optional<Double> epTTp;
   // Conversion to LAST time
-  MeasConvert<MEpoch> epConvLAST;
+  std::optional< MeasConvert<MEpoch> > epConvLAST;
   // LAST time
   std::optional<Double> epLASTp;
   // Conversion to ITRF longitude/latitude
-  MeasConvert<MPosition> posConvLong;
+  std::optional< MeasConvert<MPosition> > posConvLong;
   // Longitude
-  Vector<Double> posLongp;
+  std::optional< Vector<Double> > posLongp;
   // Position
-  MVPosition posITRFp;
+  std::optional< MVPosition> posITRFp;
   // Conversion to geodetic longitude/latitude
-  MeasConvert<MPosition> posConvLongGeo;
+  std::optional< MeasConvert<MPosition> > posConvLongGeo;
   // Latitude
-  Vector<Double> posLongGeop;
+  std::optional< Vector<Double> > posLongGeop;
   // Position
-  MVPosition posGeop;
+  std::optional< MVPosition> posGeop;
   // Conversion to J2000
-  MeasConvert<MDirection> dirConvJ2000;
+  std::optional< MeasConvert<MDirection> > dirConvJ2000;
   // Longitude
-  Vector<Double> j2000Longp;
+  std::optional< Vector<Double> > j2000Longp;
   // J2000 coordinates
-  MVDirection dirJ2000p;
+  std::optional< MVDirection> dirJ2000p;
   // Conversion to B1950
-  MeasConvert<MDirection> dirConvB1950;
+  std::optional< MeasConvert<MDirection> > dirConvB1950;
   // Longitude
-  Vector<Double> b1950Longp;
+  std::optional< Vector<Double> > b1950Longp;
   // B1950 coordinates
-  MVDirection dirB1950p;
+  std::optional< MVDirection> dirB1950p;
   // Conversion to apparent coordinates
-  MeasConvert<MDirection> dirConvApp;
+  std::optional< MeasConvert<MDirection> > dirConvApp;
   // Longitude
-  Vector<Double> appLongp;
+  std::optional< Vector<Double> > appLongp;
   // Apparent coordinates
-  MVDirection dirAppp;
+  std::optional<MVDirection> dirAppp;
   // Conversion to LSR radial velocity
-  MeasConvert<MRadialVelocity> radConvLSR;
+  std::optional< MeasConvert<MRadialVelocity> > radConvLSR;
   // Radial velocity
   std::optional<Double> radLSRp;
 };
-  
+
 MCFrame::MCFrame() :
   impl_(std::make_unique<MCFrameImplementation>()) {
 }
@@ -115,26 +115,26 @@ void MCFrame::resetEpoch() {
   impl_->epUT1p.reset();
   impl_->epTTp.reset();
   impl_->epLASTp.reset();
-  impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp = MVDirection();
+  impl_->appLongp.reset();
+  impl_->dirAppp.reset();
   impl_->radLSRp.reset();
 }
 
 void MCFrame::resetPosition() {
-  impl_->posLongp = casacore::Vector<Double>();
-  impl_->posITRFp = MVPosition();
-  impl_->posLongGeop = casacore::Vector<Double>();
-  impl_->posGeop = MVPosition();
+  impl_->posLongp.reset();
+  impl_->posITRFp.reset();
+  impl_->posLongGeop.reset();
+  impl_->posGeop.reset();
   impl_->epLASTp.reset();
 }
 
 void MCFrame::resetDirection() {
-  impl_->j2000Longp = casacore::Vector<Double>();
-  impl_->dirJ2000p = MVDirection();
-  impl_->b1950Longp = casacore::Vector<Double>();
-  impl_->dirB1950p = MVDirection();
-  impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp = MVDirection();
+  impl_->j2000Longp.reset();
+  impl_->dirJ2000p.reset();
+  impl_->b1950Longp.reset();
+  impl_->dirB1950p.reset();
+  impl_->appLongp.reset();
+  impl_->dirAppp.reset();
   impl_->radLSRp.reset();
 }
 
@@ -148,7 +148,7 @@ void MCFrame::resetComet() {
 Bool MCFrame::getTDB(Double &tdb, const MeasFrame& frame) {
   if (frame.epoch()) {
     if (!impl_->epTDBp) {
-      impl_->epTDBp = impl_->epConvTDB(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
+      impl_->epTDBp = impl_->epConvTDB.value()(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epTDBp;
@@ -161,7 +161,7 @@ Bool MCFrame::getTDB(Double &tdb, const MeasFrame& frame) {
 Bool MCFrame::getUT1(Double &tdb, const MeasFrame& frame) {
   if (frame.epoch()) {
     if (!impl_->epUT1p) {
-      impl_->epUT1p = impl_->epConvUT1(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
+      impl_->epUT1p = impl_->epConvUT1.value()(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epUT1p;
@@ -174,7 +174,7 @@ Bool MCFrame::getUT1(Double &tdb, const MeasFrame& frame) {
 Bool MCFrame::getTT(Double &tdb, const MeasFrame& frame) {
   if (frame.epoch()) {
     if (!impl_->epTTp) {
-      impl_->epTTp = impl_->epConvTT(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
+      impl_->epTTp = impl_->epConvTT.value()(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = *impl_->epTTp;
@@ -186,12 +186,12 @@ Bool MCFrame::getTT(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getLong(Double &tdb, const MeasFrame& frame) {
   if (frame.position()) {
-    if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
+    if (!(impl_->posLongp.has_value())) {
+      impl_->posITRFp = impl_->posConvLong.value()(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp.get();
+      impl_->posLongp = impl_->posITRFp.value().get();
     }
-    tdb = MVAngle(impl_->posLongp(1))(-0.5);
+    tdb = MVAngle(impl_->posLongp.value()(1))(-0.5);
     return True;
   }
   tdb = 0.0;
@@ -200,12 +200,12 @@ Bool MCFrame::getLong(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getLat(Double &tdb, const MeasFrame& frame) {
   if (frame.position()) {
-    if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
+    if (!(impl_->posLongp.has_value())) {
+      impl_->posITRFp = impl_->posConvLong.value()(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp.get();
+      impl_->posLongp = impl_->posITRFp.value().get();
     }
-    tdb = impl_->posLongp(2);
+    tdb = impl_->posLongp.value()(2);
     return True;
   }
   tdb = 0.0;
@@ -214,12 +214,12 @@ Bool MCFrame::getLat(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& frame) {
   if (frame.position()) {
-    if (impl_->posLongGeop.empty()) {
-      impl_->posGeop = impl_->posConvLongGeo(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
+    if (!(impl_->posLongGeop.has_value())) {
+      impl_->posGeop = impl_->posConvLongGeo.value()(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
         getValue();
-      impl_->posLongGeop = impl_->posGeop.get();
+      impl_->posLongGeop = impl_->posGeop.value().get();
     }
-    tdb = impl_->posLongGeop(2);
+    tdb = impl_->posLongGeop.value()(2);
     return True;
   }
   tdb = 0.0;
@@ -228,12 +228,12 @@ Bool MCFrame::getLatGeo(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& frame) {
   if (frame.position()) {
-    if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
+    if (!(impl_->posLongp.has_value())) {
+      impl_->posITRFp = impl_->posConvLong.value()(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp.get();
+      impl_->posLongp = impl_->posITRFp.value().get();
     }
-    tdb = impl_->posITRFp;
+    tdb = impl_->posITRFp.value();
     return True;
   }
   tdb = MVPosition(0.0);
@@ -242,12 +242,12 @@ Bool MCFrame::getITRF(MVPosition &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getRadius(Double &tdb, const MeasFrame& frame) {
   if (frame.position()) {
-    if (impl_->posLongp.empty()) {
-      impl_->posITRFp = impl_->posConvLong(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
+    if (!(impl_->posLongp.has_value())) {
+      impl_->posITRFp = impl_->posConvLong.value()(*dynamic_cast<const MVPosition *>(frame.position()->getData())).
 	getValue();
-      impl_->posLongp = impl_->posITRFp.get();
+      impl_->posLongp = impl_->posITRFp.value().get();
     }
-    tdb = impl_->posLongp(0);
+    tdb = impl_->posLongp.value()(0);
     return True;
   }
   tdb = 0.0;
@@ -257,7 +257,7 @@ Bool MCFrame::getRadius(Double &tdb, const MeasFrame& frame) {
 Bool MCFrame::getLAST(Double &tdb, const MeasFrame& frame) {
   if (frame.epoch()) {
     if (!impl_->epLASTp) {
-      impl_->epLASTp = impl_->epConvLAST(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
+      impl_->epLASTp = impl_->epConvLAST.value()(*dynamic_cast<const MVEpoch *>(frame.epoch()->getData())).
 	getValue().get();
     }
     tdb = fmod(*impl_->epLASTp, 1.0);
@@ -275,12 +275,12 @@ Bool MCFrame::getLASTr(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->j2000Longp.has_value())) {
+      impl_->dirJ2000p = impl_->dirConvJ2000.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->j2000Longp = impl_->dirJ2000p.get();
+      impl_->j2000Longp = impl_->dirJ2000p.value().get();
     }
-    tdb = impl_->j2000Longp(0);
+    tdb = impl_->j2000Longp.value()(0);
     return True;
   }
   tdb = 0.0;
@@ -289,12 +289,12 @@ Bool MCFrame::getJ2000Long(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->j2000Longp.has_value())) {
+      impl_->dirJ2000p = impl_->dirConvJ2000.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->j2000Longp = impl_->dirJ2000p.get();
+      impl_->j2000Longp = impl_->dirJ2000p.value().get();
     }
-    tdb = impl_->j2000Longp(1);
+    tdb = impl_->j2000Longp.value()(1);
     return True;
   }
   tdb = 0.0;
@@ -303,12 +303,12 @@ Bool MCFrame::getJ2000Lat(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->j2000Longp.empty()) {
-      impl_->dirJ2000p = impl_->dirConvJ2000(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->j2000Longp.has_value())) {
+      impl_->dirJ2000p = impl_->dirConvJ2000.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->j2000Longp = impl_->dirJ2000p.get();
+      impl_->j2000Longp = impl_->dirJ2000p.value().get();
     }
-    tdb = impl_->dirJ2000p;
+    tdb = impl_->dirJ2000p.value();
     return True;
   }
   tdb = MVDirection(0.0);
@@ -317,12 +317,12 @@ Bool MCFrame::getJ2000(MVDirection &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->b1950Longp.has_value())) {
+      impl_->dirB1950p = impl_->dirConvB1950.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->b1950Longp = impl_->dirB1950p.get();
+      impl_->b1950Longp = impl_->dirB1950p.value().get();
     }
-    tdb = impl_->b1950Longp(0);
+    tdb = impl_->b1950Longp.value()(0);
     return True;
   }
   tdb = 0.0;
@@ -331,12 +331,12 @@ Bool MCFrame::getB1950Long(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->b1950Longp.has_value())) {
+      impl_->dirB1950p = impl_->dirConvB1950.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->b1950Longp = impl_->dirB1950p.get();
+      impl_->b1950Longp = impl_->dirB1950p.value().get();
     }
-    tdb = impl_->b1950Longp(1);
+    tdb = impl_->b1950Longp.value()(1);
     return True;
   }
   tdb = 0.0;
@@ -345,12 +345,12 @@ Bool MCFrame::getB1950Lat(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->b1950Longp.empty()) {
-      impl_->dirB1950p = impl_->dirConvB1950(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->b1950Longp.has_value())) {
+      impl_->dirB1950p = impl_->dirConvB1950.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->b1950Longp = impl_->dirB1950p.get();
+      impl_->b1950Longp = impl_->dirB1950p.value().get();
     }
-    tdb = impl_->dirB1950p;
+    tdb = impl_->dirB1950p.value();
     return True;
   }
   tdb = MVDirection(0.0);
@@ -359,12 +359,12 @@ Bool MCFrame::getB1950(MVDirection &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->appLongp.has_value())) {
+      impl_->dirAppp = impl_->dirConvApp.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->appLongp = impl_->dirAppp.get();
+      impl_->appLongp = impl_->dirAppp.value().get();
     }
-    tdb = impl_->appLongp(0);
+    tdb = impl_->appLongp.value()(0);
     return True;
   }
   tdb = 0.0;
@@ -373,12 +373,12 @@ Bool MCFrame::getAppLong(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->appLongp.has_value())) {
+      impl_->dirAppp = impl_->dirConvApp.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->appLongp = impl_->dirAppp.get();
+      impl_->appLongp = impl_->dirAppp.value().get();
     }
-    tdb = impl_->appLongp(1);
+    tdb = impl_->appLongp.value()(1);
     return True;
   }
   tdb = 0.0;
@@ -387,12 +387,12 @@ Bool MCFrame::getAppLat(Double &tdb, const MeasFrame& frame) {
 
 Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& frame) {
   if (frame.direction()) {
-    if (impl_->appLongp.empty()) {
-      impl_->dirAppp = impl_->dirConvApp(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
+    if (!(impl_->appLongp.has_value())) {
+      impl_->dirAppp = impl_->dirConvApp.value()(*dynamic_cast<const MVDirection *>(frame.direction()->getData())).
 	getValue();
-      impl_->appLongp = impl_->dirAppp.get();
+      impl_->appLongp = impl_->dirAppp.value().get();
     }
-    tdb = impl_->dirAppp;
+    tdb = impl_->dirAppp.value();
     return True;
   }
   tdb = MVDirection(0.0);
@@ -402,7 +402,7 @@ Bool MCFrame::getApp(MVDirection &tdb, const MeasFrame& frame) {
 Bool MCFrame::getLSR(Double &tdb, const MeasFrame& frame) {
   if (frame.radialVelocity()) {
     if (!impl_->radLSRp) {
-      impl_->radLSRp = impl_->radConvLSR(*dynamic_cast<const MVRadialVelocity *>(frame.radialVelocity()->
+      impl_->radLSRp = impl_->radConvLSR.value()(*dynamic_cast<const MVRadialVelocity *>(frame.radialVelocity()->
 						      getData())).
 	getValue();
     }
@@ -449,26 +449,26 @@ void MCFrame::makeEpoch(MeasFrame& frame) {
 				   MEpoch::Ref(MEpoch::LAST, frame));
   frame.rep.Unfreeze(state);
   impl_->epLASTp.reset();
-  impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp = MVDirection();
+  impl_->appLongp.reset();
+  impl_->dirAppp.reset();
   impl_->radLSRp.reset();
 }
 
 void MCFrame::makePosition(const MeasFrame& frame) {
-  static const MPosition::Ref REFLONG 
+  static const MPosition::Ref REFLONG
     = MPosition::Ref(MPosition::ITRF);
   impl_->posConvLong = MPosition::Convert(*frame.position(),
 				       REFLONG);
-  impl_->posLongp = casacore::Vector<Double>();
-  impl_->posITRFp = MVPosition();
+  impl_->posLongp.reset();
+  impl_->posITRFp.reset();
   impl_->epLASTp.reset();
   impl_->radLSRp.reset();
   static const MPosition::Ref REFGEO
     = MPosition::Ref(MPosition::WGS84);
   impl_->posConvLongGeo = MPosition::Convert(*frame.position(),
 					  REFGEO);
-  impl_->posLongGeop = casacore::Vector<Double>();
-  impl_->posGeop = MVPosition();
+  impl_->posLongGeop.reset();
+  impl_->posGeop.reset();
 }
 
 void MCFrame::makeDirection(MeasFrame& frame) {
@@ -486,17 +486,17 @@ void MCFrame::makeDirection(MeasFrame& frame) {
 				       MDirection::Ref(MDirection::APP,
 						       frame));
   frame.rep.Unfreeze(state);
-  impl_->j2000Longp = casacore::Vector<Double>();
-  impl_->dirJ2000p = MVDirection();
-  impl_->b1950Longp = casacore::Vector<Double>();
-  impl_->dirB1950p = MVDirection();
-  impl_->appLongp = casacore::Vector<Double>();
-  impl_->dirAppp = MVDirection();
+  impl_->j2000Longp.reset();
+  impl_->dirJ2000p.reset();
+  impl_->b1950Longp.reset();
+  impl_->dirB1950p.reset();
+  impl_->appLongp.reset();
+  impl_->dirAppp.reset();
   impl_->radLSRp.reset();
 }
 
 void MCFrame::makeRadialVelocity(const MeasFrame& frame) {
-  static const MRadialVelocity::Ref REFLSR 
+  static const MRadialVelocity::Ref REFLSR
     = MRadialVelocity::Ref(MRadialVelocity::LSRK);
   impl_->radConvLSR = MRadialVelocity::Convert(*frame.radialVelocity(),
 					    REFLSR);


### PR DESCRIPTION
An attempt to improve the performance of frame conversion using measures. It turned out that performance degradation originated from recent update was actually due to costly constructor calls during (re-)initialization of `MCFrame` instance and associating `MCFrameImplementations` instance. Major change in this pull request is the use of `std::optional` to avoid/defer construction of some instances. The change should not affect the result.

I'm not sure this is sufficient to make the performance equivalent to the one before measures update. But I think it improves the performance at some level.