### PR TITLE
Update MacOS versions in CI

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13 # x68
-          - macos-14 # arm64
+          - macos-15-intel # x86-64 (will retire in Fall 2027)
+          - macos-15 # arm64
 
     steps:
       - name: checkout


### PR DESCRIPTION
Updated to `macos-15` (arm64) and `macos-15-intel` (x86_64).

Note: Apple has discontinued support for the x86_64 (Intel) architecture. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027.

Fixes #1455 