### PR TITLE
Handle deflate include directory

### DIFF
--- a/cmake/FindCFITSIO.cmake
+++ b/cmake/FindCFITSIO.cmake
@@ -58,15 +58,10 @@ if(NOT CFITSIO_FOUND)
   find_library(M_LIBRARY m)
   mark_as_advanced(CFITSIO_INCLUDE_DIR CFITSIO_LIBRARY M_LIBRARY)
 
-  if(CMAKE_VERSION VERSION_LESS "2.8.3")
-    find_package_handle_standard_args(CFITSIO DEFAULT_MSG
-      CFITSIO_LIBRARY M_LIBRARY CFITSIO_INCLUDE_DIR)
-  else ()
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(CFITSIO
-      REQUIRED_VARS CFITSIO_LIBRARY M_LIBRARY CFITSIO_INCLUDE_DIR
-      VERSION_VAR CFITSIO_VERSION_STRING)
-  endif ()
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(CFITSIO
+    REQUIRED_VARS CFITSIO_LIBRARY M_LIBRARY CFITSIO_INCLUDE_DIR
+    VERSION_VAR CFITSIO_VERSION_STRING)
 
   set(CFITSIO_INCLUDE_DIRS ${CFITSIO_INCLUDE_DIR})
   set(CFITSIO_LIBRARIES ${CFITSIO_LIBRARY} ${M_LIBRARY})

--- a/cmake/FindDeflate.cmake
+++ b/cmake/FindDeflate.cmake
@@ -4,7 +4,7 @@ if(NOT DEFLATE_FOUND)
 
   find_path(DEFLATE_INCLUDE_DIR libdeflate.h)
   find_library(DEFLATE_LIBRARY NAMES deflate libdeflate)
-  mark_as_advanced(WCSLIB_INCLUDE_DIR WCSLIB_LIBRARY M_LIBRARY)
+  mark_as_advanced(DEFLATE_INCLUDE_DIR DEFLATE_LIBRARY)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(DEFLATE

--- a/cmake/FindDeflate.cmake
+++ b/cmake/FindDeflate.cmake
@@ -1,0 +1,14 @@
+# Find libdeflate
+
+if(NOT DEFLATE_FOUND)
+
+  find_path(DEFLATE_INCLUDE_DIR libdeflate.h)
+  find_library(DEFLATE_LIBRARY NAMES deflate libdeflate)
+  mark_as_advanced(WCSLIB_INCLUDE_DIR WCSLIB_LIBRARY M_LIBRARY)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(DEFLATE
+      REQUIRED_VARS DEFLATE_LIBRARY DEFLATE_INCLUDE_DIR
+  )
+
+endif(NOT DEFLATE_FOUND)

--- a/cmake/FindWCSLIB.cmake
+++ b/cmake/FindWCSLIB.cmake
@@ -54,15 +54,10 @@ if(NOT WCSLIB_FOUND)
   find_library(M_LIBRARY m)
   mark_as_advanced(WCSLIB_INCLUDE_DIR WCSLIB_LIBRARY M_LIBRARY)
 
-  if(CMAKE_VERSION VERSION_LESS "2.8.3")
-    find_package_handle_standard_args(WCSLIB DEFAULT_MSG
-      WCSLIB_LIBRARY M_LIBRARY WCSLIB_INCLUDE_DIR)
-  else ()
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(WCSLIB
-      REQUIRED_VARS WCSLIB_LIBRARY M_LIBRARY WCSLIB_INCLUDE_DIR
-      VERSION_VAR WCSLIB_VERSION_STRING)
-  endif ()
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(WCSLIB
+    REQUIRED_VARS WCSLIB_LIBRARY M_LIBRARY WCSLIB_INCLUDE_DIR
+    VERSION_VAR WCSLIB_VERSION_STRING)
 
   set(WCSLIB_INCLUDE_DIRS ${WCSLIB_INCLUDE_DIR})
   set(WCSLIB_LIBRARIES ${WCSLIB_LIBRARY} ${M_LIBRARY})

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach (src ${parser_inputs})
 endforeach (src)
 
 if(BUILD_SISCO)
-find_library(DEFLATE_LIBRARY deflate)
+find_package(Deflate REQUIRED)
 endif(BUILD_SISCO)
 
 include_directories (${CMAKE_CURRENT_BINARY_DIR})
@@ -256,6 +256,7 @@ init_pch_support(casa_tables ${top_level_headers})
 target_link_libraries (casa_tables casa_casa ${CASACORE_ARCH_LIBS} ${DYSCOSTMAN_LIBRARIES} ${CASACORE_ADIOS_LIBRARY} ${CASACORE_MPI_LIBRARY})
 if(BUILD_SISCO)
   target_link_libraries (casa_tables ${DEFLATE_LIBRARY})
+  include_directories(${DEFLATE_INCLUDE_DIR})
 endif(BUILD_SISCO)
 
 add_subdirectory (apps)


### PR DESCRIPTION
I think the current main branch only builds if libdeflate is in the standard include path. This fixes that, in a way somewhat consistent with the rest of the cmake modules in casacore. I also removed some legacy code in other modules.