### PR TITLE
StokesIStMan: Refactor Stokes I functionality and fix alignment bug

### DIFF
--- a/docker/ubuntu2404_gcc.docker
+++ b/docker/ubuntu2404_gcc.docker
@@ -19,7 +19,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libboost-dev \
     libboost-filesystem-dev \
     libboost-python-dev \
-    libboost-system-dev \
     libboost-test-dev \
     libgsl-dev \
     python-is-python3 \

--- a/tables/AlternateMans/ConditionalQueue.h
+++ b/tables/AlternateMans/ConditionalQueue.h
@@ -101,15 +101,13 @@ class ConditionalQueue {
   /**
    * Makes PopIf return false once the queue is empty.
    */
-  void Finish(std::unique_lock<std::mutex>& lock) {
-    [[maybe_unused]] const std::unique_lock<std::mutex>& avoid_lock_warning =
-        lock;
+  void Finish([[maybe_unused]] std::unique_lock<std::mutex>& lock) {
     assert(lock.owns_lock());
     is_finished_ = true;
     push_condition_.notify_all();
   }
 
-  size_t Size(std::unique_lock<std::mutex>& lock) const {
+  size_t Size([[maybe_unused]] std::unique_lock<std::mutex>& lock) const {
     assert(lock.owns_lock());
     return values_.size();
   }

--- a/tables/AlternateMans/MorphingArray.h
+++ b/tables/AlternateMans/MorphingArray.h
@@ -17,17 +17,23 @@
 class MorphingArray {
  public:
   MorphingArray() noexcept = default;
+  
+  template<typename T>
+  MorphingArray() {
+    
+  }
 
-  ~MorphingArray() { std::free(data_); }
+  ~MorphingArray() noexcept { std::free(data_); }
 
   MorphingArray(const MorphingArray&) = delete;
   MorphingArray& operator=(const MorphingArray&) = delete;
 
-  MorphingArray(MorphingArray&& other) : data_(other.data_), size_(other.size_) {
+  MorphingArray(MorphingArray&& other) noexcept : data_(other.data_), size_(other.size_) {
     other.data_ = nullptr;
     other.size_ = 0;
   }
-  MorphingArray& operator=(MorphingArray&& other) {
+  MorphingArray& operator=(MorphingArray&& other) noexcept {
+    std::free(data_);
     data_ = other.data_;
     size_ = other.size_;
     other.data_ = nullptr;

--- a/tables/AlternateMans/MorphingArray.h
+++ b/tables/AlternateMans/MorphingArray.h
@@ -19,11 +19,11 @@ class MorphingArray {
   MorphingArray() noexcept = default;
   
   template<typename T>
-  MorphingArray() {
-    
+  MorphingArray(size_t size) : size_(size) {
+    Allocate<T>();
   }
 
-  ~MorphingArray() noexcept { std::free(data_); }
+  ~MorphingArray() noexcept { free(data_); }
 
   MorphingArray(const MorphingArray&) = delete;
   MorphingArray& operator=(const MorphingArray&) = delete;
@@ -33,7 +33,7 @@ class MorphingArray {
     other.size_ = 0;
   }
   MorphingArray& operator=(MorphingArray&& other) noexcept {
-    std::free(data_);
+    free(data_);
     data_ = other.data_;
     size_ = other.size_;
     other.data_ = nullptr;
@@ -49,12 +49,9 @@ class MorphingArray {
   void Resize(size_t new_size) {
     static_assert(std::is_trivially_destructible_v<T>);
     if (new_size > size_) {
-      std::free(data_);
-      const size_t n_bytes = ((new_size * sizeof(T) + alignof(T) - 1) / alignof(T)) * alignof(T);
-      data_ = std::aligned_alloc(alignof(T), n_bytes);
-      if (!data_) throw std::bad_alloc();
-      std::uninitialized_default_construct_n(reinterpret_cast<T*>(data_), new_size);
+      free(data_);
       size_ = new_size;
+      Allocate<T>();
     }
   }
 
@@ -73,6 +70,18 @@ class MorphingArray {
   size_t Size() const { return size_; }
 
  private:
+  template<typename T>
+  void Allocate() {
+    if constexpr(alignof(T) > sizeof(void*)) {
+      posix_memalign(&data_, alignof(T), size_ * sizeof(T));
+    } else {
+      data_ = malloc(size_ * sizeof(T));
+    }
+    if(!data_)
+      throw std::bad_alloc();
+    std::uninitialized_default_construct_n(reinterpret_cast<T*>(data_), size_);
+  }
+   
   void* data_ = nullptr;
   size_t size_ = 0;
 };

--- a/tables/AlternateMans/MorphingArray.h
+++ b/tables/AlternateMans/MorphingArray.h
@@ -49,7 +49,7 @@ class MorphingArray {
   void Resize(size_t new_size) {
     static_assert(std::is_trivially_destructible_v<T>);
     if (new_size > size_) {
-      free(data_);
+      std::free(data_);
       const size_t n_bytes = ((new_size * sizeof(T) + alignof(T) - 1) / alignof(T)) * alignof(T);
       data_ = std::aligned_alloc(alignof(T), n_bytes);
       if (!data_) throw std::bad_alloc();

--- a/tables/AlternateMans/MorphingArray.h
+++ b/tables/AlternateMans/MorphingArray.h
@@ -1,0 +1,74 @@
+#ifndef CASACORE_MORPHING_ARRAY_H_
+#define CASACORE_MORPHING_ARRAY_H_
+
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <type_traits>
+
+/**
+ * Array class for which the type is determined only at runtime. It handles
+ * run-time allocation and alignment of the type. It simplifies buffer allocation
+ * in the StokesIStManColumn class.
+ *
+ * Once the array is initialized using Resize(), the user must make sure its type
+ * no longer changes.
+ */
+class MorphingArray {
+ public:
+  MorphingArray() noexcept = default;
+
+  ~MorphingArray() { std::free(data_); }
+
+  MorphingArray(const MorphingArray&) = delete;
+  MorphingArray& operator=(const MorphingArray&) = delete;
+
+  MorphingArray(MorphingArray&& other) : data_(other.data_), size_(other.size_) {
+    other.data_ = nullptr;
+    other.size_ = 0;
+  }
+  MorphingArray& operator=(MorphingArray&& other) {
+    data_ = other.data_;
+    size_ = other.size_;
+    other.data_ = nullptr;
+    other.size_ = 0;
+    return *this;
+  }
+
+  /**
+   * Make sure that the array can hold as least the specified number of
+   * elements of type @p T.
+   */
+  template <typename T>
+  void Resize(size_t new_size) {
+    static_assert(std::is_trivially_destructible_v<T>);
+    if (new_size > size_) {
+      free(data_);
+      const size_t n_bytes = ((new_size * sizeof(T) + alignof(T) - 1) / alignof(T)) * alignof(T);
+      data_ = std::aligned_alloc(alignof(T), n_bytes);
+      if (!data_) throw std::bad_alloc();
+      std::uninitialized_default_construct_n(reinterpret_cast<T*>(data_), new_size);
+      size_ = new_size;
+    }
+  }
+
+  template <typename T>
+  T* Data() {
+    static_assert(std::is_trivially_destructible_v<T>);
+    return reinterpret_cast<T*>(data_);
+  }
+
+  template <typename T>
+  const T* Data() const {
+    static_assert(std::is_trivially_destructible_v<T>);
+    return reinterpret_cast<T*>(data_);
+  }
+
+  size_t Size() const { return size_; }
+
+ private:
+  void* data_ = nullptr;
+  size_t size_ = 0;
+};
+
+#endif

--- a/tables/AlternateMans/StokesIConversions.h
+++ b/tables/AlternateMans/StokesIConversions.h
@@ -44,7 +44,7 @@ inline T *TransformToStokesI(const T *input, T *buffer, size_t n) {
   for (size_t i = 0; i != n; ++i) {
     // Placement new is used, because the lifetime of type T needs
     // to be started.
-    new (&buffer[i * sizeof(T)]) T((input[i * 4] + input[i * 4 + 3]) * T(0.5));
+    buffer[i] = T((input[i * 4] + input[i * 4 + 3]) * T(0.5));
     if (input[i * 4 + 1] != T(0.0) || input[i * 4 + 2] != T(0.0))
       throw std::runtime_error(
           "Stokes-I storage modes cannot store data for which the 2nd and 3rd "

--- a/tables/AlternateMans/StokesIConversions.h
+++ b/tables/AlternateMans/StokesIConversions.h
@@ -1,0 +1,78 @@
+#ifndef CASACORE_ALTERNATE_MANS_STOKES_I_CONVERSIONS_H_
+#define CASACORE_ALTERNATE_MANS_STOKES_I_CONVERSIONS_H_
+
+namespace casacore {
+
+/**
+ * Expands @p n values from single Stokes I values
+ * to have 4 values, in place. This implies the array
+ * should have place to store n*4 values.
+ */
+template <typename T>
+inline void ExpandFromStokesI(T *data, size_t n) {
+  for (size_t i = 0; i != n; ++i) {
+    const size_t index = n - i - 1;
+    const T value = data[index];
+    data[index * 4] = value;
+    data[index * 4 + 1] = T();
+    data[index * 4 + 2] = T();
+    data[index * 4 + 3] = value;
+  }
+}
+
+template <>
+inline void ExpandFromStokesI(bool *data, size_t n) {
+  for (size_t i = 0; i != n; ++i) {
+    const size_t index = n - i - 1;
+    const bool value = data[index];
+    data[index * 4] = value;
+    data[index * 4 + 1] = value;
+    data[index * 4 + 2] = value;
+    data[index * 4 + 3] = value;
+  }
+}
+
+/**
+ * Calculates for every set of 4 input values the Stokes-I values by
+ * doing out = 0.5 * (in_pp + in_qq), where pp/qq can be xx/yy or
+ * ll/rr. If pq or qp is non-zero, an exception is thrown.
+ *
+ * If type T is bool, then out = in_pp || in_qq.
+ */
+template <typename T>
+inline T *TransformToStokesI(const T *input, T *buffer, size_t n) {
+  for (size_t i = 0; i != n; ++i) {
+    // Placement new is used, because the lifetime of type T needs
+    // to be started.
+    new (&buffer[i * sizeof(T)]) T((input[i * 4] + input[i * 4 + 3]) * T(0.5));
+    if (input[i * 4 + 1] != T(0.0) || input[i * 4 + 2] != T(0.0))
+      throw std::runtime_error(
+          "Stokes-I storage modes cannot store data for which the 2nd and 3rd "
+          "correlation are non-zero");
+    // While we could also check whether pp == qq, this is a bit more
+    // complicated because of rounding inaccuracies. The above check should
+    // catch the most crucial misuse of the stman, so a pp == qq check is not
+    // performed.
+  }
+  return reinterpret_cast<T *>(buffer);
+}
+
+template <>
+inline bool *TransformToStokesI(const bool *input, bool *buffer, size_t n) {
+  for (size_t i = 0; i != n; ++i) {
+    const bool a = input[i * 4];
+    const bool b = input[i * 4 + 1];
+    const bool c = input[i * 4 + 2];
+    const bool d = input[i * 4 + 3];
+    if (a != b || a != c || a != d)
+      throw std::runtime_error(
+          "Stokes-I storage modes cannot store boolean data for which not all "
+          "correlations are equal");
+    new (&buffer[i]) bool(a);
+  }
+  return reinterpret_cast<bool *>(buffer);
+}
+
+}  // namespace casacore
+
+#endif

--- a/tables/AlternateMans/StokesIStManColumn.h
+++ b/tables/AlternateMans/StokesIStManColumn.h
@@ -7,82 +7,14 @@
 #include <casacore/casa/Arrays/IPosition.h>
 
 #include "BufferedColumnarFile.h"
+#include "MorphingArray.h"
+#include "StokesIConversions.h"
 
 #include <optional>
 
 namespace casacore {
 
 class StokesIStMan;
-
-/**
- * Expands @p n values from single Stokes I values
- * to have 4 values, in place. This implies the array
- * should have place to store n*4 values.
- */
-template <typename T>
-void ExpandFromStokesI(T *data, size_t n) {
-  for (size_t i = 0; i != n; ++i) {
-    const size_t index = n - i - 1;
-    const T value = data[index];
-    data[index * 4] = value;
-    data[index * 4 + 1] = T();
-    data[index * 4 + 2] = T();
-    data[index * 4 + 3] = value;
-  }
-}
-
-template <>
-void ExpandFromStokesI(bool *data, size_t n) {
-  for (size_t i = 0; i != n; ++i) {
-    const size_t index = n - i - 1;
-    const bool value = data[index];
-    data[index * 4] = value;
-    data[index * 4 + 1] = value;
-    data[index * 4 + 2] = value;
-    data[index * 4 + 3] = value;
-  }
-}
-
-/**
- * Calculates for every set of 4 input values the Stokes-I values by
- * doing out = 0.5 * (in_pp + in_qq), where pp/qq can be xx/yy or
- * ll/rr. If pq or qp is non-zero, an exception is thrown.
- *
- * If type T is bool, then out = in_pp || in_qq.
- */
-template <typename T>
-inline T *TransformToStokesI(const T *input, char *buffer, size_t n) {
-  for (size_t i = 0; i != n; ++i) {
-    // Placement new is used, because the lifetime of type T needs
-    // to be started.
-    new (&buffer[i * sizeof(T)]) T((input[i * 4] + input[i * 4 + 3]) * T(0.5));
-    if (input[i * 4 + 1] != T(0.0) || input[i * 4 + 2] != T(0.0))
-      throw std::runtime_error(
-          "Stokes-I stman cannot store data for which the 2nd and 3rd "
-          "correlation are non-zero");
-    // While we could also check whether pp == qq, this is a bit more
-    // complicated because of rounding inaccuracies. The above check should
-    // catch the most crucial misuse of the stman, so a pp == qq check is not
-    // performed.
-  }
-  return reinterpret_cast<T *>(buffer);
-}
-
-template <>
-inline bool *TransformToStokesI(const bool *input, char *buffer, size_t n) {
-  for (size_t i = 0; i != n; ++i) {
-    const bool a = input[i * 4];
-    const bool b = input[i * 4 + 1];
-    const bool c = input[i * 4 + 2];
-    const bool d = input[i * 4 + 3];
-    if (a != b || a != c || a != d)
-      throw std::runtime_error(
-          "Stokes-I stman cannot store boolean data for which not all "
-          "correlations are equal");
-    new (&buffer[i]) bool(a);
-  }
-  return reinterpret_cast<bool *>(buffer);
-}
 
 /**
  * Base class for columns of the StokesIStMan.
@@ -201,8 +133,8 @@ class StokesIStManColumn final : public casacore::StManColumn {
     bool ownership;
     const T *storage = dataPtr->getStorage(ownership);
     const size_t n_values = shape_[1];
-    buffer_.resize(n_values * sizeof(T));
-    T *buffer = TransformToStokesI(storage, buffer_.data(), n_values);
+    buffer_.Resize<T>(n_values);
+    const T *buffer = TransformToStokesI(storage, buffer_.Data<T>(), n_values);
     file_.Write(rowNr, column_offset_, buffer, n_values);
     dataPtr->freeStorage(storage, ownership);
   }
@@ -212,7 +144,7 @@ class StokesIStManColumn final : public casacore::StManColumn {
   BufferedColumnarFile &file_;
   IPosition shape_;
   uint64_t column_offset_;
-  std::vector<char> buffer_;
+  MorphingArray buffer_;
 };
 }  // namespace casacore
 

--- a/tables/AlternateMans/test/CMakeLists.txt
+++ b/tables/AlternateMans/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set (testfiles
   tAntennaPairFile.cc
   tBitPacking.cc
   tColumnarFile.cc
+  tMorphingArray.cc
   tStokesIStMan.cc
   tUvwFile.cc
 )
@@ -14,7 +15,7 @@ if(BUILD_SISCO)
     tSisco.cc
     tSiscoWriter.cc
   )
-  find_library(DEFLATE_LIBRARY deflate)
+  find_package(Deflate REQUIRED)
   set (EXTRA_ALTMANTEST_LIBRARIES ${DEFLATE_LIBRARY})
 elseif()
   set (EXTRA_ALTMANTEST_LIBRARIES)
@@ -27,6 +28,9 @@ if(Boost_FOUND)
   add_executable (altmantest ${testfiles})
   add_pch_support(altmantest)
   target_link_libraries(altmantest casa_tables ${Boost_LIBRARIES} ${EXTRA_ALTMANTEST_LIBRARIES})
+  if(BUILD_SISCO)
+    target_include_directories(altmantest PUBLIC ${DEFLATE_INCLUDE_DIR})
+  endif(BUILD_SISCO)
   add_test (altmantest ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./altmantest)
   add_dependencies(check altmantest)
 endif(Boost_FOUND)

--- a/tables/AlternateMans/test/tMorphingArray.cc
+++ b/tables/AlternateMans/test/tMorphingArray.cc
@@ -1,0 +1,59 @@
+#include "../DataManagers/MorphingArray.h"
+
+#include <complex>
+
+#include <boost/test/unit_test.hpp>
+
+namespace casacore {
+
+BOOST_AUTO_TEST_SUITE(morphing_array)
+
+BOOST_AUTO_TEST_CASE(construct) {
+  BOOST_CHECK_EQUAL(MorphingArray().Size(), 0);
+  BOOST_CHECK(MorphingArray().Data<float>() == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(resize) {
+  MorphingArray a;
+  // allocate
+  a.Resize<std::complex<float>>(5);
+  BOOST_CHECK_EQUAL(a.Size(), 5);
+  BOOST_CHECK(a.Data<float>() != nullptr);
+  const std::complex<float> kValue(2.0f, 3.0f);
+  a.Data<std::complex<float>>()[4] = kValue;
+  BOOST_CHECK_EQUAL(a.Data<std::complex<float>>()[4], kValue);
+  
+  // shrink
+  a.Resize<std::complex<float>>(3);
+  a.Data<std::complex<float>>()[2] = kValue;
+  BOOST_CHECK_EQUAL(a.Data<std::complex<float>>()[2], kValue);
+  
+  // expand
+  a.Resize<std::complex<float>>(8);
+  BOOST_CHECK_EQUAL(a.Size(), 8);
+  a.Data<std::complex<float>>()[7] = kValue;
+  BOOST_CHECK_EQUAL(a.Data<std::complex<float>>()[7], kValue);
+}
+
+BOOST_AUTO_TEST_CASE(move) {
+  MorphingArray empty;
+  MorphingArray a;
+  a.Resize<char>(5);
+  a = std::move(empty);
+  BOOST_CHECK_EQUAL(a.Size(), 0);
+  BOOST_CHECK(a.Data<char>() == nullptr);
+  BOOST_CHECK_EQUAL(empty.Size(), 0);
+  BOOST_CHECK(empty.Data<char>() == nullptr);
+  
+  a.Resize<char>(5);
+  a.Data<char>()[4] = 31;
+  MorphingArray b(std::move(a));
+  BOOST_CHECK_EQUAL(a.Size(), 0);
+  BOOST_CHECK(a.Data<char>() == nullptr);
+  BOOST_CHECK_EQUAL(b.Size(), 5);
+  BOOST_CHECK_EQUAL(b.Data<char>()[4], 31);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace casacore

--- a/tables/AlternateMans/test/tMorphingArray.cc
+++ b/tables/AlternateMans/test/tMorphingArray.cc
@@ -1,4 +1,4 @@
-#include "../DataManagers/MorphingArray.h"
+#include <casacore/tables/AlternateMans/MorphingArray.h>
 
 #include <complex>
 

--- a/tables/AlternateMans/test/tStokesIStMan.cc
+++ b/tables/AlternateMans/test/tStokesIStMan.cc
@@ -1,8 +1,9 @@
 #include <boost/test/unit_test.hpp>
 
-#include <casacore/tables/AlternateMans/StokesIStManColumn.h>
+#include <casacore/tables/AlternateMans/MorphingArray.h>
+#include <casacore/tables/AlternateMans/StokesIConversions.h>
 
-BOOST_AUTO_TEST_SUITE(stokes_i_st_man_column)
+BOOST_AUTO_TEST_SUITE(stokes_i_conversions)
 
 BOOST_AUTO_TEST_CASE(expand_from_stokes_i) {
   casacore::ExpandFromStokesI<int>(nullptr, 0);
@@ -35,16 +36,18 @@ BOOST_AUTO_TEST_CASE(transform_to_stokes_i) {
 
   constexpr size_t data_a_size = 12;
   const bool test_data_a[data_a_size] = {false, false, false, false, true, true, true, true, false, false, false, false};
-  char buffer_a[data_a_size * sizeof(bool)];
-  const bool* result_a = casacore::TransformToStokesI(test_data_a, buffer_a, data_a_size/4);
+  MorphingArray buffer_a;
+  buffer_a.Resize<bool>(data_a_size);
+  const bool* result_a = casacore::TransformToStokesI(test_data_a, buffer_a.Data<bool>(), data_a_size/4);
   BOOST_CHECK(!result_a[0]);
   BOOST_CHECK(result_a[1]);
   BOOST_CHECK(!result_a[2]);
 
   constexpr size_t data_b_size = 16;
   const double test_data_b[data_b_size] = {3.0, 0.0, 0.0, 3.0, 20.0,  0.0,  0.0, 24.0, 0.0,  0.0,   0.0, 1000.0, std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, 0.0};
-  char buffer_b[data_b_size * sizeof(double)];
-  const double* result_b = casacore::TransformToStokesI(test_data_b, buffer_b, data_b_size/4);
+  MorphingArray buffer_b;
+  buffer_a.Resize<double>(data_b_size);
+  const double* result_b = casacore::TransformToStokesI(test_data_b, buffer_b.Data<double>(), data_b_size/4);
   BOOST_CHECK_CLOSE_FRACTION(result_b[0], 3.0, 1e-11);
   BOOST_CHECK_CLOSE_FRACTION(result_b[1], 22.0, 1e-11);
   BOOST_CHECK_CLOSE_FRACTION(result_b[2], 500.0, 1e-11);

--- a/tables/AlternateMans/test/tStokesIStMan.cc
+++ b/tables/AlternateMans/test/tStokesIStMan.cc
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(transform_to_stokes_i) {
   constexpr size_t data_b_size = 16;
   const double test_data_b[data_b_size] = {3.0, 0.0, 0.0, 3.0, 20.0,  0.0,  0.0, 24.0, 0.0,  0.0,   0.0, 1000.0, std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, 0.0};
   MorphingArray buffer_b;
-  buffer_a.Resize<double>(data_b_size);
+  buffer_b.Resize<double>(data_b_size);
   const double* result_b = casacore::TransformToStokesI(test_data_b, buffer_b.Data<double>(), data_b_size/4);
   BOOST_CHECK_CLOSE_FRACTION(result_b[0], 3.0, 1e-11);
   BOOST_CHECK_CLOSE_FRACTION(result_b[1], 22.0, 1e-11);

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -256,7 +256,7 @@ init_pch_support(casa_tables ${top_level_headers})
 target_link_libraries (casa_tables casa_casa ${CASACORE_ARCH_LIBS} ${DYSCOSTMAN_LIBRARIES} ${CASACORE_ADIOS_LIBRARY} ${CASACORE_MPI_LIBRARY})
 if(BUILD_SISCO)
   target_link_libraries (casa_tables ${DEFLATE_LIBRARY})
-  include_directories(${DEFLATE_INCLUDE_DIR})
+  target_include_directories(casa_tables PUBLIC ${DEFLATE_INCLUDE_DIR})
 endif(BUILD_SISCO)
 
 add_subdirectory (apps)

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -356,16 +356,6 @@ DESTINATION include/casacore/tables/Tables
 )
 
 install (FILES
-AlternateMans/AntennaPairFile.h
-AlternateMans/AntennaPairStMan.h
-AlternateMans/AntennaPairStManColumn.h
-AlternateMans/BitPacking.h
-AlternateMans/BufferedColumnarFile.h
-AlternateMans/RowBasedFile.h
-AlternateMans/SimpleColumnarFile.h
-AlternateMans/StokesIStMan.h
-AlternateMans/StokesIStManColumn.h
-AlternateMans/UvwFile.h
 DataMan/BaseMappedArrayEngine.h
 DataMan/BaseMappedArrayEngine.tcc
 DataMan/BitFlagsEngine.h
@@ -450,6 +440,22 @@ ${ADIOS2_HEADERS}
 DESTINATION include/casacore/tables/DataMan
 )
 
+install(FILES
+  AlternateMans/AntennaPairFile.h
+  AlternateMans/AntennaPairStMan.h
+  AlternateMans/AntennaPairStManColumn.h
+  AlternateMans/BitPacking.h
+  AlternateMans/BufferedColumnarFile.h
+  AlternateMans/MorphingArray.h
+  AlternateMans/RowBasedFile.h
+  AlternateMans/SimpleColumnarFile.h
+  AlternateMans/StokesIConversions.h
+  AlternateMans/StokesIStMan.h
+  AlternateMans/StokesIStManColumn.h
+  AlternateMans/UvwFile.h
+  DESTINATION include/casacore/tables/AlternateMans
+)
+
 if(BUILD_SISCO)
 install(FILES
   AlternateMans/BitFloat.h
@@ -461,7 +467,7 @@ install(FILES
   AlternateMans/SiscoStMan.h
   AlternateMans/SiscoStManColumn.h
   AlternateMans/SiscoWriter.h
-DESTINATION include/casacore/tables/DataMan)
+DESTINATION include/casacore/tables/AlternateMans)
 endif(BUILD_SISCO)
 
 install (FILES

--- a/tables/Dysco/CMakeLists.txt
+++ b/tables/Dysco/CMakeLists.txt
@@ -9,7 +9,6 @@ include_directories(${GSL_INCLUDE_DIRS})
 add_compile_options(-O3 -Wall -DNDEBUG)
 
 option(PORTABLE "Generate portable code" ON)
-option(BUILD_PACKAGES "Build Debian packages" OFF)
 
 if(NOT PORTABLE)
   if(USE_AVX512F)


### PR DESCRIPTION
The refactoring is to prepare for a Sisco Stokes I mode.

AI also found that there is an alignment bug in the Stokes I writing; an unaligned char array was allocated and used to store other types like floats (depending on the col type). Fixing this required a bit of work, and a new class "MorphingArray" is introduced to keep things generic. 

PR contains also a CMake fix ; the tests still used the 'old' style deflate library finding. The deflate includes were also changed to use the target_include_dir, which is generally advised over generic includes.

One of the docker containers still installed libboost-system-dev, which is removed.