### PR TITLE
Add a Sisco Stokes I mode

### DIFF
--- a/tables/AlternateMans/ConditionalQueue.h
+++ b/tables/AlternateMans/ConditionalQueue.h
@@ -116,7 +116,7 @@ class ConditionalQueue {
 
  private:
   template <typename Condition>
-  std::list<T>::iterator GetNext(Condition& condition) {
+  std::list<T>::iterator GetNext(Condition&& condition) {
     for (typename std::list<T>::iterator i = values_.begin();
          i != values_.end(); ++i) {
       if (condition(*i)) return i;

--- a/tables/AlternateMans/SiscoReader.cc
+++ b/tables/AlternateMans/SiscoReader.cc
@@ -157,10 +157,10 @@ void SiscoReader::Request(size_t baseline_index, size_t n_values) {
     request.chunk = current_chunk_;
     request.n_values = 0;
     request_queue_.Push(std::move(request), lock);
-    lock.unlock();
     
     results_in_chunk_counter_ = 0;
     current_chunk_ = &chunks_.emplace_back();
+    lock.unlock();
     GetNextChunk(*current_chunk_);
     chunk_item_position_ = 0;
   }

--- a/tables/AlternateMans/SiscoReader.h
+++ b/tables/AlternateMans/SiscoReader.h
@@ -54,7 +54,7 @@ class SiscoReader {
   size_t GetRequestBufferSize() const { return kRequestBufferSize; }
 
   /**
-   * This is an interface that allow parallelism over the decompression. To
+   * This is an interface that allows parallelism over the decompression. To
    * use it, one thread should issue the requests (as fast as possible), while
    * the main thread should obtain the values using @ref GetNextResult().
    * The @ref Request() method is blocking when the internal buffer of results

--- a/tables/AlternateMans/SiscoReader.h
+++ b/tables/AlternateMans/SiscoReader.h
@@ -47,9 +47,7 @@ class SiscoReader {
 
  public:
   SiscoReader(const std::string& filename);
-  SiscoReader(SiscoReader&&) = default;
   ~SiscoReader();
-  SiscoReader& operator=(SiscoReader&&) = default;
 
   void Open(std::span<std::byte> header_data);
 

--- a/tables/AlternateMans/SiscoStMan.cc
+++ b/tables/AlternateMans/SiscoStMan.cc
@@ -22,6 +22,7 @@ SiscoStMan::SiscoStMan(const casacore::String &/*name*/,
     : DataManager() {
   const std::string kDeflateLevelKey = "deflate_level";
   const std::string kPredictLevelKey = "predict_level";
+  const std::string kStokesIKey = "stokes_i";
 
   if (spec.isDefined(kDeflateLevelKey)) {
     deflate_level_ = spec.asInt(kDeflateLevelKey);
@@ -33,11 +34,14 @@ SiscoStMan::SiscoStMan(const casacore::String &/*name*/,
     if (predict_level_ < -1)
       throw std::runtime_error("Invalid value for " + kPredictLevelKey);
   }
+  if (spec.isDefined(kStokesIKey)) {
+    stokes_i_ = spec.asBool(kStokesIKey);
+  }
 }
 
 SiscoStMan::SiscoStMan(const SiscoStMan &source)
     : DataManager(),
-      name_(source.name_), deflate_level_(source.deflate_level_), predict_level_(source.predict_level_) {}
+      name_(source.name_), deflate_level_(source.deflate_level_), predict_level_(source.predict_level_), stokes_i_(source.stokes_i_) {}
 
 SiscoStMan::~SiscoStMan() noexcept = default;
 
@@ -45,6 +49,7 @@ casacore::Record SiscoStMan::dataManagerSpec() const {
   casacore::Record result;
   result.define("deflate_level", deflate_level_);
   result.define("predict_level", predict_level_);
+  result.define("stokes_i", stokes_i_);
   return result;
 }
 
@@ -77,7 +82,7 @@ casacore::DataManagerColumn *SiscoStMan::makeDirArrColumn(
 casacore::DataManagerColumn *SiscoStMan::makeIndArrColumn(
     [[maybe_unused]] const casacore::String &name, int dataType,
     [[maybe_unused]] const casacore::String &dataTypeID) {
-  column_ = std::make_unique<SiscoStManColumn>(*this, static_cast<DataType>(dataType));
+  column_ = std::make_unique<SiscoStManColumn>(*this, static_cast<DataType>(dataType), stokes_i_);
   return column_.get();
 }
 

--- a/tables/AlternateMans/SiscoStMan.cc
+++ b/tables/AlternateMans/SiscoStMan.cc
@@ -23,6 +23,7 @@ SiscoStMan::SiscoStMan(const casacore::String &/*name*/,
   const std::string kDeflateLevelKey = "deflate_level";
   const std::string kPredictLevelKey = "predict_level";
   const std::string kStokesIKey = "stokes_i";
+  const std::string kDiagonalKey = "diagonal";
 
   if (spec.isDefined(kDeflateLevelKey)) {
     deflate_level_ = spec.asInt(kDeflateLevelKey);
@@ -34,14 +35,27 @@ SiscoStMan::SiscoStMan(const casacore::String &/*name*/,
     if (predict_level_ < -1)
       throw std::runtime_error("Invalid value for " + kPredictLevelKey);
   }
+  bool stokes_i = false;
+  bool diagonal = false;
   if (spec.isDefined(kStokesIKey)) {
-    stokes_i_ = spec.asBool(kStokesIKey);
+    stokes_i = spec.asBool(kStokesIKey);
   }
+  if(spec.isDefined(kDiagonalKey)) {
+    diagonal = spec.asBool(kDiagonalKey);
+  }
+  if(stokes_i && diagonal)
+    throw std::runtime_error("Can't combine Stokes I writing with Diagonal writing");
+  if(stokes_i)
+    store_mode_ = SiscoStoreMode::StokesI;
+  else if(diagonal)
+    store_mode_ = SiscoStoreMode::Diagonal;
+  else
+    store_mode_ = SiscoStoreMode::Original;
 }
 
 SiscoStMan::SiscoStMan(const SiscoStMan &source)
     : DataManager(),
-      name_(source.name_), deflate_level_(source.deflate_level_), predict_level_(source.predict_level_), stokes_i_(source.stokes_i_) {}
+      name_(source.name_), deflate_level_(source.deflate_level_), predict_level_(source.predict_level_), store_mode_(source.store_mode_) {}
 
 SiscoStMan::~SiscoStMan() noexcept = default;
 
@@ -49,7 +63,8 @@ casacore::Record SiscoStMan::dataManagerSpec() const {
   casacore::Record result;
   result.define("deflate_level", deflate_level_);
   result.define("predict_level", predict_level_);
-  result.define("stokes_i", stokes_i_);
+  result.define("stokes_i", store_mode_ == SiscoStoreMode::StokesI);
+  result.define("diagonal", store_mode_ == SiscoStoreMode::Diagonal);
   return result;
 }
 
@@ -82,7 +97,7 @@ casacore::DataManagerColumn *SiscoStMan::makeDirArrColumn(
 casacore::DataManagerColumn *SiscoStMan::makeIndArrColumn(
     [[maybe_unused]] const casacore::String &name, int dataType,
     [[maybe_unused]] const casacore::String &dataTypeID) {
-  column_ = std::make_unique<SiscoStManColumn>(*this, static_cast<DataType>(dataType), stokes_i_);
+  column_ = std::make_unique<SiscoStManColumn>(*this, static_cast<DataType>(dataType), store_mode_);
   return column_.get();
 }
 

--- a/tables/AlternateMans/SiscoStMan.h
+++ b/tables/AlternateMans/SiscoStMan.h
@@ -147,6 +147,7 @@ class SiscoStMan final : public casacore::DataManager {
   std::unique_ptr<SiscoStManColumn> column_;
   int deflate_level_ = 9;
   int predict_level_ = 2;
+  bool stokes_i_ = false;
 };
 
 }  // namespace casacore

--- a/tables/AlternateMans/SiscoStMan.h
+++ b/tables/AlternateMans/SiscoStMan.h
@@ -3,6 +3,8 @@
 
 #include <casacore/tables/DataMan/DataManager.h>
 
+#include "SiscoStoreMode.h"
+
 #include <memory>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -147,7 +149,7 @@ class SiscoStMan final : public casacore::DataManager {
   std::unique_ptr<SiscoStManColumn> column_;
   int deflate_level_ = 9;
   int predict_level_ = 2;
-  bool stokes_i_ = false;
+  SiscoStoreMode store_mode_ = SiscoStoreMode::Original;
 };
 
 }  // namespace casacore

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -7,7 +7,7 @@
 #include <casacore/casa/Arrays/IPosition.h>
 
 #include <casacore/tables/Tables/ScalarColumn.h>
-#include <casacore/tables/AlternateMans/StokesIStManColumn.h>
+#include <casacore/tables/AlternateMans/StokesIConversions.h>
 
 #include "SiscoReader.h"
 #include "SiscoWriter.h"
@@ -28,24 +28,10 @@ class SiscoStMan;
 class SiscoStManColumn final : public StManColumn {
  public:
   /**
-   * Constructor, to be overloaded by subclass.
    * @param parent The parent stman to which this column belongs.
    * @param dtype The column's type as defined by Casacore.
    * @param stokes_i Store only one polarization value instead of 4.
-   */
-  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype)
-      : StManColumn(dtype), parent_(parent) {
-    if (dtype != casacore::TpComplex) {
-      throw std::runtime_error(
-          "Sisco storage manager column can only be used for a data column "
-          "with single precision complex values");
-    }
-  }
-
-  ~SiscoStManColumn() override { ResetWriter(); }
-
-  /**
-   * Set the stokes-I mode of this column. If set to true, the column will have
+   * If set to true, the column will have
    * a shape with 4 polarizations (e.g. xx, xy, yx, yy) but only be able to store
    * Stokes I values, so values for which the 1st and 4th value are equal and the
    * other terms are zero.
@@ -54,13 +40,16 @@ class SiscoStManColumn final : public StManColumn {
    * redundant data, but explicitly decreasing it to Stokes I has a small additional
    * effect), and makes compression more than double as fast.
    */
-  void setStokesI(bool stokes_i) {
-    stokes_i_ = stokes_i;
+  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype, bool stokes_i)
+      : StManColumn(dtype), parent_(parent), stokes_i_(stokes_i) {
+    if (dtype != casacore::TpComplex) {
+      throw std::runtime_error(
+          "Sisco storage manager column can only be used for a data column "
+          "with single precision complex values");
+    }
   }
 
-  bool stokesI() const {
-    return stokes_i_;
-  }
+  ~SiscoStManColumn() override { ResetWriter(); }
 
   /**
    * Whether this column is writable
@@ -179,7 +168,7 @@ class SiscoStManColumn final : public StManColumn {
     const int antenna1 = antenna1_column_(current_write_row_);
     const int antenna2 = antenna2_column_(current_write_row_);
     if (array.shape().size() >= 2) {
-      const int n_polarizations = array.shape()[0];
+      const int n_polarizations = stokes_i_ ? 1 : array.shape()[0];
       const size_t n_channels = array.shape()[1];
 
       if (n_channels) {
@@ -190,9 +179,13 @@ class SiscoStManColumn final : public StManColumn {
              ++polarization) {
           const size_t baseline_id = GetBaselineId(
               field_id, data_desc_id, antenna1, antenna2, polarization);
-          for (size_t channel = 0; channel != n_channels; ++channel) {
-            buffer_[channel] =
-                storage[channel * n_polarizations + polarization];
+          if(stokes_i_) {
+            TransformToStokesI(storage, buffer_.data(), n_channels);
+          } else {
+            for (size_t channel = 0; channel != n_channels; ++channel) {
+              buffer_[channel] =
+                  storage[channel * n_polarizations + polarization];
+            }
           }
           writer_->Write(baseline_id, buffer_);
         }

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -7,6 +7,7 @@
 #include <casacore/casa/Arrays/IPosition.h>
 
 #include <casacore/tables/Tables/ScalarColumn.h>
+#include <casacore/tables/AlternateMans/StokesIStManColumn.h>
 
 #include "SiscoReader.h"
 #include "SiscoWriter.h"
@@ -30,8 +31,9 @@ class SiscoStManColumn final : public StManColumn {
    * Constructor, to be overloaded by subclass.
    * @param parent The parent stman to which this column belongs.
    * @param dtype The column's type as defined by Casacore.
+   * @param stokes_i Store only one polarization value instead of 4.
    */
-  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype)
+  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype, bool stokes_i)
       : StManColumn(dtype), parent_(parent) {
     if (dtype != casacore::TpComplex) {
       throw std::runtime_error(
@@ -113,7 +115,7 @@ class SiscoStManColumn final : public StManColumn {
       shape_read_position_ = (shape_read_position_ + 1) % shape_buffer_.size();
     }
     if (shape->size() >= 2) {
-      const int n_polarizations = (*shape)[0];
+      const int n_polarizations = stokes_i_ ? 1 : (*shape)[0];
       const size_t n_channels = (*shape)[1];
 
       if (n_channels) {
@@ -127,6 +129,9 @@ class SiscoStManColumn final : public StManColumn {
             storage[channel * n_polarizations + polarization] =
                 buffer_[channel];
           }
+        }
+        if(stokes_i_) {
+          ExpandFromStokesI(storage, n_channels);
         }
         array.putStorage(storage, ownership);
       }

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -33,7 +33,7 @@ class SiscoStManColumn final : public StManColumn {
    * @param dtype The column's type as defined by Casacore.
    * @param stokes_i Store only one polarization value instead of 4.
    */
-  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype, bool stokes_i)
+  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype)
       : StManColumn(dtype), parent_(parent) {
     if (dtype != casacore::TpComplex) {
       throw std::runtime_error(
@@ -43,6 +43,24 @@ class SiscoStManColumn final : public StManColumn {
   }
 
   ~SiscoStManColumn() override { ResetWriter(); }
+
+  /**
+   * Set the stokes-I mode of this column. If set to true, the column will have
+   * a shape with 4 polarizations (e.g. xx, xy, yx, yy) but only be able to store
+   * Stokes I values, so values for which the 1st and 4th value are equal and the
+   * other terms are zero.
+   *
+   * This saves a small bit of space (Sisco is able to decrease the size of such
+   * redundant data, but explicitly decreasing it to Stokes I has a small additional
+   * effect), and makes compression more than double as fast.
+   */
+  void setStokesI(bool stokes_i) {
+    stokes_i_ = stokes_i;
+  }
+
+  bool stokesI() const {
+    return stokes_i_;
+  }
 
   /**
    * Whether this column is writable
@@ -260,7 +278,8 @@ class SiscoStManColumn final : public StManColumn {
     char header_buffer[kHeaderSize];
     std::fill_n(header_buffer, kHeaderSize, 0);
     std::copy_n(kMagic, kMagicSize, &header_buffer[0]);
-    std::copy_n(reinterpret_cast<const char *>(&kVersionMajor), 2,
+    const uint16_t major_and_stokes_i = kVersionMajor | (stokes_i_ ? 0x8000 : 0);
+    std::copy_n(reinterpret_cast<const char *>(major_and_stokes_i), 2,
                 &header_buffer[kMagicSize]);
     std::copy_n(reinterpret_cast<const char *>(&kVersionMinor), 2,
                 &header_buffer[kMagicSize + 2]);
@@ -286,13 +305,14 @@ class SiscoStManColumn final : public StManColumn {
                                 kHeaderSize);
     reader_->Open(header);
     char magic_tag[kMagicSize];
-    short version_major;
-    short version_minor;
+    uint16_t version_major_and_stokes_i;
+    uint16_t version_minor;
     std::copy_n(&header_buffer[0], kMagicSize, magic_tag);
     std::copy_n(&header_buffer[kMagicSize], 2,
-                reinterpret_cast<char *>(&version_major));
+                reinterpret_cast<char *>(&version_major_and_stokes_i));
     std::copy_n(&header_buffer[kMagicSize + 2], 2,
                 reinterpret_cast<char *>(&version_minor));
+    const uint16_t version_major = version_major_and_stokes_i & 0x7FFF;
     if (version_major != kVersionMajor) {
       throw std::runtime_error(
           "The file on disk is written as a Sisco version " +
@@ -300,6 +320,7 @@ class SiscoStManColumn final : public StManColumn {
           " file, whereas this Casacore version supports only version " +
           std::to_string(kVersionMajor));
     }
+    stokes_i_ = (version_major_and_stokes_i & 0x8000) != 0;
 
     current_read_row_ = 0;
     baseline_ids_.clear();
@@ -450,6 +471,7 @@ class SiscoStManColumn final : public StManColumn {
   std::map<std::array<int, 5>, size_t> baseline_ids_;
   size_t baseline_count_;
   bool file_exists_ = false;
+  bool stokes_i_ = false;
   /**
    * If true, writing is done to a temporary file such that reading can still
    * take place from the old file. The temporary file will be moved over the

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -10,10 +10,12 @@
 #include <casacore/tables/AlternateMans/StokesIConversions.h>
 
 #include "SiscoReader.h"
+#include "SiscoStoreMode.h"
 #include "SiscoWriter.h"
 #include "ShapesFileReader.h"
 #include "ShapesFileWriter.h"
 
+#include <cassert>
 #include <filesystem>
 #include <optional>
 
@@ -30,18 +32,22 @@ class SiscoStManColumn final : public StManColumn {
   /**
    * @param parent The parent stman to which this column belongs.
    * @param dtype The column's type as defined by Casacore.
-   * @param stokes_i Store only one polarization value instead of 4.
-   * If set to true, the column will have
-   * a shape with 4 polarizations (e.g. xx, xy, yx, yy) but only be able to store
-   * Stokes I values, so values for which the 1st and 4th value are equal and the
-   * other terms are zero.
+   * @param mode Allows storing only one or two polarization values instead of four.
+   * If set to @ref SiscoStoreMode::StokesI, the column will need to have
+   * an "apparent" shape of four correlations (e.g. xx, xy, yx, yy) but will only
+   * store Stokes I values, i.e., values for which the 1st and 4th value are
+   * equal and the other terms are zero. For @ref SiscoStoreMode::Diagional,
+   * it will store two values: the first and fourth components, and the other values
+   * should be zero. When using @ref SiscoStoreMode::Original, Sisco will
+   * store all correlations. In this mode, the (apparent) shape of the column can
+   * have any number of polarizations.
    *
    * This saves a small bit of space (Sisco is able to decrease the size of such
    * redundant data, but explicitly decreasing it to Stokes I has a small additional
    * effect), and makes compression more than double as fast.
    */
-  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype, bool stokes_i)
-      : StManColumn(dtype), parent_(parent), stokes_i_(stokes_i) {
+  explicit SiscoStManColumn(SiscoStMan &parent, DataType dtype, SiscoStoreMode mode)
+      : StManColumn(dtype), parent_(parent), store_mode_(mode) {
     if (dtype != casacore::TpComplex) {
       throw std::runtime_error(
           "Sisco storage manager column can only be used for a data column "
@@ -122,7 +128,10 @@ class SiscoStManColumn final : public StManColumn {
       shape_read_position_ = (shape_read_position_ + 1) % shape_buffer_.size();
     }
     if (shape->size() >= 2) {
-      const int n_polarizations = stokes_i_ ? 1 : (*shape)[0];
+      const int n_column_correlations = (*shape)[0];
+      const int n_polarizations = GetNStoredCorrelations(n_column_correlations);
+      assert((store_mode_ != SiscoStoreMode::StokesI && store_mode_ != SiscoStoreMode::Diagonal) || n_column_correlations == 4);
+
       const size_t n_channels = (*shape)[1];
 
       if (n_channels) {
@@ -137,8 +146,10 @@ class SiscoStManColumn final : public StManColumn {
                 buffer_[channel];
           }
         }
-        if(stokes_i_) {
+        if(store_mode_ == SiscoStoreMode::StokesI) {
           ExpandFromStokesI(storage, n_channels);
+        } else if(store_mode_ == SiscoStoreMode::Diagonal) {
+          ExpandFromDiagonal(storage, n_channels);
         }
         array.putStorage(storage, ownership);
       }
@@ -168,7 +179,12 @@ class SiscoStManColumn final : public StManColumn {
     const int antenna1 = antenna1_column_(current_write_row_);
     const int antenna2 = antenna2_column_(current_write_row_);
     if (array.shape().size() >= 2) {
-      const int n_polarizations = stokes_i_ ? 1 : array.shape()[0];
+      const int n_column_correlations = array.shape()[0];
+      const int n_polarizations = GetNStoredCorrelations(n_column_correlations);
+      if((store_mode_ == SiscoStoreMode::StokesI || store_mode_ == SiscoStoreMode::Diagonal) && n_column_correlations != 4)
+      {
+        throw std::runtime_error("Trying to store invalid number of correlations in Sisco column: Sisco was set to store full-correlation values as Stokes I or diagonal visibilities: can only store shape 4 values in this mode");
+      }
       const size_t n_channels = array.shape()[1];
 
       if (n_channels) {
@@ -179,8 +195,10 @@ class SiscoStManColumn final : public StManColumn {
              ++polarization) {
           const size_t baseline_id = GetBaselineId(
               field_id, data_desc_id, antenna1, antenna2, polarization);
-          if(stokes_i_) {
+          if(store_mode_ == SiscoStoreMode::StokesI) {
             TransformToStokesI(storage, buffer_.data(), n_channels);
+          } else if(store_mode_ == SiscoStoreMode::Diagonal) {
+            TransformToDiagonal(storage, buffer_.data(), n_channels);
           } else {
             for (size_t channel = 0; channel != n_channels; ++channel) {
               buffer_[channel] =
@@ -271,8 +289,20 @@ class SiscoStManColumn final : public StManColumn {
     char header_buffer[kHeaderSize];
     std::fill_n(header_buffer, kHeaderSize, 0);
     std::copy_n(kMagic, kMagicSize, &header_buffer[0]);
-    const uint16_t major_and_stokes_i = kVersionMajor | (stokes_i_ ? 0x8000 : 0);
-    std::copy_n(reinterpret_cast<const char *>(&major_and_stokes_i), 2,
+    uint16_t storage_mode_tag;
+    switch(store_mode_) {
+      case SiscoStoreMode::StokesI:
+        storage_mode_tag = 0x8000;
+        break;
+      case SiscoStoreMode::Diagonal:
+        storage_mode_tag = 0x4000;
+        break;
+      case SiscoStoreMode::Original:
+        storage_mode_tag = 0;
+        break;
+    }
+    const uint16_t major_and_mode = kVersionMajor | storage_mode_tag;
+    std::copy_n(reinterpret_cast<const char *>(&major_and_mode), 2,
                 &header_buffer[kMagicSize]);
     std::copy_n(reinterpret_cast<const char *>(&kVersionMinor), 2,
                 &header_buffer[kMagicSize + 2]);
@@ -298,14 +328,14 @@ class SiscoStManColumn final : public StManColumn {
                                 kHeaderSize);
     reader_->Open(header);
     char magic_tag[kMagicSize];
-    uint16_t version_major_and_stokes_i;
+    uint16_t version_major_and_mode;
     uint16_t version_minor;
     std::copy_n(&header_buffer[0], kMagicSize, magic_tag);
     std::copy_n(&header_buffer[kMagicSize], 2,
-                reinterpret_cast<char *>(&version_major_and_stokes_i));
+                reinterpret_cast<char *>(&version_major_and_mode));
     std::copy_n(&header_buffer[kMagicSize + 2], 2,
                 reinterpret_cast<char *>(&version_minor));
-    const uint16_t version_major = version_major_and_stokes_i & 0x7FFF;
+    const uint16_t version_major = version_major_and_mode & 0x3FFF;
     if (version_major != kVersionMajor) {
       throw std::runtime_error(
           "The file on disk is written as a Sisco version " +
@@ -313,7 +343,17 @@ class SiscoStManColumn final : public StManColumn {
           " file, whereas this Casacore version supports only version " +
           std::to_string(kVersionMajor));
     }
-    stokes_i_ = (version_major_and_stokes_i & 0x8000) != 0;
+
+    const uint16_t store_mode_tag = version_major_and_mode & 0xC000;
+    if(store_mode_tag == 0) {
+      store_mode_ = SiscoStoreMode::Original;
+    } else if(store_mode_tag == 0x4000) {
+      store_mode_ = SiscoStoreMode::Diagonal;
+    } else if(store_mode_tag == 0x8000) {
+      store_mode_ = SiscoStoreMode::StokesI;
+    } else {
+      throw std::runtime_error("File specifies an unknown store mode");
+    }
 
     current_read_row_ = 0;
     baseline_ids_.clear();
@@ -347,7 +387,7 @@ class SiscoStManColumn final : public StManColumn {
           data_desc_id_column_(current_requested_reading_row_);
       const int antenna1 = antenna1_column_(current_requested_reading_row_);
       const int antenna2 = antenna2_column_(current_requested_reading_row_);
-      const int n_polarizations = stokes_i_ ? 1 : shape[0];
+      const int n_polarizations = GetNStoredCorrelations(shape[0]);
       const int n_channels = shape[1];
       for (int polarization = 0; polarization != n_polarizations;
            ++polarization) {
@@ -383,7 +423,7 @@ class SiscoStManColumn final : public StManColumn {
 
   void WriteEmptyRow() {
     if (isFixedShape()) {
-      const int n_polarizations = stokes_i_ ? 1 : fixed_shape_[0];
+      const int n_polarizations = GetNStoredCorrelations(fixed_shape_[0]);
       const int n_channels = fixed_shape_[1];
       buffer_.assign(n_channels, 0.0);
       const int field_id = field_id_column_(current_write_row_);
@@ -411,7 +451,7 @@ class SiscoStManColumn final : public StManColumn {
       shape_read_position_ = (shape_read_position_ + 1) % shape_buffer_.size();
     }
     if (shape->size() >= 2) {
-      const int n_polarizations = stokes_i_ ? 1 : (*shape)[0];
+      const int n_polarizations = GetNStoredCorrelations((*shape)[0]);
       const int n_channels = (*shape)[1];
       if (n_channels) {
         buffer_.resize(n_channels);
@@ -423,6 +463,19 @@ class SiscoStManColumn final : public StManColumn {
     }
     RequestOneMoreRow();
     ++current_read_row_;
+  }
+
+  constexpr int GetNStoredCorrelations(const size_t n_column_correlations) const {
+    switch(store_mode_) {
+      case SiscoStoreMode::StokesI:
+        return 1;
+       case SiscoStoreMode::Diagonal:
+        return 2;
+      case SiscoStoreMode::Original:
+        return n_column_correlations;
+    }
+    assert(false);
+    return 0;
   }
 
   static constexpr size_t kHeaderSize = 20;
@@ -464,7 +517,7 @@ class SiscoStManColumn final : public StManColumn {
   std::map<std::array<int, 5>, size_t> baseline_ids_;
   size_t baseline_count_;
   bool file_exists_ = false;
-  bool stokes_i_ = false;
+  SiscoStoreMode store_mode_ = SiscoStoreMode::Original;
   /**
    * If true, writing is done to a temporary file such that reading can still
    * take place from the old file. The temporary file will be moved over the

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -128,13 +128,11 @@ class SiscoStManColumn final : public StManColumn {
       shape_read_position_ = (shape_read_position_ + 1) % shape_buffer_.size();
     }
     if (shape->size() >= 2) {
-      const int n_column_correlations = (*shape)[0];
-      const int n_polarizations = GetNStoredCorrelations(n_column_correlations);
-      assert((store_mode_ != SiscoStoreMode::StokesI && store_mode_ != SiscoStoreMode::Diagonal) || n_column_correlations == 4);
-
       const size_t n_channels = (*shape)[1];
-
       if (n_channels) {
+        const int n_column_correlations = (*shape)[0];
+        const int n_polarizations = GetNStoredCorrelations(n_column_correlations);
+        assert(store_mode_ == SiscoStoreMode::Original || n_column_correlations == 4);
         bool ownership;
         Complex *storage = array.getStorage(ownership);
         buffer_.resize(n_channels);

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -272,7 +272,7 @@ class SiscoStManColumn final : public StManColumn {
     std::fill_n(header_buffer, kHeaderSize, 0);
     std::copy_n(kMagic, kMagicSize, &header_buffer[0]);
     const uint16_t major_and_stokes_i = kVersionMajor | (stokes_i_ ? 0x8000 : 0);
-    std::copy_n(reinterpret_cast<const char *>(major_and_stokes_i), 2,
+    std::copy_n(reinterpret_cast<const char *>(&major_and_stokes_i), 2,
                 &header_buffer[kMagicSize]);
     std::copy_n(reinterpret_cast<const char *>(&kVersionMinor), 2,
                 &header_buffer[kMagicSize + 2]);
@@ -347,7 +347,7 @@ class SiscoStManColumn final : public StManColumn {
           data_desc_id_column_(current_requested_reading_row_);
       const int antenna1 = antenna1_column_(current_requested_reading_row_);
       const int antenna2 = antenna2_column_(current_requested_reading_row_);
-      const int n_polarizations = shape[0];
+      const int n_polarizations = stokes_i_ ? 1 : shape[0];
       const int n_channels = shape[1];
       for (int polarization = 0; polarization != n_polarizations;
            ++polarization) {
@@ -383,7 +383,7 @@ class SiscoStManColumn final : public StManColumn {
 
   void WriteEmptyRow() {
     if (isFixedShape()) {
-      const int n_polarizations = fixed_shape_[0];
+      const int n_polarizations = stokes_i_ ? 1 : fixed_shape_[0];
       const int n_channels = fixed_shape_[1];
       buffer_.assign(n_channels, 0.0);
       const int field_id = field_id_column_(current_write_row_);
@@ -411,7 +411,7 @@ class SiscoStManColumn final : public StManColumn {
       shape_read_position_ = (shape_read_position_ + 1) % shape_buffer_.size();
     }
     if (shape->size() >= 2) {
-      const int n_polarizations = (*shape)[0];
+      const int n_polarizations = stokes_i_ ? 1 : (*shape)[0];
       const int n_channels = (*shape)[1];
       if (n_channels) {
         buffer_.resize(n_channels);

--- a/tables/AlternateMans/SiscoStManColumn.h
+++ b/tables/AlternateMans/SiscoStManColumn.h
@@ -180,7 +180,6 @@ class SiscoStManColumn final : public StManColumn {
     const int antenna2 = antenna2_column_(current_write_row_);
     if (array.shape().size() >= 2) {
       const int n_column_correlations = array.shape()[0];
-      const int n_polarizations = GetNStoredCorrelations(n_column_correlations);
       if((store_mode_ == SiscoStoreMode::StokesI || store_mode_ == SiscoStoreMode::Diagonal) && n_column_correlations != 4)
       {
         throw std::runtime_error("Trying to store invalid number of correlations in Sisco column: Sisco was set to store full-correlation values as Stokes I or diagonal visibilities: can only store shape 4 values in this mode");
@@ -188,9 +187,12 @@ class SiscoStManColumn final : public StManColumn {
       const size_t n_channels = array.shape()[1];
 
       if (n_channels) {
+        const int n_polarizations = GetNStoredCorrelations(n_column_correlations);
         bool ownership;
         const std::complex<float> *storage = array.getStorage(ownership);
         buffer_.resize(n_channels);
+        if(store_mode_ == SiscoStoreMode::Diagonal)
+          CheckIsDiagonal(storage, n_channels);
         for (int polarization = 0; polarization != n_polarizations;
              ++polarization) {
           const size_t baseline_id = GetBaselineId(
@@ -198,11 +200,15 @@ class SiscoStManColumn final : public StManColumn {
           if(store_mode_ == SiscoStoreMode::StokesI) {
             TransformToStokesI(storage, buffer_.data(), n_channels);
           } else if(store_mode_ == SiscoStoreMode::Diagonal) {
-            TransformToDiagonal(storage, buffer_.data(), n_channels);
+            const size_t diagonal_index = polarization * 3; // 0 or 3
+            for (size_t channel = 0; channel != n_channels; ++channel) {
+              buffer_[channel] =
+                  storage[channel * 4 + diagonal_index];
+            }
           } else {
             for (size_t channel = 0; channel != n_channels; ++channel) {
               buffer_[channel] =
-                  storage[channel * n_polarizations + polarization];
+                  storage[channel * n_column_correlations + polarization];
             }
           }
           writer_->Write(baseline_id, buffer_);

--- a/tables/AlternateMans/SiscoStoreMode.h
+++ b/tables/AlternateMans/SiscoStoreMode.h
@@ -1,0 +1,14 @@
+#ifndef SISCO_SISCO_STORE_MODE_H_
+#define SISCO_SISCO_STORE_MODE_H_
+
+namespace casacore {
+
+enum class SiscoStoreMode {
+  Original,
+  Diagonal,
+  StokesI
+};
+
+} // namespace casacore
+
+#endif

--- a/tables/AlternateMans/StokesIConversions.h
+++ b/tables/AlternateMans/StokesIConversions.h
@@ -68,7 +68,7 @@ inline bool *TransformToStokesI(const bool *input, bool *buffer, size_t n) {
       throw std::runtime_error(
           "Stokes-I storage modes cannot store boolean data for which not all "
           "correlations are equal");
-    new (&buffer[i]) bool(a);
+    buffer[i] = a;
   }
   return reinterpret_cast<bool *>(buffer);
 }

--- a/tables/AlternateMans/StokesIConversions.h
+++ b/tables/AlternateMans/StokesIConversions.h
@@ -1,6 +1,8 @@
 #ifndef CASACORE_ALTERNATE_MANS_STOKES_I_CONVERSIONS_H_
 #define CASACORE_ALTERNATE_MANS_STOKES_I_CONVERSIONS_H_
 
+#include <stdexcept>
+
 namespace casacore {
 
 /**
@@ -33,19 +35,37 @@ inline void ExpandFromStokesI(bool *data, size_t n) {
 }
 
 /**
+ * Performs in-place expansion of @p n pair of diagonal values such that each pair
+ * becomes 4 values with zeros for the off-diagonal elements.
+ * This implies the array should have place to store n*4 values.
+ */
+template <typename T>
+inline void ExpandFromDiagonal(T *data, size_t n) {
+  for (size_t i = n*2; i > 0; i -= 2) {
+    const size_t index = i - 2;
+    data[index * 2 + 3] = data[index + 1];
+    data[index * 2 + 2] = T();
+    data[index * 2 + 1] = T();
+    data[index * 2] = data[index];
+  }
+}
+
+/**
  * Calculates for every set of 4 input values the Stokes-I values by
  * doing out = 0.5 * (in_pp + in_qq), where pp/qq can be xx/yy or
  * ll/rr. If pq or qp is non-zero, an exception is thrown.
  *
  * If type T is bool, then out = in_pp || in_qq.
+ *
+ * @param input buffer of size @p n*4 values
+ * @param buffer destination of size @p n*2 values
+ * @param n is the number of groups of 4 values to convert.
  */
 template <typename T>
 inline T *TransformToStokesI(const T *input, T *buffer, size_t n) {
   for (size_t i = 0; i != n; ++i) {
-    // Placement new is used, because the lifetime of type T needs
-    // to be started.
     buffer[i] = T((input[i * 4] + input[i * 4 + 3]) * T(0.5));
-    if (input[i * 4 + 1] != T(0.0) || input[i * 4 + 2] != T(0.0))
+    if (input[i * 4 + 1] != T(0) || input[i * 4 + 2] != T(0))
       throw std::runtime_error(
           "Stokes-I storage modes cannot store data for which the 2nd and 3rd "
           "correlation are non-zero");
@@ -54,7 +74,7 @@ inline T *TransformToStokesI(const T *input, T *buffer, size_t n) {
     // catch the most crucial misuse of the stman, so a pp == qq check is not
     // performed.
   }
-  return reinterpret_cast<T *>(buffer);
+  return buffer;
 }
 
 template <>
@@ -70,7 +90,32 @@ inline bool *TransformToStokesI(const bool *input, bool *buffer, size_t n) {
           "correlations are equal");
     buffer[i] = a;
   }
-  return reinterpret_cast<bool *>(buffer);
+  return buffer;
+}
+
+/**
+ * Transform every set of 4 input values to their diagonal values by
+ * selecting the first and fourth members of every 4 values.
+ * If pq or qp is non-zero, an exception is thrown.
+ *
+ * @param input buffer of size @p n*4 values
+ * @param buffer destination of size @p n*2 values
+ * @param n is the number of groups of 4 values to convert.
+ */
+template <typename T>
+inline void TransformToDiagonal(const T *input, T *buffer, size_t n) {
+  for (size_t i = 0; i != n; ++i) {
+    const T a = input[i * 4];
+    const T b = input[i * 4 + 1];
+    const T c = input[i * 4 + 2];
+    const T d = input[i * 4 + 3];
+    buffer[i*2] = a;
+    buffer[i*2 + 1] = d;
+    if (b != T(0) || c != T(0))
+      throw std::runtime_error(
+          "Diagonal storage modes cannot store data for which the 2nd and 3rd "
+          "correlation are non-zero");
+  }
 }
 
 }  // namespace casacore

--- a/tables/AlternateMans/StokesIConversions.h
+++ b/tables/AlternateMans/StokesIConversions.h
@@ -94,23 +94,18 @@ inline bool *TransformToStokesI(const bool *input, bool *buffer, size_t n) {
 }
 
 /**
- * Transform every set of 4 input values to their diagonal values by
- * selecting the first and fourth members of every 4 values.
+ * Check if every set of 4 input values contains only non-zeros on
+ * the diagonal (pp or qq).
  * If pq or qp is non-zero, an exception is thrown.
  *
  * @param input buffer of size @p n*4 values
- * @param buffer destination of size @p n*2 values
  * @param n is the number of groups of 4 values to convert.
  */
 template <typename T>
-inline void TransformToDiagonal(const T *input, T *buffer, size_t n) {
+inline void CheckIsDiagonal(const T *input, size_t n) {
   for (size_t i = 0; i != n; ++i) {
-    const T a = input[i * 4];
     const T b = input[i * 4 + 1];
     const T c = input[i * 4 + 2];
-    const T d = input[i * 4 + 3];
-    buffer[i*2] = a;
-    buffer[i*2 + 1] = d;
     if (b != T(0) || c != T(0))
       throw std::runtime_error(
           "Diagonal storage modes cannot store data for which the 2nd and 3rd "

--- a/tables/AlternateMans/test/tStokesIStMan.cc
+++ b/tables/AlternateMans/test/tStokesIStMan.cc
@@ -31,6 +31,25 @@ BOOST_AUTO_TEST_CASE(expand_from_stokes_i) {
   BOOST_CHECK_EQUAL(test_data_b[11].imag(), -2.1f);
 }
 
+BOOST_AUTO_TEST_CASE(expand_from_diagonal) {
+  const std::complex<float> u = {8.8, 8.8};
+  const std::complex<float> a = {-3.7, 2.0};
+  const std::complex<float> b = {5.2, 0.0};
+  const std::complex<float> c = {std::numeric_limits<float>::quiet_NaN(), -2.1};
+  const std::complex<float> d = {-3.14, 2.0};
+  std::complex<float> test_data[8] = {a, b, c, d, u,u,u,u};
+  casacore::ExpandFromDiagonal(test_data, 2);
+  const std::complex<float> reference[4] = {
+    a, {0.0}, {0.0}, b // 1
+  };
+  BOOST_CHECK_EQUAL_COLLECTIONS(test_data, test_data+4, reference, reference+4);
+  BOOST_CHECK(std::isnan(test_data[4].real()));
+  BOOST_CHECK_EQUAL(test_data[4].imag(), c.imag());
+  BOOST_CHECK_EQUAL(test_data[5], 0.0f);
+  BOOST_CHECK_EQUAL(test_data[6], 0.0f);
+  BOOST_CHECK_EQUAL(test_data[7], d);
+}
+
 BOOST_AUTO_TEST_CASE(transform_to_stokes_i) {
   casacore::TransformToStokesI<int>(nullptr, nullptr, 0);
 


### PR DESCRIPTION
When using Sisco for model data that has Stokes I values, it will still compress the values independently. Most of the redundancy gets compressed by Sisco, but not all, but what's more important, compressing 4 values takes about 4 times longer. By having a Stokes I mode, only a fourth of the data is sent to Sisco, leading to much faster compression.

Some results of Stokes I mode: in a simple test I find it is 3x faster to write Stokes I values compared to writing the full data and let Sisco find the redundancy – which is thus considerable.

Additionally, it saves 8% of space. This is because Sisco can find some of the redundancy in the polarizations when the data is Stokes I, but apparently not all.