### PR TITLE
Make Block movable and deprecate PtrBlock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# Next version
+
+## General
+
+- Clean up the Block class and deprecate the PtrBlock class.
+- Remove Block::prohibitChangingAllocator() and Block::permitChangingAllocator() as they were not used.
+
 # 3.8.0
 
 ## General

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -44,64 +44,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-// <summary>simple 1-D array</summary>
-// <use visibility=export>
-//
-// <reviewed reviewer="UNKNOWN" date="before2004/08/25" tests="" demos="">
-// </reviewed>
-//
-// <etymology>
-//     This should be viewed as a <em>block</em> of memory without sophisticated
-//     manipulation functions. Thus it is called <src>Block</src>.
-// </etymology>
-//
-// <synopsis>
-// <src>Block<T></src> is a simple templated 1-D array class. Indices are always
-// 0-based. For efficiency reasons, no index checking is done unless the
-// preprocessor symbol <src>AIPS_ARRAY_INDEX_CHECK</src> is defined. 
-// <src>Block<T></src>'s may be assigned to and constructed from other
-// <src>Block<T></src>'s.
-// As no reference counting is done this can be an expensive operation, however.
-//
-// The net effect of this class is meant to be unsurprising to users who think
-// of arrays as first class objects. The name "Block" is  intended to convey
-// the concept of a solid "chunk" of things without any intervening "fancy"
-// memory management, etc. This class was written to be
-// used in the implementations of more functional Vector, Matrix, etc. classes,
-// although it is expected <src>Block<T></src> will be useful on its own.
-//
-// The Block class should be efficient. You should normally use <src>Block</src>.
-//
-// <note role=warning> If you use the assignment operator on an element of this
-// class, you may leave dangling references to pointers released from
-// <src>storage()</src>.
-// Resizing the array will also have this effect if the underlying storage
-// is actually affected.
-// </note>
-//
-// If index checking is turned on, an out-of-bounds index will
-// generate an <src>indexError<uInt></src> exception.
-// </synopsis>
-//
-// <example> 
-// <srcblock>
-// Block<Int> a(100,0);  // 100 ints initialized to 0
-// Block<Int> b;         // 0-length Block
-// // ...
-// b = a;                // resize b and copy a into it
-// for (size_t i=0; i < a.nelements(); i++) {
-//     a[i] = i;    // Generate a sequence
-//                  // with Vectors, could simply say "indgen(myVector);"
-// }
-// b.set(-1);       // All positions in b have the value -1
-// b.resize(b.nelements()*2); // Make b twice as long, by default the old
-//                            // elements are copied over, although this can
-//                            // be defeated.
-// some_c_function(b.storage());  // Use a fn that takes an
-//                                // <src>Int *</src> pointer
-// </srcblock> 
-// </example>
-//
 class BlockTrace
 {
 public:
@@ -318,7 +260,6 @@ public:
     init(ArrayInitPolicies::NO_INIT);
 
     try {
-      //objcopy(array, other.array, get_size());
       objthrowcp1(array, other.array, get_size());
       allocator_p->construct(array, get_size(), other.array);
     } catch (...) {
@@ -327,6 +268,18 @@ public:
     }
   }
   
+  Block(Block<T> &&other) noexcept :
+      allocator_p(other.allocator_p), capacity_p(other.capacity_p), used_p(other.used_p),
+          array(other.array), destroyPointer(other.destroyPointer),
+          keep_allocator_p(other.keep_allocator_p) {
+    // The allocator of other is left as is; the storage is emptied so no need to change it.
+    other.capacity_p = 0;
+    other.used_p = 0;
+    other.array = nullptr;
+    other.destroyPointer = true;
+    other.keep_allocator_p = false;
+  }
+
   // Assign other to this. this resizes itself to the size of other, so after
   // the assignment, this->nelements() == other.nelements() always.
   Block<T> &operator=(const Block<T> &other) {
@@ -343,8 +296,29 @@ public:
     return *this;
   }
   
+  Block<T>& operator=(Block<T> &&other) noexcept
+  {
+    if (this == &other) {
+      return *this;
+    }
+    deinit();
+    allocator_p = other.allocator_p;
+    capacity_p = other.capacity_p;
+    used_p = other.used_p;
+    destroyPointer = other.destroyPointer;
+    array = other.array;
+    keep_allocator_p = other.keep_allocator_p;
+    // The allocator of other is left as is; the storage is emptied so no need to change it.
+    other.capacity_p = 0;
+    other.used_p = 0;
+    other.array = nullptr;
+    other.destroyPointer = true;
+    other.keep_allocator_p = false;
+    return *this;
+  }
+
   // Frees up the storage pointed contained in the Block.
-  ~Block() {
+  ~Block() noexcept {
     deinit();
   }
 
@@ -382,10 +356,6 @@ public:
       return;
     }
     if (n < get_size() && forceSmaller == False) {
-      if (false) { // to keep get_size() == get_capacity()
-        allocator_p->destroy(&array[n], get_size() - n);
-        set_size(n);
-      }
       return;
     }
     if (get_size() < n  && n <= get_capacity()) {
@@ -492,10 +462,6 @@ public:
       destroyPointer = True;
     } else {
       objmove(&array[whichOne], &array[whichOne + 1], get_size() - whichOne - 1);
-      if (false) { // to keep get_size() == get_capacity()
-        allocator_p->destroy(&array[n], 1);
-        set_size(n);
-      }
     }
   }
   // </group>
@@ -665,7 +631,7 @@ public:
   }
 
  private:
-  friend class Array<T>; // to allow access to following constructors.
+  //friend class Array<T>; // to allow access to following constructors.
 
   Block(size_t n, ArrayInitPolicy initPolicy,
           Allocator_private::BulkAllocator<T> *allocator) :
@@ -787,77 +753,28 @@ public:
 };
 
 
-// <summary>
-// A drop-in replacement for <src>Block<T*></src>.
-// </summary>
- 
-// <use visibility=export>
-// <prerequisite>
-//   <li> <linkto class=Block>Block</linkto>
-// </prerequisite>
- 
-// <synopsis>
-// <src>PtrBlock<T*></src> has exactly the same interface as <src>Block<T*></src>
-// and should be used in preference to the latter. It's purpose is solely to
-// reduce the number of template instantiations.
-// </synopsis>
- 
-// <todo asof="1996/05/01">
-//   <li> Partial template specialization is another implementation choice that 
-//        will be possible eventually.
-//   <li> It might be useful to have functions that know the template parameter
-//        is a pointer, e.g. that delete all the non-null pointers.
-// </todo>
- 
- template<class T> class PtrBlock {
- public:
-   PtrBlock() : block_p() {}
-   explicit PtrBlock(size_t n) : block_p(n) {}
-   PtrBlock(size_t n, T val) : block_p(n, (void *)val) {}
-   PtrBlock(size_t n, T *&storagePointer, Bool takeOverStorage = True)
-     : block_p(n, (void **&)storagePointer, takeOverStorage) {}
-   PtrBlock(const PtrBlock<T> &other) : block_p(other.block_p) {}
-   PtrBlock<T> &operator=(const PtrBlock<T> &other)
-     { block_p = other.block_p; return *this;}
-   ~PtrBlock() {}
-   void resize(size_t n, Bool forceSmaller, Bool copyElements)
-     { block_p.resize(n,forceSmaller, copyElements); }
-   void resize(size_t n) {block_p.resize(n);}
-   void resize(size_t n, Bool forceSmaller) {block_p.resize(n, forceSmaller);}
-   void remove(size_t whichOne, Bool forceSmaller) {
-     block_p.remove(whichOne, forceSmaller);}
-   void remove(size_t whichOne) {block_p.remove(whichOne);}
-   void replaceStorage(size_t n, T *&storagePointer, 
-		       Bool takeOverStorage=True)
-     {block_p.replaceStorage(n, (void **&)storagePointer, takeOverStorage);}
-   T &operator[](size_t index) {return (T &)block_p[index];}
-   const T &operator[](size_t index) const {return (const T &)block_p[index];}
-   void set(const T &val) {block_p.set((void *const &)val);}
-   PtrBlock<T> &operator=(const T &val) {set(val); return *this;}
-   T *storage()  {return (T *)block_p.storage();}
-   const T *storage() const {return (const T *)block_p.storage();}
-   size_t nelements() const {return block_p.nelements();}
-   size_t size() const {return block_p.size();}
-   Bool empty() const {return block_p.empty();}
- private:
-   Block<void*> block_p;
- };
-
+/**
+ * PtrBlock was a class that was similar to Block, but it was used to speed up compilation on older compilers.
+ * This is no longer relevant, so it is deprecated and replaced by a using statement in April 2026.
+ */
+template<typename T>
+using PtrBlock [[deprecated("Use Block<T> or std::vector<T>: the original motivation for this class no longer holds")]]
+  = Block<T>;
 
 //# Instantiate extern templates for often used types.
-  extern template class Block<Bool>;
-  extern template class Block<Char>;
-  extern template class Block<Short>;
-  extern template class Block<uShort>;
-  extern template class Block<Int>;
-  extern template class Block<uInt>;
-  extern template class Block<Int64>;
-  extern template class Block<Float>;
-  extern template class Block<Double>;
-  extern template class Block<Complex>;
-  extern template class Block<DComplex>;
-  extern template class Block<String>;
-  extern template class Block<void*>;
+extern template class Block<Bool>;
+extern template class Block<Char>;
+extern template class Block<Short>;
+extern template class Block<uShort>;
+extern template class Block<Int>;
+extern template class Block<uInt>;
+extern template class Block<Int64>;
+extern template class Block<Float>;
+extern template class Block<Double>;
+extern template class Block<Complex>;
+extern template class Block<DComplex>;
+extern template class Block<String>;
+extern template class Block<void*>;
 
 
 } //# NAMESPACE CASACORE - END

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -273,7 +273,7 @@ public:
     other.capacity_p = 0;
     other.used_p = 0;
     other.array = nullptr;
-    other.destroyPointer = true;
+    other.destroyPointer = false;
   }
 
   // Assign other to this. this resizes itself to the size of other, so after

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -631,8 +631,6 @@ public:
   }
 
  private:
-  //friend class Array<T>; // to allow access to following constructors.
-
   Block(size_t n, ArrayInitPolicy initPolicy,
           Allocator_private::BulkAllocator<T> *allocator) :
       allocator_p(allocator), used_p(n), destroyPointer(

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -144,14 +144,14 @@ public:
   // DefaultAllocator<T> is used as an allocator.
   Block() :
       allocator_p(get_allocator<typename DefaultAllocator<T>::type>()), capacity_p(
-          0), used_p(0), array(0), destroyPointer(True), keep_allocator_p(False) {
+          0), used_p(0), array(0), destroyPointer(True) {
   }
   // Create a zero-length Block. Note that any index into this Block
   // is an error.
   template<typename Allocator>
   explicit Block(AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), capacity_p(0), used_p(
-          0), array(0), destroyPointer(True), keep_allocator_p(False) {
+          0), array(0), destroyPointer(True) {
   }
 
   // Create a Block with the given number of points. The values in Block
@@ -159,7 +159,7 @@ public:
   // DefaultAllocator<T> is used as an allocator.
   explicit Block(size_t n) :
       allocator_p(get_allocator<typename DefaultAllocator<T>::type>()), used_p(
-          n), destroyPointer(True), keep_allocator_p(False) {
+          n), destroyPointer(True) {
     init(init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
 
@@ -168,7 +168,7 @@ public:
   template<typename Allocator>
   Block(size_t n, AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), used_p(n), destroyPointer(
-          True), keep_allocator_p(False) {
+          True) {
     init(init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
   }
 
@@ -177,7 +177,7 @@ public:
   // DefaultAllocator<T> is used as an allocator.
   Block(size_t n, ArrayInitPolicy initPolicy) :
       allocator_p(get_allocator<typename DefaultAllocator<T>::type>()), used_p(
-          n), destroyPointer(True), keep_allocator_p(False) {
+          n), destroyPointer(True) {
     init(initPolicy);
   }
 
@@ -187,7 +187,7 @@ public:
   Block(size_t n, ArrayInitPolicy initPolicy,
       AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), used_p(n), destroyPointer(
-          True), keep_allocator_p(False) {
+          True) {
     init(initPolicy);
   }
 
@@ -196,7 +196,7 @@ public:
   // DefaultAllocator<T> is used as an allocator.
   Block(size_t n, T const &val) :
       allocator_p(get_allocator<typename DefaultAllocator<T>::type>()), used_p(
-          n), destroyPointer(True), keep_allocator_p(False) {
+          n), destroyPointer(True) {
     init(ArrayInitPolicies::NO_INIT);
     try {
       allocator_p->construct(array, get_size(), val);
@@ -211,7 +211,7 @@ public:
   template<typename Allocator>
   Block(size_t n, T const &val, AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), used_p(n), destroyPointer(
-          True), keep_allocator_p(False) {
+          True) {
     init(ArrayInitPolicies::NO_INIT);
     try {
       allocator_p->construct(array, get_size(), val);
@@ -233,8 +233,7 @@ public:
   // to <src>DefaultAllocator<T>::value</src> in future.
   Block(size_t n, T *&storagePointer, Bool takeOverStorage = True) :
       allocator_p(get_allocator<typename NewDelAllocator<T>::type>()), capacity_p(
-          n), used_p(n), array(storagePointer), destroyPointer(takeOverStorage), keep_allocator_p(
-          False) {
+          n), used_p(n), array(storagePointer), destroyPointer(takeOverStorage) {
     if (destroyPointer)
       storagePointer = 0;
   }
@@ -247,8 +246,7 @@ public:
   Block(size_t n, T *&storagePointer, Bool takeOverStorage,
       AllocSpec<Allocator> const &) :
       allocator_p(get_allocator<typename Allocator::type>()), capacity_p(n), used_p(
-          n), array(storagePointer), destroyPointer(takeOverStorage), keep_allocator_p(
-          False) {
+          n), array(storagePointer), destroyPointer(takeOverStorage) {
     if (destroyPointer)
       storagePointer = 0;
   }
@@ -256,7 +254,7 @@ public:
   // Copy the other block into this one. Uses copy, not reference, semantics.
   Block(const Block<T> &other) :
       allocator_p(other.allocator_p), used_p(other.size()), destroyPointer(
-          True), keep_allocator_p(False) {
+          True) {
     init(ArrayInitPolicies::NO_INIT);
 
     try {
@@ -270,14 +268,12 @@ public:
   
   Block(Block<T> &&other) noexcept :
       allocator_p(other.allocator_p), capacity_p(other.capacity_p), used_p(other.used_p),
-          array(other.array), destroyPointer(other.destroyPointer),
-          keep_allocator_p(other.keep_allocator_p) {
+          array(other.array), destroyPointer(other.destroyPointer) {
     // The allocator of other is left as is; the storage is emptied so no need to change it.
     other.capacity_p = 0;
     other.used_p = 0;
     other.array = nullptr;
     other.destroyPointer = true;
-    other.keep_allocator_p = false;
   }
 
   // Assign other to this. this resizes itself to the size of other, so after
@@ -307,13 +303,11 @@ public:
     used_p = other.used_p;
     destroyPointer = other.destroyPointer;
     array = other.array;
-    keep_allocator_p = other.keep_allocator_p;
     // The allocator of other is left as is; the storage is emptied so no need to change it.
     other.capacity_p = 0;
     other.used_p = 0;
     other.array = nullptr;
     other.destroyPointer = true;
-    other.keep_allocator_p = false;
     return *this;
   }
 
@@ -466,15 +460,6 @@ public:
   }
   // </group>
 
-  // Prohibit changing allocator for this instance.
-  // <group>
-  void prohibitChangingAllocator() {
-    keep_allocator_p = True;
-  }
-  // Permit changing allocator for this instance.
-  void permitChangingAllocator() {
-    keep_allocator_p = False;
-  }
   // </group>
 
   // Replace the internal storage with a C-array (i.e. pointer).
@@ -495,10 +480,6 @@ public:
 	}
   template<typename Allocator>
   void replaceStorage(size_t n, T *&storagePointer, Bool takeOverStorage, AllocSpec<Allocator> const &) {
-    if (keep_allocator_p && ! isCompatibleAllocator<Allocator>()) {
-      throw AipsError("Block::replaceStorage - Attemption to change allocator of Block");
-    }
-
     if (array && destroyPointer) {
       traceFree (array, get_capacity());
       allocator_p->destroy(array, get_size());
@@ -631,48 +612,10 @@ public:
   }
 
  private:
-  Block(size_t n, ArrayInitPolicy initPolicy,
-          Allocator_private::BulkAllocator<T> *allocator) :
-      allocator_p(allocator), used_p(n), destroyPointer(
-          True), keep_allocator_p(False) {
-    init(initPolicy);
-  }
-  Block(size_t n, Allocator_private::AllocSpec<T> allocator) :
-      allocator_p(allocator.allocator), used_p(n), destroyPointer(
-          True), keep_allocator_p(False) {
-    init(init_anyway() ? ArrayInitPolicies::INIT : ArrayInitPolicies::NO_INIT);
-  }
-  Block(size_t n, T *&storagePointer, Bool takeOverStorage,
-          Allocator_private::BulkAllocator<T> *allocator) :
-      allocator_p(allocator), capacity_p(n), used_p(
-          n), array(storagePointer), destroyPointer(takeOverStorage), keep_allocator_p(
-          False) {
-    if (destroyPointer)
-      storagePointer = 0;
-  }
-  void construct(size_t pos, size_t n, T const *src) {
-    allocator_p->construct(&array[pos], n, src);
-  }
-  void construct(size_t pos, size_t n,
-      T const &initial_value) {
-    allocator_p->construct(&array[pos], n, initial_value);
-  }
-  void construct(size_t pos, size_type n) {
-    allocator_p->construct(&array[pos], n);
-  }
-  void destroy(size_t pos, size_type n) {
-    allocator_p->destroy(&array[pos], n);
-  }
-  Allocator_private::BulkAllocator<T> *get_allocator(){
-      return allocator_p;
-  }
-
-  static bool init_anyway() {
+  static constexpr bool init_anyway() {
      return !(Block_internal_IsFundamental<T>::value
          || Block_internal_IsPointer<T>::value);
    }
-
-  // end of friend
 
   void init(ArrayInitPolicy initPolicy) {
     set_capacity(get_size());
@@ -746,8 +689,6 @@ public:
   T *array;
   // Can we delete the storage upon destruction?
   Bool destroyPointer;
-  // Can we change allocator or not?
-  Bool keep_allocator_p;
 };
 
 

--- a/casa/Containers/Block.h
+++ b/casa/Containers/Block.h
@@ -307,7 +307,7 @@ public:
     other.capacity_p = 0;
     other.used_p = 0;
     other.array = nullptr;
-    other.destroyPointer = true;
+    other.destroyPointer = false;
     return *this;
   }
 

--- a/casa/Containers/RecordDescRep.h
+++ b/casa/Containers/RecordDescRep.h
@@ -278,7 +278,7 @@ private:
     // This isn't the most efficient representation. If this is ever an issue
     // we could calculate these, or store them in one Block, or implement
     // copy-on-write semantics.
-    PtrBlock<RecordDesc*> sub_records_p;
+    Block<RecordDesc*> sub_records_p;
     // The shape of the field [1] for scalars and sub-records.
     Block<IPosition> shapes_p;
     // True if the corresponding field is an array.

--- a/casa/Containers/RecordFieldWriter.h
+++ b/casa/Containers/RecordFieldWriter.h
@@ -159,7 +159,7 @@ public:
 private:
   // Make faster by having the RecordFieldCopiers split out so straight copying
   // is inline.
-  PtrBlock<RecordFieldWriter *> writers_p;
+  Block<RecordFieldWriter *> writers_p;
 };
 
 

--- a/casa/Containers/test/tBlock.cc
+++ b/casa/Containers/test/tBlock.cc
@@ -36,6 +36,7 @@
 #include <casacore/casa/Utilities/Assert.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/iostream.h>
+#include <array>
 #include <vector>
 #include <limits>
 #include <stdint.h>
@@ -385,6 +386,24 @@ void doit()
     }
 
                                       // Block::~Block called at end of fn
+
+  // Move constructor
+  constexpr std::array<int, 3> data{-3, 1982, 42};
+  Block<int> block_a(data.size());
+  for(size_t i=0; i!=data.size(); ++i)
+    block_a[i] = data[i];
+  Block<int> block_b(std::move(block_a));
+  AlwaysAssertExit(block_b.size() == data.size());
+  for(size_t i=0; i!=data.size(); ++i)
+    AlwaysAssertExit(block_b[i] == data[i]);
+  AlwaysAssertExit(block_a.empty());
+
+  // Move assignment
+  block_a = std::move(block_b);
+  AlwaysAssertExit(block_a.size() == data.size());
+  for(size_t i=0; i!=data.size(); ++i)
+    AlwaysAssertExit(block_a[i] == data[i]);
+  AlwaysAssertExit(block_b.empty());
 }
 
 void testIO()

--- a/casa/Containers/test/tBlock.cc
+++ b/casa/Containers/test/tBlock.cc
@@ -249,11 +249,6 @@ void doit()
 
       Int *p = new Int[20];
       try {
-        ba.replaceStorage(20, p, False);
-        AlwaysAssertExit(False);
-      } catch (std::exception const &) {
-      }
-      try {
         ba.replaceStorage(20, p, True);
       } catch (std::exception const &) {
         AlwaysAssertExit(False);

--- a/casa/Containers/test/tBlock.cc
+++ b/casa/Containers/test/tBlock.cc
@@ -248,18 +248,11 @@ void doit()
       AlwaysAssertExit(10 == bb[0] && 10 == bb[9]);
 
       Int *p = new Int[20];
-      ba.prohibitChangingAllocator();
-      try {
-        ba.replaceStorage(20, p, True);
-        AlwaysAssertExit(False);
-      } catch (std::exception const &) {
-      }
       try {
         ba.replaceStorage(20, p, False);
         AlwaysAssertExit(False);
       } catch (std::exception const &) {
       }
-      ba.permitChangingAllocator();
       try {
         ba.replaceStorage(20, p, True);
       } catch (std::exception const &) {
@@ -267,7 +260,6 @@ void doit()
       }
       AlwaysAssertExit(0 == p);
 
-      bb.prohibitChangingAllocator();
       p = DefaultAllocator<Int>::type().allocate(20);
       try {
         ba.replaceStorage(20, p, True, AllocSpec<DefaultAllocator<Int> >::value);

--- a/casa/IO/BucketCache.h
+++ b/casa/IO/BucketCache.h
@@ -343,7 +343,7 @@ private:
     // The nr of slots used in the cache.
     uInt     its_CacheSizeUsed;
     // The cache itself.
-    PtrBlock<char*> its_Cache; 
+    Block<char*> its_Cache;
     // The cache slot actually used.
     uInt         its_ActualSlot;
     // The slot numbers of the buckets in the cache (-1 = not in cache).

--- a/casa/Utilities/DynBuffer.h
+++ b/casa/Utilities/DynBuffer.h
@@ -157,7 +157,7 @@ private:
     // total length per buffer
     Block<uInt>  totlen_p;      
     // pointer to buffer
-    PtrBlock<Char*> bufptr_p;     
+    Block<Char*> bufptr_p;
     // used length of current buffer
     uInt         curuselen_p;      
     // total length of current buffer

--- a/casa/Utilities/Sort.h
+++ b/casa/Utilities/Sort.h
@@ -440,7 +440,7 @@ private:
     }
 
     //# Data memebers
-    PtrBlock<SortKey*> keys_p;                    //# keys to sort on
+    Block<SortKey*>    keys_p;                    //# keys to sort on
     size_t             nrkey_p;                   //# #sort-keys
     const void*        data_p;                    //# pointer to data records
     uInt               size_p;                    //# size of data record

--- a/casa/Utilities/test/tCopy.cc
+++ b/casa/Utilities/test/tCopy.cc
@@ -341,7 +341,6 @@ int main()
     Block<const void*> cbl2(cbl);
     Block<void*> bl(10,static_cast<void*>(0));
     Block<void*> bl2(bl);
-    // PtrBlock is based on Block<void*>
     Block<void*> bvl(10,static_cast<void*>(0));
     Block<void*> bvl2(bvl);
 

--- a/casa/Utilities/test/tCopy.cc
+++ b/casa/Utilities/test/tCopy.cc
@@ -337,10 +337,10 @@ int main()
     // Block uses objcopy.
     // Somewhere Block<void*> and Block<const void*> are used.
     // See if they compile and link well.
-    PtrBlock<const void*> cbl(10,static_cast<const void*>(0));
-    PtrBlock<const void*> cbl2(cbl);
-    PtrBlock<void*> bl(10,static_cast<void*>(0));
-    PtrBlock<void*> bl2(bl);
+    Block<const void*> cbl(10,static_cast<const void*>(0));
+    Block<const void*> cbl2(cbl);
+    Block<void*> bl(10,static_cast<void*>(0));
+    Block<void*> bl2(bl);
     // PtrBlock is based on Block<void*>
     Block<void*> bvl(10,static_cast<void*>(0));
     Block<void*> bvl2(bvl);

--- a/coordinates/Coordinates/CoordinateSystem.cc
+++ b/coordinates/Coordinates/CoordinateSystem.cc
@@ -305,8 +305,8 @@ void CoordinateSystem::transpose(const Vector<Int> &newWorldOrder,
 	found(which) = True;
     }
 //
-    PtrBlock<Block<Int> *> newWorldMaps(nc);
-    PtrBlock<Block<Int> *> newPixelMaps(nc);
+    Block<Block<Int> *> newWorldMaps(nc);
+    Block<Block<Int> *> newPixelMaps(nc);
     newWorldMaps.set(static_cast<Block<Int> *>(0));
     newPixelMaps.set(static_cast<Block<Int> *>(0));
 
@@ -1715,8 +1715,8 @@ Bool CoordinateSystem::convert (Matrix<Double>& coordsOut,
 
    IPosition velAxesIn(n);
    IPosition velAxesOut(n);
-   PtrBlock<SpectralCoordinate*> specCoordsIn(n, (SpectralCoordinate*)0);
-   PtrBlock<SpectralCoordinate*> specCoordsOut(n, (SpectralCoordinate*)0);
+   Block<SpectralCoordinate*> specCoordsIn(n, (SpectralCoordinate*)0);
+   Block<SpectralCoordinate*> specCoordsOut(n, (SpectralCoordinate*)0);
 //
    Vector<String> unitsIn2(cSysIn.worldAxisUnits().copy());
    Vector<String> unitsOut2(cSysOut.worldAxisUnits().copy());
@@ -2716,9 +2716,9 @@ CoordinateSystem* CoordinateSystem::restore(const RecordInterface &container,
        }
     }
 //
-    PtrBlock<Coordinate *> tmp;
+    Block<Coordinate *> tmp;
     Int nc = 0;                         // num coordinates
-    PtrBlock<Coordinate *> coords;
+    Block<Coordinate *> coords;
     static const String linear   = "linear";
     static const String direction = "direction";
     static const String spectral = "spectral";
@@ -4183,8 +4183,8 @@ Vector<Double> CoordinateSystem::worldMixMax () const
 }
 
 
-void CoordinateSystem::cleanUpSpecCoord (PtrBlock<SpectralCoordinate*>&  in, 
-                                         PtrBlock<SpectralCoordinate*>&  out)
+void CoordinateSystem::cleanUpSpecCoord (Block<SpectralCoordinate*>&  in, 
+                                         Block<SpectralCoordinate*>&  out)
 {
    for (uInt i=0; i<in.nelements(); i++) {
       if (in[i]) {

--- a/coordinates/Coordinates/CoordinateSystem.h
+++ b/coordinates/Coordinates/CoordinateSystem.h
@@ -870,7 +870,7 @@ public:
 
 private:
     // Where we store copies of the coordinates we are created with.
-    PtrBlock<Coordinate *> coordinates_p;
+    Block<Coordinate *> coordinates_p;
     
     // For coordinate[i] axis[j], 
     //    world_maps_p[i][j], if >=0 gives the location in the
@@ -878,22 +878,22 @@ private:
     //                        <0 means that the axis has been removed
     //    world_tmp_p[i] a temporary vector length coord[i]->nworldAxes()
     //    replacement_values_p[i][j] value to use for this axis if removed
-    PtrBlock<Block<Int> *>     world_maps_p;
-    PtrBlock<Vector<Double> *> world_tmps_p;
-    PtrBlock<Vector<Double> *> world_replacement_values_p;
+    Block<Block<Int> *>     world_maps_p;
+    Block<Vector<Double> *> world_tmps_p;
+    Block<Vector<Double> *> world_replacement_values_p;
 
     // Same meanings as for the world*'s above.
-    PtrBlock<Block<Int> *>     pixel_maps_p;
-    PtrBlock<Vector<Double> *> pixel_tmps_p;
-    PtrBlock<Vector<Double> *> pixel_replacement_values_p;
+    Block<Block<Int> *>     pixel_maps_p;
+    Block<Vector<Double> *> pixel_tmps_p;
+    Block<Vector<Double> *> pixel_replacement_values_p;
 
     // These temporaries all needed for the toMix function
-    PtrBlock<Vector<Bool> *> worldAxes_tmps_p;
-    PtrBlock<Vector<Bool> *> pixelAxes_tmps_p;
-    PtrBlock<Vector<Double> *> worldOut_tmps_p;
-    PtrBlock<Vector<Double> *> pixelOut_tmps_p;
-    PtrBlock<Vector<Double> *> worldMin_tmps_p;
-    PtrBlock<Vector<Double> *> worldMax_tmps_p;
+    Block<Vector<Bool> *> worldAxes_tmps_p;
+    Block<Vector<Bool> *> pixelAxes_tmps_p;
+    Block<Vector<Double> *> worldOut_tmps_p;
+    Block<Vector<Double> *> pixelOut_tmps_p;
+    Block<Vector<Double> *> worldMin_tmps_p;
+    Block<Vector<Double> *> worldMax_tmps_p;
 
     // Miscellaneous information about the observation associated with this
     // Coordinate System.
@@ -918,8 +918,8 @@ private:
     Bool checkAxesInThisCoordinate(const Vector<Bool>& axes, uInt which) const;
 
    // Delete some pointer blocks
-   void cleanUpSpecCoord (PtrBlock<SpectralCoordinate*>&  in,
-                          PtrBlock<SpectralCoordinate*>&  out);
+   void cleanUpSpecCoord (Block<SpectralCoordinate*>&  in,
+                          Block<SpectralCoordinate*>&  out);
 
    // Delete temporary maps
    void deleteTemps (const uInt which);

--- a/fits/FITS/CopyRecord.h
+++ b/fits/FITS/CopyRecord.h
@@ -98,24 +98,24 @@ public:
 private: 
     // We could just have a TableColumn for scalars, but we'd need all of
     // the array types anyway.
-    PtrBlock<ScalarColumn<Bool> *> table_bool;
-    PtrBlock<ScalarColumn<uChar> *> table_char;
-    PtrBlock<ScalarColumn<Short> *> table_short;
-    PtrBlock<ScalarColumn<Int> *> table_int;
-    PtrBlock<ScalarColumn<Float> *> table_float;
-    PtrBlock<ScalarColumn<Double> *> table_double;
-    PtrBlock<ScalarColumn<Complex> *> table_complex;
-    PtrBlock<ScalarColumn<DComplex> *> table_dcomplex;
-    PtrBlock<ScalarColumn<String> *> table_string;
-    PtrBlock<ArrayColumn<Bool> *> table_array_bool;
-    PtrBlock<ArrayColumn<uChar> *> table_array_char;
-    PtrBlock<ArrayColumn<Short> *> table_array_short;
-    PtrBlock<ArrayColumn<Int> *> table_array_int;
-    PtrBlock<ArrayColumn<Float> *> table_array_float;
-    PtrBlock<ArrayColumn<Double> *> table_array_double;
-    PtrBlock<ArrayColumn<Complex> *> table_array_complex;
-    PtrBlock<ArrayColumn<DComplex> *> table_array_dcomplex;
-    PtrBlock<ArrayColumn<String> *> table_array_string;
+    Block<ScalarColumn<Bool> *> table_bool;
+    Block<ScalarColumn<uChar> *> table_char;
+    Block<ScalarColumn<Short> *> table_short;
+    Block<ScalarColumn<Int> *> table_int;
+    Block<ScalarColumn<Float> *> table_float;
+    Block<ScalarColumn<Double> *> table_double;
+    Block<ScalarColumn<Complex> *> table_complex;
+    Block<ScalarColumn<DComplex> *> table_dcomplex;
+    Block<ScalarColumn<String> *> table_string;
+    Block<ArrayColumn<Bool> *> table_array_bool;
+    Block<ArrayColumn<uChar> *> table_array_char;
+    Block<ArrayColumn<Short> *> table_array_short;
+    Block<ArrayColumn<Int> *> table_array_int;
+    Block<ArrayColumn<Float> *> table_array_float;
+    Block<ArrayColumn<Double> *> table_array_double;
+    Block<ArrayColumn<Complex> *> table_array_complex;
+    Block<ArrayColumn<DComplex> *> table_array_dcomplex;
+    Block<ArrayColumn<String> *> table_array_string;
  
     Block<RORecordFieldPtr<Bool> > record_bool;
     Block<RORecordFieldPtr<uChar> > record_char;

--- a/fits/FITS/FITSTable.h
+++ b/fits/FITS/FITSTable.h
@@ -403,7 +403,7 @@ private:
     uInt nrows_written_p;
     BinaryTableExtension *bintable_p;
     Record row_p;
-    PtrBlock<FITSFieldCopier *> copiers_p;
+    Block<FITSFieldCopier *> copiers_p;
 };
 
 // <summary>

--- a/images/Images/ImageExprParse.cc
+++ b/images/Images/ImageExprParse.cc
@@ -48,7 +48,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Define pointer blocks holding temporary lattices and regions.
 static const Block<LatticeExprNode>* theTempLattices;
-static const PtrBlock<const ImageRegion*>* theTempRegions;
+static const Block<const ImageRegion*>* theTempRegions;
 
 //# Define static for holding the global directory name.
 static String theDirName;
@@ -68,7 +68,7 @@ static std::shared_ptr<HDF5File> theLastHDF5;
 
 #define SAVE_GLOBALS \
  const Block<LatticeExprNode>* savTempLattices=theTempLattices; \
- const PtrBlock<const ImageRegion*>* savTempRegions=theTempRegions; \
+ const Block<const ImageRegion*>* savTempRegions=theTempRegions; \
  String savDirName=theDirName; \
  Block<void*> savNodes=theNodes; \
  Block<Bool>  savNodesType=theNodesType; \
@@ -195,13 +195,13 @@ LatticeExprNode ImageExprParse::command (const String& str,
 					 const String& dirName)
 {
     Block<LatticeExprNode> dummyLat;
-    PtrBlock<const ImageRegion*> dummyReg;
+    Block<const ImageRegion*> dummyReg;
     return command (str, dummyLat, dummyReg, dirName);
 }
 LatticeExprNode ImageExprParse::command
                            (const String& str,
 			    const Block<LatticeExprNode>& tempLattices,
-			    const PtrBlock<const ImageRegion*>& tempRegions,
+			    const Block<const ImageRegion*>& tempRegions,
 			    const String& dirName)
 {
     // Clear the image names if at the top level.

--- a/images/Images/ImageExprParse.h
+++ b/images/Images/ImageExprParse.h
@@ -40,7 +40,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
 template<class T> class Block;
-template<class T> class PtrBlock;
 class ImageRegion;
 class Table;
 class Slice;

--- a/images/Images/ImageExprParse.h
+++ b/images/Images/ImageExprParse.h
@@ -216,7 +216,7 @@ public:
 				    const String& dirName = String());
     static LatticeExprNode command (const String& str,
 				    const Block<LatticeExprNode>& tempLattices,
-				    const PtrBlock<const ImageRegion*>& tempRegions,
+				    const Block<const ImageRegion*>& tempRegions,
 				    const String& dirName = String());
     // </group>
 

--- a/images/Images/ImageOpener.cc
+++ b/images/Images/ImageOpener.cc
@@ -219,7 +219,7 @@ LatticeBase* ImageOpener::openExpr (const String& expr,
                                     const JsonKVMap& jmap)
 {
   LatticeBase* lattice = 0;
-  PtrBlock<const ImageRegion*> regions;
+  Block<const ImageRegion*> regions;
   LatticeExprNode node = ImageExprParse::command (expr, nodes, regions);
   switch (node.dataType()) {
   case TpFloat:

--- a/images/Images/test/tImageExpr2Gram.cc
+++ b/images/Images/test/tImageExpr2Gram.cc
@@ -96,7 +96,7 @@ int main (int argc, const char* argv[])
     Block<LatticeExprNode> temps(1);
     temps[0] = LatticeExprNode(image);
 
-    PtrBlock<const ImageRegion*> tempRegs(1);
+    Block<const ImageRegion*> tempRegs(1);
     tempRegs[0] = new ImageRegion (WCBox(LCBox(shape), image.coordinates()));
 
     {

--- a/images/Images/test/tImageExprGram.cc
+++ b/images/Images/test/tImageExprGram.cc
@@ -58,7 +58,7 @@ String substituteOID (Block<LatticeExprNode>& nodes,
   exprName = expr;
   return expr;
 }
-void makeRegionBlock (PtrBlock<const ImageRegion*>& regions,
+void makeRegionBlock (Block<const ImageRegion*>& regions,
 		      const Record&,
 		      LogIO&)
 {
@@ -76,7 +76,7 @@ void doExpr (const String& expr, const Record& regions)
 
 // Get LatticeExprNode (tree) from parser
 // Convert the GlishRecord containing regions to a
-// PtrBlock<const ImageRegion*>.
+// Block<const ImageRegion*>.
 
   if (expr.empty()) {
     os << "You must specify an expression" << LogIO::EXCEPTION;
@@ -84,7 +84,7 @@ void doExpr (const String& expr, const Record& regions)
   Block<LatticeExprNode> temps;
   String exprName;
   String newexpr = substituteOID (temps, exprName, expr);
-  PtrBlock<const ImageRegion*> tempRegs;
+  Block<const ImageRegion*> tempRegs;
   makeRegionBlock (tempRegs, regions, os);
   LatticeExprNode node = ImageExprParse::command (newexpr, temps, tempRegs);
   
@@ -257,7 +257,7 @@ int main (int argc, const char* argv[])
     temps[0] = LatticeExprNode(b);
     temps[1] = LatticeExprNode(c);
     temps[2] = LatticeExprNode(d);
-    PtrBlock<const ImageRegion*> regions(1);
+    Block<const ImageRegion*> regions(1);
     regions[0] = new ImageRegion(LCBox(shape));
     LatticeExpr<Double> expr(ImageExprParse::command
          ("$1 + ($2 + $3)[$R1]",
@@ -276,7 +276,7 @@ int main (int argc, const char* argv[])
   {
     cout << "Expr:  a = nelements(b[$region]" << endl;
     Block<LatticeExprNode> temps(0);
-    PtrBlock<const ImageRegion*> regions(1);
+    Block<const ImageRegion*> regions(1);
     Matrix<Bool> mask(shape-1);
     mask = False;
     mask(0,0) = True;
@@ -299,7 +299,7 @@ int main (int argc, const char* argv[])
     cout << "Expr:  a = nelements(b[$region1 || $region2) - "
 	    "length(b[$region1],0)" << endl;
     Block<LatticeExprNode> temps(0);
-    PtrBlock<const ImageRegion*> regions(2);
+    Block<const ImageRegion*> regions(2);
     Matrix<Bool> mask1(shape-1);
     Matrix<Bool> mask2(shape-1);
     mask1 = False;

--- a/images/Regions/RegionManager.cc
+++ b/images/Regions/RegionManager.cc
@@ -516,7 +516,7 @@ namespace casacore { //# name space casa begins
       return doUnion(imageReg1, imageReg2);
   }
 
-  ImageRegion*  RegionManager::doUnion(const PtrBlock<const WCRegion*>& regions) {
+  ImageRegion*  RegionManager::doUnion(const Block<const WCRegion*>& regions) {
       *itsLog << LogOrigin("RegionManager", String(__FUNCTION__) + "_2");
       WCUnion leUnion(False, regions);
       ImageRegion* leReturn= new ImageRegion(leUnion);
@@ -554,7 +554,7 @@ namespace casacore { //# name space casa begins
   }
 
   ImageRegion*  RegionManager::doIntersection(
-      const PtrBlock<const WCRegion*>& regions)
+      const Block<const WCRegion*>& regions)
   {
       WCIntersection leIntersect(False, regions);
       ImageRegion* leReturn= new ImageRegion(leIntersect);
@@ -586,7 +586,7 @@ namespace casacore { //# name space casa begins
       return doComplement(imageReg1);
   }
 
-  ImageRegion*  RegionManager::doComplement(const PtrBlock<const WCRegion*>& regions){
+  ImageRegion*  RegionManager::doComplement(const Block<const WCRegion*>& regions){
       *itsLog << LogOrigin("RegionManager", "doComplement");
       WCComplement leComplement(False, regions);
       ImageRegion* leReturn= new ImageRegion(leComplement);
@@ -623,7 +623,7 @@ namespace casacore { //# name space casa begins
   }
 
   ImageRegion*  RegionManager::doDifference(
-      const PtrBlock<const WCRegion*>& regions)
+      const Block<const WCRegion*>& regions)
   {
       WCDifference leDiff(False, regions);
       ImageRegion* leReturn = new ImageRegion(leDiff);
@@ -654,14 +654,14 @@ namespace casacore { //# name space casa begins
      const WCRegion& region, 
      const WCBox& box )
  {
-     PtrBlock<const ImageRegion *> imageRegions(1);
+     Block<const ImageRegion *> imageRegions(1);
      imageRegions[0]= new ImageRegion(region);
      TableRecord recordBox = box.toRecord("");
      return doConcatenation(imageRegions, recordBox);
   }
 
   ImageRegion*  doConcatenation(
-      const PtrBlock<const WCRegion*>& regions, 
+      const Block<const WCRegion*>& regions, 
       const WCBox& box)
   {
       WCConcatenation leConcat(False, regions, box);
@@ -670,7 +670,7 @@ namespace casacore { //# name space casa begins
   }
 
   ImageRegion*  RegionManager::doConcatenation(
-      const PtrBlock<const ImageRegion*>& regions,
+      const Block<const ImageRegion*>& regions,
       const TableRecord& box )
   {
       *itsLog << LogOrigin("RegionManager", "doConcatenation");
@@ -697,14 +697,14 @@ namespace casacore { //# name space casa begins
   {
       *itsLog << LogOrigin("RegionManager", "doConcatenation");
 
-      // Once we convert the region Record to PtrBlock of 
+      // Once we convert the region Record to Block of 
       // ImageRegions then we just call one of the other
       // doConcatenation routines.
 
       if ( regions.nfields() < 1 )
 	  throw(AipsError(String("No regions have been supplied to concatenation" ) ) );
 
-      PtrBlock<const ImageRegion*> imageRegions(regions.nfields());
+      Block<const ImageRegion*> imageRegions(regions.nfields());
       ImageRegion* reg=0;
       TableRecord tblRec;
       for( uInt i=0; i < (regions.nfields()); i++ )

--- a/images/Regions/RegionManager.h
+++ b/images/Regions/RegionManager.h
@@ -201,29 +201,29 @@ namespace casacore {
 
       //Various versions of creating a complement region
       ImageRegion*  doComplement(const WCRegion& reg1);
-      ImageRegion*  doComplement(const PtrBlock<const WCRegion*>& reg1);
+      ImageRegion*  doComplement(const Block<const WCRegion*>& reg1);
       ImageRegion*  doComplement(const ImageRegion& reg1);
 
       //Various versions of concatenating a region onto another.
       ImageRegion*  doConcatenation(const WCRegion& region, const WCBox& box);
-      ImageRegion*  doconcatenation(const PtrBlock<const WCRegion*>& regions, const WCBox& box);
-      ImageRegion*  doConcatenation(const PtrBlock<const ImageRegion*>& regions, const TableRecord& box);
+      ImageRegion*  doconcatenation(const Block<const WCRegion*>& regions, const WCBox& box);
+      ImageRegion*  doConcatenation(const Block<const ImageRegion*>& regions, const TableRecord& box);
       ImageRegion*  doConcatenation(const Record& regions, const TableRecord& box);
 
 
       //Various versions of handling the difference of regions
       ImageRegion*  doDifference(const WCRegion& reg1, const WCRegion& reg2);
-      ImageRegion*  doDifference(const PtrBlock<const WCRegion*>& reg1);
+      ImageRegion*  doDifference(const Block<const WCRegion*>& reg1);
       ImageRegion*  doDifference(const ImageRegion& reg1, const ImageRegion& reg2);
       
       //Different versions of intersecting regions
       ImageRegion*  doIntersection(const WCRegion& reg1, const WCRegion& reg2);
-      ImageRegion*  doIntersection(const PtrBlock<const WCRegion*>& reg1);
+      ImageRegion*  doIntersection(const Block<const WCRegion*>& reg1);
       ImageRegion*  doIntersection(const ImageRegion& reg1, const ImageRegion& reg2);
 
       //Different versions of unioning regions
       ImageRegion*  doUnion(const WCRegion& reg1, const WCRegion& reg2);
-      ImageRegion*  doUnion(const PtrBlock<const WCRegion*>& reg1);
+      ImageRegion*  doUnion(const Block<const WCRegion*>& reg1);
       ImageRegion*  doUnion(const ImageRegion& reg1, const ImageRegion& reg2) const;
       
 

--- a/images/Regions/RegionManager.h
+++ b/images/Regions/RegionManager.h
@@ -50,7 +50,6 @@ namespace casacore {
   class Record;
   class WCRegion;
   class WCBox;
-  template<class T> class PtrBlock;
   class ImageRegion;
 
   class RegionManager

--- a/images/Regions/WCComplement.cc
+++ b/images/Regions/WCComplement.cc
@@ -37,7 +37,7 @@ WCComplement::WCComplement (const ImageRegion& region)
 {}
 
 WCComplement::WCComplement (Bool takeOver,
-			    const PtrBlock<const WCRegion*>& regions)
+			    const Block<const WCRegion*>& regions)
 : WCCompound (takeOver, regions)
 {}
 
@@ -73,7 +73,7 @@ LCRegion* WCComplement::doToLCRegion (const CoordinateSystem& cSys,
 				      const IPosition& pixelAxesMap,
 				      const IPosition& outOrder) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiToLCRegion (regions, cSys, shape, pixelAxesMap, outOrder);
     return new LCComplement (True, regions);
 }
@@ -99,7 +99,7 @@ TableRecord WCComplement::toRecord (const String& tableName) const
 WCComplement* WCComplement::fromRecord (const TableRecord& rec,
 					const String& tableName)
 {
-    PtrBlock<const WCRegion*> regions;
+    Block<const WCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new WCComplement (True, regions);
 }

--- a/images/Regions/WCComplement.h
+++ b/images/Regions/WCComplement.h
@@ -112,7 +112,7 @@ public:
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
     WCComplement (Bool takeOver,
-		  const PtrBlock<const WCRegion*>& regions);
+		  const Block<const WCRegion*>& regions);
 
 protected:
     // Convert to an LCRegion using the given coordinate system and shape.

--- a/images/Regions/WCCompound.cc
+++ b/images/Regions/WCCompound.cc
@@ -38,7 +38,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 WCCompound::WCCompound (const ImageRegion& region1,
 			const ImageRegion& region2)
 {
-    PtrBlock<const ImageRegion*> regions(2);
+    Block<const ImageRegion*> regions(2);
     regions[0] = &region1;
     regions[1] = &region2;
     makeWCRegion (regions);
@@ -56,7 +56,7 @@ WCCompound::WCCompound (const ImageRegion* region1,
 			const ImageRegion* region9,
 			const ImageRegion* region10)
 {
-    PtrBlock<const ImageRegion*> regions(10);
+    Block<const ImageRegion*> regions(10);
     uInt n=0;
     regions[n++] = region1;
     if (region2 != 0) regions[n++] = region2;
@@ -73,14 +73,14 @@ WCCompound::WCCompound (const ImageRegion* region1,
     init (False);
 }
 
-WCCompound::WCCompound (const PtrBlock<const ImageRegion*>& regions)
+WCCompound::WCCompound (const Block<const ImageRegion*>& regions)
 {
     makeWCRegion (regions);
     init (False);
 }
 
 WCCompound::WCCompound (Bool takeOver,
-			const PtrBlock<const WCRegion*>& regions)
+			const Block<const WCRegion*>& regions)
 : itsRegions (regions)
 {
     init (takeOver);
@@ -124,7 +124,7 @@ WCCompound& WCCompound::operator= (const WCCompound& other)
     return *this;
 }
 
-void WCCompound::multiToLCRegion (PtrBlock<const LCRegion*>& regions,
+void WCCompound::multiToLCRegion (Block<const LCRegion*>& regions,
 				  const CoordinateSystem& cSys,
 				  const IPosition& shape,
 				  const IPosition& pixelAxesMap,
@@ -193,7 +193,7 @@ Bool WCCompound::operator== (const WCRegion& other) const
     return True;
 }
 
-void WCCompound::makeWCRegion (const PtrBlock<const ImageRegion*>& regions)
+void WCCompound::makeWCRegion (const Block<const ImageRegion*>& regions)
 {
     uInt nr = regions.nelements();
     itsRegions.resize (nr);
@@ -249,7 +249,7 @@ TableRecord WCCompound::makeRecord (const String& tableName) const
     return rec;
 }
 
-void WCCompound::unmakeRecord (PtrBlock<const WCRegion*>& regions,
+void WCCompound::unmakeRecord (Block<const WCRegion*>& regions,
 			       const TableRecord& rec,
 			       const String& tableName)
 {

--- a/images/Regions/WCCompound.h
+++ b/images/Regions/WCCompound.h
@@ -97,13 +97,13 @@ public:
 		const ImageRegion* region8 = 0,
 		const ImageRegion* region9 = 0,
 		const ImageRegion* region10 = 0);
-    WCCompound (const PtrBlock<const ImageRegion*>& regions);
+    WCCompound (const Block<const ImageRegion*>& regions);
     // </group>
 
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    WCCompound (Bool takeOver, const PtrBlock<const WCRegion*>& regions);
+    WCCompound (Bool takeOver, const Block<const WCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     WCCompound (const WCCompound& other);
@@ -114,7 +114,7 @@ public:
     virtual Bool operator==(const WCRegion& other) const;
 
     // Get the contributing regions.
-    const PtrBlock<const WCRegion*>& regions() const;
+    const Block<const WCRegion*>& regions() const;
     
 protected:
     // Assignment (copy semantics) makes only sense for a derived class.
@@ -123,7 +123,7 @@ protected:
     // Convert each WCRegion to an LCRegion.
     // The axes argument tells which axes to use from the coordinate
     // system and shape.
-    void multiToLCRegion (PtrBlock<const LCRegion*>& regions,
+    void multiToLCRegion (Block<const LCRegion*>& regions,
 			  const CoordinateSystem& cSys,
 			  const IPosition& shape,
 			  const IPosition& pixelAxesMap,
@@ -133,25 +133,25 @@ protected:
     TableRecord makeRecord (const String& tableName) const;
 
     // Retrieve the contributing objects from the record.
-    static void unmakeRecord (PtrBlock<const WCRegion*>&,
+    static void unmakeRecord (Block<const WCRegion*>&,
 			      const TableRecord&,
 			      const String& tableName);
 
 private:
     // Check if the ImageRegion's contain WCRegion's and extract them.
-    void makeWCRegion (const PtrBlock<const ImageRegion*>&);
+    void makeWCRegion (const Block<const ImageRegion*>&);
 
     // Check if the regions are correct.
     // If needed, make a copy of the region objects.
     void init (Bool takeOver);
 
     //# Member variables.
-    PtrBlock<const WCRegion*> itsRegions;
+    Block<const WCRegion*> itsRegions;
     Block<IPosition>          itsAxesUsed;
 };
 
 
-inline const PtrBlock<const WCRegion*>& WCCompound::regions() const
+inline const Block<const WCRegion*>& WCCompound::regions() const
 {
     return itsRegions;
 }

--- a/images/Regions/WCConcatenation.cc
+++ b/images/Regions/WCConcatenation.cc
@@ -36,7 +36,7 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-WCConcatenation::WCConcatenation (const PtrBlock<const ImageRegion*>& regions,
+WCConcatenation::WCConcatenation (const Block<const ImageRegion*>& regions,
 				  const WCBox& extendBox)
 : WCCompound   (regions),
   itsExtendBox (extendBox)
@@ -45,7 +45,7 @@ WCConcatenation::WCConcatenation (const PtrBlock<const ImageRegion*>& regions,
 }
 
 WCConcatenation::WCConcatenation (Bool takeOver,
-				  const PtrBlock<const WCRegion*>& regions,
+				  const Block<const WCRegion*>& regions,
 				  const WCBox& extendBox)
 : WCCompound   (takeOver, regions),
   itsExtendBox (extendBox)
@@ -145,7 +145,7 @@ LCRegion* WCConcatenation::doToLCRegion (const CoordinateSystem& cSys,
     // Great, we're almost there.
     // Convert the regions and the box and combine them into an LCConcatenation.
     // The extend axis is the last axis of outOrder.
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiToLCRegion (regions, cSys, shape, regPixMap, regOutOrd);
     LCRegion* boxptr = itsExtendBox.toLCRegionAxes (cSys, shape, boxPixMap,
 						    boxOutOrd);
@@ -179,7 +179,7 @@ TableRecord WCConcatenation::toRecord (const String& tableName) const
 WCConcatenation* WCConcatenation::fromRecord (const TableRecord& rec,
 					      const String& tableName)
 {
-    PtrBlock<const WCRegion*> regions;
+    Block<const WCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     WCRegion* boxptr = WCRegion::fromRecord (rec.asRecord("box"), tableName);
     DebugAssert (boxptr->type() == WCBox::className(), AipsError);

--- a/images/Regions/WCConcatenation.h
+++ b/images/Regions/WCConcatenation.h
@@ -79,7 +79,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // so they do not need to be deleted (the WCConcatenation destructor does it).
 // <srcblock>
 // IPosition center (2,10,20);
-// PtrBlock<ImageRegion*> cirPtr(n);
+// Block<ImageRegion*> cirPtr(n);
 // for (i=0; i<n; i++) {
 //   // Each circle has a different radius.
 //   cirPtr(i) = new WCEllipsoid cir1 (center, 1 + i%(n/2));
@@ -112,9 +112,9 @@ public:
     // given regions. Otherwise a copy of the regions is made.
     // The extend range has to be given as a 1-dimensional box.
     // <group>
-    WCConcatenation (const PtrBlock<const ImageRegion*>& regions,
+    WCConcatenation (const Block<const ImageRegion*>& regions,
 		     const WCBox& extendRange);
-    WCConcatenation (Bool takeOver, const PtrBlock<const WCRegion*>& regions,
+    WCConcatenation (Bool takeOver, const Block<const WCRegion*>& regions,
 		     const WCBox& extendRange);
     // </group>
 

--- a/images/Regions/WCDifference.cc
+++ b/images/Regions/WCDifference.cc
@@ -37,11 +37,11 @@ WCDifference::WCDifference (const ImageRegion& region1,
 : WCCompound (region1, region2)
 {}
 
-WCDifference::WCDifference (const PtrBlock<const ImageRegion*>& regions)
+WCDifference::WCDifference (const Block<const ImageRegion*>& regions)
 : WCCompound (regions)
 {}
 
-WCDifference::WCDifference (Bool takeOver, const PtrBlock<const WCRegion*>& regions)
+WCDifference::WCDifference (Bool takeOver, const Block<const WCRegion*>& regions)
 : WCCompound (takeOver, regions)
 {}
 
@@ -75,7 +75,7 @@ LCRegion* WCDifference::doToLCRegion (const CoordinateSystem& cSys,
 				      const IPosition& pixelAxesMap,
 				      const IPosition& outOrder) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiToLCRegion (regions, cSys, shape, pixelAxesMap, outOrder);
     return new LCDifference (True, regions);
 }
@@ -101,7 +101,7 @@ TableRecord WCDifference::toRecord (const String& tableName) const
 WCDifference* WCDifference::fromRecord (const TableRecord& rec,
 					const String& tableName)
 {
-    PtrBlock<const WCRegion*> regions;
+    Block<const WCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new WCDifference (True, regions);
 }

--- a/images/Regions/WCDifference.h
+++ b/images/Regions/WCDifference.h
@@ -85,13 +85,13 @@ public:
     // exception is thrown.
     // <group>
     WCDifference (const ImageRegion& region1, const ImageRegion& region2);
-    WCDifference (const PtrBlock<const ImageRegion*>& regions);
+    WCDifference (const Block<const ImageRegion*>& regions);
     // </group>
 
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    WCDifference (Bool takeOver, const PtrBlock<const WCRegion*>& regions);
+    WCDifference (Bool takeOver, const Block<const WCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     WCDifference (const WCDifference& other);

--- a/images/Regions/WCExtension.cc
+++ b/images/Regions/WCExtension.cc
@@ -42,7 +42,7 @@ WCExtension::WCExtension (const ImageRegion& region,
 : WCCompound (region, ImageRegion(extendBox))
 {}
 
-WCExtension::WCExtension (Bool takeOver, const PtrBlock<const WCRegion*>& regions)
+WCExtension::WCExtension (Bool takeOver, const Block<const WCRegion*>& regions)
 : WCCompound (takeOver, regions)
 {}
 
@@ -244,7 +244,7 @@ TableRecord WCExtension::toRecord (const String& tableName) const
 WCExtension* WCExtension::fromRecord (const TableRecord& rec,
 				      const String& tableName)
 {
-    PtrBlock<const WCRegion*> regions;
+    Block<const WCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new WCExtension (True, regions);
 }

--- a/images/Regions/WCExtension.h
+++ b/images/Regions/WCExtension.h
@@ -132,7 +132,7 @@ private:
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    WCExtension (Bool takeOver, const PtrBlock<const WCRegion*>& regions);
+    WCExtension (Bool takeOver, const Block<const WCRegion*>& regions);
 
     // Find the axes to be extended and stretched.
     // The extend axes are the axis numbers in the box.

--- a/images/Regions/WCIntersection.cc
+++ b/images/Regions/WCIntersection.cc
@@ -51,12 +51,12 @@ WCIntersection::WCIntersection (const ImageRegion* region1,
 	      region6, region7, region8, region9, region10)
 {}
 
-WCIntersection::WCIntersection (const PtrBlock<const ImageRegion*>& regions)
+WCIntersection::WCIntersection (const Block<const ImageRegion*>& regions)
 : WCCompound (regions)
 {}
 
 WCIntersection::WCIntersection (Bool takeOver,
-				const PtrBlock<const WCRegion*>& regions)
+				const Block<const WCRegion*>& regions)
 : WCCompound (takeOver, regions)
 {}
 
@@ -90,7 +90,7 @@ LCRegion* WCIntersection::doToLCRegion (const CoordinateSystem& cSys,
 					const IPosition& pixelAxesMap,
 					const IPosition& outOrder) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiToLCRegion (regions, cSys, shape, pixelAxesMap, outOrder);
     return new LCIntersection (True, regions);
 }
@@ -116,7 +116,7 @@ TableRecord WCIntersection::toRecord (const String& tableName) const
 WCIntersection* WCIntersection::fromRecord (const TableRecord& rec,
 					    const String& tableName)
 {
-    PtrBlock<const WCRegion*> regions;
+    Block<const WCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new WCIntersection (True, regions);
 }

--- a/images/Regions/WCIntersection.h
+++ b/images/Regions/WCIntersection.h
@@ -95,13 +95,13 @@ public:
 		    const ImageRegion* region8 = 0,
 		    const ImageRegion* region9 = 0,
 		    const ImageRegion* region10 = 0);
-    WCIntersection (const PtrBlock<const ImageRegion*>& regions);
+    WCIntersection (const Block<const ImageRegion*>& regions);
     // </group>
 
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    WCIntersection (Bool takeOver, const PtrBlock<const WCRegion*>& regions);
+    WCIntersection (Bool takeOver, const Block<const WCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     WCIntersection (const WCIntersection& other);

--- a/images/Regions/WCUnion.cc
+++ b/images/Regions/WCUnion.cc
@@ -51,11 +51,11 @@ WCUnion::WCUnion (const ImageRegion* region1,
 	      region6, region7, region8, region9, region10)
 {}
 
-WCUnion::WCUnion (const PtrBlock<const ImageRegion*>& regions)
+WCUnion::WCUnion (const Block<const ImageRegion*>& regions)
 : WCCompound (regions)
 {}
 
-WCUnion::WCUnion (Bool takeOver, const PtrBlock<const WCRegion*>& regions)
+WCUnion::WCUnion (Bool takeOver, const Block<const WCRegion*>& regions)
 : WCCompound (takeOver, regions)
 {}
 
@@ -89,7 +89,7 @@ LCRegion* WCUnion::doToLCRegion (const CoordinateSystem& cSys,
 				 const IPosition& pixelAxesMap,
 				 const IPosition& outOrder) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiToLCRegion (regions, cSys, shape, pixelAxesMap, outOrder);
     return new LCUnion (True, regions);
 }
@@ -115,7 +115,7 @@ TableRecord WCUnion::toRecord (const String& tableName) const
 WCUnion* WCUnion::fromRecord (const TableRecord& rec,
 			      const String& tableName)
 {
-    PtrBlock<const WCRegion*> regions;
+    Block<const WCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new WCUnion (True, regions);
 }

--- a/images/Regions/WCUnion.h
+++ b/images/Regions/WCUnion.h
@@ -98,13 +98,13 @@ public:
 	     const ImageRegion* region8 = 0,
 	     const ImageRegion* region9 = 0,
 	     const ImageRegion* region10 = 0);
-    WCUnion (const PtrBlock<const ImageRegion*>& regions);
+    WCUnion (const Block<const ImageRegion*>& regions);
     // </group>
 
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    WCUnion (Bool takeOver, const PtrBlock<const WCRegion*>& regions);
+    WCUnion (Bool takeOver, const Block<const WCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     WCUnion (const WCUnion& other);

--- a/lattices/LRegions/LCComplement.cc
+++ b/lattices/LRegions/LCComplement.cc
@@ -42,7 +42,7 @@ LCComplement::LCComplement (const LCRegion& region)
 }
 
 LCComplement::LCComplement (Bool takeOver,
-			    const PtrBlock<const LCRegion*>& regions)
+			    const Block<const LCRegion*>& regions)
 : LCRegionMulti (takeOver, regions)
 {
     defineBox();
@@ -77,7 +77,7 @@ LCRegion* LCComplement::cloneRegion() const
 LCRegion* LCComplement::doTranslate (const Vector<Float>& translateVector,
 				     const IPosition& newLatticeShape) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiTranslate (regions, translateVector, newLatticeShape);
     return new LCComplement (True, regions);
 }
@@ -104,7 +104,7 @@ TableRecord LCComplement::toRecord (const String& tableName) const
 LCComplement* LCComplement::fromRecord (const TableRecord& rec,
 					const String& tableName)
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new LCComplement (True, regions);
 }

--- a/lattices/LRegions/LCComplement.h
+++ b/lattices/LRegions/LCComplement.h
@@ -75,7 +75,7 @@ public:
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    LCComplement (Bool takeOver, const PtrBlock<const LCRegion*>& regions);
+    LCComplement (Bool takeOver, const Block<const LCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     LCComplement (const LCComplement& other);

--- a/lattices/LRegions/LCConcatenation.cc
+++ b/lattices/LRegions/LCConcatenation.cc
@@ -37,7 +37,7 @@ LCConcatenation::LCConcatenation()
 {}
 
 LCConcatenation::LCConcatenation (Bool takeOver,
-				  const PtrBlock<const LCRegion*>& regions,
+				  const Block<const LCRegion*>& regions,
 				  Int extendAxis)
 : LCRegionMulti (takeOver, regions),
   itsExtendAxis (extendAxis)
@@ -50,7 +50,7 @@ LCConcatenation::LCConcatenation (Bool takeOver,
 }
 
 LCConcatenation::LCConcatenation (Bool takeOver,
-				  const PtrBlock<const LCRegion*>& regions,
+				  const Block<const LCRegion*>& regions,
 				  Int extendAxis,
 				  const LCBox& extendBox)
 : LCRegionMulti (takeOver, regions),
@@ -126,7 +126,7 @@ LCRegion* LCConcatenation::doTranslate (const Vector<Float>& translateVector,
 	regTransVec(i) = translateVector(axis);
 	regLatShape(i) = newLatticeShape(axis);
     }
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiTranslate (regions, regTransVec, regLatShape);
     // Create the new LCConcatenation object.
     LCConcatenation* extPtr = new LCConcatenation (True, regions,
@@ -158,7 +158,7 @@ TableRecord LCConcatenation::toRecord (const String& tableName) const
 LCConcatenation* LCConcatenation::fromRecord (const TableRecord& rec,
 					      const String& tableName)
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     LCBox* boxPtr = (LCBox*)(LCRegion::fromRecord (rec.asRecord("box"),
 						   tableName));

--- a/lattices/LRegions/LCConcatenation.h
+++ b/lattices/LRegions/LCConcatenation.h
@@ -81,7 +81,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // so they do not need to be deleted (the LCConcatenation destructor does it).
 // <srcblock>
 // IPosition center (2,10,20);
-// PtrBlock<LCRegion*> cirPtr(n);
+// Block<LCRegion*> cirPtr(n);
 // for (i=0; i<n; i++) {
 //   // Each circle has a different radius.
 //   cirPtr(i) = new LCEllipsoid cir1 (center, 1 + i%(n/2));
@@ -108,9 +108,9 @@ public:
     // The extend range has to be given as a 1-dimensional box.
     // The default range is the entire axis.
     // <group>
-    LCConcatenation (Bool takeOver, const PtrBlock<const LCRegion*>& regions,
+    LCConcatenation (Bool takeOver, const Block<const LCRegion*>& regions,
 		     Int extendAxis);
-    LCConcatenation (Bool takeOver, const PtrBlock<const LCRegion*>& regions,
+    LCConcatenation (Bool takeOver, const Block<const LCRegion*>& regions,
 		     Int extendAxis, const LCBox& extendRange);
     // </group>
 

--- a/lattices/LRegions/LCDifference.cc
+++ b/lattices/LRegions/LCDifference.cc
@@ -43,7 +43,7 @@ LCDifference::LCDifference (const LCRegion& region1, const LCRegion& region2)
 }
 
 LCDifference::LCDifference (Bool takeOver,
-			    const PtrBlock<const LCRegion*>& regions)
+			    const Block<const LCRegion*>& regions)
 : LCRegionMulti (takeOver, regions)
 {
     defineBox();
@@ -78,7 +78,7 @@ LCRegion* LCDifference::cloneRegion() const
 LCRegion* LCDifference::doTranslate (const Vector<Float>& translateVector,
 				     const IPosition& newLatticeShape) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiTranslate (regions, translateVector, newLatticeShape);
     return new LCDifference (True, regions);
 }
@@ -104,7 +104,7 @@ TableRecord LCDifference::toRecord (const String& tableName) const
 LCDifference* LCDifference::fromRecord (const TableRecord& rec,
 					const String& tableName)
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new LCDifference (True, regions);
 }

--- a/lattices/LRegions/LCDifference.h
+++ b/lattices/LRegions/LCDifference.h
@@ -78,7 +78,7 @@ public:
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    LCDifference (Bool takeOver, const PtrBlock<const LCRegion*>& regions);
+    LCDifference (Bool takeOver, const Block<const LCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     LCDifference (const LCDifference& other);

--- a/lattices/LRegions/LCIntersection.cc
+++ b/lattices/LRegions/LCIntersection.cc
@@ -59,7 +59,7 @@ LCIntersection::LCIntersection (Bool takeOver, const LCRegion* region1,
 }
 
 LCIntersection::LCIntersection (Bool takeOver,
-				const PtrBlock<const LCRegion*>& regions)
+				const Block<const LCRegion*>& regions)
 : LCRegionMulti (takeOver, regions)
 {
     defineBox();
@@ -96,7 +96,7 @@ LCRegion* LCIntersection::cloneRegion() const
 LCRegion* LCIntersection::doTranslate (const Vector<Float>& translateVector,
 				       const IPosition& newLatticeShape) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiTranslate (regions, translateVector, newLatticeShape);
     return new LCIntersection (True, regions);
 }
@@ -122,7 +122,7 @@ TableRecord LCIntersection::toRecord (const String& tableName) const
 LCIntersection* LCIntersection::fromRecord (const TableRecord& rec,
 					    const String& tableName)
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new LCIntersection (True, regions);
 }

--- a/lattices/LRegions/LCIntersection.h
+++ b/lattices/LRegions/LCIntersection.h
@@ -87,7 +87,7 @@ public:
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    LCIntersection (Bool takeOver, const PtrBlock<const LCRegion*>& regions);
+    LCIntersection (Bool takeOver, const Block<const LCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     LCIntersection (const LCIntersection& other);

--- a/lattices/LRegions/LCRegionMulti.cc
+++ b/lattices/LRegions/LCRegionMulti.cc
@@ -75,7 +75,7 @@ LCRegionMulti::LCRegionMulti (Bool takeOver, const LCRegion* region1,
 }
 
 LCRegionMulti::LCRegionMulti (Bool takeOver,
-			      const PtrBlock<const LCRegion*>& regions)
+			      const Block<const LCRegion*>& regions)
 : LCRegion   (regions[0]->latticeShape()),
   itsRegions (regions)
 {
@@ -134,7 +134,7 @@ Bool LCRegionMulti::hasMask() const
     return (itsHasMask >= 0);
 }
 
-void LCRegionMulti::multiTranslate (PtrBlock<const LCRegion*>& regions,
+void LCRegionMulti::multiTranslate (Block<const LCRegion*>& regions,
 				    const Vector<Float>& translateVector,
 				    const IPosition& newLatticeShape) const
 {
@@ -312,7 +312,7 @@ TableRecord LCRegionMulti::makeRecord (const String& tableName) const
     return rec;
 }
 
-void LCRegionMulti::unmakeRecord (PtrBlock<const LCRegion*>& regions,
+void LCRegionMulti::unmakeRecord (Block<const LCRegion*>& regions,
 				  const TableRecord& rec,
 				  const String& tableName)
 {

--- a/lattices/LRegions/LCRegionMulti.h
+++ b/lattices/LRegions/LCRegionMulti.h
@@ -94,7 +94,7 @@ public:
     // Construct from multiple regions given as a Block.
     // When <src>takeOver</src> is True, the destructor will delete the
     // given regions. Otherwise a copy of the regions is made.
-    LCRegionMulti (Bool takeOver, const PtrBlock<const LCRegion*>& regions);
+    LCRegionMulti (Bool takeOver, const Block<const LCRegion*>& regions);
 
     // Copy constructor (copy semantics).
     LCRegionMulti (const LCRegionMulti& other);
@@ -115,12 +115,12 @@ protected:
     TableRecord makeRecord (const String& tableName) const;
 
     // Retrieve the contributing objects from the record.
-    static void unmakeRecord (PtrBlock<const LCRegion*>&,
+    static void unmakeRecord (Block<const LCRegion*>&,
 			      const TableRecord&,
 			      const String& tableName);
 
     // Translate all regions.
-    void multiTranslate (PtrBlock<const LCRegion*>&,
+    void multiTranslate (Block<const LCRegion*>&,
 			 const Vector<Float>& translateVector,
 			 const IPosition& newLatticeShape) const;
 
@@ -134,7 +134,7 @@ protected:
 		    const Slicer& section, uInt regNr) const;
 
     // Get the contributing regions.
-    const PtrBlock<const LCRegion*>& regions() const;
+    const Block<const LCRegion*>& regions() const;
     
 protected:
     // Construct from lattice shape and region pointer, which is
@@ -162,11 +162,11 @@ private:
     //# >=0 means this region has a mask.
     //# Its value gives the region with the biggest mask.
     Int itsHasMask;
-    PtrBlock<const LCRegion*> itsRegions;
+    Block<const LCRegion*> itsRegions;
 };
 
 
-inline const PtrBlock<const LCRegion*>& LCRegionMulti::regions() const
+inline const Block<const LCRegion*>& LCRegionMulti::regions() const
 {
     return itsRegions;
 }

--- a/lattices/LRegions/LCUnion.cc
+++ b/lattices/LRegions/LCUnion.cc
@@ -60,7 +60,7 @@ LCUnion::LCUnion (Bool takeOver, const LCRegion* region1,
 }
 
 LCUnion::LCUnion (Bool takeOver,
-		  const PtrBlock<const LCRegion*>& regions)
+		  const Block<const LCRegion*>& regions)
 : LCRegionMulti (takeOver, regions)
 {
     defineBox();
@@ -94,7 +94,7 @@ LCRegion* LCUnion::cloneRegion() const
 LCRegion* LCUnion::doTranslate (const Vector<Float>& translateVector,
 				const IPosition& newLatticeShape) const
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     multiTranslate (regions, translateVector, newLatticeShape);
     return new LCUnion (True, regions);
 }
@@ -120,7 +120,7 @@ TableRecord LCUnion::toRecord (const String& tableName) const
 LCUnion* LCUnion::fromRecord (const TableRecord& rec,
 			      const String& tableName)
 {
-    PtrBlock<const LCRegion*> regions;
+    Block<const LCRegion*> regions;
     unmakeRecord (regions, rec.asRecord("regions"), tableName);
     return new LCUnion (True, regions);
 }

--- a/lattices/LRegions/LCUnion.h
+++ b/lattices/LRegions/LCUnion.h
@@ -91,7 +91,7 @@ public:
 	     const LCRegion* region8 = 0,
 	     const LCRegion* region9 = 0,
 	     const LCRegion* region10 = 0);
-    LCUnion (Bool takeOver, const PtrBlock<const LCRegion*>& regions);
+    LCUnion (Bool takeOver, const Block<const LCRegion*>& regions);
     // </group>
 
     // Copy constructor (copy semantics).

--- a/lattices/LRegions/test/tLCConcatenation.cc
+++ b/lattices/LRegions/test/tLCConcatenation.cc
@@ -46,7 +46,7 @@ void doIt (const IPosition& latticeShape,
     LCBox box (start, end, latticeShape);
     LCEllipsoid cir (center, radius, latticeShape);
     LCEllipsoid cir1 (center, radius-1, latticeShape);
-    PtrBlock<const LCRegion*> ptrs(3);
+    Block<const LCRegion*> ptrs(3);
     ptrs[0] = &cir;
     ptrs[1] = &box;
     ptrs[2] = &cir1;
@@ -138,7 +138,7 @@ void doIt (const IPosition& latticeShape,
     }
     {
     // Test ordered equality. 
-	PtrBlock<const LCRegion*> ptrs(2);
+	Block<const LCRegion*> ptrs(2);
 	ptrs[0] = &box;
 	ptrs[1] = &cir;
 	LCConcatenation union1 (False, ptrs, start.nelements());
@@ -147,7 +147,7 @@ void doIt (const IPosition& latticeShape,
     }
     {
     // Test unordered equality. 
-	PtrBlock<const LCRegion*> ptrs(2);
+	Block<const LCRegion*> ptrs(2);
 	ptrs[0] = &box;
 	ptrs[1] = &cir;
 	LCConcatenation union1 (False, ptrs, start.nelements());

--- a/lattices/LatticeMath/LatticeApply.h
+++ b/lattices/LatticeMath/LatticeApply.h
@@ -164,13 +164,13 @@ public:
 // of the supplied region).
 // The default region is the entire input lattice.
 // <group>
-    static void lineMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut, 
+    static void lineMultiApply (Block<MaskedLattice<U>*>& latticeOut, 
 				const MaskedLattice<T>& latticeIn,
 				LineCollapser<T,U>& collapser,
 				uInt collapseAxis,
 				LatticeProgress* tellProgress = 0);
 
-    static void lineMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut, 
+    static void lineMultiApply (Block<MaskedLattice<U>*>& latticeOut, 
 				const MaskedLattice<T>& latticeIn,
 				const LatticeRegion& region,
 				LineCollapser<T,U>& collapser,
@@ -218,12 +218,12 @@ public:
 // Thus they cannot be used yet.
 // </note>
 // <group>
-    static void tiledMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut, 
+    static void tiledMultiApply (Block<MaskedLattice<U>*>& latticeOut, 
 				 const MaskedLattice<T>& latticeIn,
 				 TiledCollapser<T,U>& collapser,
 				 const IPosition& collapseAxes,
 				 LatticeProgress* tellProgress = 0);
-    static void tiledMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut, 
+    static void tiledMultiApply (Block<MaskedLattice<U>*>& latticeOut, 
 				 const MaskedLattice<T>& latticeIn,
 				 const LatticeRegion& region,
 				 TiledCollapser<T,U>& collapser,

--- a/lattices/LatticeMath/LatticeApply.tcc
+++ b/lattices/LatticeMath/LatticeApply.tcc
@@ -61,7 +61,7 @@ void LatticeApply<T,U>::lineApply (MaskedLattice<U>& latticeOut,
 }
 
 template <class T, class U>
-void LatticeApply<T,U>::lineMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut,
+void LatticeApply<T,U>::lineMultiApply (Block<MaskedLattice<U>*>& latticeOut,
 				      const MaskedLattice<T>& latticeIn,
 				      const LatticeRegion& region,
 				      LineCollapser<T,U>& collapser,
@@ -213,7 +213,7 @@ void LatticeApply<T,U>::lineApply (MaskedLattice<U>& latticeOut,
 }
 
 template <class T, class U>
-void LatticeApply<T,U>::lineMultiApply (PtrBlock<MaskedLattice<U>*>& latticeOut,
+void LatticeApply<T,U>::lineMultiApply (Block<MaskedLattice<U>*>& latticeOut,
 				      const MaskedLattice<T>& latticeIn,
 				      LineCollapser<T,U>& collapser,
 				      uInt collapseAxis,

--- a/lattices/LatticeMath/LatticeCleaner.h
+++ b/lattices/LatticeMath/LatticeCleaner.h
@@ -274,11 +274,11 @@ private:
   Int itsNscales;
   Vector<Float> itsScaleSizes;
 
-  PtrBlock<TempLattice<T>* > itsScales;
-  PtrBlock<TempLattice<Complex>* > itsScaleXfrs;
-  PtrBlock<TempLattice<T>* > itsPsfConvScales;
-  PtrBlock<TempLattice<T>* > itsDirtyConvScales;
-  PtrBlock<TempLattice<T>* > itsScaleMasks;
+  Block<TempLattice<T>* > itsScales;
+  Block<TempLattice<Complex>* > itsScaleXfrs;
+  Block<TempLattice<T>* > itsPsfConvScales;
+  Block<TempLattice<T>* > itsDirtyConvScales;
+  Block<TempLattice<T>* > itsScaleMasks;
 
   Bool itsScalesValid;
 

--- a/lattices/LatticeMath/MultiTermLatticeCleaner.h
+++ b/lattices/LatticeMath/MultiTermLatticeCleaner.h
@@ -52,7 +52,7 @@ public:
   ~MultiTermLatticeCleaner();
 
   // Input : number of Taylor terms
-  //         Reshapes PtrBlocks to hold the correct number of PSFs and Residual images
+  //         Reshapes Blocks to hold the correct number of PSFs and Residual images
   Bool setntaylorterms(const int & nterms);
   
   // Input : scales
@@ -138,39 +138,39 @@ private:
   Bool donePSF_p,donePSP_p,doneCONV_p;
  
   // h(s) [nx,ny,nscales]
-  PtrBlock<TempLattice<Float>* > vecScales_p; 
-  PtrBlock<TempLattice<Complex>* > vecScalesFT_p; 
+  Block<TempLattice<Float>* > vecScales_p; 
+  Block<TempLattice<Complex>* > vecScalesFT_p; 
   
   // B_k  [nx,ny,ntaylor]
-  PtrBlock<TempLattice<Float>* > vecPsf_p; 
-  PtrBlock<TempLattice<Complex>* > vecPsfFT_p; 
+  Block<TempLattice<Float>* > vecPsf_p; 
+  Block<TempLattice<Complex>* > vecPsfFT_p; 
   
   // I_D : Residual/Dirty Images [nx,ny,ntaylor]
-  PtrBlock<TempLattice<Float>* > vecDirty_p; 
+  Block<TempLattice<Float>* > vecDirty_p; 
  
   // I_M : Model Images [nx,ny,ntaylor]
-  PtrBlock<TempLattice<Float>* > vecModel_p; 
+  Block<TempLattice<Float>* > vecModel_p; 
  
   // A_{smn} = B_{sm} * B{sn} [nx,ny,ntaylor,ntaylor,nscales,nscales]
   // A_{s1s2mn} = B_{s1m} * B{s2n} [nx,ny,ntaylor,ntaylor,nscales,nscales]
-  PtrBlock<TempLattice<Float>* > cubeA_p; 
-  PtrBlock<LatticeIterator<Float>* > itercubeA_p;
+  Block<TempLattice<Float>* > cubeA_p; 
+  Block<LatticeIterator<Float>* > itercubeA_p;
   
   // R_{sk} = I_D * B_{sk} [nx,ny,ntaylor,nscales]
-  PtrBlock<TempLattice<Float>* > matR_p; 
-  PtrBlock<LatticeIterator<Float>* > itermatR_p;
+  Block<TempLattice<Float>* > matR_p; 
+  Block<LatticeIterator<Float>* > itermatR_p;
   
   // a_{sk} = Solution vectors. [nx,ny,ntaylor,nscales]
-  PtrBlock<TempLattice<Float>* > matCoeffs_p; 
-  PtrBlock<LatticeIterator<Float>* > itermatCoeffs_p;
+  Block<TempLattice<Float>* > matCoeffs_p; 
+  Block<LatticeIterator<Float>* > itermatCoeffs_p;
 
   // Memory to be allocated per TempLattice
   Double memoryMB_p;
   
   // Solve [A][Coeffs] = [I_D * B]
   // Shape of A : [ntaylor,ntaylor]
-  PtrBlock<Matrix<Double>*> matA_p;    // 2D matrix to be inverted.
-  PtrBlock<Matrix<Double>*> invMatA_p; // Inverse of matA_p;
+  Block<Matrix<Double>*> matA_p;    // 2D matrix to be inverted.
+  Block<Matrix<Double>*> invMatA_p; // Inverse of matA_p;
 
   // Scratch Lattices and iterators.
   TempLattice<Complex>* cWork_p;

--- a/lattices/LatticeMath/test/tLatticeApply.cc
+++ b/lattices/LatticeMath/test/tLatticeApply.cc
@@ -353,7 +353,7 @@ void doIt (int argc, const char* argv[])
 	Table paTable1(paSetup1);
 	PagedArray<Int> arrout1(TiledShape(l2Shape, t2Shape), paTable1);
 	SubLattice<Int> latout1(arrout1, True);
-	PtrBlock<MaskedLattice<Int>*> blat(2);
+	Block<MaskedLattice<Int>*> blat(2);
 	blat[0] = &latout0;
 	blat[1] = &latout1;
 	MyLineCollapser collapser;
@@ -539,7 +539,7 @@ void doIt (int argc, const char* argv[])
 	Table paTable1(paSetup1);
 	PagedArray<Int> arrout1(l3Shape, paTable1);
 	SubLattice<Int> latout1(arrout1, True);
-	PtrBlock<MaskedLattice<Int>*> blat(2);
+	Block<MaskedLattice<Int>*> blat(2);
 	blat[0] = &latout0;
 	blat[1] = &latout1;
 	MyLineCollapser collapser;

--- a/lattices/LatticeMath/test/tLatticeApply2.cc
+++ b/lattices/LatticeMath/test/tLatticeApply2.cc
@@ -326,7 +326,7 @@ void doIt (int argc, const char* argv[])
         ArrayLattice<Bool> mask1(l2Shape); mask0.set(True);
         mLatOut1.setPixelMask(mask1,False); 
 //
-	PtrBlock<MaskedLattice<Float>*> blat(2);
+	Block<MaskedLattice<Float>*> blat(2);
 	blat[0] = &mLatOut0;
 	blat[1] = &mLatOut1;
 	MyLineCollapser collapser;

--- a/lattices/Lattices/LatticeConcat.h
+++ b/lattices/Lattices/LatticeConcat.h
@@ -250,7 +250,7 @@ public:
 
  
 private:
-   PtrBlock<MaskedLattice<T>* > lattices_p;
+   Block<MaskedLattice<T>* > lattices_p;
    uInt axis_p;
    IPosition shape_p;
    Bool isMasked_p, dimUpOne_p, tempClose_p;

--- a/lattices/Lattices/TiledShape.cc
+++ b/lattices/Lattices/TiledShape.cc
@@ -211,7 +211,7 @@ IPosition TiledShape::defaultTileShape (uInt nrPixelsPerTile,
     }
     // Find the shapes on each axis that will be tried.
     Block<uInt> nval(nrdim, uInt(0));
-    PtrBlock<Block<Int>*> values(nrdim);
+    Block<Block<Int>*> values(nrdim);
     for (i=0; i<nrdim; i++) {
 	values[i] = new Block<Int> (maxShape(i) - minShape(i) + 1);
 	// First find exactly fitting shapes.

--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -1563,7 +1563,7 @@ Bool JPLDE(tableProperties &tprop, inputValues &inVal) {
   vector<vector<Double> > allcol;
   while (read_line(line, infile)) {
     if (line.size() < 2 || int_data(line[1]) != Int(ncoeff)) continue;
-    Double st0;
+    Double st0 = 0.0;
     vector<Double> res;
     while (read_line(line, infile)) {
       for (uInt i=0; i<line.size(); ++i) {

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -427,7 +427,7 @@ protected:
 
   MSIter* This;
   Block<MeasurementSet> bms_p;
-  PtrBlock<TableIterator* > tabIter_p;
+  Block<TableIterator* > tabIter_p;
   Block<Bool> tabIterAtStart_p;
 
   // This booleans determine if given columns are part of the sorting

--- a/scimath/Fitting/GenericL2Fit.h
+++ b/scimath/Fitting/GenericL2Fit.h
@@ -467,12 +467,12 @@ template<class T> class GenericL2Fit : public LSQaips {
   // as parameters; giving <src>[1,1,1]</src> as argument vector and
   // <src>3.1415</src> as value.
   // <group>
-  PtrBlock<Function<typename FunctionTraits<T>::DiffType,
+  Block<Function<typename FunctionTraits<T>::DiffType,
     typename FunctionTraits<T>::DiffType>*> constrFun_p;
   // List of vectors describing the constraint equations' arguments
-  PtrBlock<Vector<typename FunctionTraits<T>::BaseType>*> constrArg_p;
+  Block<Vector<typename FunctionTraits<T>::BaseType>*> constrArg_p;
   // List of values describing the constraint equations' value
-  PtrBlock<typename FunctionTraits<T>::BaseType *> constrVal_p;
+  Block<typename FunctionTraits<T>::BaseType *> constrVal_p;
   // </group>
   // Number of available parameters
   uInt pCount_p;

--- a/scimath/Functionals/CombiParam.h
+++ b/scimath/Functionals/CombiParam.h
@@ -181,7 +181,7 @@ protected:
   uInt ndim_p;
   
   // Pointer to each added function
-  PtrBlock<Function<T> *> functionPtr_p;
+  Block<Function<T> *> functionPtr_p;
 
   //# Make members of parent classes known.
 public:

--- a/scimath/Functionals/CombiParam.tcc
+++ b/scimath/Functionals/CombiParam.tcc
@@ -59,7 +59,7 @@ CombiParam<T>& CombiParam<T>::operator=(const CombiParam<T> &other) {
     for (uInt i=0; i<functionPtr_p.nelements(); i++) {
       delete functionPtr_p[i]; functionPtr_p[i] = 0;
     }
-    functionPtr_p =  PtrBlock<Function<T> *>(other.functionPtr_p.nelements());
+    functionPtr_p =  Block<Function<T> *>(other.functionPtr_p.nelements());
     for (uInt i=0; i<functionPtr_p.nelements(); ++i) {
       functionPtr_p[i] = (*(other.functionPtr_p[i])).clone();
     }

--- a/scimath/Functionals/CompoundParam.h
+++ b/scimath/Functionals/CompoundParam.h
@@ -202,7 +202,7 @@ private:
 protected:
   //# Data
   // Pointer to each added function
-  PtrBlock<Function<T> *> functionPtr_p;
+  Block<Function<T> *> functionPtr_p;
   // Index of offset for each function to its parameters in general list
   Block<uInt> paroff_p;
   // Index of function belonging to parameter

--- a/scimath/Functionals/CompoundParam.tcc
+++ b/scimath/Functionals/CompoundParam.tcc
@@ -70,7 +70,7 @@ operator=(const CompoundParam<T> &other) {
     for (uInt i=0; i<functionPtr_p.nelements(); i++) {
       delete functionPtr_p[i]; functionPtr_p[i] = 0;
     }
-    functionPtr_p =  PtrBlock<Function<T> *>(other.functionPtr_p.nelements());
+    functionPtr_p =  Block<Function<T> *>(other.functionPtr_p.nelements());
     paroff_p = Block<uInt>(other.paroff_p.nelements());
     funpar_p = Block<uInt>(other.funpar_p.nelements());
     locpar_p = Block<uInt>(other.locpar_p.nelements());

--- a/scimath/Functionals/FunctionOrder.h
+++ b/scimath/Functionals/FunctionOrder.h
@@ -136,7 +136,7 @@ template<class T> class FunctionOrder : public RecordTransformable {
   // String parameters
   String string_p;
   // List of functions (say for Combi and Compound)
-  PtrBlock<Function<T> *> function_p;
+  Block<Function<T> *> function_p;
   // Scale of y (length 1)
   Vector<T> scale_p;
   // Centers of x (length ndim)

--- a/scimath/Functionals/FunctionOrder.tcc
+++ b/scimath/Functionals/FunctionOrder.tcc
@@ -73,7 +73,7 @@ FunctionOrder<T> &FunctionOrder<T>::operator=(const FunctionOrder<T> &other) {
     for (uInt i=0; i<function_p.nelements(); ++i) {
       delete function_p[i]; function_p[i] = 0;
     }
-    function_p =  PtrBlock<Function<T> *>(other.function_p.nelements());
+    function_p =  Block<Function<T> *>(other.function_p.nelements());
     for (uInt i=0; i<function_p.nelements(); ++i) {
       function_p[i] = (*(other.function_p[i])).clone();
     }

--- a/scimath/Mathematics/InterpolateArray1D.h
+++ b/scimath/Mathematics/InterpolateArray1D.h
@@ -31,7 +31,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template <class T> class PtrBlock;
 template <class T> class Block;
 
 // <summary> Interpolate in one dimension </summary>
@@ -233,55 +232,55 @@ public:
 
 private:
   // Interpolate the y-vectors of length ny from x values xin to xout.
-  static void interpolatePtr(PtrBlock<Range*>& yout, 
+  static void interpolatePtr(Block<Range*>& yout,
 			     Int ny, 
 			     const Vector<Domain>& xout, 
 			     const Vector<Domain>& xin,
-			     const PtrBlock<const Range*>& yin, 
+			     const Block<const Range*>& yin,
 			     Int method);
 
   // Interpolate the y-vectors of length ny from x values xin to xout.
   // Take flagging into account
-  static void interpolatePtr(PtrBlock<Range*>& yout, 
-			     PtrBlock<Bool*>& youtFlags,
+  static void interpolatePtr(Block<Range*>& yout,
+			     Block<Bool*>& youtFlags,
 			     Int ny, 
 			     const Vector<Domain>& xout, 
 			     const Vector<Domain>& xin,
-			     const PtrBlock<const Range*>& yin, 
-			     const PtrBlock<const Bool*>& yinFlags, 
+			     const Block<const Range*>& yin,
+			     const Block<const Bool*>& yinFlags,
 			     Int method, Bool goodIsTrue,
 			     Bool extrapolate);
 
   // Interpolate along yaxis 
-  static void interpolateyPtr(PtrBlock<Range*>& yout,
+  static void interpolateyPtr(Block<Range*>& yout,
                              Int na,
                              Int nb,
                              Int nc,
                              const Vector<Domain>& xout,
                              const Vector<Domain>& xin,
-                             const PtrBlock<const Range*>& yin,
+                             const Block<const Range*>& yin,
                              Int method);
 
   // Take flagging into account
-  static void interpolateyPtr(PtrBlock<Range*>& yout, 
-			     PtrBlock<Bool*>& youtFlags,
+  static void interpolateyPtr(Block<Range*>& yout,
+			     Block<Bool*>& youtFlags,
                              Int na,
 			     Int nb, 
 			     Int nc, 
 			     const Vector<Domain>& xout, 
 			     const Vector<Domain>& xin,
-			     const PtrBlock<const Range*>& yin, 
-			     const PtrBlock<const Bool*>& yinFlags, 
+			     const Block<const Range*>& yin,
+			     const Block<const Bool*>& yinFlags,
 			     Int method, Bool goodIsTrue,
 			     Bool extrapolate);
 
   // Interpolate the y-vectors of length ny from x values xin to xout
   // using polynomial interpolation with specified order.
-  static void polynomialInterpolation(PtrBlock<Range*>& yout, 
+  static void polynomialInterpolation(Block<Range*>& yout,
 				      Int ny, 
 				      const Vector<Domain>& xout, 
 				      const Vector<Domain>& xin,
-				      const PtrBlock<const Range*>& yin, 
+				      const Block<const Range*>& yin,
 				      Int order);
 
 };

--- a/scimath/Mathematics/InterpolateArray1D.tcc
+++ b/scimath/Mathematics/InterpolateArray1D.tcc
@@ -61,8 +61,8 @@ void InterpolateArray1D<Domain,Range>::interpolate(Array<Range>& yout,
   yout.resize(youtShape);
   Range* pyout=yout.getStorage(deleteYout);
 
-  PtrBlock<const Range*> yinPtrs(nxin);
-  PtrBlock<Range*> youtPtrs(nxout);
+  Block<const Range*> yinPtrs(nxin);
+  Block<Range*> youtPtrs(nxout);
   for (i=0; i<nxin; i++) yinPtrs[i]=pyin+i*yStep;
   for (i=0; i<nxout; i++) youtPtrs[i]=pyout+i*yStep;
   
@@ -115,10 +115,10 @@ void InterpolateArray1D<Domain,Range>::interpolate(Array<Range>& yout,
   Range* pyout=yout.getStorage(deleteYout);
   Bool* pyoutFlags=youtFlags.getStorage(deleteYoutFlags);
 
-  PtrBlock<const Range*> yinPtrs(nxin);
-  PtrBlock<const Bool*> yinFlagPtrs(nxin);
-  PtrBlock<Range*> youtPtrs(nxout);
-  PtrBlock<Bool*> youtFlagPtrs(nxout);
+  Block<const Range*> yinPtrs(nxin);
+  Block<const Bool*> yinFlagPtrs(nxin);
+  Block<Range*> youtPtrs(nxout);
+  Block<Bool*> youtFlagPtrs(nxout);
   for (i=0; i<nxin; i++) {
     yinPtrs[i]=pyin+i*yStep;
     yinFlagPtrs[i]=pyinFlags+i*yStep;
@@ -176,8 +176,8 @@ void InterpolateArray1D<Domain,Range>::interpolatey(Cube<Range>& yout,
   yout.resize(youtShape);
   Range* pyout=yout.getStorage(deleteYout);
 
-  PtrBlock<const Range*> yinPtrs(na*nb*nc);
-  PtrBlock<Range*> youtPtrs(na*nxout*nc);
+  Block<const Range*> yinPtrs(na*nb*nc);
+  Block<Range*> youtPtrs(na*nxout*nc);
   Int i;
   for (i=0; i<(na*nb*nc); i++) yinPtrs[i]=pyin+i;
   for (i=0; i<(na*nxout*nc); i++) {
@@ -220,10 +220,10 @@ void InterpolateArray1D<Domain,Range>::interpolatey(Cube<Range>& yout,
   Range* pyout=yout.getStorage(deleteYout);
   Bool* pyoutFlags=youtFlags.getStorage(deleteYoutFlags);
 
-  PtrBlock<const Range*> yinPtrs(na*nb*nc);
-  PtrBlock<const Bool*> yinFlagPtrs(na*nb*nc);
-  PtrBlock<Range*> youtPtrs(na*nxout*nc);
-  PtrBlock<Bool*> youtFlagPtrs(na*nxout*nc);
+  Block<const Range*> yinPtrs(na*nb*nc);
+  Block<const Bool*> yinFlagPtrs(na*nb*nc);
+  Block<Range*> youtPtrs(na*nxout*nc);
+  Block<Bool*> youtFlagPtrs(na*nxout*nc);
   Int i;
   for (i=0; i<(na*nb*nc); i++) {
     yinPtrs[i]=pyin+i;
@@ -242,11 +242,11 @@ void InterpolateArray1D<Domain,Range>::interpolatey(Cube<Range>& yout,
 }
 
 template <class Domain, class Range>
-void InterpolateArray1D<Domain,Range>::interpolatePtr(PtrBlock<Range*>& yout, 
+void InterpolateArray1D<Domain,Range>::interpolatePtr(Block<Range*>& yout,
                                                       Int ny, 
   					              const Vector<Domain>& xout, 
 						      const Vector<Domain>& xin,
-						      const PtrBlock<const Range*>& yin, 
+						      const Block<const Range*>& yin,
                                                       Int method)
 {
   uInt nElements=xin.nelements();
@@ -397,13 +397,13 @@ void InterpolateArray1D<Domain,Range>::interpolatePtr(PtrBlock<Range*>& yout,
 }  
 
 template <class Domain, class Range>
-void InterpolateArray1D<Domain,Range>::interpolatePtr(PtrBlock<Range*>& yout, 
-						      PtrBlock<Bool*>& youtFlags, 
+void InterpolateArray1D<Domain,Range>::interpolatePtr(Block<Range*>& yout,
+						      Block<Bool*>& youtFlags,
 						      Int ny, 
  						      const Vector<Domain>& xout, 
 						      const Vector<Domain>& xin,
-						      const PtrBlock<const Range*>& yin, 
-						      const PtrBlock<const Bool*>& yinFlags, 
+						      const Block<const Range*>& yin,
+						      const Block<const Bool*>& yinFlags,
 						      Int method,
 						      Bool goodIsTrue,
 						      Bool extrapolate)
@@ -643,13 +643,13 @@ void InterpolateArray1D<Domain,Range>::interpolatePtr(PtrBlock<Range*>& yout,
 }  
 
 template <class Domain, class Range>
-void InterpolateArray1D<Domain,Range>::interpolateyPtr(PtrBlock<Range*>& yout,
+void InterpolateArray1D<Domain,Range>::interpolateyPtr(Block<Range*>& yout,
                                                       Int na,
                                                       Int nb,
                                                       Int nc,
                                                       const Vector<Domain>& xout,
                                                       const Vector<Domain>& xin,
-                                                      const PtrBlock<const Range*>& yin,
+                                                      const Block<const Range*>& yin,
                                                       Int method)
 {
   uInt nElements=xin.nelements();
@@ -707,15 +707,15 @@ void InterpolateArray1D<Domain,Range>::interpolateyPtr(PtrBlock<Range*>& yout,
 }
 
 template <class Domain, class Range>
-void InterpolateArray1D<Domain,Range>::interpolateyPtr(PtrBlock<Range*>& yout,
-                                                      PtrBlock<Bool*>& youtFlags,
+void InterpolateArray1D<Domain,Range>::interpolateyPtr(Block<Range*>& yout,
+                                                      Block<Bool*>& youtFlags,
                                                       Int na,
                                                       Int nb,
                                                       Int nc,
                                                       const Vector<Domain>& xout,
                                                       const Vector<Domain>& xin,
-                                                      const PtrBlock<const Range*>& yin,
-                                                      const PtrBlock<const Bool*>& yinFlags,
+                                                      const Block<const Range*>& yin,
+                                                      const Block<const Bool*>& yinFlags,
                                                       Int method,
                                                       Bool goodIsTrue,
                                                       Bool extrapolate)
@@ -802,11 +802,11 @@ void InterpolateArray1D<Domain,Range>::interpolateyPtr(PtrBlock<Range*>& yout,
 // using polynomial interpolation with specified order
 template <class Domain, class Range>
 void InterpolateArray1D<Domain,Range>::polynomialInterpolation
-(PtrBlock<Range*>& yout,
+(Block<Range*>& yout,
  Int ny, 
  const Vector<Domain>& xout, 
  const Vector<Domain>& xin,
- const PtrBlock<const Range*>& yin, 
+ const Block<const Range*>& yin,
  Int order)
 {
   // Based on Nevilles Algorithm (Numerical Recipies 2nd ed., Section 3.1)

--- a/tables/DataMan/Adios2StManImpl.h
+++ b/tables/DataMan/Adios2StManImpl.h
@@ -86,7 +86,7 @@ private:
     Adios2StMan &parent;
     String itsDataManName = "Adios2StMan";
     rownr_t itsRows {0};
-    PtrBlock<Adios2StManColumn *> itsColumnPtrBlk;
+    Block<Adios2StManColumn *> itsColumnPtrBlk;
 
     std::shared_ptr<adios2::ADIOS> itsAdios;
     std::shared_ptr<adios2::IO> itsAdiosIO;

--- a/tables/DataMan/ForwardCol.h
+++ b/tables/DataMan/ForwardCol.h
@@ -520,7 +520,7 @@ private:
 
 
     // Define the various engine column objects.
-    PtrBlock<ForwardColumn*> refColumns_p;
+    Block<ForwardColumn*> refColumns_p;
     // The referenced table.
     // For newly created tables this is filled in by the constructor.
     // For existing tables this is filled in by the first ForwardColumn

--- a/tables/DataMan/ForwardColRow.h
+++ b/tables/DataMan/ForwardColRow.h
@@ -364,7 +364,7 @@ private:
     String                          rowColumnName_p;
     ScalarColumn<uInt>              rowColumn_p;
     // Define the various engine column objects.
-    PtrBlock<ForwardColumnIndexedRow*> refColumns_p;
+    Block<ForwardColumnIndexedRow*> refColumns_p;
     // Cache of last row used to get row number.
     Int64   lastRow_p;
     rownr_t rowNumber_p;

--- a/tables/DataMan/ISMBase.h
+++ b/tables/DataMan/ISMBase.h
@@ -350,7 +350,7 @@ private:
     // The number of rows in the columns.
     rownr_t      nrrow_p;
     // The assembly of all columns.
-    PtrBlock<ISMColumn*>  colSet_p;
+    Block<ISMColumn*>  colSet_p;
     // The cache with the ISM buckets.
     BucketCache* cache_p;
     // The file containing all data.

--- a/tables/DataMan/ISMBucket.h
+++ b/tables/DataMan/ISMBucket.h
@@ -298,10 +298,10 @@ private:
     uInt              indexLeng_p;
     // The row index per column; each index contains the row number
     // of each value stored in the bucket (for that column).
-    PtrBlock<Block<rownr_t>*> rowIndex_p;
+    Block<Block<rownr_t>*> rowIndex_p;
     // The offset index per column; each index contains the offset (in bytes)
     // of each value stored in the bucket (for that column).
-    PtrBlock<Block<uInt>*> offIndex_p;
+    Block<Block<uInt>*> offIndex_p;
     // Nr of used elements in each index; i.e. the number of stored values
     // per column.
     Block<uInt>       indexUsed_p;

--- a/tables/DataMan/MSMBase.h
+++ b/tables/DataMan/MSMBase.h
@@ -189,7 +189,7 @@ protected:
   // The number of rows in create().
   rownr_t nrrowCreate_p;
   // The assembly of all columns.
-  PtrBlock<MSMColumn*> colSet_p;
+  Block<MSMColumn*> colSet_p;
   // Has anything been put since the last flush?
   Bool    hasPut_p;
 };

--- a/tables/DataMan/SSMBase.h
+++ b/tables/DataMan/SSMBase.h
@@ -407,7 +407,7 @@ private:
   Block<uInt> itsColIndexMap;
 
   // Will contain all indices
-  PtrBlock<SSMIndex*>  itsPtrIndex;
+  Block<SSMIndex*>  itsPtrIndex;
   
   // The cache with the SSM buckets.
   BucketCache* itsCache;
@@ -454,7 +454,7 @@ private:
   uInt itsBucketRows;
   
   // The assembly of all columns.
-  PtrBlock<SSMColumn*> itsPtrColumn;
+  Block<SSMColumn*> itsPtrColumn;
   
   // Has the data changed since the last flush?
   Bool isDataChanged;

--- a/tables/DataMan/TSMCube.cc
+++ b/tables/DataMan/TSMCube.cc
@@ -623,7 +623,7 @@ void TSMCube::extendCoordinates (const Record& coordValues,
     }
 }
 
-Bool TSMCube::matches (const PtrBlock<TSMColumn*>& idColSet,
+Bool TSMCube::matches (const Block<TSMColumn*>& idColSet,
                        const Record& idValues)
 {
     for (uInt i=0; i<idColSet.nelements(); i++) {

--- a/tables/DataMan/TSMCube.h
+++ b/tables/DataMan/TSMCube.h
@@ -202,7 +202,7 @@ public:
     // </group>
 
     // Test if the id values match.
-    Bool matches (const PtrBlock<TSMColumn*>& idColSet,
+    Bool matches (const Block<TSMColumn*>& idColSet,
                  const Record& idValues);
 
     // Extend the last dimension of the cube with the given number.

--- a/tables/DataMan/TiledDataStMan.cc
+++ b/tables/DataMan/TiledDataStMan.cc
@@ -188,7 +188,7 @@ void TiledDataStMan::extendHypercube (uInt64 incrInLastDim,
     // Check if the number of rows involved fits in the table.
     checkNrrow (cubeSet_p[cubeNr]->cubeShape(), incrInLastDim);
     // Check if values for the last coordinate are given correctly.
-    PtrBlock<TSMColumn*> lastCoord (1, coordColSet_p[nrdim_p-1]);
+    Block<TSMColumn*> lastCoord (1, coordColSet_p[nrdim_p-1]);
     IPosition lastDim (1, incrInLastDim);
     checkCoordinates (lastCoord, lastDim, values);
     cubeSet_p[cubeNr]->extend (incrInLastDim, values, lastCoord[0]);

--- a/tables/DataMan/TiledStMan.cc
+++ b/tables/DataMan/TiledStMan.cc
@@ -206,7 +206,7 @@ IPosition TiledStMan::makeTileShape (const IPosition& hypercubeShape,
     }
     // Find the shapes on each axis that will be tried.
     Block<uInt64> nval(nrdim, uInt64(0));
-    PtrBlock<Block<Int64>*> values(nrdim);
+    Block<Block<Int64>*> values(nrdim);
     for (i=0; i<nrdim; i++) {
 	values[i] = new Block<Int64> (maxShape(i) - minShape(i) + 1);
 	// First find exactly fitting shapes.
@@ -725,7 +725,7 @@ void TiledStMan::setup (Int extraNdim)
 	idColSet_p[i] = idColSet_p[i]->makeIdColumn();
     }
     uInt nrd = dataColSet_p.nelements();
-    PtrBlock<TSMDataColumn*> dataColSet(nrd);
+    Block<TSMDataColumn*> dataColSet(nrd);
     for (i=0; i<nrd; i++) {
 	dataColSet[i] = dataColSet_p[i]->makeDataColumn();
     }
@@ -848,7 +848,7 @@ void TiledStMan::initCoordinates (TSMCube* hypercube)
 
 
 uInt TiledStMan::getBindings (const Vector<String>& columnNames,
-			      PtrBlock<TSMColumn*>& colSet,
+			      Block<TSMColumn*>& colSet,
 			      Bool mustExist) const
 {
     colSet = static_cast<TSMColumn*>(0);
@@ -939,7 +939,7 @@ Int TiledStMan::getCubeIndex (const Record& idValues) const
 }
 
 
-void TiledStMan::checkValues (const PtrBlock<TSMColumn*>& colSet,
+void TiledStMan::checkValues (const Block<TSMColumn*>& colSet,
 			      const Record& values) const
 {
     // Check if all values are given and if their data types match.
@@ -956,7 +956,7 @@ void TiledStMan::checkValues (const PtrBlock<TSMColumn*>& colSet,
     }
 }
 
-void TiledStMan::checkCoordinates (const PtrBlock<TSMColumn*>& coordColSet,
+void TiledStMan::checkCoordinates (const Block<TSMColumn*>& coordColSet,
 				   const IPosition& cubeShape,
 				   const Record& values) const
 {

--- a/tables/DataMan/TiledStMan.h
+++ b/tables/DataMan/TiledStMan.h
@@ -391,7 +391,7 @@ protected:
     // is not bound.
     // It returns the number of bound columns.
     uInt getBindings (const Vector<String>& columnNames,
-		      PtrBlock<TSMColumn*>& colSet,
+		      Block<TSMColumn*>& colSet,
 		      Bool mustExist) const;
 
     // Function setup calls this function to allow the derived class
@@ -407,14 +407,14 @@ protected:
     // Check if values are given in the record for all columns in
     // the block. Also check if the data types are correct.
     // An exception is thrown if something is incorrect.
-    void checkValues (const PtrBlock<TSMColumn*>& colSet,
+    void checkValues (const Block<TSMColumn*>& colSet,
 		      const Record& values) const;
 
     // Check if the coordinate values are correct.
     // This calls checkValues and checks if their shapes match the
     // hypercube shape.
     // An exception is thrown if invalid.
-    void checkCoordinates (const PtrBlock<TSMColumn*>& coordColSet,
+    void checkCoordinates (const Block<TSMColumn*>& coordColSet,
 			   const IPosition& cubeShape,
 			   const Record& values) const;
 
@@ -497,20 +497,20 @@ protected:
     // The number of rows in the columns.
     rownr_t nrrow_p;
     // The assembly of all columns.
-    PtrBlock<TSMColumn*>  colSet_p;
+    Block<TSMColumn*>  colSet_p;
     // The assembly of all data columns.
-    PtrBlock<TSMDataColumn*> dataCols_p;
-    PtrBlock<TSMColumn*>  dataColSet_p;
+    Block<TSMDataColumn*> dataCols_p;
+    Block<TSMColumn*>  dataColSet_p;
     // The assembly of all id columns.
-    PtrBlock<TSMColumn*>  idColSet_p;
+    Block<TSMColumn*>  idColSet_p;
     // The assembly of all coordinate columns.
-    PtrBlock<TSMColumn*>  coordColSet_p;
+    Block<TSMColumn*>  coordColSet_p;
     // The assembly of all TSMFile objects.
     // The first file is for all non-extensible cubes, while the others
     // are for one file per extensible cube.
-    PtrBlock<TSMFile*> fileSet_p;
+    Block<TSMFile*> fileSet_p;
     // The assembly of all TSMCube objects.
-    PtrBlock<TSMCube*> cubeSet_p;
+    Block<TSMCube*> cubeSet_p;
     // The persistent maximum cache size (in MiB) for a hypercube.
     uInt      persMaxCacheSize_p;
     // The actual maximum cache size for a hypercube (in MiB).

--- a/tables/TaQL/test/tTableGram.cc
+++ b/tables/TaQL/test/tTableGram.cc
@@ -164,7 +164,7 @@ void docomm()
 void showtab (const Table& tab, const Vector<String>& colnam)
 {
   uInt nrcol = 0;
-  PtrBlock<TableColumn*> tableColumns(colnam.nelements());
+  Block<TableColumn*> tableColumns(colnam.nelements());
   for (uInt i=0; i<colnam.nelements(); i++) {
     if (! tab.tableDesc().isColumn (colnam(i))) {
       cout << "Column " << colnam(i) << " does not exist" << endl;

--- a/tables/Tables/BaseTabIter.h
+++ b/tables/Tables/BaseTabIter.h
@@ -130,7 +130,7 @@ protected:
     rownr_t                lastRow_p;     //# last row used from reftab
     uInt                   nrkeys_p;      //# nr of columns in group
     String                 keyChangeAtLastNext_p;  //# name of column that terminated most recent next()
-    PtrBlock<BaseColumn*>  colPtr_p;      //# pointer to column objects
+    Block<BaseColumn*>     colPtr_p;      //# pointer to column objects
     Block<std::shared_ptr<BaseCompare>> cmpObj_p;  //# comparison object per column
 
     // Copy constructor (to be used by clone)

--- a/tables/Tables/BaseTable.cc
+++ b/tables/Tables/BaseTable.cc
@@ -692,7 +692,7 @@ std::shared_ptr<BaseTable> BaseTable::sort
     }
     //# Get the Column pointers.
     //# Check if a sort key is indeed a column of scalars.
-    PtrBlock<BaseColumn*> sortCol(nrkey);
+    Block<BaseColumn*> sortCol(nrkey);
     for (uInt i=0; i<nrkey; i++) {
         sortCol[i] = getColumn (names[i]);         // get BaseColumn object
         if (!sortCol[i]->columnDesc().isScalar()) {
@@ -707,7 +707,7 @@ std::shared_ptr<BaseTable> BaseTable::sort
 
 //# Do the actual sort.
 std::shared_ptr<BaseTable> BaseTable::doSort
-(PtrBlock<BaseColumn*>& sortCol,
+(Block<BaseColumn*>& sortCol,
  const Block<std::shared_ptr<BaseCompare>>& cmpObj,
  const Block<Int>& order, int option,
  std::shared_ptr<Vector<rownr_t>> sortIterBoundaries,

--- a/tables/Tables/BaseTable.h
+++ b/tables/Tables/BaseTable.h
@@ -57,7 +57,6 @@ class BaseTableIterator;
 class DataManager;
 class IPosition;
 template<class T> class Block;
-template<class T> class PtrBlock;
 class AipsIO;
 
 
@@ -475,7 +474,7 @@ public:
     // The default implementation is suitable for almost all cases.
     // Only in RefTable a smarter implementation is provided.
     virtual std::shared_ptr<BaseTable> doSort
-    (PtrBlock<BaseColumn*>&,
+    (Block<BaseColumn*>&,
      const Block<std::shared_ptr<BaseCompare>>&,
      const Block<Int>& sortOrder,
      int sortOption,

--- a/tables/Tables/NullTable.cc
+++ b/tables/Tables/NullTable.cc
@@ -249,7 +249,7 @@ Bool NullTable::adjustRownrs (rownr_t, Vector<rownr_t>&,
   throw makeError ("adjustRownrs");
 }
 
-  std::shared_ptr<BaseTable> NullTable::doSort (PtrBlock<BaseColumn*>&,
+  std::shared_ptr<BaseTable> NullTable::doSort (Block<BaseColumn*>&,
                                                 const Block<std::shared_ptr<BaseCompare>>&,
                                                 const Block<Int>&,
                                                 int,

--- a/tables/Tables/NullTable.h
+++ b/tables/Tables/NullTable.h
@@ -134,7 +134,7 @@ public:
   virtual Vector<rownr_t>& rowStorage() override;
   virtual Bool adjustRownrs (rownr_t nrrow, Vector<rownr_t>& rownrs,
 			     Bool determineOrder) const override;
-  virtual std::shared_ptr<BaseTable> doSort (PtrBlock<BaseColumn*>&,
+  virtual std::shared_ptr<BaseTable> doSort (Block<BaseColumn*>&,
                                              const Block<std::shared_ptr<BaseCompare>>&,
                                              const Block<Int>&,
                                              int,

--- a/tables/Tables/RowCopier.cc
+++ b/tables/Tables/RowCopier.cc
@@ -53,8 +53,8 @@ private:
     Table out;
 
     // Blocks of pointers to the TableColumns that will be involved in copying
-    PtrBlock<TableColumn *> inTabCol;
-    PtrBlock<TableColumn *> outTabCol;
+    Block<TableColumn *> inTabCol;
+    Block<TableColumn *> outTabCol;
 
 };
 

--- a/tables/apps/taql.cc
+++ b/tables/apps/taql.cc
@@ -450,7 +450,7 @@ void showTable (const Table& tab, const Vector<String>& colnam,
                 Bool printMeasure, const String& separator, ostream& os)
 {
   uInt nrcol = 0;
-  PtrBlock<TableColumn*> tableColumns(colnam.nelements());
+  Block<TableColumn*> tableColumns(colnam.nelements());
   Block<Vector<String> > timeUnit(colnam.nelements());
   Block<Vector<String> > posUnit(colnam.nelements());
   Block<Vector<String> > dirUnit(colnam.nelements());


### PR DESCRIPTION
This improves performance of Block slightly.

The deprecation of PtrBlock causes many changes in casacore. The motivation for PtrBlock is however confusing and based on old compiler behaviour, and removing it makes the code more consistent.
    
If Casa still uses PtrBlock, this change will cause deprecation warnings there, which can be solved using a find-replace of PtrBlock with Block.

The code also listed all the documentation in comments twice -- hence the removal of the comments.