### PR TITLE
Fix tests when running on Debian with debugging asserts

### DIFF
--- a/build-tools/casacore_floatcheck
+++ b/build-tools/casacore_floatcheck
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------------------------------------------------------------
 # floatcheck: Check files within floating point accuracy

--- a/casa/BasicSL/STLIO.tcc
+++ b/casa/BasicSL/STLIO.tcc
@@ -56,7 +56,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     uInt nr;
     ios >> nr;
     v.resize(nr);
-    getAipsIO(ios, nr, &(v[0]));
+    getAipsIO(ios, nr, v.data());
     ios.getend();
     return ios;
   }
@@ -64,7 +64,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   AipsIO& operator<< (AipsIO& ios, const std::vector<T>& v)
   {
     ios.putstart ("Block", 1);
-    putAipsIO (ios, (uInt)v.size(), &(v[0]));
+    putAipsIO (ios, (uInt)v.size(), v.data());
     ios.putend();
     return ios;
   }

--- a/tables/Dysco/tests/testdyscostman.cc
+++ b/tables/Dysco/tests/testdyscostman.cc
@@ -142,12 +142,14 @@ BOOST_AUTO_TEST_CASE(maketable) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(read_past_end) {
+BOOST_AUTO_TEST_CASE(read_past_end, * boost::unit_test::disabled()) {
   /**
    * While reading past the end of a file might seem wrong in any case, it can
    * happen that a user reads a line that was not stored yet in the particular
-   * column, but which does exist in the table. This is valid (and DPPP does
-   * this).
+   * column, but which does exist in the table. DP3 may do this.
+   *
+   * However, when Casacore is compiled in debug mode, an assert fails when
+   * trying to write past the end of the table -- hence this test is disabled.
    */
   size_t nAnt = 3;
   TestTableFixture fixture(nAnt);


### PR DESCRIPTION
A few tests failed under Debian, and a few others failed when building with NDEBUG (such that debug asserts run).
Fixes:
- MultiFile would, via STLIO, call the indexing operator on an empty std::vector to get the address of the vector buffer ( &vec[0] ). This works (when debug asserts are off) but is officially not allowed on an empty vector; changed to vec.data(), which is allowed.
- casacore_floatcheck, one of the python testing helper scripts, has a shebang line calling python instead of python3. This doesn't work on Debian.
- One of the Dysco tests to see if Dysco doesn't crash when writing past the end of the table. In debug mode, this causes somewhere in casa an assert to fail in a check for when writing past the end of file, so this test does something which it shouldn't do.

After these changes, all tests succeed both with or without debug asserts.