### PR TITLE
Build Sisco by default

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -26,7 +26,7 @@ jobs:
           # Delete GitHub Python, See https://github.com/orgs/Homebrew/discussions/3895#discussioncomment-4130560
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -print -delete
 
-          brew install bison fftw hdf5 boost-python3 numpy cfitsio wcslib gsl ninja gcc
+          brew install bison fftw hdf5 boost-python3 numpy cfitsio wcslib gsl ninja gcc libdeflate
 
           # ensure we use homebrew python and gcc
           export PATH=$(brew --prefix python)/bin:${PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ option (BUILD_PYTHON3 "Build the python3 bindings" YES)
 option (BUILD_DEPRECATED "build and install deprecated classes (such as Map)" NO)
 option (BUILD_FFTPACK_DEPRECATED "build FFTPack" NO)
 option (BUILD_DYSCO "Build the Dysco compression storage manager" YES)
-option (BUILD_SISCO "Build the Sisco compression storage manager" NO)
+option (BUILD_SISCO "Build the Sisco compression storage manager" YES)
 
 # By default build shared libraries
 option (ENABLE_SHARED "Build shared libraries" YES)

--- a/cmake/FindDeflate.cmake
+++ b/cmake/FindDeflate.cmake
@@ -2,8 +2,8 @@
 
 if(NOT DEFLATE_FOUND)
 
-  find_path(DEFLATE_INCLUDE_DIR libdeflate.h)
-  find_library(DEFLATE_LIBRARY NAMES deflate libdeflate)
+  find_path(DEFLATE_INCLUDE_DIR libdeflate.h HINTS ${DEFLATE_ROOT_DIR}/include)
+  find_library(DEFLATE_LIBRARY NAMES deflate libdeflate HINTS ${DEFLATE_ROOT_DIR}/lib)
   mark_as_advanced(DEFLATE_INCLUDE_DIR DEFLATE_LIBRARY)
 
   include(FindPackageHandleStandardArgs)

--- a/docker/py_wheel.docker
+++ b/docker/py_wheel.docker
@@ -15,6 +15,9 @@ ENV BOOSTMINOR=0
 ENV BOOST=1.${BOOSTMAJOR}.${BOOSTMINOR}
 ENV BOOST_=1_${BOOSTMAJOR}_${BOOSTMINOR}
 
+# libdeflate version
+ENV LIBDEFLATE=1.25
+
 # where do we epect casacore data build time and runtime
 ENV CASACORE_DATA=/usr/share/casacore/data
 
@@ -26,6 +29,7 @@ WORKDIR /tmp
 RUN curl -L http://www.iausofa.org/s/sofa_f-20231011tar.gz --output /tmp/sofa.tgz
 RUN curl -L https://www.astron.nl/iers/WSRT_Measures.ztar --output /tmp/measures.tgz
 RUN curl -L https://archives.boost.io/release/${BOOST}/source/boost_${BOOST_}.tar.bz2 --output /tmp/boost.tar.bz2
+RUN curl -L https://github.com/ebiggers/libdeflate/releases/download/v${LIBDEFLATE}/libdeflate-${LIBDEFLATE}.tar.gz --output /tmp/libdeflate.tgz
 
 RUN mkdir /build
 WORKDIR /build
@@ -40,7 +44,6 @@ RUN tar zxvf /tmp/sofa.tgz
 WORKDIR /build/sofa/20231011/f77/src
 RUN make -j${THREADS}
 
-
 # setup boost
 WORKDIR /build
 RUN tar jxf /tmp/boost.tar.bz2
@@ -53,6 +56,14 @@ RUN ./bootstrap.sh --prefix=/opt/boost \
 RUN ./b2 -j${THREADS} \
     cxxflags="-fPIC -I/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}/" \
     link=static,shared install
+
+# setup libdeflate
+WORKDIR /build
+RUN tar zxvf /tmp/libdeflate.tgz
+WORKDIR /build/libdeflate-${LIBDEFLATE}/build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=/opt/libdeflate
+RUN make -j${THREADS}
+RUN make install
 
 # casacore wants numpy. Do not take oldest_supported_numpy, because we want numpy 2.0 compatibility
 RUN /opt/python/${TARGET}/bin/pip install numpy
@@ -69,6 +80,7 @@ RUN cmake .. \
     -DPython3_EXECUTABLE=/opt/python/${TARGET}/bin/python3 \
     -DPython3_LIBRARY=/opt/boost/lib/libboost_python${PYMAJOR}${PYMINOR}.so \
     -DPython3_INCLUDE_DIR=/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}/ \
+    -DDEFLATE_ROOT_DIR=/opt/libdeflate \
     -DSOFA_ROOT_DIR=/build \
     -DBUILD_TESTING=OFF \
     -DDATA_DIR=${CASACORE_DATA} \

--- a/docker/ubuntu2404_clang.docker
+++ b/docker/ubuntu2404_clang.docker
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libboost-dev \
     libboost-python-dev \
     libboost-test-dev \
+    libdeflate-dev \
     libgsl-dev \
     python-is-python3 \
     python3-numpy \

--- a/docker/ubuntu2404_gcc.docker
+++ b/docker/ubuntu2404_gcc.docker
@@ -20,6 +20,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libboost-filesystem-dev \
     libboost-python-dev \
     libboost-test-dev \
+    libdeflate-dev \
     libgsl-dev \
     python-is-python3 \
     python3-numpy \

--- a/docker/ubuntu2604_clang.docker
+++ b/docker/ubuntu2604_clang.docker
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libboost-dev \
     libboost-python-dev \
     libboost-test-dev \
+    libdeflate-dev \
     libgsl-dev \
     python-is-python3 \
     python3-numpy \

--- a/docker/ubuntu2604_gcc.docker
+++ b/docker/ubuntu2604_gcc.docker
@@ -20,6 +20,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libboost-filesystem-dev \
     libboost-python-dev \
     libboost-test-dev \
+    libdeflate-dev \
     libgsl-dev \
     python-is-python3 \
     python3-numpy \

--- a/tables/AlternateMans/SiscoWriter.cc
+++ b/tables/AlternateMans/SiscoWriter.cc
@@ -269,7 +269,7 @@ void SiscoWriter::WriteLoop()
   assert(scheduled_tasks.empty());
 }
 
-void SiscoWriter::WriteChunk(uint64_t uncompressed_size, std::span<const std::byte> data) {
+void SiscoWriter::WriteChunk(size_t uncompressed_size, std::span<const std::byte> data) {
   file_.write(reinterpret_cast<const char*>(&uncompressed_size), sizeof(uncompressed_size));
   const uint64_t compressed_size = data.size();
   file_.write(reinterpret_cast<const char*>(&compressed_size), sizeof(compressed_size));

--- a/tables/AlternateMans/test/tConditionalQueue.cc
+++ b/tables/AlternateMans/test/tConditionalQueue.cc
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <complex>
+#include <thread>
 
 namespace casacore::sisco {
 


### PR DESCRIPTION
Enable Sisco by default. 

This change requires that we build `libdeflate` ourselves for our Docker base images, because the version in the `manylinux` base image repository is too old.