### PR TITLE
Require a C++-20 compatible compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,14 +204,8 @@ if (NOT CMAKE_BUILD_TYPE)
     endif(_cmpvar STREQUAL "dbg" OR _cmpvar STREQUAL "debug")
 endif (NOT CMAKE_BUILD_TYPE)
 
-# Sisco requires a C++20 compatible compiler. If Sisco is not built, fall back to C++17 for the
-# time being.
-if(BUILD_SISCO)
-  set(CMAKE_CXX_STANDARD 20)
-else(BUILD_SISCO)
-  set(CMAKE_CXX_STANDARD 17)
-endif(BUILD_SISCO)
-
+# We need a C++-20 compatible compiler
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Ensure clang is not complaining about unused arguments.


### PR DESCRIPTION
Make the use of a C++-20 compatible compiler required unconditionally. Before, when not building Sisco, C++-17 would suffice, but it is better to always use the same compatibility level.