### PR TITLE
Use readline includes via READLINE_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ if (DL_FOUND)
     add_definitions(-DHAVE_DL)
 endif (DL_FOUND)
 if (READLINE_FOUND)
+    include_directories (SYSTEM ${READLINE_INCLUDE_DIRS})
     add_definitions(-DHAVE_READLINE)
 endif (READLINE_FOUND)
 


### PR DESCRIPTION
On a RedHat 9.7 system, which does not have /usr/include/readline/readline.h, compiling casacore failed because it couldn't find <readline/readline.h>. Adding a single line to CMakeLists.txt, similar to other libraries, fixes it.