### PR TITLE
Remove 'using std::string' et al from String.h

### DIFF
--- a/casa/BasicSL/String.cc
+++ b/casa/BasicSL/String.cc
@@ -53,7 +53,7 @@ Int String::freq(Char c) const {
   return found;
 }
 
-Int String::freq(const string &str) const {
+Int String::freq(const std::string &str) const {
   size_type p(0);
   Int found(0);
   while (p < length()) {
@@ -152,7 +152,7 @@ SubString String::at(size_type pos, size_type len) {
   return _substr(pos, len);
 }
 
-SubString String::at(const string &str, Int startpos) {
+SubString String::at(const std::string &str, Int startpos) {
   return _substr(index(str, startpos), str.length());
 }
 
@@ -168,7 +168,7 @@ SubString String::before(size_type pos) const {
   return _substr(0, pos);
 }
 
-SubString String::before(const string &str, size_type startpos) const {
+SubString String::before(const std::string &str, size_type startpos) const {
   return _substr(0, index(str, startpos));
 }
 
@@ -184,7 +184,7 @@ SubString String::through(size_type pos) {
   return _substr(0, pos+1);
 }
 
-SubString String::through(const string &str, size_type startpos) {
+SubString String::through(const std::string &str, size_type startpos) {
   size_type last(index(str, startpos));
   if (last != npos) last += str.length();
   return _substr(0, last);
@@ -206,7 +206,7 @@ SubString String::from(size_type pos) {
   return _substr(pos, length()-pos);
 }
 
-SubString String::from(const string &str, size_type startpos) {
+SubString String::from(const std::string &str, size_type startpos) {
   size_type first(index(str, startpos));
   return _substr(first, length()-first);
 }
@@ -225,7 +225,7 @@ SubString String::after(size_type pos) {
   return _substr(pos+1, length()-(pos+1));
 }
 
-SubString String::after(const string &str, size_type startpos) {
+SubString String::after(const std::string &str, size_type startpos) {
   size_type first(index(str, startpos));
   if (first != npos) first += str.length();
   return _substr(first, length()-first);
@@ -244,7 +244,7 @@ SubString String::after(Char c, size_type startpos) {
 }
 
 // Prepend string
-void String::prepend(const string &str) {
+void String::prepend(const std::string &str) {
   insert(size_type(0), str);
 }
 
@@ -261,7 +261,7 @@ void String::del(size_type pos, size_type len) {
   erase(pos, len);
 }
 
-void String::del(const string &str, size_type startpos) {
+void String::del(const std::string &str, size_type startpos) {
   erase(index(str, startpos), str.length());
 }
 
@@ -274,7 +274,7 @@ void String::del(Char c, size_type startpos) {
 }
 
 // Global substitution
-Int String::gsub(const string &pat, const string &repl) {
+Int String::gsub(const std::string &pat, const std::string &repl) {
   Int nmatches(0);
   if (length() == 0 || pat.length() == 0 ||
       length() < pat.length()) return nmatches;
@@ -292,7 +292,7 @@ Int String::gsub(const string &pat, const string &repl) {
   return nmatches;
 }
 
-Int String::gsub(const Char *pat, const string &repl) {
+Int String::gsub(const Char *pat, const std::string &repl) {
   return gsub(String(pat), repl);
 }
 
@@ -340,7 +340,7 @@ String::size_type String::find(const Regex &r, size_type pos) const {
   return r.find(c_str(), length(), unused, pos);
 }
 
-Bool String::matches(const string &str, Int pos) const {
+Bool String::matches(const std::string &str, Int pos) const {
   Bool rstat(False);
   if (pos < 0) {
     if (this->index(str,pos) == 0) {
@@ -416,7 +416,7 @@ void String::del(const Regex &r, size_type startpos) {
   }
 }
 
-Int String::gsub(const Regex &pat, const string &repl) {
+Int String::gsub(const Regex &pat, const std::string &repl) {
   Int nmatches(0);
   if (length() == 0) return nmatches;
   Int pl;
@@ -444,31 +444,31 @@ Int String::gsub(const Regex &pat, const string &repl) {
 }
 
 // Global functions
-String reverse(const string& str) {
+String reverse(const std::string& str) {
   String s(str);
   std::reverse(s.begin(), s.end());
   return s;
 }
 
-String upcase(const string& str) {
+String upcase(const std::string& str) {
   String s(str);
   std::transform(s.begin(), s.end(), s.begin(), ToUpper);
   return s;
 }
 
-String downcase(const string& str) {
+String downcase(const std::string& str) {
   String s(str);
   std::transform(s.begin(), s.end(), s.begin(), ToLower);
   return s;
 }
 
-String capitalize(const string& str) {
+String capitalize(const std::string& str) {
   String s(str);
   s.capitalize();
   return s;
 }
 
-String trim(const string& str) {
+String trim(const std::string& str) {
   String s(str);
   s.trim();
   return s;
@@ -478,15 +478,15 @@ String replicate(Char c, String::size_type n) {
   return String(n, c);
 }
 
-String replicate(const string &str, String::size_type n) {
+String replicate(const std::string &str, String::size_type n) {
   String t(str);
   t.reserve(n*str.length());
   while (--n > 0) t += str;
   return t;
 }
 
-Int split(const string &str, string res[], Int maxn,
-	  const string &sep) {
+Int split(const std::string &str, std::string res[], Int maxn,
+	  const std::string &sep) {
   Int i(0);
   String::size_type pos(0);
   while (i < maxn && pos < str.length()) {
@@ -499,7 +499,7 @@ Int split(const string &str, string res[], Int maxn,
   return i;
 }
 
-Int split(const string &str, string res[], Int maxn,
+Int split(const std::string &str, std::string res[], Int maxn,
 	  const Regex &sep) {
   Int i(0);
   String::size_type pos(0);
@@ -514,12 +514,12 @@ Int split(const string &str, string res[], Int maxn,
   return i;
 }
 
-Int split(const string &str, string res[], Int maxn,
+Int split(const std::string &str, std::string res[], Int maxn,
 	  const Char sep) {
   return split(str, res, maxn, String(sep));
 }
 
-String common_prefix(const string &x, const string &y, 
+String common_prefix(const std::string &x, const std::string &y,
 		     Int startpos) {
   if (static_cast<String::size_type>(startpos) == String::npos ||
       static_cast<String::size_type>(startpos) >= x.length() ||
@@ -531,7 +531,7 @@ String common_prefix(const string &x, const string &y,
   return String(x, startpos, l);
 }
 
-String common_suffix(const string &x, const string &y, 
+String common_suffix(const std::string &x, const std::string &y,
 		     Int startpos) {
   if (startpos >= 0 ||
       startpos + Int(x.length()) < 0 ||
@@ -543,7 +543,7 @@ String common_suffix(const string &x, const string &y,
   return String(x, x.length()+startpos+1-l, l);
 }
 
-String join(string src[], Int n, const string& sep) {
+String join(std::string src[], Int n, const std::string& sep) {
   String x;
   for (Int i=0; i<n; i++) {
     x += src[i];
@@ -555,14 +555,14 @@ String join(string src[], Int n, const string& sep) {
 Int fcompare(const String& x, const String& y) {
   // Determine minimum size and result in case characters compare equal.
   Int res = 0;
-  string::size_type sz = x.size();
+  std::string::size_type sz = x.size();
   if (x.size() < y.size()) {
     res = -1;
   } else if (x.size() > y.size()) {
     res = 1;
     sz  = y.size();
   }
-  for (string::size_type i=0; i<sz; ++i) {
+  for (std::string::size_type i=0; i<sz; ++i) {
     // Maybe it makes no sense to first test x[i] != y[i].
     char xc = tolower(x[i]);
     char yc = tolower(y[i]);
@@ -585,17 +585,17 @@ SubString &SubString::operator=(const SubString &str) {
 }
 
 SubString &SubString::operator=(const String &str) {
-  const_cast<string &>(ref_p).replace(pos_p, len_p, str);
+  const_cast<std::string &>(ref_p).replace(pos_p, len_p, str);
   return *this;
 }
 
 SubString &SubString::operator=(const Char *s) {
-  const_cast<string &>(ref_p).replace(pos_p, len_p, s);
+  const_cast<std::string &>(ref_p).replace(pos_p, len_p, s);
   return *this;
 }
 
 SubString &SubString::operator=(const Char c) {
-  const_cast<string &>(ref_p).replace(pos_p, len_p, 1, c);
+  const_cast<std::string &>(ref_p).replace(pos_p, len_p, 1, c);
   return *this;
 }
 

--- a/casa/BasicSL/String.h
+++ b/casa/BasicSL/String.h
@@ -26,16 +26,10 @@
 #ifndef CASA_STRING_H
 #define CASA_STRING_H
 
-//# Includes
 #include <casacore/casa/aips.h>
 
-//# Includes
+#include <sstream>
 #include <string>
-
-using std::string;
-
-#include <casacore/casa/iosstrfwd.h>
-#include <casacore/casa/sstream.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -61,7 +55,7 @@ public:
   //# Friends
   friend class String;
   // Make a string
-  operator const string() const { return string(ref_p, pos_p, len_p); }
+  operator const std::string() const { return std::string(ref_p, pos_p, len_p); }
   // Default copy constructor.
   SubString (const SubString&) = default;
   // Assignment
@@ -74,20 +68,20 @@ public:
   // Get as (const) C array
   const Char *chars() const;
   // Obtain length
-  string::size_type length() const { return len_p; }
+  std::string::size_type length() const { return len_p; }
 
 private:
   //# Constructors
   // Constructor (there are no public constructors)
-  SubString(const string &str, string::size_type pos,
-	    string::size_type len);
+  SubString(const std::string &str, std::string::size_type pos,
+	    std::string::size_type len);
   //# Data
   // Referenced string
-  const string &ref_p;
+  const std::string &ref_p;
   // Start of sub-string
-  string::size_type pos_p;
+  std::string::size_type pos_p;
   // Length of sub-string
-  string::size_type len_p;
+  std::string::size_type len_p;
 };
 
 // <summary> 
@@ -220,90 +214,90 @@ private:
 //   <li> add more tests (for string methods) when old String disappears
 // </todo>
 
-class String : public string {
+class String : public std::string {
 
  public:
 
   //# Basic container typedefs
-  typedef string::traits_type 		traits_type;
-  typedef string::value_type		value_type;
-  typedef string::allocator_type	allocator_type;
-  typedef string::size_type 		size_type;
-  typedef string::difference_type	difference_type;
+  typedef std::string::traits_type 		traits_type;
+  typedef std::string::value_type		value_type;
+  typedef std::string::allocator_type	allocator_type;
+  typedef std::string::size_type 		size_type;
+  typedef std::string::difference_type	difference_type;
 
-  typedef string::reference 		reference;
-  typedef string::const_reference 	const_reference;
-  typedef string::pointer		pointer;
-  typedef string::const_pointer		const_pointer;
+  typedef std::string::reference 		reference;
+  typedef std::string::const_reference 	const_reference;
+  typedef std::string::pointer		pointer;
+  typedef std::string::const_pointer		const_pointer;
 
-  typedef string::iterator iterator;
-  typedef string::const_iterator const_iterator;
-  typedef string::reverse_iterator reverse_iterator;
-  typedef string::const_reverse_iterator const_reverse_iterator;
+  typedef std::string::iterator iterator;
+  typedef std::string::const_iterator const_iterator;
+  typedef std::string::reverse_iterator reverse_iterator;
+  typedef std::string::const_reverse_iterator const_reverse_iterator;
   //# Next cast necessary to stop warning in gcc
   static const size_type npos = static_cast<size_type>(-1);
 
   //# Constructors
   // Default constructor
-  String() : string("") {}
-  // Construct from std string
+  String() = default;
+  // Construct from std::string
   // Construct from (part of) other string: acts as copy constructor
   // <thrown>
   // <li> out_of_range if pos > str.size()
   // </thrown>
-  String(const string& str, size_type pos=0, size_type n=npos) :
-    string(str, pos, n) {}
+  String(const std::string& str, size_type pos=0, size_type n=npos) :
+    std::string(str, pos, n) {}
   // Construct from char* with given length
   // <thrown>
   // <li> length_error if n == npos
   // </thrown>
-  String(const Char* s, size_type n) : string(s, n) {}
+  String(const Char* s, size_type n) : std::string(s, n) {}
   // Construct from char array
-  String(const Char* s) : string(s) {}
+  String(const Char* s) : std::string(s) {}
   // Construct from a single char (repeated n times)
   // <thrown>
   // <li> length_error if n == npos
   // </thrown>
-  String(size_type n, Char c) : string(n, c) {}
+  String(size_type n, Char c) : std::string(n, c) {}
   // Construct from iterator
   template<class InputIterator>
-    String(InputIterator begin, InputIterator end) : string(begin, end) {}
+    String(InputIterator begin, InputIterator end) : std::string(begin, end) {}
   // From single char (** Casacore addition).
   // <note role=warning> Note that there is no automatic Char-to-String
   // conversion available. This stops inadvertent conversions of
   // integer to string. </note>
-  explicit String(Char c) : string(1, c) {}
+  explicit String(Char c) : std::string(1, c) {}
   // Construct from a SubString
-  String(const SubString &str) : string(str.ref_p, str.pos_p, str.len_p) {}
+  String(const SubString &str) : std::string(str.ref_p, str.pos_p, str.len_p) {}
   // Construct from a stream.
-  String(ostringstream &os);
+  String(std::ostringstream &os);
 
   //# Destructor
   // Destructor
-  ~String() {}
+  ~String() = default;
 
   //# Operators
   // Assignments (they are all deep copies according to standard)
   // <group>
-  String& operator=(const string& str) {
-    return static_cast<String&>(string::operator=(str)); }
+  String& operator=(const std::string& str) {
+    return static_cast<String&>(std::string::operator=(str)); }
   String& operator=(const SubString &str) {
     return (*this = String(str)); }
   String& operator=(const Char* s) {
-    return static_cast<String&>(string::operator=(s)); }
+    return static_cast<String&>(std::string::operator=(s)); }
   String& operator=(Char c) {
-    return static_cast<String&>(string::operator=(c)); }
+    return static_cast<String&>(std::string::operator=(c)); }
   // </group>
   // ** Casacore addition: synonym for at(pos, len)
   SubString operator()(size_type pos, size_type len);
   // Concatenate
   // <group>
-  String& operator+=(const string& str) {
-    return static_cast<String&>(string::operator+=(str)); }
+  String& operator+=(const std::string& str) {
+    return static_cast<String&>(std::string::operator+=(str)); }
   String& operator+=(const Char* s) {
-    return static_cast<String&>(string::operator+=(s)); }
+    return static_cast<String&>(std::string::operator+=(s)); }
   String& operator+=(Char c) {
-    return static_cast<String&>(string::operator+=(c)); }
+    return static_cast<String&>(std::string::operator+=(c)); }
   // </group>
 
   // Indexing. The standard version is undefined if <src>pos > size()</src>, or 
@@ -312,13 +306,13 @@ class String : public string {
   // for the gcc compiler: no const [] exists. </note>
   // <group>
   const_reference operator[](size_type pos) const {
-    return string::at(pos); }
+    return std::string::at(pos); }
   reference operator[](size_type pos) {
-    return string::operator[](pos); }
+    return std::string::operator[](pos); }
   // *** Casacore addition
   // <group>
   const_reference elem(size_type pos) const {
-    return string::at(pos); }
+    return std::string::at(pos); }
   Char firstchar() const { return at(static_cast<size_type>(0)); }
   Char lastchar() const { return at(length()-1); }
   // </group>
@@ -327,24 +321,24 @@ class String : public string {
   //# Member functions
   // Iterators
   // <group>
-  iterator begin() { return string::begin(); }
-  const_iterator begin() const { return string::begin(); }
-  iterator end() { return string::end(); }
-  const_iterator end() const { return string::end(); }
-  reverse_iterator rbegin() { return string::rbegin(); }
-  const_reverse_iterator rbegin() const { return string::rbegin(); }
-  reverse_iterator rend() { return string::rend(); }
-  const_reverse_iterator rend() const { return string::rend(); }
+  iterator begin() { return std::string::begin(); }
+  const_iterator begin() const { return std::string::begin(); }
+  iterator end() { return std::string::end(); }
+  const_iterator end() const { return std::string::end(); }
+  reverse_iterator rbegin() { return std::string::rbegin(); }
+  const_reverse_iterator rbegin() const { return std::string::rbegin(); }
+  reverse_iterator rend() { return std::string::rend(); }
+  const_reverse_iterator rend() const { return std::string::rend(); }
   // </group>
 
   // Capacity, size
   // <group>
-  size_type size() const { return string::size(); }
-  size_type length() const { return string::length(); }
-  size_type max_size() const { return string::max_size(); }
-  size_type capacity() const { return string::capacity(); }
+  size_type size() const { return std::string::size(); }
+  size_type length() const { return std::string::length(); }
+  size_type max_size() const { return std::string::max_size(); }
+  size_type capacity() const { return std::string::capacity(); }
   // ** Casacore addition -- works as a capacity(n) -- Note Int
-  Int allocation() const { return string::capacity(); } 
+  Int allocation() const { return std::string::capacity(); }
   // </group>
 
   // Resize by truncating or extending with copies of <src>c</src> (default 
@@ -357,30 +351,30 @@ class String : public string {
   // <note role=tip> The reserve length given is non-binding on the
   // implementation </note>
   String& resize(size_type n) {
-    string::resize(n); return *this; }
+    std::string::resize(n); return *this; }
   String& resize(size_type n, Char c) {
-    string::resize(n, c); return *this; }
+    std::string::resize(n, c); return *this; }
   String& reserve(size_type res_arg = 0) {
-    string::reserve(res_arg); return *this; }
+    std::string::reserve(res_arg); return *this; }
   // ** Casacore addition -- works as a resize(n)
-  void alloc(size_type n) { string::resize(n); }
+  void alloc(size_type n) { std::string::resize(n); }
   // </group>
 
   // Clear the string
   // <note role=warning> clear() executed as erase() due to missing clear() in
   // gcc </note> 
-  void clear() { string::erase(begin(), end()); }
+  void clear() { std::string::erase(begin(), end()); }
 
   // Test for empty
-  Bool empty() const { return string::empty(); }
+  Bool empty() const { return std::string::empty(); }
 
   // Addressing
   // <thrown>
   // <li> out_of_range if pos >= size()
   // </thrown>
   // <group>
-  const_reference at(size_type n) const { return string::at(n); }
-  reference at(size_type n) { return string::at(n); }
+  const_reference at(size_type n) const { return std::string::at(n); }
+  reference at(size_type n) { return std::string::at(n); }
   // </group>
 
   // Append
@@ -393,22 +387,22 @@ class String : public string {
   // probably is a remnant of the full list of container functions pop/push
   // back/front. </note>
   // <group>
-  String& append(const string& str) {
-    return static_cast<String&>(string::append(str)); }
-  String& append(const string& str, size_type pos, size_type n) {
-    return static_cast<String&>(string::append(str, pos, n)); }
+  String& append(const std::string& str) {
+    return static_cast<String&>(std::string::append(str)); }
+  String& append(const std::string& str, size_type pos, size_type n) {
+    return static_cast<String&>(std::string::append(str, pos, n)); }
   String& append(const Char* s, size_type n) {
-    return static_cast<String&>(string::append(s, n)); }
+    return static_cast<String&>(std::string::append(s, n)); }
   String& append(const Char* s) {
-    return static_cast<String&>(string::append(s)); }
+    return static_cast<String&>(std::string::append(s)); }
   String& append(size_type n, Char c) {
-    return static_cast<String&>(string::append(n, c)); }
+    return static_cast<String&>(std::string::append(n, c)); }
   template<class InputIterator>
     String& append(InputIterator first, InputIterator last) {
-    return static_cast<String&>(string::append(first, last)); }
+    return static_cast<String&>(std::string::append(first, last)); }
   // ** Casacore addition
   String& append(Char c) {
-    return static_cast<String&>(string::append(1, c)); }
+    return static_cast<String&>(std::string::append(1, c)); }
   // </group>
 
   // Assign
@@ -416,22 +410,22 @@ class String : public string {
   // <li> out_of_range if pos > str.size()
   // </thrown>
   // <group>
-  String& assign(const string& str) {
-    return static_cast<String&>(string::assign(str)); }
-  String& assign(const string& str, size_type pos, size_type n) {
-    return static_cast<String&>(string::assign(str, pos, n)); }
+  String& assign(const std::string& str) {
+    return static_cast<String&>(std::string::assign(str)); }
+  String& assign(const std::string& str, size_type pos, size_type n) {
+    return static_cast<String&>(std::string::assign(str, pos, n)); }
   String& assign(const Char* s, size_type n) {
-    return static_cast<String&>(string::assign(s, n)); }
+    return static_cast<String&>(std::string::assign(s, n)); }
   String& assign(const Char* s) {
-    return static_cast<String&>(string::assign(s)); }
+    return static_cast<String&>(std::string::assign(s)); }
   String& assign(size_type n, Char c) {
-    return static_cast<String&>(string::assign(n, c)); }
+    return static_cast<String&>(std::string::assign(n, c)); }
   template<class InputIterator>
     String& assign(InputIterator first, InputIterator last) {
-    return static_cast<String&>(string::assign(first, last)); }
+    return static_cast<String&>(std::string::assign(first, last)); }
   // ** Casacore addition
   String& assign(Char c)  {
-    return static_cast<String&>(string::assign(1, c)); }
+    return static_cast<String&>(std::string::assign(1, c)); }
   // </group>
 
   // Insert
@@ -440,36 +434,36 @@ class String : public string {
   // <li> length_error if new size() >= npos
   // </thrown>
   // <group>
-  String& insert(size_type pos1, const string& str) {
-    return static_cast<String&>(string::insert(pos1, str)); }
-  String& insert(size_type pos1, const string& str,
+  String& insert(size_type pos1, const std::string& str) {
+    return static_cast<String&>(std::string::insert(pos1, str)); }
+  String& insert(size_type pos1, const std::string& str,
 		 size_type pos2, size_type n) {
-    return static_cast<String&>(string::insert(pos1, str, pos2, n)); }
+    return static_cast<String&>(std::string::insert(pos1, str, pos2, n)); }
   String& insert(size_type pos, const Char* s, size_type n) {
-    return static_cast<String&>(string::insert(pos, s, n)); }
+    return static_cast<String&>(std::string::insert(pos, s, n)); }
   String& insert(size_type pos, const Char* s) {
-    return static_cast<String&>(string::insert(pos, s)); }
+    return static_cast<String&>(std::string::insert(pos, s)); }
   String& insert(size_type pos, size_type n, Char c) {
-    return static_cast<String&>(string::insert(pos, n, c)); }
+    return static_cast<String&>(std::string::insert(pos, n, c)); }
   // ** Casacore addition
   String& insert(size_type pos, Char c) {
-    return static_cast<String&>(string::insert(pos, 1, c)); }
+    return static_cast<String&>(std::string::insert(pos, 1, c)); }
 
   iterator insert(iterator p, Char c) {
-    return string::insert(p, c); }
+    return std::string::insert(p, c); }
   void insert(iterator p, size_type n, Char c) {
-    string::insert(p, n, c); }
+    std::string::insert(p, n, c); }
   template<class InputIterator>
     void insert(iterator p, InputIterator first, InputIterator last) {
-    string::insert(p, first, last); }
+    std::string::insert(p, first, last); }
   // ** Casacore additions
   // <group>
-  String& insert(iterator p, const string& str) {
-    return static_cast<String&>(string::insert(p-begin(), str)); }
+  String& insert(iterator p, const std::string& str) {
+    return static_cast<String&>(std::string::insert(p-begin(), str)); }
   String& insert(iterator p, const Char* s, size_type n) {
-    return static_cast<String&>(string::insert(p-begin(), s, n)); }
+    return static_cast<String&>(std::string::insert(p-begin(), s, n)); }
   String& insert(iterator p, const Char* s) {
-    return static_cast<String&>(string::insert(p-begin(), s)); }
+    return static_cast<String&>(std::string::insert(p-begin(), s)); }
   // </group>
   // </group>
 
@@ -478,15 +472,15 @@ class String : public string {
   // <note role=warning> The gcc compiler does not have the proper standard
   // compare functions. Hence they are locally implemented. </note>
   // <group>
-  Int compare(const string& str) const {	
-    return string::compare(str); }
-  Int compare(size_type pos1, size_type n1, const string& str) const {
+  Int compare(const std::string& str) const {
+    return std::string::compare(str); }
+  Int compare(size_type pos1, size_type n1, const std::string& str) const {
     return String(*this, pos1, n1).compare(str); }
-  Int compare(size_type pos1, size_type n1, const string& str,
+  Int compare(size_type pos1, size_type n1, const std::string& str,
 	      size_type pos2, size_type n2) const {
     return String(*this, pos1, n1).compare(String(str, pos2, n2)); }
   Int compare(const Char* s) const {
-    return string::compare(s); }
+    return std::string::compare(s); }
   Int compare(size_type pos1, size_type n1, const Char* s,
 	      size_type n2=npos) const {
     return String(*this, pos1, n1).compare(String(s, n2)); }
@@ -495,11 +489,11 @@ class String : public string {
   // Erase
   // <group>
   String& erase(size_type pos, size_type n = npos) {
-    return static_cast<String&>(string::erase(pos, n)); }
+    return static_cast<String&>(std::string::erase(pos, n)); }
   iterator erase(iterator position) {
-    return string::erase(position); }
+    return std::string::erase(position); }
   iterator erase(iterator first, iterator last) {
-    return string::erase(first, last); }
+    return std::string::erase(first, last); }
   // </group>
 
   // Replace
@@ -508,35 +502,35 @@ class String : public string {
   // <li> length_error if new size() > npos
   // </thrown>
   // <group>
-  String& replace(size_type pos1, size_type n1, const string& str) {
-    return static_cast<String&>(string::replace(pos1, n1, str)); }
-  String& replace(size_type pos1, size_type n1, const string& str,
+  String& replace(size_type pos1, size_type n1, const std::string& str) {
+    return static_cast<String&>(std::string::replace(pos1, n1, str)); }
+  String& replace(size_type pos1, size_type n1, const std::string& str,
 		  size_type pos2, size_type n2) {
-    return static_cast<String&>(string::replace(pos1, n1, str, pos2, n2)); }
+    return static_cast<String&>(std::string::replace(pos1, n1, str, pos2, n2)); }
   String& replace(size_type pos, size_type n1, const Char* s, size_type n2) {
-    return static_cast<String&>(string::replace(pos, n1, s, n2)); }
+    return static_cast<String&>(std::string::replace(pos, n1, s, n2)); }
   String& replace(size_type pos, size_type n1, const Char* s) {
-    return static_cast<String&>(string::replace(pos, n1, s)); }
+    return static_cast<String&>(std::string::replace(pos, n1, s)); }
   String& replace(size_type pos, size_type n1, size_type n2, Char c) {
-    return static_cast<String&>(string::replace(pos, n1, n2, c)); }
+    return static_cast<String&>(std::string::replace(pos, n1, n2, c)); }
   // ** Casacore addition
   String& replace(size_type pos, size_type n1, Char c) {
-    return static_cast<String&>(string::replace(pos, n1, 1, c)); }
-  String& replace(iterator i1, iterator i2, const string& str) {
-    return static_cast<String&>(string::replace(i1, i2, str)); }
+    return static_cast<String&>(std::string::replace(pos, n1, 1, c)); }
+  String& replace(iterator i1, iterator i2, const std::string& str) {
+    return static_cast<String&>(std::string::replace(i1, i2, str)); }
   String& replace(iterator i1, iterator i2, const Char* s, size_type n) {
-    return static_cast<String&>(string::replace(i1, i2, s, n)); }
+    return static_cast<String&>(std::string::replace(i1, i2, s, n)); }
   String& replace(iterator i1, iterator i2, const Char* s) {
-    return static_cast<String&>(string::replace(i1, i2, s)); }
+    return static_cast<String&>(std::string::replace(i1, i2, s)); }
   String& replace(iterator i1, iterator i2, size_type n, Char c) {
-    return static_cast<String&>(string::replace(i1, i2, n, c)); }
+    return static_cast<String&>(std::string::replace(i1, i2, n, c)); }
   // ** Casacore addition
   String& replace(iterator i1, iterator i2, Char c) {
-    return static_cast<String&>(string::replace(i1, i2, 1, c)); }
+    return static_cast<String&>(std::string::replace(i1, i2, 1, c)); }
   template<class InputIterator>
     String& replace(iterator i1, iterator i2, InputIterator j1, 
 		    InputIterator j2) {
-    return static_cast<String&>(string::replace(i1, i2, j1, j2)); }
+    return static_cast<String&>(std::string::replace(i1, i2, j1, j2)); }
   // </group>
 
   // Copy
@@ -544,24 +538,24 @@ class String : public string {
   // <li> out_of_range if pos > size()
   // </thrown>
   size_type copy(Char* s, size_type n, size_type pos = 0) const {
-    return string::copy(s, n, pos); }
+    return std::string::copy(s, n, pos); }
 
   // Swap
-  void swap(string& s) { string::swap(s); }
+  void swap(std::string& s) { std::string::swap(s); }
 
   // Get char array
   // <group>
   // As a proper null terminated C-string
-  const Char *c_str() const { return string::c_str(); }
+  const Char *c_str() const { return std::string::c_str(); }
   // As pointer to char array 
-  const Char *data() const { return string::data(); }
+  const Char *data() const { return std::string::data(); }
   // ** Casacore synonym
-  const Char *chars() const { return string::c_str(); }
+  const Char *chars() const { return std::string::c_str(); }
   // </group>
 
   // Get allocator used
   // <note role=warning> gcc has no get_allocator() </note>
-  allocator_type get_allocator() const { return string::allocator_type(); }
+  allocator_type get_allocator() const { return std::string::allocator_type(); }
 
   // Get a sub string
   // <thrown>
@@ -635,68 +629,68 @@ class String : public string {
   void rtrim(char c);
 
   // Does the string start with the specified string?
-  Bool startsWith(const string& beginString) const
+  Bool startsWith(const std::string& beginString) const
     { return find(beginString) == 0; }
 
   // Search functions. Returns either npos (if not found); else position.
   // <note role=warning> The Regex ones are ** Casacore additions</note>
   // <group>
-  size_type find(const string &str, size_type pos=0) const {
-    return string::find(str, pos); }
+  size_type find(const std::string &str, size_type pos=0) const {
+    return std::string::find(str, pos); }
   size_type find(const Char *s, size_type pos=0) const {
-    return string::find(s, pos); }
+    return std::string::find(s, pos); }
   size_type find(const Char *s, size_type pos, size_type n) const {
-    return string::find(s, pos, n); }
+    return std::string::find(s, pos, n); }
   size_type find(Char c, size_type pos=0) const {
-    return string::find(c, pos); }
+    return std::string::find(c, pos); }
   size_type find(const Regex &r, size_type pos=0) const;
-  size_type rfind(const string &str, size_type pos=npos) const {
-    return string::rfind(str, pos); }
+  size_type rfind(const std::string &str, size_type pos=npos) const {
+    return std::string::rfind(str, pos); }
   size_type rfind(const Char *s, size_type pos=npos) const {
-    return string::rfind(s, pos); }
+    return std::string::rfind(s, pos); }
   size_type rfind(const Char *s, size_type pos, size_type n) const {
-    return string::rfind(s, pos, n); }
+    return std::string::rfind(s, pos, n); }
   size_type rfind(Char c, size_type pos=npos) const {
-    return string::rfind(c, pos); }
-  size_type find_first_of(const string &str, size_type pos=0) const {
-    return string::find_first_of(str, pos); }
+    return std::string::rfind(c, pos); }
+  size_type find_first_of(const std::string &str, size_type pos=0) const {
+    return std::string::find_first_of(str, pos); }
   size_type find_first_of(const Char *s, size_type pos=0) const {
-    return string::find_first_of(s, pos); }
+    return std::string::find_first_of(s, pos); }
   size_type find_first_of(const Char *s, size_type pos, size_type n) const {
-    return string::find_first_of(s, pos, n); }
+    return std::string::find_first_of(s, pos, n); }
   size_type find_first_of(Char c, size_type pos=0) const {
-    return string::find_first_of(c, pos); }
-  size_type find_last_of(const string &str, size_type pos=npos) const {
-    return string::find_last_of(str, pos); }
+    return std::string::find_first_of(c, pos); }
+  size_type find_last_of(const std::string &str, size_type pos=npos) const {
+    return std::string::find_last_of(str, pos); }
   size_type find_last_of(const Char *s, size_type pos=npos) const {
-    return string::find_last_of(s, pos); }
+    return std::string::find_last_of(s, pos); }
   size_type find_last_of(const Char *s, size_type pos, size_type n) const {
-    return string::find_last_of(s, pos, n); }
+    return std::string::find_last_of(s, pos, n); }
   size_type find_last_of(Char c, size_type pos=npos) const {
-    return string::find_last_of(c, pos); }
-  size_type find_first_not_of(const string &str, size_type pos=0) const {
-    return string::find_first_not_of(str, pos); }
+    return std::string::find_last_of(c, pos); }
+  size_type find_first_not_of(const std::string &str, size_type pos=0) const {
+    return std::string::find_first_not_of(str, pos); }
   size_type find_first_not_of(const Char *s, size_type pos=0) const {
-    return string::find_first_not_of(s, pos); }
+    return std::string::find_first_not_of(s, pos); }
   size_type find_first_not_of(const Char *s, size_type pos, size_type n) const {
-    return string::find_first_not_of(s, pos, n); }
+    return std::string::find_first_not_of(s, pos, n); }
   size_type find_first_not_of(Char c, size_type pos=0) const {
-    return string::find_first_not_of(c, pos); }
-  size_type find_last_not_of(const string &str, size_type pos=npos) const {
-    return string::find_last_not_of(str, pos); }
+    return std::string::find_first_not_of(c, pos); }
+  size_type find_last_not_of(const std::string &str, size_type pos=npos) const {
+    return std::string::find_last_not_of(str, pos); }
   size_type find_last_not_of(const Char *s, size_type pos=npos) const {
-    return string::find_last_not_of(s, pos); }
+    return std::string::find_last_not_of(s, pos); }
   size_type find_last_not_of(const Char *s, size_type pos, size_type n) const {
-    return string::find_last_not_of(s, pos, n); }
+    return std::string::find_last_not_of(s, pos, n); }
   size_type find_last_not_of(Char c, size_type pos=npos) const {
-    return string::find_last_not_of(c, pos); }
+    return std::string::find_last_not_of(c, pos); }
   // </group>
   
   // Containment. ** Casacore addition
   // <group name=contains>
   Bool contains(Char c) const {
     return (find(c) != npos); }
-  Bool contains(const string &str) const {
+  Bool contains(const std::string &str) const {
     return (find(str) != npos); }
   Bool contains(const Char *s) const {
     return (find(s) != npos); }
@@ -707,7 +701,7 @@ class String : public string {
   // ** Casacore addition
   // <group name=contains_pos>
   Bool contains(Char c, Int pos) const;
-  Bool contains(const string &str, Int pos) const;
+  Bool contains(const std::string &str, Int pos) const;
   Bool contains(const Char *s, Int pos) const;
   Bool contains(const Regex &r, Int pos) const;
   // </group>
@@ -715,7 +709,7 @@ class String : public string {
   // Matches entire string from pos
   // (or till pos if negative pos). ** Casacore addition
   // <group name=matches>
-  Bool matches(const string &str, Int pos = 0) const;
+  Bool matches(const std::string &str, Int pos = 0) const;
   Bool matches(Char c, Int pos = 0) const {
     return matches(String(c), pos); };
   Bool matches(const Char *s, Int pos = 0) const {
@@ -725,7 +719,7 @@ class String : public string {
 
   // Concatenate by prepending the argument onto String. ** Casacore addition
   // <group name=concatenation_method>
-  void prepend(const string &str); 
+  void prepend(const std::string &str);
   void prepend(const Char *s);
   void prepend(Char c);
   // </group> 
@@ -736,7 +730,7 @@ class String : public string {
   size_type index(Char c, Int startpos = 0) const {
     return ((startpos >= 0) ? find(c, startpos) :
 	    rfind(c, length() + startpos - 1)); }
-  size_type index(const string &str, Int startpos = 0) const { 
+  size_type index(const std::string &str, Int startpos = 0) const {
     return ((startpos >= 0) ? find(str, startpos) :
 	    rfind(str, length() + startpos - str.length())); }
   size_type index(const Char *s, Int startpos = 0) const {
@@ -748,7 +742,7 @@ class String : public string {
   //  Return the number of occurences of target in String. ** Casacore addition
   // <group name=freq>
   Int freq(Char c) const; 
-  Int freq(const string &str) const;
+  Int freq(const std::string &str) const;
   Int freq(const Char *s) const;
   // </group>
 
@@ -757,8 +751,8 @@ class String : public string {
   SubString at(size_type pos, size_type len);
   String at(size_type pos, size_type len) const {
     return String(*this, pos, len); }
-  SubString at(const string &str, Int startpos = 0);
-  String at(const string &str, Int startpos = 0) const;
+  SubString at(const std::string &str, Int startpos = 0);
+  String at(const std::string &str, Int startpos = 0) const;
   SubString at(const Char *s, Int startpos = 0);
   String at(const Char *s, Int startpos = 0) const;
   SubString at(Char c, Int startpos = 0);
@@ -788,7 +782,7 @@ class String : public string {
   // position, exclusive. ** Casacore addition
   // <group name=before>
   SubString before(size_type pos) const;
-  SubString before(const string &str, size_type startpos = 0) const;
+  SubString before(const std::string &str, size_type startpos = 0) const;
   SubString before(const Char *s, size_type startpos = 0) const;
   SubString before(Char c, size_type startpos = 0) const;
   SubString before(const Regex &r, size_type startpos = 0) const;
@@ -801,7 +795,7 @@ class String : public string {
   // position, inclusive. ** Casacore addition
   // <group name=through>
   SubString through(size_type pos);
-  SubString through(const string &str, size_type startpos = 0);
+  SubString through(const std::string &str, size_type startpos = 0);
   SubString through(const Char *s, size_type startpos = 0);
   SubString through(Char c, size_type startpos = 0);
   SubString through(const Regex &r, size_type startpos = 0);
@@ -814,7 +808,7 @@ class String : public string {
   // position, inclusive, to the String's end. ** Casacore addition
   // <group name=from>
   SubString from(size_type pos);
-  SubString from(const string &str, size_type startpos = 0);
+  SubString from(const std::string &str, size_type startpos = 0);
   SubString from(const Char *s, size_type startpos = 0);
   SubString from(Char c, size_type startpos = 0);
   SubString from(const Regex &r, size_type startpos = 0);
@@ -828,7 +822,7 @@ class String : public string {
   // position, exclusive, to the String's end. ** Casacore addition
   // <group name=after>
   SubString after(size_type pos);
-  SubString after(const string &str, size_type startpos = 0);
+  SubString after(const std::string &str, size_type startpos = 0);
   SubString after(const Char *s, size_type startpos = 0);
   SubString after(Char c, size_type startpos = 0);
   SubString after(const Regex &r, size_type startpos = 0);
@@ -855,7 +849,7 @@ class String : public string {
 
   // Delete the first occurrence of target after startpos. ** Casacore addition
   //<group name=del_after>
-  void del(const string &str, size_type startpos = 0);
+  void del(const std::string &str, size_type startpos = 0);
   void del(const Char *s, size_type startpos = 0);
   void del(Char c, size_type startpos = 0);
   void del(const Regex &r, size_type startpos = 0);
@@ -868,10 +862,10 @@ class String : public string {
   // return the number of replacements.
   // ** Casacore addition
   //<group name=gsub>
-  Int gsub(const string &pat, const string &repl);
-  Int gsub(const Char *pat, const string &repl);
+  Int gsub(const std::string &pat, const std::string &repl);
+  Int gsub(const Char *pat, const std::string &repl);
   Int gsub(const Char *pat, const Char *repl);
-  Int gsub(const Regex &pat, const string &repl);
+  Int gsub(const Regex &pat, const std::string &repl);
   //</group>
 
 private:
@@ -948,11 +942,11 @@ inline Bool operator<=(const String &x, const Char t) {
 // ** Casacore additions of global compares. Returns 0 if equal; lt or gt 0 if
 // strings unequal or of unequal lengths.
 // <group>
-inline Int compare(const string &x, const string &y) {
+inline Int compare(const std::string &x, const std::string &y) {
   return x.compare(y); }
-inline Int compare(const string &x, const Char *y) {
+inline Int compare(const std::string &x, const Char *y) {
   return x.compare(y); }
-inline Int compare(const string &x, const Char y) {
+inline Int compare(const std::string &x, const Char y) {
   return x.compare(String(y)); }
 // this version ignores case. ** Casacore addition. Result is 0 if equal
 // strings of equal lengths; else lt or gt 0 to indicate differences.
@@ -964,53 +958,53 @@ Int fcompare(const String& x, const String& y);
 // Global function which splits the String into string array res at separator
 // and returns the number of elements.  ** Casacore addition
 // <group name=split>
-Int split(const string &str, string res[], Int maxn,
-	  const string &sep);
-Int split(const string &str, string res[], Int maxn,
+Int split(const std::string &str, std::string res[], Int maxn,
+	  const std::string &sep);
+Int split(const std::string &str, std::string res[], Int maxn,
 	  const Char sep);
-Int split(const string &str, string res[], Int maxn,
+Int split(const std::string &str, std::string res[], Int maxn,
 	  const Regex &sep);
 //</group> 
 
 // <summary> Some general functions </summary>
 // Functions to find special patterns, join and replicate
 // <group name=common>
-String common_prefix(const string &x, const string &y, 
+String common_prefix(const std::string &x, const std::string &y,
 		     Int startpos = 0);
-String common_suffix(const string &x, const string &y, 
+String common_suffix(const std::string &x, const std::string &y,
 		     Int startpos = -1);
 String replicate(Char c, String::size_type n);
-String replicate(const string &str, String::size_type n);
-String join(string src[], Int n, const string &sep);
+String replicate(const std::string &str, String::size_type n);
+String join(std::string src[], Int n, const std::string &sep);
 // </group>
 
 // <summary> Casing and related functions </summary>
 // Case conversion and rearrangement functions
 // <group name=case>
 // Global function which returns a transformation to reverse order of String.
-String reverse(const string& str);
+String reverse(const std::string& str);
 // Global function  which returns a transformation to uppercase of String.
-String upcase(const string& str);
+String upcase(const std::string& str);
 // Global function  which returns a transformation to lowercase of String.
-String downcase(const string& str);
+String downcase(const std::string& str);
 // Global function  which returns a transformation to capitalization of 
 // String.
-String capitalize(const string& str);
+String capitalize(const std::string& str);
 // Global function  which removes leading and trailing whitespace.
-String trim(const string& str);
+String trim(const std::string& str);
 // </group>
 
 // <summary> IO </summary>
 // <group name=io>
 // Output
-ostream &operator<<(ostream &s, const String &x);
+std::ostream &operator<<(std::ostream &s, const String &x);
 // </group>
 
 //# Inlines
-inline SubString::SubString(const string &str, string::size_type pos,
-			    string::size_type len) :
+inline SubString::SubString(const std::string &str, std::string::size_type pos,
+			    std::string::size_type len) :
   ref_p(str), pos_p((pos > str.length()) ? str.length() : pos),
-  len_p((len == string::npos || pos_p+len > str.length()) ?
+  len_p((len == std::string::npos || pos_p+len > str.length()) ?
 	str.length()-pos_p : len) {}
 
 inline SubString String::operator()(size_type pos, size_type len) {
@@ -1020,14 +1014,14 @@ inline  const Char *SubString::chars() const {
 
 inline Bool String::contains(Char c, Int pos) const {
   return (index(c, pos) != npos); }
-inline Bool String::contains(const string &str, Int pos) const {
+inline Bool String::contains(const std::string &str, Int pos) const {
   return (index(str, pos) != npos); }
 inline Bool String::contains(const Char *s, Int pos) const {
   return (index(s, pos) != npos); }
 inline Bool String::contains(const Regex &r, Int pos) const {
   return (index(r, pos) != npos); }
 
-inline ostream &operator<<(ostream &s, const String &x) {
+inline std::ostream &operator<<(std::ostream &s, const String &x) {
   s << x.c_str(); return s; }
 
 
@@ -1043,6 +1037,6 @@ struct hash<casacore::String>
     { return std::hash<std::string>()(k); }
 };
 
-}
+} // namespace casacore
 
 #endif

--- a/casa/Exceptions/Error2.cc
+++ b/casa/Exceptions/Error2.cc
@@ -64,7 +64,7 @@ AipsError::AipsError (const String &msg, const String& filename,
                       uInt lineNumber, Category c)
   : category(c)
 {
-  ostringstream os;
+  std::ostringstream os;
   os << msg << " at File: " << filename << ", line: " << lineNumber;
   message = os.str();
   AddStackTrace ();
@@ -175,7 +175,7 @@ AipsError AipsError::repackageAipsError (AipsError& error,
                                          const char* file,
                                          Int line, const char* func)
 {
-  ostringstream os;
+  std::ostringstream os;
   AipsError tmp (message, file, line);
   os << "+++Exception: " << tmp.getMesg() << ".\n...Thrown by " << func << ": "
      << "\n...Lower level exception: " << error.getMesg()

--- a/casa/Json/JsonOut.cc
+++ b/casa/Json/JsonOut.cc
@@ -314,7 +314,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         break;
       default:
         if (iscntrl(in[i])) {
-          ostringstream oss;
+          std::ostringstream oss;
           oss << "\\u" << std::hex << std::uppercase << std::setfill('0')
               << std::setw(4) << static_cast<int>(in[i]);
           out.append (oss.str());

--- a/casa/Json/JsonOut.h
+++ b/casa/Json/JsonOut.h
@@ -116,7 +116,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     JsonOut (const String& name);
 
     // Create the object using the given ostream object.
-    JsonOut (ostream& os);
+    JsonOut (std::ostream& os);
 
     // Close the stream. It closes the ofstream object if created.
     ~JsonOut();

--- a/casa/OS/Path.cc
+++ b/casa/OS/Path.cc
@@ -421,10 +421,10 @@ String Path::makeAbsoluteName (const String& inString) const
 String Path::removeDots (const String& inString) const
 {
     // Split the name at the slashes.
-    Vector<string> parts (strToVector (inString, '/'));
+    Vector<std::string> parts (strToVector (inString, '/'));
     Vector<uInt> validParts (parts.nelements());
-    string dot(".");
-    string dotdot("..");
+    std::string dot(".");
+    std::string dotdot("..");
     uInt nvalid = 0;
     uInt i;
     // Count the number of valid parts and keep their index.

--- a/casa/OS/Time.cc
+++ b/casa/OS/Time.cc
@@ -180,7 +180,7 @@ String Time::toString(const Bool iso) const
   // Tue Mar 22 16:40:24 1994
   // with GMT time
 
-  ostringstream out;
+  std::ostringstream out;
 
   int i,j,jd,l,n,day,month,year,dayweek,sec;
   double jdf,hour,min;

--- a/casa/System/Choice.cc
+++ b/casa/System/Choice.cc
@@ -66,7 +66,7 @@ String Choice::ostreamChoice (std::ostream& os,
       os << ',' << choices[i];
     }
     os << "): ";
-    cin.getline (answer, sizeof(answer));
+    std::cin.getline (answer, sizeof(answer));
     String str(answer);
     if (str.size() == 0) {
       return choices[0];

--- a/casa/Utilities/StringDistance.h
+++ b/casa/Utilities/StringDistance.h
@@ -79,7 +79,7 @@ public:
 
   // Get data members.
   // <group>
-  const string& source() const
+  const std::string& source() const
     { return itsSource; }
   Int maxDistance() const
     { return itsMaxDistance; }

--- a/casa/Utilities/test/tPrecision.cc
+++ b/casa/Utilities/test/tPrecision.cc
@@ -61,7 +61,7 @@ void testit(
 int main () {
 
   try {
-	  ostringstream test;
+	  std::ostringstream test;
 	  Vector<Double> x(2, 0);
 	  Vector<Double> y;
 	  uInt expected = 3;

--- a/casa/apps/casahdf5support.cc
+++ b/casa/apps/casahdf5support.cc
@@ -23,6 +23,8 @@
 //#                        520 Edgemont Road
 //#                        Charlottesville, VA 22903-2475 USA
 
+#include <iostream>
+
 #include <casacore/casa/HDF5/HDF5Object.h>
 
 using namespace casacore;
@@ -35,12 +37,12 @@ int main(int argc, char*[])
 {
   if (HDF5Object::hasHDF5Support()) {
     if (argc < 2) {
-      cout << "casacore built with HDF5 support" << endl;
+      std::cout << "casacore built with HDF5 support" << std::endl;
     }
     return 0;
   }
   if (argc < 2) {
-    cout << "casacore built without HDF5 support" << endl;
+    std::cout << "casacore built without HDF5 support" << std::endl;
   }
   return 1;
 }

--- a/coordinates/Coordinates/CoordinateSystem.cc
+++ b/coordinates/Coordinates/CoordinateSystem.cc
@@ -2619,7 +2619,7 @@ String CoordinateSystem::coordRecordName(uInt which) const
 {
   // Write each string into a field it's type plus coordinate
   // number, e.g. direction0
-  string basename = "unknown";
+  std::string basename = "unknown";
   switch (coordinates_p[which]->type()) {
   case Coordinate::LINEAR:    basename = "linear"; break;
   case Coordinate::DIRECTION: basename = "direction"; break;

--- a/coordinates/Coordinates/FITSCoordinateUtil.cc
+++ b/coordinates/Coordinates/FITSCoordinateUtil.cc
@@ -320,7 +320,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		// determine which axis is the "latitude" axis, i.e. DEC or xLAT
 		int theLatAxisNum = -1;
 		for (uInt k=0; k<ctype.nelements(); k++){
-		    string theType(ctype[k]);
+		    std::string theType(ctype[k]);
 		    if (theType.substr(0,3) == "DEC" || theType.substr(1,3) == "LAT"){
 			theLatAxisNum = k;
 			break;

--- a/coordinates/Coordinates/SpectralCoordinate.cc
+++ b/coordinates/Coordinates/SpectralCoordinate.cc
@@ -1912,7 +1912,7 @@ void SpectralCoordinate::toFITS(RecordInterface &header, uInt whichAxis,
 
     } // end for
     if (maxDeviation>0. && gridSpacing>0. && maxDeviation/gridSpacing>1E-3) {
-      string sUnit = "Hz";
+      std::string sUnit = "Hz";
       if(preferWavelength){
 	sUnit = "m";
       }

--- a/derivedmscal/DerivedMC/MSCalEngine.cc
+++ b/derivedmscal/DerivedMC/MSCalEngine.cc
@@ -455,7 +455,7 @@ void MSCalEngine::fillCalDesc()
   for (rownr_t i=itsCalIdMap.size(); i<tab.nrow(); ++i) {
     String msName = nameCol(i);
     Int inx = itsCalMap.size();
-    map<string,int>::iterator iter = itsCalMap.find (msName);
+    map<std::string,int>::iterator iter = itsCalMap.find (msName);
     if (iter == itsCalMap.end()) {
       // New MS name, so add it.
       itsCalMap[msName] = inx;

--- a/derivedmscal/DerivedMC/MSCalEngine.h
+++ b/derivedmscal/DerivedMC/MSCalEngine.h
@@ -201,7 +201,7 @@ private:
   ScalarColumn<Double>        itsTimeCol;      //# TIME
   ScalarMeasColumn<MEpoch>    itsTimeMeasCol;  //# TIME as Measure
   ScalarColumn<Int>           itsCalCol;       //# CAL_DESC_ID
-  map<string,int>             itsCalMap;       //# map of MS name to index
+  map<std::string,int>        itsCalMap;       //# map of MS name to index
   vector<Int>                 itsCalIdMap;     //# map of calId to index
   MPosition                   itsArrayPos;
   Vector<double>              itsArrayItrf;    //# ITRF array position

--- a/images/Images/FITSImage.cc
+++ b/images/Images/FITSImage.cc
@@ -331,7 +331,7 @@ String FITSImage::imageType() const
 
 String FITSImage::className()
 {
-    static const string x = "FITSImage";
+    static const std::string x = "FITSImage";
     return x;
 }
 

--- a/images/Images/FITSImgParser.cc
+++ b/images/Images/FITSImgParser.cc
@@ -611,7 +611,7 @@ String FITSImgParser::get_errorext(const Int &ext_index){
 
 	// make sure the extension index does exist
 	if (ext_index < 0 || ext_index > (Int)numhdu_p-1){
-		ostringstream os;
+		std::ostringstream os;
 		os << ext_index;
 		throw (AipsError("FITSImgParser::get_errorext - Can not access extension: "+String(os)+" in image: " + fitsname(True)));
 	}
@@ -643,7 +643,7 @@ String FITSImgParser::get_maskext(const Int &ext_index){
 
 	// make sure the extension index does exist
 	if (ext_index < 0 || ext_index > (Int)numhdu_p-1){
-		ostringstream os;
+		std::ostringstream os;
 		os << ext_index;
 		throw (AipsError("FITSImgParser::get_maskext - Can not access extension: "+String(os)+" in image: " + fitsname(True)));
 	}
@@ -704,7 +704,7 @@ Bool FITSImgParser::index_is_HDUtype(const Int &ext_index, const String &hdutype
 
 	// make sure the extension index does exist
 	if (ext_index < 0 || ext_index > (Int)numhdu_p-1){
-		ostringstream os;
+		std::ostringstream os;
 		os << ext_index;
 		throw (AipsError("FITSImgParser::index_is_HDUtype - Can not access extension: "+String(os)+" in image: " + fitsname(True)));
 	}
@@ -860,7 +860,7 @@ String FITSExtInfo::get_extexpr(void)
 		extexpr += ':' + extname_p;
 
 		if (extversion_p > -1){
-		ostringstream os;
+		std::ostringstream os;
 		os << extversion_p;
 		extexpr += "," + String(os);
 		}

--- a/images/Images/ImageAttrGroupHDF5.cc
+++ b/images/Images/ImageAttrGroupHDF5.cc
@@ -162,7 +162,7 @@ namespace casacore {
 
   String makeRowName (uInt rownr)
   {
-    ostringstream ostr;
+    std::ostringstream ostr;
     ostr << std::setfill('0') << std::setw(5) << rownr;
     return ostr.str();
   }

--- a/images/Images/ImageBeamSet.cc
+++ b/images/Images/ImageBeamSet.cc
@@ -559,7 +559,7 @@ void ImageBeamSet::summarize(
         spCoord = &csys.spectralCoordinate();
         chanWidth = max(4, Int(log10(beamsShape[0])) + 1);
         // yes these really should be separated because width applies only to the first.
-        ostringstream x;
+        std::ostringstream x;
         Double freq;
         spCoord->toWorld(freq, 0);
         if (spCoord->pixelValues().size() > 0) {

--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -1201,7 +1201,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // ORIGIN
     //
     if (origin.empty()) {
-      header.define("ORIGIN", "casacore-" + string(getVersion()));
+      header.define("ORIGIN", "casacore-" + std::string(getVersion()));
     } else {
       header.define("ORIGIN", origin);
     }

--- a/images/Images/ImageFITS2Converter.cc
+++ b/images/Images/ImageFITS2Converter.cc
@@ -399,7 +399,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       cursorShape(i) = shape(i);
     }
 
-    ostringstream buffer;
+    std::ostringstream buffer;
     if (axis == Int(ndim) - 1) {
       buffer << "All pixels fit in memory";
     } else {
@@ -434,7 +434,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       CoordinateSystem cSys2;
       Vector<String> names(shape.nelements());
       for (uInt i=0; i<names.nelements(); i++) {
-        ostringstream oss;
+        std::ostringstream oss;
         oss << i;
         names(i) = String("linear") + String(oss);
       }   
@@ -1168,7 +1168,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
                 break;
             default:
                 {
-                    ostringstream mytype;
+                    std::ostringstream mytype;
                     mytype << misctype;
                     os << LogIO::NORMAL << "Not writing miscInfo field '" <<
                     miscname << "' - cannot handle type " << String(mytype) <<

--- a/images/Images/ImageInfo.cc
+++ b/images/Images/ImageInfo.cc
@@ -414,7 +414,7 @@ Bool ImageInfo::fromFITS(
 				setRestoringBeam(GaussianBeam(bmajq, bminq, bpaq));
 			}
 			else {
-				ostringstream oss;
+				std::ostringstream oss;
 				oss << "BMAJ, BMIN ("<< bmaj << ", " << bmin <<") are not positive";
 				error(0) = oss.str();
 				ok = False;

--- a/images/Images/ImageProxy.cc
+++ b/images/Images/ImageProxy.cc
@@ -572,7 +572,7 @@ namespace casacore { //# name space casa begins
   String ImageProxy::dataType() const
   {
     checkNull();
-    ostringstream ostr;
+    std::ostringstream ostr;
     ostr << itsLattice->dataType();
     return ostr.str();
   }

--- a/images/Images/ImageStatistics.h
+++ b/images/Images/ImageStatistics.h
@@ -196,8 +196,8 @@ private:
     ) const;
 
 // List min and max with world coordinates
-   virtual void listMinMax (ostringstream& osMin,
-                            ostringstream& osMax,
+   virtual void listMinMax (std::ostringstream& osMin,
+                            std::ostringstream& osMax,
                             Int oWidth, DataType type);
 
 // List the statistics

--- a/images/Regions/RegionHandler.cc
+++ b/images/Regions/RegionHandler.cc
@@ -128,7 +128,7 @@ String RegionHandler::makeUniqueRegionName (const String& rootName,
 					    uInt startNumber) const
 {
   while (True) {
-    ostringstream oss;
+    std::ostringstream oss;
     oss << startNumber;
     String name = rootName + String(oss);
     if (! hasRegion (name, RegionHandler::Any)) {

--- a/images/Regions/RegionManager.cc
+++ b/images/Regions/RegionManager.cc
@@ -225,7 +225,7 @@ namespace casacore { //# name space casa begins
     else{
       String error; 
       if(!qh.fromString(error, leString)){
-	ostringstream oss;
+	std::ostringstream oss;
 	String err="Error " + error + " In converting quantity " + leString;
 	throw( AipsError(err));
       }

--- a/images/Regions/WCEllipsoid.cc
+++ b/images/Regions/WCEllipsoid.cc
@@ -557,7 +557,7 @@ void WCEllipsoid::_init() {
 }
 
 void WCEllipsoid::_checkPixelAxes() const {
-	ostringstream oss;
+	std::ostringstream oss;
 	oss << _pixelAxes;
 	String paAsString = oss.str();
 	for (uInt i=0; i<_pixelAxes.size(); i++) {

--- a/images/Regions/WCRegion.cc
+++ b/images/Regions/WCRegion.cc
@@ -186,7 +186,7 @@ LCRegion* WCRegion::toLCRegion (const CoordinateSystem& cSys,
     // Make sure shape length matches number of pixel axes.
 
     if (shape.nelements() != cSys.nPixelAxes()) {
-    	ostringstream os;
+    	std::ostringstream os;
     	os << "WCRegion::" << __FUNCTION__ << ": shape has "
 			<< shape.nelements() << " elements, the coordinate system has "
 			<< cSys.nPixelAxes() << " axes. The actual shape is "

--- a/lattices/LRegions/LCMask.cc
+++ b/lattices/LRegions/LCMask.cc
@@ -171,7 +171,7 @@ void LCMask::clearCache()
   itsMask->clearCache();
 }
 
-void LCMask::showCacheStatistics (ostream& os) const
+void LCMask::showCacheStatistics (std::ostream& os) const
 {
   itsMask->showCacheStatistics (os);
 }

--- a/lattices/LRegions/LCMask.h
+++ b/lattices/LRegions/LCMask.h
@@ -146,7 +146,7 @@ public:
   virtual void clearCache();
 
   // Report on cache success.
-  virtual void showCacheStatistics (ostream& os) const;
+  virtual void showCacheStatistics (std::ostream& os) const;
 
   // Handle the (un)locking.
   // <group>

--- a/lattices/LRegions/LCPagedMask.cc
+++ b/lattices/LRegions/LCPagedMask.cc
@@ -158,7 +158,7 @@ void LCPagedMask::clearCache()
     itsMask.clearCache();
 }
 
-void LCPagedMask::showCacheStatistics (ostream& os) const
+void LCPagedMask::showCacheStatistics (std::ostream& os) const
 {
     itsMask.showCacheStatistics (os);
 }

--- a/lattices/LRegions/LCPagedMask.h
+++ b/lattices/LRegions/LCPagedMask.h
@@ -129,7 +129,7 @@ public:
     virtual void clearCache();
 
     // Report on cache success.
-    virtual void showCacheStatistics (ostream& os) const;
+    virtual void showCacheStatistics (std::ostream& os) const;
 
     // Handle deletion of the region by deleting the associated table.
     virtual void handleDelete();

--- a/lattices/LRegions/LatticeRegion.cc
+++ b/lattices/LRegions/LatticeRegion.cc
@@ -143,7 +143,7 @@ void LatticeRegion::clearCache()
   itsRegion->clearCache();
 }
 
-void LatticeRegion::showCacheStatistics (ostream& os) const
+void LatticeRegion::showCacheStatistics (std::ostream& os) const
 {
   itsRegion->showCacheStatistics (os);
 }

--- a/lattices/LRegions/LatticeRegion.h
+++ b/lattices/LRegions/LatticeRegion.h
@@ -193,7 +193,7 @@ public:
     virtual void clearCache();
 
     // Report on cache success.
-    virtual void showCacheStatistics (ostream& os) const;
+    virtual void showCacheStatistics (std::ostream& os) const;
 
     // The following "put" functions are described in detail in class
     // <linkto class=Lattice>Lattice</linkto>.

--- a/lattices/LatticeMath/LatticeHistograms.h
+++ b/lattices/LatticeMath/LatticeHistograms.h
@@ -371,10 +371,10 @@ private:
    Bool setInclude (Vector<T>& range,
                     Bool& noInclude,  
                     const Vector<T>& include,
-                    ostream& os);
+                    std::ostream& os);
 
 // Set stream attributes
-   void setStream (ostream& os, Int oPrec);
+   void setStream (std::ostream& os, Int oPrec);
 
 // Make a string with pixel coordinates of display axes.  This function
 // is over-ridden by ImageHistograms which inherits from LatticeHistograms.

--- a/lattices/LatticeMath/LatticeStatistics.h
+++ b/lattices/LatticeMath/LatticeStatistics.h
@@ -485,7 +485,7 @@ protected:
 // Non-virtual functions
 //
 // set stream manipulators
-   void setStream (ostream& os, Int oPrec);
+   void setStream (std::ostream& os, Int oPrec);
 
    // get the storage lattice shape
    inline IPosition _storageLatticeShape() const { return pStoreLattice_p->shape(); }

--- a/lattices/LatticeMath/LatticeStatsBase.cc
+++ b/lattices/LatticeMath/LatticeStatsBase.cc
@@ -140,7 +140,7 @@ String LatticeStatsBase::toStatisticName (StatisticsTypes type)
 
 
 Bool LatticeStatsBase::setNxy (Vector<Int>& nxy,
-                               ostream& os)
+                               std::ostream& os)
 {
    Int n = nxy.nelements();
    nxy.resize(2,True);

--- a/lattices/LatticeMath/LatticeStatsBase.h
+++ b/lattices/LatticeMath/LatticeStatsBase.h
@@ -30,6 +30,7 @@
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/BasicSL/String.h>
 
+#include <ostream>
 #include <set>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -163,7 +164,7 @@ enum StatisticsTypes {
 // is resized to 2 before assignment.  A return value of <src>False</src> indicates 
 // invalid arguments.
    static Bool setNxy (Vector<Int>& nxy,
-                       ostream& os);
+                       std::ostream& os);
 
 // A storage image is used to accumulate information as a function of the display
 // axes as an image is iterated through.  This function sets the storage image shape 

--- a/lattices/Lattices/LatticeBase.cc
+++ b/lattices/Lattices/LatticeBase.cc
@@ -148,7 +148,7 @@ void LatticeBase::setCacheSizeFromPath (const IPosition&,
 void LatticeBase::clearCache()
 {}
 
-void LatticeBase::showCacheStatistics (ostream&) const
+void LatticeBase::showCacheStatistics (std::ostream&) const
 {}
 
 void LatticeBase::throwBoolMath() const

--- a/lattices/Lattices/LatticeBase.h
+++ b/lattices/Lattices/LatticeBase.h
@@ -249,7 +249,7 @@ public:
 
   // Report on cache success.
   // <br>The default implementation does nothing.
-  virtual void showCacheStatistics (ostream& os) const;
+  virtual void showCacheStatistics (std::ostream& os) const;
 
 
 protected:

--- a/lattices/Lattices/LatticeCache.h
+++ b/lattices/Lattices/LatticeCache.h
@@ -118,7 +118,7 @@ public:
   IPosition& cacheLocation(IPosition& cacheLoc, const IPosition& tileLoc);
 
   // Show the statistics of cache access
-  virtual void showCacheStatistics(ostream& os);
+  virtual void showCacheStatistics(std::ostream& os);
 
   // Clear the statistics of cache access
   virtual void clearCacheStatistics();

--- a/lattices/Lattices/PagedArray.h
+++ b/lattices/Lattices/PagedArray.h
@@ -514,7 +514,7 @@ public:
 
   // Generate a report on how the cache is doing. This is reset every
   // time <src>clearCache</src> is called.
-  virtual void showCacheStatistics (ostream& os) const;
+  virtual void showCacheStatistics (std::ostream& os) const;
 
   // Return the value of the single element located at the argument
   // IPosition.

--- a/lattices/Lattices/TempLattice.h
+++ b/lattices/Lattices/TempLattice.h
@@ -240,7 +240,7 @@ public:
   virtual void clearCache();
 
   // Report on cache success.
-  virtual void showCacheStatistics (ostream& os) const;
+  virtual void showCacheStatistics (std::ostream& os) const;
 
   // Get or put a single element in the lattice.
   // Note that Lattice::operator() can also be used to get a single element.

--- a/lattices/Lattices/TempLatticeImpl.h
+++ b/lattices/Lattices/TempLatticeImpl.h
@@ -176,7 +176,7 @@ public:
     { itsLatticePtr->clearCache(); }
 
   // Report on cache success.
-  void showCacheStatistics (ostream& os) const
+  void showCacheStatistics (std::ostream& os) const
     { itsLatticePtr->showCacheStatistics (os); }
 
   // Get or put a single element in the lattice.

--- a/measures/apps/measuresdata/measuresdata.cc
+++ b/measures/apps/measuresdata/measuresdata.cc
@@ -61,7 +61,7 @@
 
 
 // Version
-const string PROG_VS = "20110502wnb";
+const std::string PROG_VS = "20110502wnb";
 
 
 // Using

--- a/ms/MSOper/MS1ToMS2Converter.cc
+++ b/ms/MSOper/MS1ToMS2Converter.cc
@@ -186,7 +186,7 @@ Bool MS1ToMS2Converter::convert()
     }
 
     if (renumber) {
-      // cout <<"Renumbering antennas in main table and all subtables"<<endl;
+      // cout <<"Renumbering antennas in main table and all subtables"<<std::endl;
       // Main
       {
         Vector<Int> newAnt1(t.nrow());
@@ -819,7 +819,7 @@ Bool MS1ToMS2Converter::convert()
   }
 
   if (sourceTab.tableDesc().isColumn("SYSVEL_OLD")) {
-    cout << "Array column SYSVEL_OLD seems to exist" << endl;
+    cout << "Array column SYSVEL_OLD seems to exist" << std::endl;
   } else {
     sourceTab.renameColumn("SYSVEL_OLD", "SYSVEL");
     sourceTab.addColumn(ArrayColumnDesc<Double>("SYSVEL", 1));
@@ -919,7 +919,7 @@ Bool MS1ToMS2Converter::convert()
 
   // get correct shape for array weight
   if (t.tableDesc().isColumn("WEIGHT_OLD")) {
-    cout << "Array column WEIGHT_OLD seems to exist" << endl;
+    cout << "Array column WEIGHT_OLD seems to exist" << std::endl;
   } else {
     t.renameColumn ("WEIGHT_OLD", "WEIGHT");
     t.addColumn (ArrayColumnDesc<Float>("WEIGHT", 1));

--- a/ms/MSOper/MSConcat.cc
+++ b/ms/MSOper/MSConcat.cc
@@ -225,13 +225,13 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     log << LogIO::NORMAL << "No valid state tables present. Result won't have one either." << LogIO::POST;
   }
   else if(itsStateNull && !otherStateNull){
-    log << LogIO::WARN << itsMS.tableName() << " does not have a valid state table," << endl
+    log << LogIO::WARN << itsMS.tableName() << " does not have a valid state table," << std::endl
 	<< "  the MS to be appended, however, has one. Result won't have one."
 	<< LogIO::POST;
     doState = True; // i.e. the appended MS Main table state id will have to be set to -1
   }
   else if(!itsStateNull && otherStateNull){
-    log << LogIO::WARN << itsMS.tableName() << " does have a valid state table," << endl
+    log << LogIO::WARN << itsMS.tableName() << " does have a valid state table," << std::endl
 	<< "  the MS to be appended, however, doesn't. Result won't have one."
 	<< LogIO::POST;
     doState = True; // i.e. itsMS Main table state id will have to be set to -1
@@ -301,7 +301,7 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
 						       otherMS.feed());
   Bool antIndexTrivial = True;
   for(uInt ii=0; ii<newAntIndices.size(); ii++){
-    //cout << "i, newAntIndices(i) " << ii << " " << newAntIndices[ii] << endl;
+    //cout << "i, newAntIndices(i) " << ii << " " << newAntIndices[ii] << std::endl;
     if(newAntIndices[ii]!=ii){
       antIndexTrivial=False;
       break;
@@ -312,10 +312,10 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     rownr_t matchedRows = otherMS.antenna().nrow() - addedRows;
     log << "Added " << addedRows
 	<< " rows and matched " << matchedRows
-	<< " from the antenna subtable" << endl;
+	<< " from the antenna subtable" << std::endl;
     addedRows = itsMS.feed().nrow() - oldFeedRows;
     log << "Added " << addedRows
-	<< " rows to the feed subtable" << endl;
+	<< " rows to the feed subtable" << std::endl;
   }
 
 
@@ -504,10 +504,10 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
 	maxScan.resize(0);
 	maxScanThis=0;
       }
-      //cout << "distinctObsIdSet " << Vector<Int>(distinctObsIdSet) << endl;
-      //cout << "minScan " << Vector<Int>(minScan) << endl;
-      //cout << "maxScan " << Vector<Int>(maxScan) << endl;
-      //cout << "maxScanThis " << maxScanThis << endl;
+      //cout << "distinctObsIdSet " << Vector<Int>(distinctObsIdSet) << std::endl;
+      //cout << "minScan " << Vector<Int>(minScan) << std::endl;
+      //cout << "maxScan " << Vector<Int>(maxScan) << std::endl;
+      //cout << "maxScanThis " << maxScanThis << std::endl;
     }
     else{
       log << LogIO::NORMAL << "Will create auxiliary file " << obsidAndScanTableName << LogIO::POST;
@@ -679,21 +679,21 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     if (!ofs) {
       log << LogIO::WARN << "Error opening file " << obsidAndScanTableName
 	  << "will continue but the next virtual concat will lack this information:" << LogIO::POST;
-      log << "distinctObsIdSet " << Vector<Int>(distinctObsIdSet) << endl;
-      log << "minScan " << Vector<Int>(minScan) << endl;
-      log << "maxScan " << Vector<Int>(maxScan) << endl;
+      log << "distinctObsIdSet " << Vector<Int>(distinctObsIdSet) << std::endl;
+      log << "minScan " << Vector<Int>(minScan) << std::endl;
+      log << "maxScan " << Vector<Int>(maxScan) << std::endl;
       log << "maxScanOther " << maxScanOther << LogIO::POST;
     }
     else{
       log << LogIO::NORMAL << "Writing to " << obsidAndScanTableName << LogIO::POST;
       uInt n = distinctObsIdSet.size();
-      ofs << n << endl;
+      ofs << n << std::endl;
       for(uInt i=0; i<n; i++){
-	ofs << distinctObsIdSet[i] << endl;
-	ofs << minScan[i] << endl;
-	ofs << maxScan[i] << endl;
+	ofs << distinctObsIdSet[i] << std::endl;
+	ofs << minScan[i] << std::endl;
+	ofs << maxScan[i] << std::endl;
       }
-      ofs << maxScanOther << endl; // note: this max is determined after the modification of scanOther
+      ofs << maxScanOther << std::endl; // note: this max is determined after the modification of scanOther
     }
     ofs.close();
 
@@ -742,14 +742,14 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
       Int newA2 = newAntIndices[otherAnt2[r]];
 
       if(newA1>newA2){ // swap indices and multiply UVW by -1
-	//cout << "   corrected order r: " << r << " " << newA2 << " " << newA1 << endl;
+	//cout << "   corrected order r: " << r << " " << newA2 << " " << newA1 << std::endl;
 	otherAnt1[r] = newA2;
 	otherAnt2[r] = newA1;
 	Array<Double> newUvw;
 	newUvw.assign(otherUvw(r));
 	//cout << "   old UVW " << newUvw;
 	newUvw *= -1.;
-	//cout << ", new UVW " << newUvw << endl;
+	//cout << ", new UVW " << newUvw << std::endl;
 	otherUvw.put(r, newUvw);
 	doConjugateVis = True;
       }
@@ -1000,10 +1000,10 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
   LogIO log(LogOrigin("MSConcat", "concatenate", WHERE));
 
   if(destMSName.empty()){
-    log << "Appending " << otherMS.tableName() << " to " << itsMS.tableName() << endl << LogIO::POST;
+    log << "Appending " << otherMS.tableName() << " to " << itsMS.tableName() << std::endl << LogIO::POST;
   }
   else{
-    log << "Virtually appending " << otherMS.tableName() << " to " << itsMS.tableName() << endl << LogIO::POST;
+    log << "Virtually appending " << otherMS.tableName() << " to " << itsMS.tableName() << std::endl << LogIO::POST;
   }
 
   switch(handling){
@@ -1088,7 +1088,7 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     checkCategories(otherMainCols);
   }
 
-  log << LogIO::DEBUG1 << "ms shapes verified " << endl << LogIO::POST;
+  log << LogIO::DEBUG1 << "ms shapes verified " << std::endl << LogIO::POST;
 
   // merge STATE
   Block<uInt> newStateIndices;
@@ -1101,13 +1101,13 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     log << LogIO::NORMAL << "No valid state tables present. Result won't have one either." << LogIO::POST;
   }
   else if(itsStateNull && !otherStateNull){
-    log << LogIO::WARN << itsMS.tableName() << " does not have a valid state table," << endl
+    log << LogIO::WARN << itsMS.tableName() << " does not have a valid state table," << std::endl
 	<< "  the MS to be appended, however, has one. Result won't have one."
 	<< LogIO::POST;
     doState = True; // i.e. the appended MS Main table state id will have to be set to -1
   }
   else if(!itsStateNull && otherStateNull){
-    log << LogIO::WARN << itsMS.tableName() << " does have a valid state table," << endl
+    log << LogIO::WARN << itsMS.tableName() << " does have a valid state table," << std::endl
 	<< "  the MS to be appended, however, doesn't. Result won't have one."
 	<< LogIO::POST;
     doState = True; // i.e. itsMS Main table state id will have to be set to -1
@@ -1184,14 +1184,14 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     rownr_t matchedRows = otherMS.antenna().nrow() - addedRows;
     log << "Added " << addedRows
 	<< " rows and matched " << matchedRows
-	<< " from the antenna subtable" << endl;
+	<< " from the antenna subtable" << std::endl;
     addedRows = itsMS.feed().nrow() - oldFeedRows;
     log << "Added " << addedRows
-	<< " rows to the feed subtable" << endl;
+	<< " rows to the feed subtable" << std::endl;
   }
 
   //for(uInt ii=0; ii<newAntIndices.size(); ii++){
-  //  cout << "i, newAntIndices(i) " << ii << " " << newAntIndices[ii] << endl;
+  //  cout << "i, newAntIndices(i) " << ii << " " << newAntIndices[ii] << std::endl;
   //}
 
 
@@ -1293,14 +1293,14 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
 
   if (!destMS->canAddRow()) {
     log << LogIO::WARN << "Can't add rows to this ms!  Something is seriously wrong with "
-	<< destMS->tableName() << endl << LogIO::POST;
+	<< destMS->tableName() << std::endl << LogIO::POST;
   }
 
   log << LogIO::DEBUG1 << "trying to add " << newRows << " data rows to the ms, now at: "
-      << destMS->nrow() << endl << LogIO::POST;
+      << destMS->nrow() << std::endl << LogIO::POST;
   destMS->addRow(newRows);
   log << LogIO::DEBUG1 << "added " << newRows << " data rows to the ms, now at: "
-      << destMS->nrow() << endl << LogIO::POST;
+      << destMS->nrow() << std::endl << LogIO::POST;
 
   // create column objects for those columns which need not be modified
   const ScalarColumn<Double>& otherTime = otherMainCols.time();
@@ -1544,14 +1544,14 @@ IPosition MSConcat::isFixedShape(const TableDesc& td) {
     Int newA2 = newAntIndices[otherAnt2(r)];
     Bool doConjugateVis = False;
     if(newA1>newA2){ // swap indices and multiply UVW by -1
-      //cout << "   corrected order r: " << r << " " << newA2 << " " << newA1 << endl;
+      //cout << "   corrected order r: " << r << " " << newA2 << " " << newA1 << std::endl;
       thisAnt1.put(curRow, newA2);
       thisAnt2.put(curRow, newA1);
       Array<Double> newUvw;
       newUvw.assign(otherUvw(r));
       //cout << "   old UVW " << newUvw;
       newUvw *= -1.;
-      //cout << ", new UVW " << newUvw << endl;
+      //cout << ", new UVW " << newUvw << std::endl;
       thisUvw.put(curRow, newUvw);
       doConjugateVis = True;
     }
@@ -1958,7 +1958,7 @@ Bool MSConcat::copyPointing(const MSPointing& otherPoint,const
     return True;
   }
   else if(itsPointingNull && !otherPointingNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid pointing table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid pointing table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
     return False;
@@ -2036,7 +2036,7 @@ Bool MSConcat::copyPointingB(MSPointing& otherPoint,const
     return True;
   }
   else if(itsPointingNull && !otherPointingNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid pointing table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid pointing table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
 
@@ -2114,7 +2114,7 @@ Bool MSConcat::copySysCal(const MSSysCal& otherSysCal,
     return True;
   }
   else if(itsSysCalNull && !otherSysCalNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid syscal table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid syscal table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
     return False;
@@ -2205,7 +2205,7 @@ Bool MSConcat::copyWeather(const MSWeather& otherWeather,
     return True;
   }
   else if(itsWeatherNull && !otherWeatherNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid weather table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid weather table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
     return False;
@@ -2278,7 +2278,7 @@ Bool MSConcat::copyGainCurve(const MeasurementSet& otherMS,
     return True;
   }
   else if(itsGainCurveNull && !otherGainCurveNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid gain curve table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid gain curve table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
     return False;
@@ -2374,7 +2374,7 @@ Bool MSConcat::copyPhaseCal(const MeasurementSet& otherMS,
     return True;
   }
   else if(itsPhaseCalNull && !otherPhaseCalNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid gain curve table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid gain curve table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
     return False;
@@ -2469,7 +2469,7 @@ Bool MSConcat::copyEOP(const MeasurementSet& otherMS){
     return True;
   }
   else if(itsEOPNull && !otherEOPNull){
-    os << LogIO::WARN << itsMS.tableName() << " does not have a valid EOP table," << endl
+    os << LogIO::WARN << itsMS.tableName() << " does not have a valid EOP table," << std::endl
        << "  the MS to be appended, however, has one. Result won't have one."
        << LogIO::POST;
     return False;
@@ -2765,7 +2765,7 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
       Unit m("m");
 
       if(itsFeedsToCompare.nelements() == nFeedsToCompare){
-	//cout << "Antenna " << a << " same number of feeds: "<< nFeedsToCompare << endl;
+	//cout << "Antenna " << a << " same number of feeds: "<< nFeedsToCompare << std::endl;
 	for(uInt f=0; f<nFeedsToCompare; f++){
 	  uInt k = feedsToCompare(f);
 	  Quantum<Double> newTimeQ;
@@ -2773,7 +2773,7 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
 
 	  Int newSPWId = otherFeedCols.spectralWindowId()(k);
 	  if(doSPW_p){ // the SPW table was rearranged
-	    //cout << "modifiying spwid from " << newSPWId << " to " << newSPWIndex_p.at(newSPWId) << endl;
+	    //cout << "modifiying spwid from " << newSPWId << " to " << newSPWIndex_p.at(newSPWId) << std::endl;
 	    newSPWId = getMapValue (newSPWIndex_p, newSPWId);
 	  }
 	  Quantum<Double> fLengthQ;
@@ -2797,14 +2797,14 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
 							 fLengthQ
 							 );
 	  if(matchingFeedRow>=0){
-	    //cout << "Antenna " << a << " found matching feed " << matchingFeedRow << endl;
+	    //cout << "Antenna " << a << " found matching feed " << matchingFeedRow << std::endl;
 	    if(newTimeQ.getValue(s)!=0.){ // need to adjust time information
 
 //  	      cout << "this " << feedCols.timeQuant()(matchingFeedRow).getValue(s) << " "
-//  	          <<  feedCols.intervalQuant()(matchingFeedRow).getValue(s) << endl;
+//  	          <<  feedCols.intervalQuant()(matchingFeedRow).getValue(s) << std::endl;
 //  	      cout << " other " << otherFeedCols.timeQuant()(k).getValue(s) << " "
-//  	          << otherFeedCols.intervalQuant()(k).getValue(s)   << endl;
-//  	      cout << " new " << newTimeQ.getValue(s) << " " << newIntervalQ.getValue(s) << endl;
+//  	          << otherFeedCols.intervalQuant()(k).getValue(s)   << std::endl;
+//  	      cout << " new " << newTimeQ.getValue(s) << " " << newIntervalQ.getValue(s) << std::endl;
 
 	      // modify matchingFeedRow
 	      feedCols.timeQuant().put(matchingFeedRow, newTimeQ);
@@ -2822,7 +2822,7 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
 
       if(matchingFeeds != nFeedsToCompare){
 //  	cout << "Antenna " << a << " did not find all needed feeds "
-//  	     << matchingFeeds << "/" << nFeedsToCompare << endl;
+//  	     << matchingFeeds << "/" << nFeedsToCompare << std::endl;
 	const Vector<rownr_t> feedsToCopy = feedIndex.getRowNumbers();
 	const uInt nFeedsToCopy = feedsToCopy.nelements();
 	rownr_t destRow = feed.nrow();
@@ -2841,17 +2841,17 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
 	    if(doSPW_p){ // the SPW table was rearranged
 	      Int newSPWId = otherFeedCols.spectralWindowId()(feedsToCopy(f));
 //  	      cout << "When writing new feed row: modifiying spwid from " << newSPWId
-//  		   << " to " << newSPWIndex_p.at(newSPWId) << endl;
+//  		   << " to " << newSPWIndex_p.at(newSPWId) << std::endl;
 	      feedRecord.define(spwField, getMapValue(newSPWIndex_p, newSPWId));
 	    }
 	    feedRow.putMatchingFields(destRow, feedRecord);
 	    destRow++;
 	  }
 	}
-	//	cout << "Added " << rCount << " rows to the Feed table." << endl;
+	//	cout << "Added " << rCount << " rows to the Feed table." << std::endl;
       }
 //       else{
-// 	cout << "Antenna " << a << " found all matching feeds: " << matchingFeeds << endl;
+// 	cout << "Antenna " << a << " found all matching feeds: " << matchingFeeds << std::endl;
 //       }
 
     }
@@ -2869,7 +2869,7 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
 					   otherAntCols.positionMeas()(a), Quantum<Double>(100, "AU")))
 	  >= 0){
 	os << "*** Antenna " << antCols.name()(movedAntId) << " (station " <<  antCols.station()(movedAntId)
-	   << ", ID " << movedAntId << ") has changed its position between MSs."  << endl
+	   << ", ID " << movedAntId << ") has changed its position between MSs."  << std::endl
  	   << "    Moved antenna is on station " << otherAntCols.station()(a)
 	   << " and will have ID " << antMap[a] << "." << LogIO::POST;
 // 	String newName = otherAntCols.name()(a)+"m";
@@ -2895,13 +2895,13 @@ Block<uInt> MSConcat::copyAntennaAndFeed(const MSAntenna& otherAnt,
       const uInt nFeedsToCopy = feedsToCopy.nelements();
       rownr_t destRow = feed.nrow();
       feed.addRow(nFeedsToCopy);
-      //cout << "antenna " << antMap[a] << ": copying " <<  nFeedsToCopy << " feeds." << endl;
+      //cout << "antenna " << antMap[a] << ": copying " <<  nFeedsToCopy << " feeds." << std::endl;
       for (uInt f = 0; f < nFeedsToCopy; f++, destRow++) {
 	feedRecord = otherFeedRow.get(feedsToCopy(f));
 	feedRecord.define(antField, static_cast<Int>(antMap[a]));
 	Int newSPWId = otherFeedCols.spectralWindowId()(feedsToCopy(f));
 	if(doSPW_p){ // the SPW table was rearranged
-	  //cout << "modifiying spwid from " << newSPWId << " to " << newSPWIndex_p.at(newSPWId) << endl;
+	  //cout << "modifiying spwid from " << newSPWId << " to " << newSPWIndex_p.at(newSPWId) << std::endl;
 	  newSPWId = getMapValue(newSPWIndex_p, newSPWId);
 	  feedRecord.define(spwField, newSPWId);
 	}
@@ -3028,7 +3028,7 @@ Block<uInt>  MSConcat::copyField(const MeasurementSet& otherms) {
     const Int newFld = fieldCols.matchDirection(refDir, delayDir, phaseDir,
 						tolerance, tryRow,
 						otherOrigTime); // compare at the start time of the other field
-    // cout << "other field, newFld " << f << ", " << newFld << endl;
+    // cout << "other field, newFld " << f << ", " << newFld << std::endl;
 
     Bool canUseThisEntry = (newFld>=0);
     if(canUseThisEntry){
@@ -3051,10 +3051,10 @@ Block<uInt>  MSConcat::copyField(const MeasurementSet& otherms) {
 	  }
 	  if(!canUseThisEntry){
 	    LogIO os(LogOrigin("MSConcat", "copyField"));
-	    os << LogIO::NORMAL << "Ephemeris " << thisEphPath << endl
+	    os << LogIO::NORMAL << "Ephemeris " << thisEphPath << std::endl
 	       << " from field " << newFld << " (" << fieldCols.name()(newFld) << ") "
 	       << " cannot be used for data from field " << f << " (" << otherFieldCols.name()(f) << ", to be appended)"
-	       << " because it does not cover time(s) " << ss.str() << endl
+	       << " because it does not cover time(s) " << ss.str() << std::endl
 	       << " creating separate FIELD table entry." << LogIO::POST;
 	  }
 	}
@@ -3137,7 +3137,7 @@ Bool MSConcat::copySource(const MeasurementSet& otherms){
     }
     if(newSource.nrow()==0){
       maxSrcId = -1;
-      //cout << "Initial source table is empty." << endl;
+      //cout << "Initial source table is empty." << std::endl;
     }
     else{
       maxSrcId=max(sourceCol.sourceId().getColumn());
@@ -3276,7 +3276,7 @@ Bool MSConcat::updateSource(){ // to be called after copySource and copySpwAndPo
  	      Bool sameSolSystObjects = ((reftypek==reftypej) && (reftypek>-1)) // object with solar syst ref frame
  		|| ((reftypek==reftypej) && (reftypek==-2)); // ephemeris object
 	      if( sourceRowsEquivalent(sourceCol, j, k, sameSolSystObjects) ){ // and all columns are the same (not testing source, spw id, time, and interval)
-		//cout << "Found SOURCE rows " << j << " and " << k << " to be identical." << endl;
+		//cout << "Found SOURCE rows " << j << " and " << k << " to be identical." << std::endl;
 
 		// set the time and interval to a superset of the two
 		Double blowk = sourceCol.time()(k) - sourceCol.interval()(k)/2.;
@@ -3286,7 +3286,7 @@ Bool MSConcat::updateSource(){ // to be called after copySource and copySpwAndPo
 		Double newInterval = max(bhighk,bhighj)-min(blowk,blowj);
 		Double newTime = (max(bhighk,bhighj)+min(blowk,blowj))/2.;
 
-		//cout << "new time = " << newTime << ", new interval = " << newInterval << endl;
+		//cout << "new time = " << newTime << ", new interval = " << newInterval << std::endl;
 
 		sourceCol.interval().put(j, newTime);
 		sourceCol.interval().put(k, newTime);
@@ -3309,7 +3309,7 @@ Bool MSConcat::updateSource(){ // to be called after copySource and copySpwAndPo
       if(rowsToBeRemoved.size()>0){ // actually remove the rows
 	Vector<rownr_t> rowsTBR(rowsToBeRemoved);
 	newSource.removeRow(rowsTBR);
-//	cout << "Removed " << rowsToBeRemoved.size() << " redundant rows from SOURCE table." << endl;
+//	cout << "Removed " << rowsToBeRemoved.size() << " redundant rows from SOURCE table." << std::endl;
 	newNumrows_this=newSource.nrow(); // update number of rows
  	sourceCol.sourceId().getColumn(newThisId, True); // update vector if IDs
       }
@@ -3343,7 +3343,7 @@ Bool MSConcat::updateSource(){ // to be called after copySource and copySpwAndPo
 	                                          // all columns are the same except source id (not testing spw id),
 	                                          // spw id must be different, otherwise row would have been deleted above
 	      //cout << "Found SOURCE rows " << j << " and " << k << " to be identical except for the SPW ID and source id. "
-	      //	 << newThisId(k) << " mapped to " << newThisId(j) << endl;
+	      //	 << newThisId(k) << " mapped to " << newThisId(j) << std::endl;
 	      // give same source id
 	      // make entry in map for (k, j) and rename k
 	      tempSourceIndex3[newThisId(k)] = newThisId(j);
@@ -3361,7 +3361,7 @@ Bool MSConcat::updateSource(){ // to be called after copySource and copySpwAndPo
 	sourceCol.sourceId().putColumn(thisSourceId);
       }
 
-//      cout << "Ndistinct = " << nDistinctSources << endl;
+//      cout << "Ndistinct = " << nDistinctSources << std::endl;
 
       if(rowsRenamed){ 	// reduce ID values to minimal range
  	sourceCol.sourceId().getColumn(newThisId, True); // update vector if IDs
@@ -3375,7 +3375,7 @@ Bool MSConcat::updateSource(){ // to be called after copySource and copySpwAndPo
 	    counter++;
 // 	    cout << "Found SOURCE row " << j << " to have a source id " << newThisId(j)
 //               << " larger than the number of distinct sources: " << nDistinctSources << ". "
-// 		 << newThisId(j) << " mapped to " << nDistinctSources-counter-1 << endl;
+// 		 << newThisId(j) << " mapped to " << nDistinctSources-counter-1 << std::endl;
 	  }
 	}
       }
@@ -3448,7 +3448,7 @@ Bool MSConcat::updateSource2(){ // to be called after copyField
       // loop over the rows of the merged source table
       for (Int j=0 ; j < numrows_this ; ++j){
 	if(std::find(thisFSId.begin(), thisFSId.end(), thisId[j]) == thisFSId.end()){ // source id doesn't exist in field table
-	  //cout << "source id " <<   thisId[j] << " doesn't exist in field table" << endl;
+	  //cout << "source id " <<   thisId[j] << " doesn't exist in field table" << std::endl;
 	  // find equivalent source with different SPW and take that ID
 	  Int foundRow = -1;
 	  for(Int k=0; k < numrows_this ; ++k){
@@ -3463,7 +3463,7 @@ Bool MSConcat::updateSource2(){ // to be called after copyField
 	    thisId[j] = thisId[foundRow];
 	  }
 	  else{ // no adequate source id found
-	    //cout << "Selecting row " << j << " for removal from SOURCE table." << endl;
+	    //cout << "Selecting row " << j << " for removal from SOURCE table." << std::endl;
 	    rowsToBeRemoved.push_back(j);
 	  }
 	  rval = True;
@@ -3473,7 +3473,7 @@ Bool MSConcat::updateSource2(){ // to be called after copyField
       if(rowsToBeRemoved.size()>0){ // actually remove the rows
 	Vector<rownr_t> rowsTBR(rowsToBeRemoved);
 	newSource.removeRow(rowsTBR);
-	//cout << "Removed " << rowsToBeRemoved.size() << " stray rows from SOURCE table." << endl;
+	//cout << "Removed " << rowsToBeRemoved.size() << " stray rows from SOURCE table." << std::endl;
       }
 
     }
@@ -3499,7 +3499,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const rown
      areEQ(sourceCol.properMotion(), rowi, rowj)
      ){
 
-    //    cout << "All non-optionals equal" << endl;
+    //    cout << "All non-optionals equal" << std::endl;
 
     // test the optional columns next
     areEquivalent = True;
@@ -3511,7 +3511,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const rown
 	// row has invalid data
 	areEquivalent = True;
       }
-      //      if(!areEquivalent) cout << "not equal position" << endl;
+      //      if(!areEquivalent) cout << "not equal position" << std::endl;
     }
     if(!(sourceCol.pulsarId().isNull())){
       try {
@@ -3521,7 +3521,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const rown
 	// row has invalid data
 	areEquivalent = True;
       }
-      //      if(!areEquivalent) cout << "not equal pulsarId" << endl;
+      //      if(!areEquivalent) cout << "not equal pulsarId" << std::endl;
     }
     if(!dontTestTransAndRest && !(sourceCol.restFrequency().isNull())){
       try {
@@ -3531,7 +3531,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const rown
 	// row has invalid data
 	areEquivalent = True;
       }
-      //      if(!areEquivalent) cout << "not equal restFrequency" << endl;
+      //      if(!areEquivalent) cout << "not equal restFrequency" << std::endl;
     }
     if(!(sourceCol.sysvel().isNull())){
       try {
@@ -3541,7 +3541,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const rown
 	// row has invalid data
 	areEquivalent = True;
       }
-      //      if(!areEquivalent) cout << "not equal sysvel" << endl;
+      //      if(!areEquivalent) cout << "not equal sysvel" << std::endl;
     }
     if(!dontTestTransAndRest && !(sourceCol.transition().isNull())){
       try {
@@ -3551,7 +3551,7 @@ Bool MSConcat::sourceRowsEquivalent(const MSSourceColumns& sourceCol, const rown
 	// row has invalid data
 	areEquivalent = True;
       }
-      //      if(!areEquivalent) cout << "not equal transition" << endl;
+      //      if(!areEquivalent) cout << "not equal transition" << std::endl;
     }
   }
   return areEquivalent;
@@ -3639,7 +3639,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
 
   // loop over the rows of the other data description table
   for (uInt d = 0; d < nDDs; d++) {
-    //cout << "other DD " << d << endl;
+    //cout << "other DD " << d << std::endl;
     Bool matchedSPW = False;
     DebugAssert(otherDDCols.spectralWindowId()(d) >= 0 &&
 		otherDDCols.spectralWindowId()(d) < static_cast<Int>(otherSpw.nrow()),
@@ -3663,7 +3663,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
 				  otherFreqs, itsChanReversed[d]);
 
     if (*newSpwPtr < 0) {
-      // cout << "no counterpart found for other spw " << otherSpwId << endl;
+      // cout << "no counterpart found for other spw " << otherSpwId << std::endl;
       // need to add a new entry in the SPECTRAL_WINDOW subtable
       *newSpwPtr= spw.nrow();
       spw.addRow();
@@ -3675,7 +3675,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
     }
     else{
       // cout << "counterpart found for other spw " << otherSpwId
-      //     << " found in this spw " << *newSpwPtr << endl;
+      //     << " found in this spw " << *newSpwPtr << std::endl;
       matchedSPW = True;
       if(*newSpwPtr != otherSpwId){
 	newSPWIndex_p[otherSpwId] = *newSpwPtr;
@@ -3698,7 +3698,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
     while ( numActPol < polCols.nrow() ){
       *newPolPtr = polCols.match(corrPol, numActPol);
       if (*newPolPtr < 0) {
-	// cout << "need to add a new entry in the POLARIZATION subtable" << endl;
+	// cout << "need to add a new entry in the POLARIZATION subtable" << std::endl;
 	*newPolPtr= pol.nrow();
 	pol.addRow();
 	polRow.putMatchingFields(*newPolPtr, otherPolRow.get(otherPolId));
@@ -3710,7 +3710,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
 	  // table with the required spectral window and polarization index.
 	  ddMap[d] = ddIndex.getRowNumber(matchedDD); // sets matchedDD to True if a matching DD table entry is found
 	}
-	//cout << "Found matching pol. Fould matching DD? " << matchedDD << " d ddMap[d] " << d << " " << ddMap[d] << endl;
+	//cout << "Found matching pol. Fould matching DD? " << matchedDD << " d ddMap[d] " << d << " " << ddMap[d] << std::endl;
       }
       ++numActPol;
     }
@@ -3747,7 +3747,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
 				      otherFreqs, chanReversed);
 
       if (newSpwId < 0) {
-	// cout << "Second iteration: no counterpart found for other spw " << otherSpwId << endl;
+	// cout << "Second iteration: no counterpart found for other spw " << otherSpwId << std::endl;
 	// need to add a new entry in the SPECTRAL_WINDOW subtable
 	newSpwId = spw.nrow();
 	spw.addRow();
@@ -3758,7 +3758,7 @@ Block<uInt> MSConcat::copySpwAndPol(const MSSpectralWindow& otherSpw,
       }
       // else{
       // cout << "Second iteration: counterpart found for other spw " << otherSpwId
-      //     << " found in this spw " << newSpwId << endl;
+      //     << " found in this spw " << newSpwId << std::endl;
       //
       // }
 

--- a/ms/MSOper/MSConcat.cc
+++ b/ms/MSOper/MSConcat.cc
@@ -3039,7 +3039,7 @@ Block<uInt>  MSConcat::copyField(const MeasurementSet& otherms) {
 	}
 	else{ // both use an ephemeris
 	  // is the time coverage of this ephem sufficient to be also used for the other field?
-	  stringstream ss;
+	  std::stringstream ss;
 	  for(uInt i=0; i<2; i++){
 	    try{
 	      MDirection tMDir = fieldCols.phaseDirMeas(newFld, validityRange(i));

--- a/ms/MSOper/MSDerivedValues.cc
+++ b/ms/MSOper/MSDerivedValues.cc
@@ -298,7 +298,7 @@ Double MSDerivedValues::parAngle()
     // pa_p(iant)+= receptorAngle_p(iant);
     //#if (iant==0) 
     //#  cout<<"Antenna "<<iant<<" at time: "<<MVTime(mEpoch.getValue())<<
-    //#  " has PA = "<<pa_p(iant)*57.28<<endl;
+    //#  " has PA = "<<pa_p(iant)*57.28<<std::endl;
     
   } else if (mount_p(antenna_p)==3) {
     Double ha = cRADecToHADec_p().getValue().get()(0);

--- a/ms/MSOper/MSFlagger.cc
+++ b/ms/MSOper/MSFlagger.cc
@@ -580,7 +580,7 @@ Bool MSFlagger::clipDataBuffer(Float pixelLevel, Float timeLevel,
     }
     if (iter) {
       if (deleteFlag||deleteFlagRow) {
-	cerr << " arrays have to be written back "<<endl;
+	cerr << " arrays have to be written back "<<std::endl;
 	flag.putStorage(pflag,deleteFlag);
 	flagRow.putStorage(pflagRow,deleteFlagRow);
       }
@@ -588,7 +588,7 @@ Bool MSFlagger::clipDataBuffer(Float pixelLevel, Float timeLevel,
       getStats(medTF,adTF,medT,medFmedT,adT,medF,medTmedF,adF,
 	       diff, flag, flagRow);
       if (deleteFlag||deleteFlagRow) {
-	cerr << " arrays have to be read back "<<endl;
+	cerr << " arrays have to be read back "<<std::endl;
 	pflag=flag.getStorage(deleteFlag);
 	pflagRow=flagRow.getStorage(deleteFlagRow);
       }

--- a/ms/MSOper/MSKeys.cc
+++ b/ms/MSOper/MSKeys.cc
@@ -57,7 +57,7 @@ String toString(const SubScanKey& subScanKey) {
 }
 
 std::ostream& operator<<(std::ostream& os, const SubScanKey& subScanKey) {
-    os << toString(subScanKey) << endl;
+    os << toString(subScanKey) << std::endl;
     return os;
 }
 
@@ -102,8 +102,8 @@ std::set<Int> scanNumbers(const std::set<ScanKey>& scanKeys) {
     return scanNumbers;
 }
 
-ostream& operator<<(ostream& os, const ScanKey& scanKey) {
-    os << toString(scanKey) << endl;
+std::ostream& operator<<(std::ostream& os, const ScanKey& scanKey) {
+    os << toString(scanKey) << std::endl;
     return os;
 }
 

--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -1062,7 +1062,7 @@ void MSLister::listData(const int pageRows,
                   ) {
                 // query the user, if we are interactive
                 if (listfile == "" &&  prompt && countPageRow != 0) {
-                  string contStr;
+                  std::string contStr;
                   myout << "Type Q to quit, A to toggle long/short list, or RETURN to continue [continue]: ";
                   getline(cin,contStr);
                   if ( (contStr.compare(0,1,"q") == 0) or
@@ -1129,7 +1129,7 @@ void MSLister::listData(const int pageRows,
       if (endOutput) {break;} // break out of msIter
       myout << hSeparator << endl;
       if (listfile == "") {
-        string contStr;
+        std::string contStr;
         myout << "Type Q to quit, A to toggle long/short list, or RETURN to continue [continue]: ";
         getline(cin,contStr);
         if ( (contStr.compare(0,1,"q") == 0) or

--- a/ms/MSOper/MSLister.cc
+++ b/ms/MSOper/MSLister.cc
@@ -285,7 +285,7 @@ void MSLister::listHeader()
         throw(AipsError("Unrecognized value in parameter datacolumn"));
     }
     // logStream_p << "dataColSel = " << dataColSel << LogIO::POST;
-    // cout << "dataColSel = " << dataColSel << endl;
+    // cout << "dataColSel = " << dataColSel << std::endl;
 
     // Fill unused variables to avoid compiler warnings.
     nchan = 0;
@@ -335,19 +335,19 @@ void MSLister::selectvis(const String& timerange,
     logStream_p << LogIO::DEBUG1 << "Begin: MSLister::selectvis" << LogIO::POST;
 
     // List input parameter values.
-    logStream_p << LogIO::DEBUG1 << "timerange   = " << timerange   << " , strlen = " << timerange.length()   << endl;
-    logStream_p << LogIO::DEBUG1 << "spw         = " << spw         << " , strlen = " << spw.length()         << endl;
-    logStream_p << LogIO::DEBUG1 << "scan        = " << scan        << " , strlen = " << scan.length()        << endl;
-    logStream_p << LogIO::DEBUG1 << "field       = " << field       << " , strlen = " << field.length()       << endl;
-    logStream_p << LogIO::DEBUG1 << "antenna     = " << antenna     << " , strlen = " << antenna.length()     << endl;
-    logStream_p << LogIO::DEBUG1 << "uvrange     = " << uvrange     << " , strlen = " << uvrange.length()     << endl;
-    logStream_p << LogIO::DEBUG1 << "correlation = " << correlation << " , strlen = " << correlation.length() << endl;
-    logStream_p << LogIO::DEBUG1 << "array       = " << array       << " , strlen = " << array.length()       << endl;
-    logStream_p << LogIO::DEBUG1 << "observation = " << observation << " , strlen = " << observation.length() << endl;
+    logStream_p << LogIO::DEBUG1 << "timerange   = " << timerange   << " , strlen = " << timerange.length()   << std::endl;
+    logStream_p << LogIO::DEBUG1 << "spw         = " << spw         << " , strlen = " << spw.length()         << std::endl;
+    logStream_p << LogIO::DEBUG1 << "scan        = " << scan        << " , strlen = " << scan.length()        << std::endl;
+    logStream_p << LogIO::DEBUG1 << "field       = " << field       << " , strlen = " << field.length()       << std::endl;
+    logStream_p << LogIO::DEBUG1 << "antenna     = " << antenna     << " , strlen = " << antenna.length()     << std::endl;
+    logStream_p << LogIO::DEBUG1 << "uvrange     = " << uvrange     << " , strlen = " << uvrange.length()     << std::endl;
+    logStream_p << LogIO::DEBUG1 << "correlation = " << correlation << " , strlen = " << correlation.length() << std::endl;
+    logStream_p << LogIO::DEBUG1 << "array       = " << array       << " , strlen = " << array.length()       << std::endl;
+    logStream_p << LogIO::DEBUG1 << "observation = " << observation << " , strlen = " << observation.length() << std::endl;
     logStream_p << LogIO::DEBUG1 << "msSelect    = " << uvrange     << " , strlen = " << msSelect.length()    << LogIO::POST;
-    // logStream_p << "feed        = " << feed        << " , strlen = " << feed.length()        << endl;
-    // logStream_p << "average     = " << uvrange     << " , strlen = " << average.length()     << endl;
-    // logStream_p << "showflags   = " << uvrange     << " , strlen = " << showflags.length()   << endl;
+    // logStream_p << "feed        = " << feed        << " , strlen = " << feed.length()        << std::endl;
+    // logStream_p << "average     = " << uvrange     << " , strlen = " << average.length()     << std::endl;
+    // logStream_p << "showflags   = " << uvrange     << " , strlen = " << showflags.length()   << std::endl;
 
     // Apply selection to the original MeasurementSet
     if (!(timerange.empty() && spw.empty() && scan.empty() && field.empty() &&
@@ -420,15 +420,15 @@ void MSLister::selectvis(const String& timerange,
     // the whole thing.
     String selectedMS = "MSLister.selected.ms";
     logStream_p << LogIO::NORMAL1 << "Writing selected MS to disk (overwriting if necessary)." << LogIO::POST;
-    cout << "Writing selected MS to disk (overwriting if necessary)." << endl;
+    cout << "Writing selected MS to disk (overwriting if necessary)." << std::endl;
     pMSSel_p->deepCopy(selectedMS, Table::New);
     logStream_p << LogIO::NORMAL1 << selectedMS << " written." << LogIO::POST;
-    cout << selectedMS << " written." << endl;
+    cout << selectedMS << " written." << std::endl;
     */
 
     // What channels are contained in the selected data?
     chanList_p=pMSSelection->getChanList();
-    logStream_p << LogIO::DEBUG1 << "pMSSelection->getChanList() = " << endl
+    logStream_p << LogIO::DEBUG1 << "pMSSelection->getChanList() = " << std::endl
                 << pMSSelection->getChanList() << LogIO::POST;
 
     // Do not make a list of all channels!
@@ -503,7 +503,7 @@ void MSLister::selectvis(const String& timerange,
     /// logStream_p << LogIO::NORMAL2 << "Number of selected channels = "
     ///           << nchan_p << LogIO::POST;
     /// logStream_p << LogIO::DEBUG1 << "nchan_p = " << nchan_p << LogIO::POST;
-    logStream_p << LogIO::DEBUG2 << "msSpwinC.numChan() = " << endl
+    logStream_p << LogIO::DEBUG2 << "msSpwinC.numChan() = " << std::endl
               << msSpWinC.numChan().getColumn()
               << LogIO::POST;
 
@@ -583,7 +583,7 @@ void MSLister::listData(const int pageRows,
         throw(AipsError(errmsg));
       }
       else
-        cerr << "Writing output to file: " << listfile << endl;
+        cerr << "Writing output to file: " << listfile << std::endl;
 
       file.open(listfile.data());
       myout.rdbuf(file.rdbuf());   // DON'T redirect cout to file!
@@ -617,7 +617,7 @@ void MSLister::listData(const int pageRows,
     // setting
     //getRanges(*pMSSel_p);
 
-    //myout << "pMSSel_p.nrows=" << pMSSel_p->nrow() << endl;
+    //myout << "pMSSel_p.nrows=" << pMSSel_p->nrow() << std::endl;
 
 /////////////////////////////////////////////////////
 //////read whole ms into mem is not practical, slow and waste memory
@@ -637,12 +637,12 @@ void MSLister::listData(const int pageRows,
       }
       if (!splitMS.nrow())
           break;
-      //myout << "splitMS.nrow()=" << splitMS.nrow() << endl;
+      //myout << "splitMS.nrow()=" << splitMS.nrow() << std::endl;
 
       getRanges(splitMS);
 
       // UNCOMMENT TO: PRINT RECORD OF RANGES (Records can be written to ostreams, but not to LogIO.)
-      // myout << "ranges_p = " << endl << ranges_p << endl;
+      // myout << "ranges_p = " << std::endl << ranges_p << std::endl;
 
       // From here on, all MS access should go through mss_p.
 
@@ -672,7 +672,7 @@ void MSLister::listData(const int pageRows,
       Array <Float>         weight;
       Array <Double>         uvw;
 
-      //myout << "type=" << dataRecords_p.type(dataRecords_p.fieldNumber("uvw")) << endl;
+      //myout << "type=" << dataRecords_p.type(dataRecords_p.fieldNumber("uvw")) << std::endl;
       // Fill the arrays.
       rowTime = dataRecords_p.asArrayDouble(RecordFieldId("time"));
       // ACQUIRE ANTENNA NAME VECTORS
@@ -764,7 +764,7 @@ void MSLister::listData(const int pageRows,
       }
 
       /* List available units on the top of the output */
-      myout << "Units of columns are: Date/Time(YYMMDD/HH:MM:SS UT), UVDist(wavelength), Phase(deg), UVW(m)" << endl;
+      myout << "Units of columns are: Date/Time(YYMMDD/HH:MM:SS UT), UVDist(wavelength), Phase(deg), UVW(m)" << std::endl;
       // Add or adjust ranges_p to non-zero absolutes for non-index and/or
       // converted values (so we can use ranges_p for field width and
       // precision setting):
@@ -781,7 +781,7 @@ void MSLister::listData(const int pageRows,
       amplminmax(0)=min(ampl(ampl>=0.0f));
       amplminmax(1)=max(ampl);
 	  if(amplminmax(0) == amplminmax(1))
-		{ myout << "All selected data has AMPLITUDE = " << amplminmax(0) << endl; }
+		{ myout << "All selected data has AMPLITUDE = " << amplminmax(0) << std::endl; }
 
 	  ranges_p.define(dataColSel(0),amplminmax);
 
@@ -794,7 +794,7 @@ void MSLister::listData(const int pageRows,
 		  phminmax(0) = min(abs(phase));
 		  phminmax(1) = max(abs(phase));
 		  if(phminmax(0) == phminmax(1))
-			{ myout << "All selected data has PHASE = " << phminmax(0) << endl; }
+			{ myout << "All selected data has PHASE = " << phminmax(0) << std::endl; }
 
 		  ranges_p.define(dataColSel(1),phminmax);
       }
@@ -804,26 +804,26 @@ void MSLister::listData(const int pageRows,
       // this is necessary.  We shall see!..
       //
       //    MaskedArray<float> maPhase(phase, (phase!=0.0f));
-      //    myout << "phase = " << endl << phase << endl;
-      //    myout << "maPhase.nelements() = " << maPhase.nelements() << endl;
-      //    myout << "phase(phase!=0.0f).nelements() = " << phase(phase!=0.0f).nelements() << endl;
-      //    myout << "abs(phase(phase!=0.0f)).nelements() = " << abs(phase(phase!=0.0f)).nelements() << endl;
-      //    myout << "min(abs(phase(phase!=0.0f))) = " << min(abs(phase(phase!=0.0f))) << endl;
-      //    myout << "min(phase(phase!=0.0f)) = " << min(phase(phase!=0.0f)) << endl;
+      //    myout << "phase = " << std::endl << phase << std::endl;
+      //    myout << "maPhase.nelements() = " << maPhase.nelements() << std::endl;
+      //    myout << "phase(phase!=0.0f).nelements() = " << phase(phase!=0.0f).nelements() << std::endl;
+      //    myout << "abs(phase(phase!=0.0f)).nelements() = " << abs(phase(phase!=0.0f)).nelements() << std::endl;
+      //    myout << "min(abs(phase(phase!=0.0f))) = " << min(abs(phase(phase!=0.0f))) << std::endl;
+      //    myout << "min(phase(phase!=0.0f)) = " << min(phase(phase!=0.0f)) << std::endl;
       //    if (maPhase.nelementsValid() != 0) {
       //      logStream_p << LogIO::DEBUG2 << "maPhase contains at least 1 element" << LogIO::POST;
       //      // logStream_p << LogIO::DEBUG2 << "phase = " << phase << LogIO::POST;
       //      // CANNOT BE DONE myout << "phase(phase !=0.0f) = " << phase(phase!=0.0f);
-      //      // CANNOT BE DONE myout << "maPhase = " << maPhase << endl;
+      //      // CANNOT BE DONE myout << "maPhase = " << maPhase << std::endl;
       //      phminmax(0)=min(abs(phase(phase!=0.0f)));
-      //      myout << "phminmax(0) = " << phminmax(0) << endl;
+      //      myout << "phminmax(0) = " << phminmax(0) << std::endl;
       //      phminmax(1)=max(phase);
-      //      myout << "phminmax(1) = " << phminmax(1) << endl;
+      //      myout << "phminmax(1) = " << phminmax(1) << std::endl;
       //    } else {
       //      phminmax(0) = 0.0f;
       //      phminmax(1) = 0.0f;
       //      logStream_p << LogIO::NORMAL1 << "All selected data has phase = 0.0" << LogIO::POST;
-      //      myout << "All selected data has phase = 0.0" << endl;
+      //      myout << "All selected data has phase = 0.0" << std::endl;
       //    }
 //      if (!is_float) {ranges_p.define(dataColSel(1),phminmax);}
 
@@ -832,7 +832,7 @@ void MSLister::listData(const int pageRows,
       wtminmax(0)=min(abs(weight));
       wtminmax(1)=max(abs(weight));
       if(wtminmax(0) == wtminmax(1))
-        myout << "WEIGHT: " << wtminmax[0] << endl;
+        myout << "WEIGHT: " << wtminmax[0] << std::endl;
       ranges_p.define("weight",wtminmax);
 
       //logStream_p << LogIO::DEBUG2 << "Setting the uvw min and max." << LogIO::POST;
@@ -840,12 +840,12 @@ void MSLister::listData(const int pageRows,
       uvwminmax(0)=min(abs(uvw));
       uvwminmax(1)=max(abs(uvw));
       //if(uvwminmax(0) == uvwminmax(1))
-      //  { myout << "All selected data has UVW = " << uvwminmax(0) << endl; }
+      //  { myout << "All selected data has UVW = " << uvwminmax(0) << std::endl; }
       ranges_p.define("uvw",uvwminmax);
 
       // Records currently only support output to stdio, not to LogIO!
-      //myout << "Printing out the Record ranges_p:" << endl
-      //     << ranges_p << endl;
+      //myout << "Printing out the Record ranges_p:" << std::endl
+      //     << ranges_p << std::endl;
       //logStream_p << LogIO::DEBUG2 << "Setting flags for output:" << LogIO::POST;
 
       // TURN THIS FLAG SETTING INTO A NEW FUNCTION
@@ -860,7 +860,7 @@ void MSLister::listData(const int pageRows,
         doFld_p = False;
         //logStream_p << LogIO::NORMAL << "All selected data has FIELD = "
         //            << fieldid(0) << LogIO::POST;
-        myout << "FIELD: " << fieldid[0] << endl;
+        myout << "FIELD: " << fieldid[0] << std::endl;
       }
       // doSpW_p = (ranges_p.asArrayInt(RecordFieldId("data_desc_id")).nelements() > 1);
       if (ranges_p.asArrayInt(RecordFieldId("data_desc_id")).nelements() > 1) {
@@ -869,7 +869,7 @@ void MSLister::listData(const int pageRows,
         doSpW_p = False;
         //logStream_p << LogIO::NORMAL << "All selected data has SPW = "
         //          << datadescid(0) << LogIO::POST;
-        myout << "SPW: " << datadescid[0] << endl;
+        myout << "SPW: " << datadescid[0] << std::endl;
       }
       if (multiChan_p) {
         doChn_p = True; // Output a CHANNEL column
@@ -877,19 +877,19 @@ void MSLister::listData(const int pageRows,
         doChn_p = False;
         //logStream_p << LogIO::NORMAL << "All selected data has CHANNEL = "
         //            << chanList_p(0,1) << LogIO::POST;
-        myout << "CHANNEL: " << chanList_p(0, 1) << endl;
+        myout << "CHANNEL: " << chanList_p(0, 1) << std::endl;
       }
 
-      // logStream_p << LogIO::DEBUG2 << "Fld id : " << ranges_p.get("field_id") << endl
+      // logStream_p << LogIO::DEBUG2 << "Fld id : " << ranges_p.get("field_id") << std::endl
       //           << "SpW id : " << ranges_p.get("spectral_window_id") << LogIO::POST;
 
       // From this point on, don't change scaling in list arrays, since the
       // field sizes are determined directly from the data.
 //      logStream_p << LogIO::DEBUG1
-//                  << "(Min, max) uvdist: " << uvminmax[0] << ", " << uvminmax[1] << endl
-//                  << "(Min, max) uvw:    " << uvwminmax[0] << ", " << uvwminmax[1] << endl
-//                  << "(Min, max) amp:    " << amplminmax[0] << ", " << amplminmax[1] << endl
-//                  << "(Min, max) phase:  " << phminmax[0] << ", " << phminmax[1] << endl
+//                  << "(Min, max) uvdist: " << uvminmax[0] << ", " << uvminmax[1] << std::endl
+//                  << "(Min, max) uvw:    " << uvwminmax[0] << ", " << uvwminmax[1] << std::endl
+//                  << "(Min, max) amp:    " << amplminmax[0] << ", " << amplminmax[1] << std::endl
+//                  << "(Min, max) phase:  " << phminmax[0] << ", " << phminmax[1] << std::endl
 //                  << "(Min, max) weight: " << wtminmax[0] << ", " << wtminmax[1]
 //                  << LogIO::POST;
 
@@ -975,8 +975,8 @@ void MSLister::listData(const int pageRows,
       // replicate does not work if the first parameter is "-", but it does for '-'.
       // Bug report here: https://bugs.aoc.nrao.edu/browse/CAS-511
       String hSeparator=replicate('-',wTotal_p+1);
-      //myout << "wTotal_p=" << wTotal_p << endl;
-      //myout << "hSeparator.length=" << hSeparator.size() << endl;
+      //myout << "wTotal_p=" << wTotal_p << std::endl;
+      //myout << "hSeparator.length=" << hSeparator.size() << std::endl;
       uInt colPos=0;
       colPos+=wTime_p;   hSeparator[colPos]='|';
       colPos+=wIntrf_p;  hSeparator[colPos]='|';
@@ -992,8 +992,8 @@ void MSLister::listData(const int pageRows,
       colPos+=wUVW_p; hSeparator[colPos]='|';
       colPos+=wUVW_p; hSeparator[colPos]='|';
       colPos+=wUVW_p; hSeparator[colPos]='|';
-      //myout << "wTotal_p=" << wTotal_p << " colPos=" << colPos << endl;
-      //myout << "hSeparator.length=" << hSeparator.size() << endl;
+      //myout << "wTotal_p=" << wTotal_p << " colPos=" << colPos << std::endl;
+      //myout << "hSeparator.length=" << hSeparator.size() << std::endl;
       //hSeparator.resize(colPos, True);
 
 
@@ -1007,16 +1007,16 @@ void MSLister::listData(const int pageRows,
       // But what exactly to say, since number of channels can vary between
       // spws?
       //logStream_p << LogIO::NORMAL << "Listing " << rowTime.nelements()
-      //          << " data records satisfying selection criteria, " << endl
+      //          << " data records satisfying selection criteria, " << std::endl
       //          << "for each of " << npols_p << " polarisation(s) and " << (chanList_p(0,2)+1)
       //          << " spectral channel(s)." << LogIO::POST;
 
       Int countPageRow=0;
 
-      //myout << "pageRows=" << pageRows << endl;
+      //myout << "pageRows=" << pageRows << std::endl;
       if(pageRows == 0) { // Do not paginate; print header only once.
         listColumnHeader(myout);
-        myout << hSeparator << endl;
+        myout << hSeparator << std::endl;
       }
 
 
@@ -1075,7 +1075,7 @@ void MSLister::listData(const int pageRows,
                 if (endOutput) {break;} // break out of if block
                 //if (prompt) {
                 listColumnHeader(myout);
-                myout << hSeparator << endl;
+                myout << hSeparator << std::endl;
                 //}
               }
               lastdate_p = date_p;
@@ -1118,7 +1118,7 @@ void MSLister::listData(const int pageRows,
                 myout.precision(precUVW_p);
                 myout.width(wUVW_p);myout << uvw(IPosition(2, u, tableRow));
               }
-              myout << endl;
+              myout << std::endl;
             } // chan loop
           }
           if (endOutput) {break;} // break out of spw loop
@@ -1127,7 +1127,7 @@ void MSLister::listData(const int pageRows,
         if (endOutput) {break;} // break out of row loop
       } // row loop
       if (endOutput) {break;} // break out of msIter
-      myout << hSeparator << endl;
+      myout << hSeparator << std::endl;
       if (listfile == "") {
         std::string contStr;
         myout << "Type Q to quit, A to toggle long/short list, or RETURN to continue [continue]: ";
@@ -1182,7 +1182,7 @@ void MSLister::listColumnHeader(ostream& cout) {
   cout.width(wUVW_p);           cout << " ";
   cout.width(wUVW_p);           cout << " ";
   cout.width(wUVW_p);           cout << " ";
-  cout << endl;
+  cout << std::endl;
 
   // Second line of column header
   cout.setf(ios::left, ios::adjustfield);
@@ -1203,7 +1203,7 @@ void MSLister::listColumnHeader(ostream& cout) {
   cout.width(wUVW_p);           cout << "U";
   cout.width(wUVW_p);           cout << "V";
   cout.width(wUVW_p);           cout << "W";
-  cout << endl;
+  cout << std::endl;
 } // end listColumnHeader()
 
 Int MSLister::columnWidth(const Vector<String> antNames) {
@@ -1296,8 +1296,8 @@ void MSLister::polarizationParse(String correlation) {
 			logStream_p << LogIO::DEBUG2 << correlation << LogIO::POST;
 		}
 
-		logStream_p << LogIO::NORMAL2 << "Correlation selections identified:" << endl
-				<< parseCorrs << endl
+		logStream_p << LogIO::NORMAL2 << "Correlation selections identified:" << std::endl
+				<< parseCorrs << std::endl
 				<< "Number of polarization selections = " << nParseCorrs
 				<< LogIO::POST;
 
@@ -1329,7 +1329,7 @@ void MSLister::polarizationParse(String correlation) {
 			}
 		}
 
-		logStream_p << LogIO::DEBUG1 << "indexPols_p = " << indexPols_p << endl
+		logStream_p << LogIO::DEBUG1 << "indexPols_p = " << indexPols_p << std::endl
 				<< "pols_p = " << pols_p << LogIO::POST;
 
 	} // end try

--- a/ms/MSOper/MSMetaData.cc
+++ b/ms/MSOper/MSMetaData.cc
@@ -3100,7 +3100,7 @@ vector<String> MSMetaData::getFieldNamesForFieldIDs(
     uInt max = *max_element(fieldIDs.begin(), fieldIDs.end());
     uInt nField = nFields();
     if (max >= nField) {
-        ostringstream os;
+        std::ostringstream os;
         os << "MSMetaData::" << __FUNCTION__ << ": This MS only has "
             << nField << " fields so requested field number " << max
             << " does not exist";
@@ -4984,7 +4984,7 @@ std::shared_ptr<vector<int>> MSMetaData::_almaReceiverBands(uint nspw) const {
                         (*freqBands)[myid] = myrb;               
                     }
                     else {
-                        ostringstream os;
+                        std::ostringstream os;
                         os << "Unable to find spw id for row " << i
                             << " in table " << asdm_rx.path().absoluteName();
                         throw AipsError(os.str());

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -167,9 +167,9 @@ void MSSummary::list (LogIO& os, Record& outRec, Bool verbose,
     //  listWeather (os,verbose);
 
     // List a summary of table sizes
-    //  os << dashlin1 << endl << endl;
+    //  os << dashlin1 << std::endl << std::endl;
     //  listTables (os,verbose);
-    //  os << dashlin2 << endl;
+    //  os << dashlin2 << std::endl;
 
     // Post it
     os.post();
@@ -189,8 +189,8 @@ void MSSummary::listTitle (LogIO& os) const
 
     // List the MS name and version as the title of the Summary
     os << LogIO::NORMAL;
-    os << dashlin2 << endl << "           MeasurementSet Name:  " << this->name()
-            << "      MS Version " << vers << endl << dashlin2 << endl;
+    os << dashlin2 << std::endl << "           MeasurementSet Name:  " << this->name()
+            << "      MS Version " << vers << std::endl << dashlin2 << std::endl;
 }
 
 
@@ -239,7 +239,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
         Bool fillRecord) const
 {
     if (nrow()<=0) {
-        os << "The MAIN table is empty: there are no data!!!" << endl << LogIO::POST;
+        os << "The MAIN table is empty: there are no data!!!" << std::endl << LogIO::POST;
         return;
     }
        _msmd->setForceSubScanPropsToCache(True);
@@ -254,11 +254,11 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
     String timeref=msmc.time().keywordSet().subRecord("MEASINFO").asString("Ref");
     // Output info
     os << "Data records: " << nrow() << "       Total elapsed time = "
-            << exposTime << " seconds" << endl
+            << exposTime << " seconds" << std::endl
             << "   Observed from   " << MVTime(startTime/C::day).string(MVTime::DMY,7)  //startMVT.string()
             << "   to   " << MVTime(stopTime/C::day).string(MVTime::DMY,7)  // stopMVT.string()
             << " (" << timeref << ")"
-            << endl << endl;
+            << std::endl << std::endl;
     os << LogIO::POST;
 
     if(fillRecord){
@@ -326,8 +326,8 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
         Int arrid = iter->arrayID;
         if (verbose) {
             // Report OBSID and ARRID, and header for listing:
-            os << endl << "   ObservationID = " << obsid;
-            os << "         ArrayID = " << arrid << endl;
+            os << std::endl << "   ObservationID = " << obsid;
+            os << "         ArrayID = " << arrid << std::endl;
             String datetime="  Date        Timerange                ";
             datetime.replace(24,1,"(");
             datetime.replace(25,timeref.length(),timeref);
@@ -338,7 +338,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
             if (_listUnflaggedRowCount) {
                 os << "nUnflRows   ";
             }
-            os << "SpwIds   Average Interval(s)    ScanIntent" << endl;
+            os << "SpwIds   Average Interval(s)    ScanIntent" << std::endl;
         }
         std::set<SubScanKey> subScans = _msmd->getSubScanKeys(*iter);
         os.output().precision(3);
@@ -420,7 +420,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
                 if (! intents.empty()) {
                     os << intents;
                 }
-                os << endl;
+                os << std::endl;
             }
             if(fillRecord && (recLength < maxRecLength))  {
                 if(lastscan == thisscan && siter != subScans.begin()) {
@@ -460,7 +460,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
         }
     }
     if (verbose){
-        os << "           (nRows = Total number of rows per scan) " << endl;
+        os << "           (nRows = Total number of rows per scan) " << std::endl;
         os << LogIO::POST;
     }
     os << LogIO::POST;
@@ -528,14 +528,14 @@ void MSSummary::getScanSummary (Record& outRec) const
         TableVector<Int> arridcol(obsarrtab,"ARRAY_ID");
 
         // Report OBSID and ARRID, and header for listing:
-        //     os << endl << "   ObservationID = " << obsid;
-        //     os << "         ArrayID = " << arrid << endl;
+        //     os << std::endl << "   ObservationID = " << obsid;
+        //     os << "         ArrayID = " << arrid << std::endl;
         String datetime="  Date        Timerange                ";
         datetime.replace(24,1,"(");
         datetime.replace(25,timeref.length(),timeref);
         datetime.replace(25+timeref.length(),1,")");
         //     os << datetime;
-        //     os << "Scan  FldId FieldName    nVis   Int(s)   SpwIds" << endl;
+        //     os << "Scan  FldId FieldName    nVis   Int(s)   SpwIds" << std::endl;
 
         // Setup iteration over timestamps within this iteration:
         Block<String> jcols(2);
@@ -753,7 +753,7 @@ void MSSummary::getScanSummary (Record& outRec) const
 void MSSummary::listAntenna (LogIO& os, Bool verbose) const
 {
     if (_msmd->nAntennas() == 0) { 
-        os << "The ANTENNA table is empty" << endl;
+        os << "The ANTENNA table is empty" << std::endl;
         return;
     }    
     // Determine antennas  present in the main table
@@ -780,7 +780,7 @@ void MSSummary::listAntenna (LogIO& os, Bool verbose) const
         os.output().setf(ios::fixed, ios::floatfield);
         os.output().setf(ios::left, ios::adjustfield);
         // Write the title:
-        os << title << endl;
+        os << title << std::endl;
         // Write the column headings:
         os << indent;
         os.output().width(indwidth);    os << "ID";
@@ -793,7 +793,7 @@ void MSSummary::listAntenna (LogIO& os, Bool verbose) const
         os << "       Offset from array center (m)";
         os.output().width(3*positionwidth);
         os << "         ITRF Geocentric coordinates (m)";
-        os << endl;
+        os << std::endl;
         os << indent;
         os.output().width(
             indwidth + namewidth + statwidth + diamwidth + 4
@@ -813,7 +813,7 @@ void MSSummary::listAntenna (LogIO& os, Bool verbose) const
         os << "y";
         os.output().width(positionwidth);
         os << "z";
-        os << endl;
+        os << std::endl;
         vector<MPosition> antPos = _msmd->getAntennaPositions();
         Bool posIsITRF = antPos[0].getRef().getType() != MPosition::ITRF;
         vector<QVD> offsets = _msmd->getAntennaOffsets();
@@ -860,12 +860,12 @@ void MSSummary::listAntenna (LogIO& os, Bool verbose) const
             os << xyz[1];
             os.output().width(positionwidth);
             os << xyz[2];
-            os << endl;
+            os << std::endl;
         }
     }
     else {
         // Horizontal list of the stations names:
-        os << "Antennas: " << nAnt << " 'name'='station' " <<  endl;
+        os << "Antennas: " << nAnt << " 'name'='station' " <<  std::endl;
         String line, leader;
         Int last = *antIds.begin() - 1;
         std::set<Int>::const_iterator iter = antIds.begin();
@@ -886,7 +886,7 @@ void MSSummary::listAntenna (LogIO& os, Bool verbose) const
                 os << "   ID=";
                 os.output().setf(ios::right, ios::adjustfield);
                 os.output().width(8); os << leader;
-                os << line << endl;
+                os << line << std::endl;
                 line = "";
                 last = ant;
             }
@@ -904,7 +904,7 @@ void MSSummary::listFeed (LogIO& os, Bool verbose, Bool oneBased) const
         MSFeedColumns msFC(pMS->feed());
 
         if (msFC.antennaId().nrow()<=0) {
-            os << "The FEED table is empty" << endl;
+            os << "The FEED table is empty" << std::endl;
         }
         else {
             os << "Feeds: " << msFC.antennaId().nrow();
@@ -915,14 +915,14 @@ void MSSummary::listFeed (LogIO& os, Bool verbose, Bool oneBased) const
             Int widthSpWinId    = 20;
             Int widthNumRec    = 15;
             Int widthPolType    = 10;
-            os << endl;
+            os << std::endl;
             os.output().setf(ios::left, ios::adjustfield);
             os.output().width(widthLead);    os << "  ";
             os.output().width(widthAnt);    os << "Antenna";
             os.output().width(widthSpWinId);    os << "Spectral Window";
             os.output().width(widthNumRec);    os << "# Receptors";
             os.output().width(widthPolType);    os << "Polarizations";
-            os << endl;
+            os << std::endl;
 
             // loop through rows
             // for (rownr_t row=0; row<msFC.antennaId().nrow(); row++) {
@@ -935,7 +935,7 @@ void MSSummary::listFeed (LogIO& os, Bool verbose, Bool oneBased) const
                 os.output().width(widthSpWinId);os << spwId;
                 os.output().width(widthNumRec);    os << msFC.numReceptors()(row);
                 os.output().width(widthPolType);os << msFC.polarizationType()(row);
-                os << endl;
+                os << std::endl;
             }
         }
     }
@@ -956,13 +956,13 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
     std::set<Int> uniqueFields = _msmd->getUniqueFieldIDs();
     uInt nFieldsInMain = uniqueFields.size();
     if (nfields <= 0) {
-        os << "The FIELD table is empty" << endl;
+        os << "The FIELD table is empty" << std::endl;
     }
     else if (uniqueFields.empty()) {
-        os << "The MAIN table is empty" << endl;
+        os << "The MAIN table is empty" << std::endl;
     }
     else {
-        os << "Fields: " << nFieldsInMain << endl;
+        os << "Fields: " << nFieldsInMain << std::endl;
         Int widthLead  =  2;
         Int widthField =  5;
         Int widthCode  =  5;
@@ -996,7 +996,7 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
                 os << "nUnflRows";
             }
         }
-        os << endl;
+        os << std::endl;
         // loop through fields
         vector<String> fieldNames = _msmd->getFieldNames();
         vector<String> codes = _msmd->getFieldCodes();
@@ -1040,7 +1040,7 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
                         os << xx.str();
                     }
                 }
-                os << endl;
+                os << std::endl;
                 if(fillRecord){
                     Record fieldrec;
                     fieldrec.define("name", name);
@@ -1056,11 +1056,11 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
                     }
                 }
             } else {
-                os << "Field "<<fld<<" not found in FIELD table"<<endl;
+                os << "Field "<<fld<<" not found in FIELD table"<<std::endl;
             }
         }
     }
-    os << endl << LogIO::POST;
+    os << std::endl << LogIO::POST;
 }
 
 void MSSummary::listObservation (LogIO& os, Bool verbose) const
@@ -1070,18 +1070,18 @@ void MSSummary::listObservation (LogIO& os, Bool verbose) const
     const MSObservationColumns& msOC(msc.observation());
 
     if (msOC.project().nrow()<=0) {
-        os << "The OBSERVATION table is empty" << endl;
+        os << "The OBSERVATION table is empty" << std::endl;
     }
     else {
         os << "   Observer: " << msOC.observer()(0) << "  "
                 << "   Project: " << msOC.project()(0) << "  ";
-        //v2os << "   Obs Date: " << msOC.obsDate()(0) << endl
+        //v2os << "   Obs Date: " << msOC.obsDate()(0) << std::endl
         //     << "   Tel name: " << msOC.telescopeName()(0);
         if (msc.observation().telescopeName().nrow()>0) {
-            os<<endl << "Observation: " << msc.observation().telescopeName()(0);
+            os<<std::endl << "Observation: " << msc.observation().telescopeName()(0);
         }
         if (!verbose) os << "(" << msc.antenna().name().nrow() << " antennas)";
-        os << endl << endl;
+        os << std::endl << std::endl;
 
         if (msOC.project().nrow()>1) {
             // for version 2 of the MS
@@ -1097,7 +1097,7 @@ void MSSummary::listObservation (LogIO& os, Bool verbose) const
             os.output().width(widthDate);    os << "Observation Date";
             os.output().width(widthObs);    os << "Observer";
             os.output().width(widthProj);    os << "Project";
-            os << endl;
+            os << std::endl;
 
             for (rownr_t row=0;row<msOC.project().nrow();row++) {
                 os.output().setf(ios::left, ios::adjustfield);
@@ -1106,7 +1106,7 @@ void MSSummary::listObservation (LogIO& os, Bool verbose) const
                 os.output().width(widthDate);    os << msOC.timeRange()(row);
                 os.output().width(widthObs);    os << msOC.observer()(row);
                 os.output().width(widthProj);    os << msOC.project()(row);
-                os << endl;
+                os << std::endl;
             }
         }
     }
@@ -1127,11 +1127,11 @@ void MSSummary::listHistory (LogIO& os) const
     MSHistoryColumns msHis(pMS->history());
 
     if (msHis.nrow()<=0) {
-        os << "The HISTORY table is empty" << endl;
+        os << "The HISTORY table is empty" << std::endl;
     }
     else {
         uInt nmessages = msHis.time().nrow();
-        os << "History table entries: " << nmessages << endl << LogIO::POST;
+        os << "History table entries: " << nmessages << std::endl << LogIO::POST;
         const ScalarColumn<Double> &theTimes((msHis.time()));
         const ScalarColumn<String> &messOrigin((msHis.origin()));
         const ScalarColumn<String> &messString((msHis.message()));
@@ -1178,7 +1178,7 @@ void MSSummary::listSource (LogIO& os, Bool verbose) const
 
     // Check if optional SOURCE table is present:
     if (pMS->source().isNull()) {
-        os << "The SOURCE table is absent: see the FIELD table" << endl;
+        os << "The SOURCE table is absent: see the FIELD table" << std::endl;
         return;
     }
 
@@ -1190,12 +1190,12 @@ void MSSummary::listSource (LogIO& os, Bool verbose) const
     Bool sysVelOK=pMS->source().tableDesc().isColumn("SYSVEL");
 
     if (msSC.name().nrow()<=0) {
-        os << "The SOURCE table is empty: see the FIELD table" << endl;
+        os << "The SOURCE table is empty: see the FIELD table" << std::endl;
     }
     else {
 
         if (verbose) {  // activated: CAS-3180
-            os << "Sources: " << msSC.name().nrow() << endl;
+            os << "Sources: " << msSC.name().nrow() << std::endl;
 
             //  Line is    Time Name RA Dec SysVel
             Int widthLead =  2;
@@ -1221,7 +1221,7 @@ void MSSummary::listSource (LogIO& os, Bool verbose) const
             if (sysVelOK) {
                 os.output().width(widthVel);     os << "SysVel(km/s)";
             }
-            os << endl;
+            os << std::endl;
 
             os.output().precision(12);
 
@@ -1270,13 +1270,13 @@ void MSSummary::listSource (LogIO& os, Bool verbose) const
                     else
                         os<<"-";
                 }
-                os << endl;
+                os << std::endl;
             }
 
             if (!restFreqOK)
-                os << "  NB: No rest frequency information found in SOURCE table." << endl;
+                os << "  NB: No rest frequency information found in SOURCE table." << std::endl;
             if (!sysVelOK)
-                os << "  NB: No systemic velocity information found in SOURCE table." << endl;
+                os << "  NB: No systemic velocity information found in SOURCE table." << std::endl;
         }
     }
     os << LogIO::POST;
@@ -1291,10 +1291,10 @@ void MSSummary::listSpectralWindow (LogIO& os, Bool verbose) const
     if (verbose) {}    //null; always the same output
 
     if (msSWC.refFrequency().nrow()<=0) {
-        os << "The SPECTRAL_WINDOW table is empty: see the FEED table" << endl;
+        os << "The SPECTRAL_WINDOW table is empty: see the FEED table" << std::endl;
     }
     else {
-        os << "Spectral Windows: " << msSWC.refFrequency().nrow() << endl;
+        os << "Spectral Windows: " << msSWC.refFrequency().nrow() << std::endl;
         // The 8 columns below are all in the SpWin subtable of Version 1 of
         // the MS definition.  For Version 2, some info will appear in other
         // subtables, as indicated.
@@ -1313,7 +1313,7 @@ void MSSummary::listSpectralWindow (LogIO& os, Bool verbose) const
         os.output().width(widthFreq);    os << "Resolution";
         os.output().width(widthFreq);    os << "TotalBW";
         //    os.output().width(widthCorrTypes);os << "Correlations";
-        os << endl;
+        os << std::endl;
 
         // For each row of the SpWin subtable, write the info
         for (rownr_t row=0; row<msSWC.refFrequency().nrow(); row++) {
@@ -1347,7 +1347,7 @@ void MSSummary::listSpectralWindow (LogIO& os, Bool verbose) const
             //    Int index = msSWC.corrType()(row)(IPosition(1,i));
             //    os << Stokes::name(Stokes::type(index));
             //      }
-            os << endl;
+            os << std::endl;
         }
     }
     os << LogIO::POST;
@@ -1413,10 +1413,10 @@ void MSSummary::listPolarization (LogIO& os, Bool) const {
 
     rownr_t nRow = pMS->polarization().nrow();
     if (nRow<=0) {
-        os << "The POLARIZATION table is empty: see the FEED table" << endl;
+        os << "The POLARIZATION table is empty: see the FEED table" << std::endl;
     }
     else {
-        os << "Polarization setups: " << nRow << endl;
+        os << "Polarization setups: " << nRow << std::endl;
 
         // Define the column widths
         Int widthLead    =  2;
@@ -1427,7 +1427,7 @@ void MSSummary::listPolarization (LogIO& os, Bool) const {
         os.output().setf(ios::left, ios::adjustfield);
         os.output().width(widthLead);    os << "  ";
         os.output().width(widthCorrTypes); os << "Correlations";
-        os << endl;
+        os << std::endl;
 
         // For each row of the Pol subtable, write the info
         for (rownr_t row=0; row<nRow; row++) {
@@ -1439,7 +1439,7 @@ void MSSummary::listPolarization (LogIO& os, Bool) const {
                 Int index = msPolC.corrType()(row)(IPosition(1,i));
                 os << Stokes::name(Stokes::type(index));
             }
-            os << endl;
+            os << std::endl;
         }
     }
     os << LogIO::POST;
@@ -1449,13 +1449,13 @@ void MSSummary::listSpectralAndPolInfo (
     LogIO& os, Bool, Bool
 ) const {
     if (_msmd->nDataDescriptions() == 0) {
-        os << "The DATA_DESCRIPTION table is empty: see the FEED table" << endl;
+        os << "The DATA_DESCRIPTION table is empty: see the FEED table" << std::endl;
     }
     if (_msmd->nSpw(True) == 0) {
-        os << "The SPECTRAL_WINDOW table is empty: see the FEED table" << endl;
+        os << "The SPECTRAL_WINDOW table is empty: see the FEED table" << std::endl;
     }
     if (_msmd->nPol() == 0) {
-        os << "The POLARIZATION table is empty: see the FEED table" << endl;
+        os << "The POLARIZATION table is empty: see the FEED table" << std::endl;
     }
     // determine the data_desc_ids present in the main table
     std::set<uInt> ddId = _msmd->getUniqueDataDescIDs();
@@ -1476,7 +1476,7 @@ void MSSummary::listSpectralAndPolInfo (
     if (! ddId.empty()) {
         os << "Spectral Windows: ";
         os << " (" << uniqueSpws.size() << " unique spectral windows and ";
-        os << uniquePolIDs.size() << " unique polarization setups)"<<endl;
+        os << uniquePolIDs.size() << " unique polarization setups)"<<std::endl;
 
         vector<String> names = _msmd->getSpwNames();
         Int widthName = 5;
@@ -1517,7 +1517,7 @@ void MSSummary::listSpectralAndPolInfo (
             os << "BBC Num ";
         }
         os.output().width(widthCorrTypes);  os << " Corrs";
-        os << endl;
+        os << std::endl;
 
         vector<uInt> nChans = _msmd->nChans();
         vector<QVD> chanFreqs = _msmd->getChanFreqs();
@@ -1595,7 +1595,7 @@ void MSSummary::listSpectralAndPolInfo (
             // CAS-9072 avoid printing blank lines if there are
             // spws that are not represented in the main table
             if (isSpwInMainTable) {
-                os << endl;
+                os << std::endl;
             }
         }
     }
@@ -1607,7 +1607,7 @@ void MSSummary::listSysCal (LogIO& os, Bool verbose) const
 {
     // Check for existence of optional SYSCAL table:
     if (pMS->sysCal().isNull()) {
-        os << "The SYSCAL table is absent" << endl;
+        os << "The SYSCAL table is absent" << std::endl;
         return;
     }
 
@@ -1618,12 +1618,12 @@ void MSSummary::listSysCal (LogIO& os, Bool verbose) const
         MSSysCalColumns msSCC(pMS->sysCal());
 
         if (msSCC.tsys().nrow()<=0) {
-            os << "The SYSCAL table is empty" << endl;
+            os << "The SYSCAL table is empty" << std::endl;
         }
         else {
-            os << "SysCal entries: " << msSCC.tsys().nrow() << endl;
+            os << "SysCal entries: " << msSCC.tsys().nrow() << std::endl;
             os << "   The average Tsys for all data is "
-                    << sum(msSCC.tsys()(0))/msSCC.tsys()(0).nelements() << " K" << endl;
+                    << sum(msSCC.tsys()(0))/msSCC.tsys()(0).nelements() << " K" << std::endl;
         }
     }
     os << LogIO::POST;
@@ -1634,7 +1634,7 @@ void MSSummary::listWeather (LogIO& os, Bool verbose) const
 {
     // Check for existence of optional WEATHER table:
     if (pMS->weather().isNull()) {
-        os << "The WEATHER table is absent" << endl;
+        os << "The WEATHER table is absent" << std::endl;
         return;
     }
 
@@ -1645,13 +1645,13 @@ void MSSummary::listWeather (LogIO& os, Bool verbose) const
         MSWeatherColumns msWC(pMS->weather());
 
         if (msWC.H2O().nrow()<=0) {
-            os << "The WEATHER table is empty" << endl;
+            os << "The WEATHER table is empty" << std::endl;
         }
         else {
-            os << "Weather entries: " << msWC.H2O().nrow() << endl;
+            os << "Weather entries: " << msWC.H2O().nrow() << std::endl;
             os << "   Average H2O column density = " << msWC.H2O()(0)
                     << " m**-2      Average air temperature = "
-                    << msWC.temperature()(0) << " K" << endl;
+                    << msWC.temperature()(0) << " K" << std::endl;
         }
     }
     os<< LogIO::POST;
@@ -1726,7 +1726,7 @@ void MSSummary::listTables (LogIO& os, Bool verbose) const
     if (!verbose) os << "(rows)";
     os << ":";
     if (!verbose) os << "   (-1 = table absent)";
-    os << endl;
+    os << std::endl;
     for (uInt i=0; i<18; i++) {
         if (verbose) {
             os.output().setf(ios::left, ios::adjustfield);
@@ -1748,9 +1748,9 @@ void MSSummary::listTables (LogIO& os, Bool verbose) const
             os.output().setf(ios::left, ios::adjustfield);
             os.output().width(10);
             os << rowStrings(i);
-            os << endl;
+            os << std::endl;
         }
-        else if ((i%5)==0) os << endl;
+        else if ((i%5)==0) os << std::endl;
     }
     os << LogIO::POST;
 }

--- a/ms/MSOper/MSSummary.cc
+++ b/ms/MSOper/MSSummary.cc
@@ -393,7 +393,7 @@ void MSSummary::listMain (LogIO& os, Record& outRec, Bool verbose,
                 os.output().setf(ios::right, ios::adjustfield);
                 os <<  nrowMap->find(*siter)->second;
                 if (_listUnflaggedRowCount) {
-                    ostringstream xx;
+                    std::ostringstream xx;
                     xx << std::fixed << setprecision(2)
                         << _msmd->nUnflaggedRows(
                             MSMetaData::BOTH, arrid, obsid, siter->scan, siter->fieldID
@@ -1034,7 +1034,7 @@ void MSSummary::listField (LogIO& os, Record& outrec,  Bool verbose, Bool fillRe
                     os << _msmd->nRows(MSMetaData::BOTH, fld);
                     if (_listUnflaggedRowCount) {
                         os.output().width(widthNUnflaggedRows);
-                        ostringstream xx;
+                        std::ostringstream xx;
                         xx << std::fixed << setprecision(2) << std::right
                             << _msmd->nUnflaggedRows(MSMetaData::BOTH, fld);
                         os << xx.str();
@@ -1116,7 +1116,7 @@ void MSSummary::listObservation (LogIO& os, Bool verbose) const
 String formatTime(const Double time) {
     MVTime mvtime(Quantity(time, "s"));
     Time t=mvtime.getTime();
-    ostringstream os;
+    std::ostringstream os;
     os << t;
     return os.str();
 }

--- a/ms/MSOper/NewMSSimulator.cc
+++ b/ms/MSOper/NewMSSimulator.cc
@@ -1181,7 +1181,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
   polc.corrProduct().get(baseSpWID,corrProduct);
   Int nCorr=corrProduct.ncolumn();
 //  {
-//    ostringstream oss;
+//    std::ostringstream oss;
 //    oss << "Spectral window : "<<spWindowName<<endl
 //	<< "     reference frequency : " << startFreq/1.0e9 << "GHz" << endl
 //	<< "     number of channels : " << nChan << endl
@@ -1821,7 +1821,7 @@ void NewMSSimulator::blockage(Double &fraction1, Double &fraction2,
 String NewMSSimulator::formatDirection(const MDirection& direction) {
   MVAngle mvRa=direction.getAngle().getValue()(0);
   MVAngle mvDec=direction.getAngle().getValue()(1);
-  ostringstream oss;
+  std::ostringstream oss;
   oss.setf(ios::left, ios::adjustfield);
   oss.width(14);
   oss << mvRa(0.0).string(MVAngle::TIME,8);

--- a/ms/MSOper/NewMSSimulator.cc
+++ b/ms/MSOper/NewMSSimulator.cc
@@ -441,7 +441,7 @@ void NewMSSimulator::initAnt(const String& telescope,
     MVAngle mvLong= mRefLocation.getAngle().getValue()(0);
     MVAngle mvLat= mRefLocation.getAngle().getValue()(1);
     
-    os << "Using local coordinates for the antennas" << endl
+    os << "Using local coordinates for the antennas" << std::endl
        << "Reference position = ";
     os.output().width(13); os << mvLong.string(MVAngle::ANGLE,7);
     os.output().width(14);  os << mvLat.string(MVAngle::DIG2,7);
@@ -886,7 +886,7 @@ void NewMSSimulator::initFeeds(const String& mode,
   
   Int nFeed=x.nelements();
 
-  //  cout << "nFeed = " << nFeed << endl;
+  //  cout << "nFeed = " << nFeed << std::endl;
   
   String feedPol0="R", feedPol1="L";
   Bool isList=False;
@@ -909,8 +909,8 @@ void NewMSSimulator::initFeeds(const String& mode,
     }
   }
 
-  //cout << "Mode in initFeeds = " << mode << endl;
-  //cout << "feedPol0,1 = " << feedPol0 << " " << feedPol1 << endl;
+  //cout << "Mode in initFeeds = " << mode << std::endl;
+  //cout << "feedPol0,1 = " << feedPol0 << " " << feedPol1 << std::endl;
   
   Int nRow=nFeed*nAnt;
   Vector<Int> feedAntId(nRow);
@@ -1182,11 +1182,11 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
   Int nCorr=corrProduct.ncolumn();
 //  {
 //    std::ostringstream oss;
-//    oss << "Spectral window : "<<spWindowName<<endl
-//	<< "     reference frequency : " << startFreq/1.0e9 << "GHz" << endl
-//	<< "     number of channels : " << nChan << endl
-//	<< "     total bandwidth : " << nChan*freqInc/1.0e9 << "GHz" << endl
-//	<< "     number of correlations : " << nCorr << endl;
+//    oss << "Spectral window : "<<spWindowName<<std::endl
+//	<< "     reference frequency : " << startFreq/1.0e9 << "GHz" << std::endl
+//	<< "     number of channels : " << nChan << std::endl
+//	<< "     total bandwidth : " << nChan*freqInc/1.0e9 << "GHz" << std::endl
+//	<< "     number of correlations : " << nCorr << std::endl;
 //    os<<String(oss)<<LogIO::DEBUG1;
 //  }
   
@@ -1224,7 +1224,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
   MDirection fieldCenter=fcs(0);
   {
     os << "First source: "<< sourceNames[iSrc]
-       << " @ " << formatDirection(fieldCenter) << endl;
+       << " @ " << formatDirection(fieldCenter) << std::endl;
   }
 
 
@@ -1269,7 +1269,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
     msd.setFieldCenter(fieldCenter);  // set to first sourceName above
     t_offset_p = - msd.hourAngle() * 3600.0 * 180.0/M_PI / 15.0; // in seconds
     hourAngleDefined_p=True;
-    //      os << "Times specified are interpreted as hour angles for first source observed" << endl
+    //      os << "Times specified are interpreted as hour angles for first source observed" << std::endl
     //	 << "     offset in time = " << t_offset_p / 3600.0 << " hours from "
     //	 << formatTime(taiRefTime.get("s").getValue("s")) << LogIO::DEBUG1;
   }
@@ -1293,7 +1293,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
   Int maxObsId=-1;
   Int maxArrayId=0;
 
-  //cout << "OBSERVATION table has "<< nobsrow << " rows"<<endl;
+  //cout << "OBSERVATION table has "<< nobsrow << " rows"<<std::endl;
 
   if (add_observation or nobsrow<=0) {
     obs.addRow();
@@ -1312,7 +1312,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
     tmpids=msc.arrayId().getColumn();
     if (tmpids.nelements()>0) maxArrayId=max(tmpids);
 
-    //cout << "OBSERVATION table added to; nobsrow now ="<< nobsrow <<endl;
+    //cout << "OBSERVATION table added to; nobsrow now ="<< nobsrow <<std::endl;
   }
 
 
@@ -1326,7 +1326,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
   MSStateColumns& msstateCol = msc.state();
   Int staterow = -1; // the state row to use in the main table
 
-  //cout << "STATE table has " <<msstate.nrow() <<"rows.. searching for match"<<endl;
+  //cout << "STATE table has " <<msstate.nrow() <<"rows.. searching for match"<<std::endl;
   
   for (uInt i = 0; i < msstate.nrow(); i++) {
     if ((msstateCol.sig()(i) == state_sig) &&
@@ -1339,7 +1339,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
     }
   }
 
-  //cout << " (matching) staterow = "<<staterow<< endl;
+  //cout << " (matching) staterow = "<<staterow<< std::endl;
   
   if (staterow<0) {
     msstate.addRow();
@@ -1353,7 +1353,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
     msstateCol.flagRow().put(staterow, false);
   }
 
-  //cout << " after adding a row, staterow = "<<staterow<< endl;
+  //cout << " after adding a row, staterow = "<<staterow<< std::endl;
   
 
 
@@ -1446,7 +1446,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
   Matrix<Bool> flag(nCorr,nChan); 
   flag=False;
 
-  os << "Calculating a total of " << nIntegrations << " integrations" << endl 
+  os << "Calculating a total of " << nIntegrations << " integrations" << std::endl 
      << LogIO::POST;
 
   for(Int feed=0; feed<nFeed; feed++) {
@@ -1527,11 +1527,11 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
 	os << LogIO::DEBUG1 
 	   << "   Field " << pointing << ": " << sourceNames(pointing)
 	   << " @ " << formatDirection(fieldCenter) 
-	   << " for " << nIntegrations << " integrations " << endl;
+	   << " for " << nIntegrations << " integrations " << std::endl;
       } else {
 	if (pointing==20) {
 	  os << LogIO::DEBUG1 
-	     << "   (continuing without printing to log -- see MS for details) " << endl << LogIO::POST;
+	     << "   (continuing without printing to log -- see MS for details) " << std::endl << LogIO::POST;
 	}
       }
 
@@ -1769,7 +1769,7 @@ void NewMSSimulator::observe(const Vector<String>& sourceNames,
 //  os << (row+1) << " visibilities simulated " << LogIO::DEBUG1;
 //  os << nShadowed << " visibilities flagged due to shadowing " << LogIO::DEBUG1;
 //  os << nSubElevation << " visibilities flagged due to elevation limit of " << 
-//    elevationLimit_p.getValue("deg") << " degrees " << endl << LogIO::DEBUG1;
+//    elevationLimit_p.getValue("deg") << " degrees " << std::endl << LogIO::DEBUG1;
   
 }
 

--- a/ms/MSOper/test/tMSDerivedValues.cc
+++ b/ms/MSOper/test/tMSDerivedValues.cc
@@ -36,9 +36,9 @@ int main()
 {
   try {
     Quantity longitude; Quantity::read(longitude,"149.33.00.5");
-    cout << "longitude: "<<MVAngle(longitude)<<endl;
+    cout << "longitude: "<<MVAngle(longitude)<<std::endl;
     Quantity latitude;  Quantity::read(latitude,"-30.18.46.385");
-    cout << "latitude : "<<MVAngle(latitude)<<endl;
+    cout << "latitude : "<<MVAngle(latitude)<<std::endl;
     Vector<MPosition> pos(1);
     pos(0)=MPosition(Quantity(236.9,"m"),longitude,latitude,
 		     MPosition::Ref(MPosition::WGS84));
@@ -49,52 +49,52 @@ int main()
     Quantity time; MVTime::read(time,"today");
     MEpoch today(time);
 
-    cout <<" Current time: "<<MVTime(today.getValue())<<endl;
+    cout <<" Current time: "<<MVTime(today.getValue())<<std::endl;
 
     msd.setEpoch(today);
 
     MEpoch last = msd.last();
     
-    cout <<" Current last: "<< MVTime(last.getValue())<<endl;
+    cout <<" Current last: "<< MVTime(last.getValue())<<std::endl;
 
     Quantity ra; Quantity::read(ra,"12:00:00.0");
     Quantity dec; Quantity::read(dec,"-30.00.00.0");
     MDirection mySource(ra,dec);
    
-    cout <<" FieldCenter: "<< mySource.getAngle("deg") <<endl;
+    cout <<" FieldCenter: "<< mySource.getAngle("deg") <<std::endl;
 
     msd.setFieldCenter(mySource);
 
-    cout <<" Hour angle : "<< MVAngle(msd.hourAngle()) <<endl;
+    cout <<" Hour angle : "<< MVAngle(msd.hourAngle()) <<std::endl;
 
-    cout <<" Az & El    : "<< msd.azel().getAngle("deg")<<endl;
+    cout <<" Az & El    : "<< msd.azel().getAngle("deg")<<std::endl;
 
     Vector<String> mount(1); mount(0)="alt-az";
 
     msd.setAntennaMount(mount);
 
-    cout << " Par. angle: "<< MVAngle(msd.parAngle()) << endl;
+    cout << " Par. angle: "<< MVAngle(msd.parAngle()) << std::endl;
 
     // test the obsVel conversion
     
     cout << " observatory velocity in LSR  frame: "<< msd.obsVel().get("km/s").
-      getValue() << "km/s"<<endl;
+      getValue() << "km/s"<<std::endl;
 
     msd.setVelocityFrame(MRadialVelocity::BARY);
     cout << " observatory velocity in BARY frame: "<< msd.obsVel().get("km/s").
-      getValue() << "km/s"<<endl;
+      getValue() << "km/s"<<std::endl;
 
     
     msd.setVelocityFrame(MRadialVelocity::GEO);
     cout << " observatory velocity in GEO frame: "<< msd.obsVel().get("km/s").
-      getValue() << "km/s"<<endl;
+      getValue() << "km/s"<<std::endl;
 
     Quantity restFreq(1.42041,"GHz");
     Quantity radioVel(2196.25,"km/s");
     msd.setVelocityReference(MDoppler::RADIO);
     msd.setFrequencyReference(MFrequency::TOPO);
     cout << "radio velocity " << radioVel << " is frequency " << 
-      msd.toFrequency(radioVel, restFreq) << endl;
+      msd.toFrequency(radioVel, restFreq) << std::endl;
     //====
     /*
     MSDerivedValues msd1;
@@ -105,19 +105,19 @@ int main()
     //locate restFrequency for field 0 and spwid 0
     Bool hasRestFreq=msd1.setRestFrequency(0,0);
     if(!hasRestFreq){
-      cout << "Ou la la .....has no restfrequency in this ms" << endl;
+      cout << "Ou la la .....has no restfrequency in this ms" << std::endl;
     }
     else{
      cout << "radio velocity " << radioVel << " is frequency " << 
-       msd1.toFrequency(radioVel) << endl; 
+       msd1.toFrequency(radioVel) << std::endl; 
     }
     */
 
     } catch (std::exception& x) {
-	cout << "Caught exception " << endl;
-	cout << x.what() << endl;
+	cout << "Caught exception " << std::endl;
+	cout << x.what() << std::endl;
 	return 1;
     } 
-    cout << "Done." << endl;
+    cout << "Done." << std::endl;
     return 0;
 }

--- a/ms/MSOper/test/tMSKeys.cc
+++ b/ms/MSOper/test/tMSKeys.cc
@@ -36,7 +36,7 @@ using namespace std;
 int main() {
     try {
         {
-            cout << "*** test uniqueArrayKeys()" << endl;
+            cout << "*** test uniqueArrayKeys()" << std::endl;
             ScanKey s;
             s.arrayID = 0;
             s.obsID = 2;
@@ -55,7 +55,7 @@ int main() {
             AlwaysAssert(iter->arrayID == 1 && iter->obsID == 2, AipsError);
         }
         {
-            cout << "*** test ArrayKey==" << endl;
+            cout << "*** test ArrayKey==" << std::endl;
             ArrayKey first, second;
             first.arrayID = 4;
             first.obsID = 6;
@@ -69,7 +69,7 @@ int main() {
             AlwaysAssert(first != second, AipsError);
         }
         {
-            cout << "*** test filter" << endl;
+            cout << "*** test filter" << std::endl;
             std::set<ScanKey> scanKeys;
             ScanKey sk;
             sk.obsID = 0;
@@ -99,10 +99,10 @@ int main() {
                 AlwaysAssert(*filtered.begin() == expec, AipsError);
             }
         }
-        cout << "OK" << endl;
+        cout << "OK" << std::endl;
     } 
     catch (const std::exception& x) {
-    	cerr << "Exception : " << x.what() << endl;
+    	cerr << "Exception : " << x.what() << std::endl;
     	return 1;
     }
     return 0;

--- a/ms/MSOper/test/tMSMetaData.cc
+++ b/ms/MSOper/test/tMSMetaData.cc
@@ -54,7 +54,7 @@ void _printSet(const std::set<uInt>& set) {
         }
         cout << *iter;
     }
-    cout << endl;
+    cout << std::endl;
 }
 
 void _printSet(const std::set<String>& set) {
@@ -68,18 +68,18 @@ void _printSet(const std::set<String>& set) {
         }
         cout << *iter;
     }
-    cout << endl;
+    cout << std::endl;
 }
 
 void testIt(MSMetaData& md) {
     ArrayKey arrayKey;
     arrayKey.obsID = 0;
     arrayKey.arrayID = 0;
-    cout << "*** test nStates()" << endl;
+    cout << "*** test nStates()" << std::endl;
     AlwaysAssert(md.nStates() == 43, AipsError);
-    cout << "*** cache size " << md.getCache() << endl;
+    cout << "*** cache size " << md.getCache() << std::endl;
 
-    cout << "*** test getScansForState()" << endl;
+    cout << "*** test getScansForState()" << std::endl;
     for (uInt stateID=0; stateID<md.nStates(); ++stateID) {
         std::set<Int> scans = md.getScansForState(stateID, 0, 0);
         std::set<Int> expec;
@@ -114,16 +114,16 @@ void testIt(MSMetaData& md) {
         }
         AlwaysAssert(scans == expec, AipsError);
     }
-    cout << "*** cache size " << md.getCache() << endl;
+    cout << "*** cache size " << md.getCache() << std::endl;
 
-    cout << "*** test getIntents()" << endl;
-    cout << "*** size " << md.getIntents().size() << endl;
-    cout << "*** size " << md.getIntents().size() << endl;
+    cout << "*** test getIntents()" << std::endl;
+    cout << "*** size " << md.getIntents().size() << std::endl;
+    cout << "*** size " << md.getIntents().size() << std::endl;
 
     AlwaysAssert(md.getIntents().size() == 11, AipsError);
-    cout << "*** cache size " << md.getCache() << endl;
+    cout << "*** cache size " << md.getCache() << std::endl;
 
-    cout << "*** test getScanNumbers()" << endl;
+    cout << "*** test getScanNumbers()" << std::endl;
     std::set<Int> scans = md.getScanNumbers(0, 0);
     uInt myints[] = {
             1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
@@ -133,10 +133,10 @@ void testIt(MSMetaData& md) {
         std::set<Int> exp;
         exp.insert(myints, myints+32);
         AlwaysAssert(scans == exp, AipsError);
-        cout << "*** cache size " << md.getCache() << endl;
+        cout << "*** cache size " << md.getCache() << std::endl;
     }
     std::set<String> uniqueIntents;
-    cout << "*** test getIntentsForScan()" << endl;
+    cout << "*** test getIntentsForScan()" << std::endl;
     ScanKey scanKey;
     scanKey.obsID = 0;
     scanKey.arrayID = 0;
@@ -219,7 +219,7 @@ void testIt(MSMetaData& md) {
         AlwaysAssert(intents == exp, AipsError);
     }
     AlwaysAssert(md.getIntents() == uniqueIntents, AipsError);
-    cout << "*** test getSpwsForIntent()" << endl;
+    cout << "*** test getSpwsForIntent()" << std::endl;
     for (
         auto intent=uniqueIntents.cbegin();
         intent!=uniqueIntents.cend(); ++intent
@@ -262,11 +262,11 @@ void testIt(MSMetaData& md) {
         }
         AlwaysAssert(md.getSpwsForIntent(*intent) == exp, AipsError);
     }
-    cout << "*** test nSpw()" << endl;
+    cout << "*** test nSpw()" << std::endl;
     uInt nSpw = md.nSpw(True);
     AlwaysAssert(nSpw == 40, AipsError);
     AlwaysAssert(md.nSpw(False) == 40, AipsError);
-    cout << "*** test getIntentsForSpw()" << endl;
+    cout << "*** test getIntentsForSpw()" << std::endl;
     for (uInt spw=0; spw<nSpw; ++spw) {
         std::set<String> exp;
         if (spw == 0) {
@@ -316,10 +316,10 @@ void testIt(MSMetaData& md) {
         AlwaysAssert(md.getIntentsForSpw(spw) == exp, AipsError);
     }
     {
-        cout << "*** test nFields()" << endl;
+        cout << "*** test nFields()" << std::endl;
         uInt nFields = md.nFields();
         AlwaysAssert(nFields == 6, AipsError);
-        cout << "*** test getSpwsForField() and getFieldsToSpwsMap()" << endl;
+        cout << "*** test getSpwsForField() and getFieldsToSpwsMap()" << std::endl;
         std::map<Int, std::set<uInt> > mymap = md.getFieldsToSpwsMap();
         String names[] = {
                 "3C279", "J1337-129", "Titan",
@@ -348,14 +348,14 @@ void testIt(MSMetaData& md) {
                 };
                 exp.insert(myints, myints+17);
             }
-            cout << "*** i " << i << " " << md.getSpwsForField(i) << endl;
+            cout << "*** i " << i << " " << md.getSpwsForField(i) << std::endl;
             AlwaysAssert(md.getSpwsForField(i) == exp, AipsError);
             AlwaysAssert(md.getSpwsForField(names[i]) == exp, AipsError);
             AlwaysAssert(mymap[i] == exp, AipsError);
-            cout << "*** cache size " << md.getCache() << endl;
+            cout << "*** cache size " << md.getCache() << std::endl;
 
         }
-        cout << "*** test phaseDirFromFieldIDAndTime()" << endl;
+        cout << "*** test phaseDirFromFieldIDAndTime()" << std::endl;
         {
 
           MDirection phasCen=md.phaseDirFromFieldIDAndTime(2);
@@ -364,7 +364,7 @@ void testIt(MSMetaData& md) {
                 AipsError
             );
         }
-        cout << "*** test getFieldIDsForSpw()" << endl;
+        cout << "*** test getFieldIDsForSpw()" << std::endl;
         for (uInt i=0; i<md.nSpw(True); ++i) {
             std::set<Int> exp;
             std::set<String> expNames;
@@ -404,11 +404,11 @@ void testIt(MSMetaData& md) {
         }
     }
     {
-        cout << "*** test nScans()" << endl;
-        cout << "nscans " << md.nScans() << endl;
+        cout << "*** test nScans()" << std::endl;
+        cout << "nscans " << md.nScans() << std::endl;
         AlwaysAssert(md.nScans() == 32, AipsError);
         std::set<Int> scanNumbers = md.getScanNumbers(0, 0);
-        cout << "*** test getSpwsForScan(), getScanToSpwsMap(), getPolarizationIDs()" << endl;
+        cout << "*** test getSpwsForScan(), getScanToSpwsMap(), getPolarizationIDs()" << std::endl;
         std::map<ScanKey, std::set<uInt> > mymap = md.getScanToSpwsMap();
         ScanKey scanKey;
         scanKey.obsID = 0;
@@ -465,7 +465,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getScansForSpw() and getSpwToScansMap()" << endl;
+            cout << "*** test getScansForSpw() and getSpwToScansMap()" << std::endl;
             vector<std::set<ScanKey> > spwToScans = md.getSpwToScansMap();
             ScanKey scanKey;
             scanKey.obsID = 0;
@@ -514,9 +514,9 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test nAntennas()" << endl;
+            cout << "*** test nAntennas()" << std::endl;
             AlwaysAssert(md.nAntennas()==15, AipsError);
-            cout << "*** test getAntennaName()" << endl;
+            cout << "*** test getAntennaName()" << std::endl;
             String name;
             String expnames[] = {
                 "DA43", "DA44", "DV02", "DV03", "DV05",
@@ -532,7 +532,7 @@ void testIt(MSMetaData& md) {
                     AipsError
                 );
             }
-            cout << "*** test getAntennaID()" << endl;
+            cout << "*** test getAntennaID()" << std::endl;
             std::map<String, std::set<uInt> > mymap;
             for (uInt i=0; i<md.nAntennas(); ++i) {
                 vector<uInt> ids(1);
@@ -544,7 +544,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getTDMSpw()" << endl;
+            cout << "*** test getTDMSpw()" << std::endl;
             std::set<uInt> exp;
             uInt myints[] = {
                 0, 1, 3, 5, 7, 9, 11, 13, 15, 25, 26, 27, 28, 29,
@@ -554,14 +554,14 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(md.getTDMSpw() == exp, AipsError);
         }
         {
-            cout << "*** test getFDMSpw()" << endl;
+            cout << "*** test getFDMSpw()" << std::endl;
             std::set<uInt> exp;
             uInt myints[] = {17, 19, 21, 23};
             exp.insert(myints, myints+4);
             AlwaysAssert(md.getFDMSpw() == exp, AipsError);
         }
         {
-            cout << "*** test getChannelAvgSpw()" << endl;
+            cout << "*** test getChannelAvgSpw()" << std::endl;
             std::set<uInt> exp;
             uInt myints[] = {
                 2, 4, 6, 8, 10, 12, 14,
@@ -571,7 +571,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(md.getChannelAvgSpw() == exp, AipsError);
         }
         {
-            cout << "*** test getWVRSpw()" << endl;
+            cout << "*** test getWVRSpw()" << std::endl;
             std::set<uInt> exp;
             /*
             uInt myints[] = {
@@ -579,12 +579,12 @@ void testIt(MSMetaData& md) {
                 32, 33, 34, 35, 36, 37, 38, 39
             };
             exp.insert(myints, myints+16);
-            cout << "wvr " << md.getWVRSpw() << endl;
+            cout << "wvr " << md.getWVRSpw() << std::endl;
             */
             AlwaysAssert(md.getWVRSpw() == exp, AipsError);
         }
         {
-            cout << "*** test getScansForTimes()" << endl;
+            cout << "*** test getScansForTimes()" << std::endl;
             std::set<Int> exp;
             exp.insert(27);
             AlwaysAssert(
@@ -601,7 +601,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getTimesForScans()" << endl;
+            cout << "*** test getTimesForScans()" << std::endl;
             std::set<Double> expec;
             Double myd[] = {
                 4842825928.7, 4842825929.5,
@@ -630,7 +630,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getTimesForScan()" << endl;
+            cout << "*** test getTimesForScan()" << std::endl;
             std::set<Double> expec;
             Double myd[] = {
                 4842825003.6,
@@ -654,7 +654,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getStatesForScan() getScanToStatesMap()" << endl;
+            cout << "*** test getStatesForScan() getScanToStatesMap()" << std::endl;
             std::set<Int> expec;
             std::set<Int> scanNumbers = md.getScanNumbers(0, 0);
             std::map<ScanKey, std::set<Int> > mymap = md.getScanToStatesMap();
@@ -722,10 +722,10 @@ void testIt(MSMetaData& md) {
                 scanKey.scan = *curScan;
                 AlwaysAssert(mymap[scanKey] == expec, AipsError);
             }
-            cout << "*** cache size " << md.getCache() << endl;
+            cout << "*** cache size " << md.getCache() << std::endl;
         }
         {
-            cout << "*** test getScansForIntent()" << endl;
+            cout << "*** test getScansForIntent()" << std::endl;
             std::set<String> intents = md.getIntents();
             for (
                 std::set<String>::const_iterator intent=intents.begin();
@@ -791,7 +791,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getScansForFieldID() and getFieldToScansMap" << endl;
+            cout << "*** test getScansForFieldID() and getFieldToScansMap" << std::endl;
             vector<std::set<ScanKey> > mymap = md.getFieldToScansMap();
             std::set<Int> expec;
             ArrayKey aKey;
@@ -839,7 +839,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getFieldIDsForField()" << endl;
+            cout << "*** test getFieldIDsForField()" << std::endl;
             for (uInt i=0; i<6; ++i) {
                 std::set<Int> expec;
                 expec.insert(i);
@@ -856,7 +856,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getScansForField()" << endl;
+            cout << "*** test getScansForField()" << std::endl;
             for (uInt i=0; i<6; ++i) {
                 std::set<Int> expec;
                 String name;
@@ -907,10 +907,10 @@ void testIt(MSMetaData& md) {
                 }
                 AlwaysAssert(md.getScansForField(name, 0, 0) == expec, AipsError);
             }
-            cout << "*** cache size " << md.getCache() << endl;
+            cout << "*** cache size " << md.getCache() << std::endl;
         }
         {
-            cout << "*** test getFieldsForScan() and getFieldsForScans()" << endl;
+            cout << "*** test getFieldsForScan() and getFieldsForScans()" << std::endl;
             std::set<Int> scans = md.getScanNumbers(0, 0);
             std::set<Int> expec2;
             std::set<Int> curScanSet;
@@ -985,7 +985,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getFieldsForIntent() and getIntentToFieldsMap()" << endl;
+            cout << "*** test getFieldsForIntent() and getIntentToFieldsMap()" << std::endl;
             std::map<String, std::set<Int> > mymap = md.getIntentToFieldsMap();
             std::set<String> intents = md.getIntents();
             for (
@@ -1041,7 +1041,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getFieldNamesForFieldIDs()" << endl;
+            cout << "*** test getFieldNamesForFieldIDs()" << std::endl;
             for (uInt i=0; i<md.nFields(); ++i) {
                 String name;
                 switch(i) {
@@ -1067,16 +1067,16 @@ void testIt(MSMetaData& md) {
                     throw AipsError("Unknown field ID");
                 }
                 String got = md.getFieldNamesForFieldIDs(vector<uInt>(1, i))[0];
-                cout << "*** expec " << name << " got " << got << endl;
+                cout << "*** expec " << name << " got " << got << std::endl;
                 AlwaysAssert(
                     got == name,
                     AipsError
                 );
             }
-            cout << "*** cache size " << md.getCache() << endl;
+            cout << "*** cache size " << md.getCache() << std::endl;
         }
         {
-            cout << "*** test getFieldsForTime()" << endl;
+            cout << "*** test getFieldsForTime()" << std::endl;
             std::set<Int> expec;
             expec.insert(0);
             AlwaysAssert(md.getFieldsForTimes(4842824746.0, 10) == expec, AipsError);
@@ -1088,7 +1088,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getTimesForField()" << endl;
+            cout << "*** test getTimesForField()" << std::endl;
             uInt nfields = md.nFields();
             for (uInt i=0; i< nfields; ++i) {
                 std::set<Double> times = md.getTimesForField(i);
@@ -1103,35 +1103,35 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getObservatoryNames()" << endl;
+            cout << "*** test getObservatoryNames()" << std::endl;
             vector<String> names = md.getObservatoryNames();
             AlwaysAssert(names.size() == 1, AipsError);
             AlwaysAssert(names[0] == "ALMA", AipsError);
         }
         {
-            cout << "*** test getObservatoryPosition()" << endl;
+            cout << "*** test getObservatoryPosition()" << std::endl;
             MPosition tPos = md.getObservatoryPosition(0);
             Vector<Double> angles = tPos.getAngle("deg").getValue();
-            cout << angles << endl;
+            cout << angles << std::endl;
             AlwaysAssert(near(angles[0], -67.7549, 1e-6), AipsError);
             AlwaysAssert(near(angles[1], -23.0229, 1e-6), AipsError);
-            cout << "*** cache size " << md.getCache() << endl;
+            cout << "*** cache size " << md.getCache() << std::endl;
 
         }
         {
-            cout << "*** test getAntennaPosition()" << endl;
+            cout << "*** test getAntennaPosition()" << std::endl;
             cout
                 << Vector<MPosition>(
                     md.getAntennaPositions(vector<uInt>(1, 2))
                 )
-                << endl;
+                << std::endl;
         }
         {
-            cout << "*** test getAntennaOffset()" << endl;
-            cout << md.getAntennaOffset(2) << endl;
+            cout << "*** test getAntennaOffset()" << std::endl;
+            cout << md.getAntennaOffset(2) << std::endl;
         }
         {
-            cout << "*** test getAntennaStations()" << endl;
+            cout << "*** test getAntennaStations()" << std::endl;
             vector<uInt> ids(3);
             ids[0] = 2;
             ids[1] = 4;
@@ -1152,14 +1152,14 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getAntennaDiameters" << endl;
+            cout << "*** test getAntennaDiameters" << std::endl;
             Quantum<Vector<Double> > antennaDiameters = md.getAntennaDiameters();
             AlwaysAssert(
                 allEQ(antennaDiameters.getValue(), 12.0), AipsError
             );
         }
         {
-            cout << "*** Test getIntentsForField()" << endl;
+            cout << "*** Test getIntentsForField()" << std::endl;
             uInt nFields = md.nFields();
             const auto fieldNames = md.getFieldNames();
             for (uInt i=0; i<nFields; ++i) {
@@ -1222,7 +1222,7 @@ void testIt(MSMetaData& md) {
                 default:
                     break;
                 }
-                cout << "*** i " << i << endl;
+                cout << "*** i " << i << std::endl;
                 _printSet(md.getIntentsForField(i));
                 AlwaysAssert(md.getIntentsForField(i) == expec, AipsError);
                 AlwaysAssert(
@@ -1231,16 +1231,16 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getUniqueBaselines() and nBaselines()" << endl;
+            cout << "*** test getUniqueBaselines() and nBaselines()" << std::endl;
             AlwaysAssert(md.nBaselines(False) == 21, AipsError);
             AlwaysAssert(md.nBaselines(True) == 25, AipsError);
         }
         {
-            cout << "*** test getEffectiveTotalExposureTime()" << endl;
-            cout << "effective exposure time is " << md.getEffectiveTotalExposureTime() << endl;
+            cout << "*** test getEffectiveTotalExposureTime()" << std::endl;
+            cout << "effective exposure time is " << md.getEffectiveTotalExposureTime() << std::endl;
         }
         {
-            cout << "*** test BBCNosToSpwMap()" << endl;
+            cout << "*** test BBCNosToSpwMap()" << std::endl;
             for (uInt i=0; i<3; ++i) {
                 MSMetaData::SQLDSwitch sqldSwitch = i == 0 ? MSMetaData::SQLD_INCLUDE
                     : i == 1 ? MSMetaData::SQLD_EXCLUDE : MSMetaData::SQLD_ONLY;
@@ -1317,7 +1317,7 @@ void testIt(MSMetaData& md) {
                 }
             }
             {
-                cout << "*** test getSpwIDPolIDToDataDescIDMap()" << endl;
+                cout << "*** test getSpwIDPolIDToDataDescIDMap()" << std::endl;
                 std::map<std::pair<uInt, uInt>, uInt> dataDescToPolID = md.getSpwIDPolIDToDataDescIDMap();
                 std::map<std::pair<uInt, uInt>, uInt>::const_iterator iter;
                 std::map<std::pair<uInt, uInt>, uInt>::const_iterator begin = dataDescToPolID.begin();
@@ -1335,25 +1335,25 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test nPol()" << endl;
+            cout << "*** test nPol()" << std::endl;
             AlwaysAssert(md.nPol() == 2, AipsError);
         }
         {
-            cout << "*** test getSQLDSpw()" << endl;
+            cout << "*** test getSQLDSpw()" << std::endl;
             std::set<uInt> res = md.getSQLDSpw();
             AlwaysAssert(res.size() == 1 && *res.begin() == 3, AipsError);
         }
         {
-            cout << "*** test getFirstExposureTimeMap() (deprecated)" << endl;
+            cout << "*** test getFirstExposureTimeMap() (deprecated)" << std::endl;
             vector<std::map<Int, Quantity> > mymap = md.getFirstExposureTimeMap();
-            cout << "val " << mymap[0][30].getValue("s") << endl;
-            cout << "val " << mymap[0][30] << endl;
+            cout << "val " << mymap[0][30].getValue("s") << std::endl;
+            cout << "val " << mymap[0][30] << std::endl;
             AlwaysAssert(near(mymap[0][30].getValue("s"), 1.152), AipsError);
             AlwaysAssert(near(mymap[10][17].getValue("s"), 1.008), AipsError)
-            cout << "mymap " << mymap[10][17] << endl;
+            cout << "mymap " << mymap[10][17] << std::endl;
         }
         {
-            cout << "*** test getScanToFirstExposureTimeMap()" << endl;
+            cout << "*** test getScanToFirstExposureTimeMap()" << std::endl;
             std::map<ScanKey, MSMetaData::FirstExposureTimeMap> mymap
                 = md.getScanToFirstExposureTimeMap(False);
             ScanKey scan;
@@ -1365,7 +1365,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(near(mymap[scan][10].second.getValue("s"), 1.008), AipsError)
         }
         {
-            cout << "*** test getUniqueFiedIDs()" << endl;
+            cout << "*** test getUniqueFiedIDs()" << std::endl;
             std::set<Int> expec;
             for (Int i=0; i<6; ++i) {
                 expec.insert(i);
@@ -1373,7 +1373,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(md.getUniqueFieldIDs() == expec, AipsError);
         }
         {
-            cout << "*** test getCenterFreqs()" << endl;
+            cout << "*** test getCenterFreqs()" << std::endl;
             vector<Quantity> centers = md.getCenterFreqs();
             Double mine[] = {
                 187550000000.0,    214250000000.0,
@@ -1403,14 +1403,14 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** Test getCorrBits" << endl;
+            cout << "*** Test getCorrBits" << std::endl;
             vector<String> cb = md.getCorrBits();
             for ( const auto &el : cb) {
                 AlwaysAssert(el == "UNKNOWN", AipsError);
             }
         }
         {
-            cout << "*** Test getFieldsForSourceMap" << endl;
+            cout << "*** Test getFieldsForSourceMap" << std::endl;
             std::map<Int, std::set<Int> > res = md.getFieldsForSourceMap();
             std::map<Int, std::set<String> > res2 = md.getFieldNamesForSourceMap();
             String names[] = {
@@ -1426,7 +1426,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** Test getPointingDirection" << endl;
+            cout << "*** Test getPointingDirection" << std::endl;
             Int ant1, ant2;
             Double time;
             std::pair<MDirection, MDirection> pDirs = md.getPointingDirection(
@@ -1453,13 +1453,13 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** Test getTimeRange()" << endl;
+            cout << "*** Test getTimeRange()" << std::endl;
             std::pair<Double, Double> timerange = md.getTimeRange();
             AlwaysAssert(near(timerange.first, 4842824745.020, 1e-12), AipsError);
             AlwaysAssert(near(timerange.second, 4842830012.448, 1e-12), AipsError);
         }
         {
-            cout << "*** test getTimesForIntent" << endl;
+            cout << "*** test getTimesForIntent" << std::endl;
             std::set<String> intents = md.getIntents();
             std::set<String>::const_iterator intent = intents.begin();
             std::set<String>::const_iterator end = intents.end();
@@ -1504,23 +1504,23 @@ void testIt(MSMetaData& md) {
                 ++intent;
             }
             {
-                cout << "*** test getSummary()" << endl;
-                //cout << "summary " << md.getSummary() << endl;
+                cout << "*** test getSummary()" << std::endl;
+                //cout << "summary " << md.getSummary() << std::endl;
             }
             {
-                cout << "*** test getProjects()" << endl;
+                cout << "*** test getProjects()" << std::endl;
                 vector<String> projects = md.getProjects();
                 AlwaysAssert(projects.size() == 1, AipsError);
                 AlwaysAssert(projects[0] == "T.B.D.", AipsError);
             }
             {
-                cout << "*** test getObservers()" << endl;
+                cout << "*** test getObservers()" << std::endl;
                 vector<String> observers = md.getObservers();
                 AlwaysAssert(observers.size() == 1, AipsError);
                 AlwaysAssert(observers[0] == "csalyk", AipsError);
             }
             {
-                cout << "*** test getSchedules()" << endl;
+                cout << "*** test getSchedules()" << std::endl;
                 vector<vector<String> > schedules = md.getSchedules();
                 AlwaysAssert(schedules.size() == 1, AipsError);
                 AlwaysAssert(schedules[0].size() == 2, AipsError);
@@ -1530,7 +1530,7 @@ void testIt(MSMetaData& md) {
             {
                 // 4842824633.4720001
                 // 4842830031.632
-                cout << "*** test getTimeRangesOfObservations()" << endl;
+                cout << "*** test getTimeRangesOfObservations()" << std::endl;
                 vector<std::pair<MEpoch, MEpoch> > timers = md.getTimeRangesOfObservations();
                 AlwaysAssert(timers.size() == 1, AipsError);
                 AlwaysAssert(timers[0].first.getRefString() == "UTC", AipsError);
@@ -1545,7 +1545,7 @@ void testIt(MSMetaData& md) {
                 );
             }
             {
-                cout << "*** test getRefFreqs()" << endl;
+                cout << "*** test getRefFreqs()" << std::endl;
                 Double expec[] = {
                     1.83300000e+11, 2.15250000e+11, 2.15250000e+11,
                     2.17250000e+11, 2.17250000e+11, 2.29250000e+11,
@@ -1572,7 +1572,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getCorrTypes" << endl;
+            cout << "*** test getCorrTypes" << std::endl;
             vector<vector<Int> > corrTypes = md.getCorrTypes();
             AlwaysAssert(corrTypes[0].size() == 2, AipsError);
             AlwaysAssert(corrTypes[0][0] == 9, AipsError);
@@ -1581,7 +1581,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(corrTypes[1][0] == 1, AipsError);
         }
         {
-            cout << "*** test getCorrProducts" << endl;
+            cout << "*** test getCorrProducts" << std::endl;
             vector<Array<Int> > corrProds = md.getCorrProducts();
             AlwaysAssert(corrProds[0].size() == 4, AipsError);
             AlwaysAssert(corrProds[0](IPosition(2, 0, 0)) == 0, AipsError);
@@ -1592,7 +1592,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(allTrue(corrProds[1] == 0), AipsError);
         }
         {
-            cout << "*** test getSourceTableSourceIDs" << endl;
+            cout << "*** test getSourceTableSourceIDs" << std::endl;
             vector<Int> sourceIDs = md.getSourceTableSourceIDs();
             AlwaysAssert(sourceIDs.size() == 200, AipsError);
             for (uInt i=0; i<200; ++i) {
@@ -1628,7 +1628,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getPhaseDirs()" << endl;
+            cout << "*** test getPhaseDirs()" << std::endl;
             vector<MDirection> phaseDirs = md.getPhaseDirs();
             AlwaysAssert(phaseDirs.size() == md.nFields(), AipsError);
             Double elong[] = {
@@ -1647,7 +1647,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getFieldTableSourceIDs" << endl;
+            cout << "*** test getFieldTableSourceIDs" << std::endl;
             vector<Int> sourceIDs = md.getFieldTableSourceIDs();
             AlwaysAssert(sourceIDs.size() == md.nFields(), AipsError);
             for (uInt i=0; i<sourceIDs.size(); ++i) {
@@ -1655,7 +1655,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getAntennasForScan()" << endl;
+            cout << "*** test getAntennasForScan()" << std::endl;
             std::set<Int> scans = md.getScanNumbers(0, 0);
             std::set<Int>::const_iterator iter = scans.begin();
             std::set<Int>::const_iterator end = scans.end();
@@ -1681,7 +1681,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getSourceNames()" << endl;
+            cout << "*** test getSourceNames()" << std::endl;
             vector<String> sourceNames = md.getSourceNames();
             String expec[] = {
                 "3C279", "3C279", "3C279", "3C279", "3C279", "3C279", "3C279",
@@ -1725,7 +1725,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getSourceDirections()" << endl;
+            cout << "*** test getSourceDirections()" << std::endl;
             vector<MDirection> dirs = md.getSourceDirections();
             AlwaysAssert(dirs.size() == 200, AipsError);
             Double elong[] = {
@@ -1820,7 +1820,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getProperMotions()" << endl;
+            cout << "*** test getProperMotions()" << std::endl;
             vector<std::pair<Quantity, Quantity> > pm = md.getProperMotions();
             AlwaysAssert(pm.size() == 200, AipsError);
             for (uInt i=0; i<200; ++i) {
@@ -1831,7 +1831,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getSpwToTimesForScan()" << endl;
+            cout << "*** test getSpwToTimesForScan()" << std::endl;
             ScanKey scan;
             scan.obsID = 0;
             scan.arrayID = 0;
@@ -1993,7 +1993,7 @@ void testIt(MSMetaData& md) {
                     expec = std::set<Double>(z, z+50);
                 }
                 else {
-                    cout << "found channel " << i << " which shouldn't be in this set" << endl;
+                    cout << "found channel " << i << " which shouldn't be in this set" << std::endl;
                     AlwaysAssert(False, AipsError);
                 }
                 AlwaysAssert(times[i].size() == expec.size(), AipsError);
@@ -2008,12 +2008,12 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test nUniqueSourceIDsFromSourceTable()" << endl;
+            cout << "*** test nUniqueSourceIDsFromSourceTable()" << std::endl;
             uInt n = md.nUniqueSourceIDsFromSourceTable();
             AlwaysAssert(n == 6, AipsError);
         }
         {
-            cout << "*** test getFieldNames()" << endl;
+            cout << "*** test getFieldNames()" << std::endl;
             vector<String> fnames = md.getFieldNames();
             String z[] = {"3C279", "J1337-129", "Titan", "J1625-254", "V866 Sco", "RNO 90"};
             vector<String> expec(z, z+6);
@@ -2027,7 +2027,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getNetSidebands()" << endl;
+            cout << "*** test getNetSidebands()" << std::endl;
             vector<Int> netsb = md.getNetSidebands();
             Int expec[] = {
                 3, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2,
@@ -2039,7 +2039,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getReferenceDirection()" << endl;
+            cout << "*** test getReferenceDirection()" << std::endl;
             uInt nfields = md.nFields();
             for (uInt i=0; i<nfields; ++i) {
                 MDirection dir = md.getReferenceDirection(i);
@@ -2075,7 +2075,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getChanEffectiveBWs()" << endl;
+            cout << "*** test getChanEffectiveBWs()" << std::endl;
             vector<QVector<Double> > ebw = md.getChanEffectiveBWs(False);
             vector<QVector<Double> >::const_iterator iter = ebw.begin();
             vector<QVector<Double> >::const_iterator end = ebw.end();
@@ -2109,7 +2109,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(ebwv[9].getUnit() == "km/s", AipsError);
         }
         {
-            cout << "*** test getChanResolutions()" << endl;
+            cout << "*** test getChanResolutions()" << std::endl;
             vector<QVector<Double> > ebw = md.getChanResolutions(False);
             vector<QVector<Double> >::const_iterator iter = ebw.begin();
             vector<QVector<Double> >::const_iterator end = ebw.end();
@@ -2143,7 +2143,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(ebwv[9].getUnit() == "km/s", AipsError);
         }
         {
-            cout << "test getRestFrequencies()" << endl;
+            cout << "test getRestFrequencies()" << std::endl;
             std::map<SourceKey, std::shared_ptr<vector<MFrequency> > > rfs = md.getRestFrequencies();
             std::map<SourceKey, std::shared_ptr<vector<MFrequency> > >::const_iterator iter = rfs.begin();
             std::map<SourceKey, std::shared_ptr<vector<MFrequency> > >::const_iterator end = rfs.end();
@@ -2160,7 +2160,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "test getTransitions()" << endl;
+            cout << "test getTransitions()" << std::endl;
             std::map<SourceKey, std::shared_ptr<vector<String> > > rfs = md.getTransitions();
             std::map<SourceKey, std::shared_ptr<vector<String> > >::const_iterator iter = rfs.begin();
             std::map<SourceKey, std::shared_ptr<vector<String> > >::const_iterator end = rfs.end();
@@ -2177,7 +2177,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "test getSubScanProperties" << endl;
+            cout << "test getSubScanProperties" << std::endl;
             SubScanKey sskey;
             sskey.arrayID = 0;
             sskey.fieldID = 0;
@@ -2215,7 +2215,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getScanKeys()" << endl;
+            cout << "*** test getScanKeys()" << std::endl;
             std::set<ScanKey> keys = md.getScanKeys();
             ScanKey expec;
             expec.arrayID = 0;
@@ -2231,7 +2231,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getIntentsForSubScan() and getSubScanToIntentsMap()" << endl;
+            cout << "*** test getIntentsForSubScan() and getSubScanToIntentsMap()" << std::endl;
             ArrayKey arrayKey;
             arrayKey.obsID = 0;
             arrayKey.arrayID = 0;
@@ -2316,7 +2316,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getSpwsForSubScan()" << endl;
+            cout << "*** test getSpwsForSubScan()" << std::endl;
             ArrayKey arrayKey;
             arrayKey.obsID = 0;
             arrayKey.arrayID = 0;
@@ -2358,7 +2358,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "test getAverageIntervalsForSubScan()" << endl;
+            cout << "test getAverageIntervalsForSubScan()" << std::endl;
             ArrayKey arrayKey;
             arrayKey.obsID = 0;
             arrayKey.arrayID = 0;
@@ -2403,7 +2403,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getSpwIDs()" << endl;
+            cout << "*** test getSpwIDs()" << std::endl;
             std::set<uInt> spws = md.getSpwIDs();
             AlwaysAssert(spws.size() == 25, AipsError);
             std::set<uInt>::const_iterator iter = spws.begin();
@@ -2414,7 +2414,7 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getScanToTimeRangeMap()" << endl;
+            cout << "*** test getScanToTimeRangeMap()" << std::endl;
             std::shared_ptr<const std::map<ScanKey, std::pair<Double,Double> > > mymap
                 = md.getScanToTimeRangeMap();
             ScanKey key;
@@ -2425,7 +2425,7 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(near(mymap->find(key)->second.second, 4842824839.0, 1.0), AipsError);
         }
         {
-            cout << "*** test getNRowsMap()" << endl;
+            cout << "*** test getNRowsMap()" << std::endl;
             SubScanKey key;
             key.arrayID = 0;
             key.obsID = 0;
@@ -2439,12 +2439,12 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(xc->find(key)->second == 316, AipsError);
         }
         {
-            cout << "*** test getFieldCodes()" << endl;
+            cout << "*** test getFieldCodes()" << std::endl;
             Vector<String> codes = Vector<String>(md.getFieldCodes());
             AlwaysAssert(allEQ(codes, String("none")), AipsError);
         }
         {
-            cout << "*** test getUniqueDataDescIDs()" << endl;
+            cout << "*** test getUniqueDataDescIDs()" << std::endl;
             std::set<uInt> ddids = md.getUniqueDataDescIDs();
             Vector<uInt> expec = indgen(25, (uInt)0, (uInt)1);
             AlwaysAssert(
@@ -2454,7 +2454,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getUniqueAntennaIDs()" << endl;
+            cout << "*** test getUniqueAntennaIDs()" << std::endl;
             std::set<Int> ants = md.getUniqueAntennaIDs();
             Int evals[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13};
             Vector<Int> expec(vector<Int>(evals, evals+13));
@@ -2465,7 +2465,7 @@ void testIt(MSMetaData& md) {
             );
         }
         {
-            cout << "*** test getFirstExposureTimeMap()" << endl;
+            cout << "*** test getFirstExposureTimeMap()" << std::endl;
             vector<std::map<Int, Quantity> > mymap = md.getFirstExposureTimeMap();
             AlwaysAssert(mymap.size() == 25, AipsError);
             for (Int i=0; i<25; ++i) {
@@ -2504,14 +2504,14 @@ void testIt(MSMetaData& md) {
             }
         }
         {
-            cout << "*** test getUniqueSpwIDs()" << endl;
+            cout << "*** test getUniqueSpwIDs()" << std::endl;
             std::set<uInt> spws = md.getUniqueSpwIDs();
             Vector<Int> expV = casacore::indgen(25, 0, 1);
             std::set<uInt> expec(expV.begin(), expV.end());
             AlwaysAssert(spws == expec, AipsError);
         }
         {
-            cout << "*** test getSourceTimes()" << endl;
+            cout << "*** test getSourceTimes()" << std::endl;
             std::shared_ptr<const Quantum<Vector<Double> > > times = md.getSourceTimes();
             Vector<Double> v = times->getValue();
             AlwaysAssert(v.size() == 200, AipsError);
@@ -2520,14 +2520,14 @@ void testIt(MSMetaData& md) {
             AlwaysAssert(allNear(v, expec, 1e-10), AipsError);
         }
         {
-            cout << "*** test getIntervalStatistics()" << endl;
+            cout << "*** test getIntervalStatistics()" << std::endl;
             MSMetaData::ColumnStats stats = md.getIntervalStatistics();
             AlwaysAssert(near(stats.min, 1.008), AipsError);
             AlwaysAssert(near(stats.max, 6.048), AipsError);
             AlwaysAssert(near(stats.median, 1.008), AipsError);
         }
         {
-            cout << "test getTimesForSpws()" << endl;
+            cout << "test getTimesForSpws()" << std::endl;
             std::vector<std::set<Double> > vec = md.getTimesForSpws();
             uInt n = vec.size();
             AlwaysAssert(n == 40, AipsError);
@@ -2572,7 +2572,7 @@ void testIt(MSMetaData& md) {
 
         }
         {
-            cout << "*** cache size " << md.getCache() << endl;
+            cout << "*** cache size " << md.getCache() << std::endl;
         }
     }
 }
@@ -2584,9 +2584,9 @@ int main() {
         String datadir = parts[0] + "/data/";
         delete [] parts;
         casacore::MeasurementSet ms(datadir + "regression/unittest/MSMetaData/MSMetaData.ms");
-        cout << "*** test on-demand constructor" << endl;
+        cout << "*** test on-demand constructor" << std::endl;
         MSMetaData md1(&ms, 100);
-        cout << "*** cache size " << md1.getCache() << endl;
+        cout << "*** cache size " << md1.getCache() << std::endl;
 
         testIt(md1);
         // test after everything is cached
@@ -2595,10 +2595,10 @@ int main() {
         MSMetaData md2(&ms, 0);
         testIt(md2);
         AlwaysAssert(md2.getCache() == 0, AipsError);
-        cout << "OK" << endl;
+        cout << "OK" << std::endl;
     } 
     catch (const std::exception& x) {
-        cerr << "Exception : " << x.what() << endl;
+        cerr << "Exception : " << x.what() << std::endl;
         return 1;
     }
     return 0;

--- a/ms/MSOper/test/tMSReader.cc
+++ b/ms/MSOper/test/tMSReader.cc
@@ -37,11 +37,11 @@ int main(int argc, const char* argv[])
 {
     try {
 	if (argc<2) {
-	    cout << "Usage: " << argv[0] << " ms_name" << endl; 
+	    cout << "Usage: " << argv[0] << " ms_name" << std::endl; 
 	    return 1;
 	}
 	String msName(argv[1]);
-	cout << "MS Name = " << msName << endl;
+	cout << "MS Name = " << msName << std::endl;
 
 	// construct the MS
 	MeasurementSet ms(msName);
@@ -52,7 +52,7 @@ int main(int argc, const char* argv[])
 	MSReader reader(ms);
 	timer.show("Construction : ");
 
-	cout << "Tables : " << reader.tables() << endl;
+	cout << "Tables : " << reader.tables() << std::endl;
 	Vector<String> tables(reader.tables());
 
 	timer.mark();
@@ -64,12 +64,12 @@ int main(int argc, const char* argv[])
 		if (j > 0) cout << " | ";
 		cout << reader.rowNumber(tables(j));
 	    }
-	    cout << endl;
+	    cout << std::endl;
 	}
 	timer.show("read to end : ");
-	cout << "done" << endl;
+	cout << "done" << std::endl;
     } catch (std::exception& x) {
-	cerr << "Exception : " << x.what() << endl;
+	cerr << "Exception : " << x.what() << std::endl;
     } 
  
     return 0;

--- a/ms/MSOper/test/tMSSummary.cc
+++ b/ms/MSOper/test/tMSSummary.cc
@@ -42,7 +42,7 @@ void testSumm()
   // which will be printed on stdout at the ended.
   MeasurementSet ms("tMSSummary_tmp.MS", Table::Old);
   MSSummary mss(ms);
-  ostringstream ostr;
+  std::ostringstream ostr;
   LogSink logsink(LogMessage::NORMAL, &ostr, False);
   LogIO os(logsink);
   mss.list (os, True);

--- a/ms/MSOper/test/tMSSummary.cc
+++ b/ms/MSOper/test/tMSSummary.cc
@@ -55,8 +55,8 @@ void testSumm()
 int main(int argc, const char* argv[])
 {
   try {
-    cout << "MSSummary" << endl;
-    cout << "--------------------------------------" << endl;
+    cout << "MSSummary" << std::endl;
+    cout << "--------------------------------------" << std::endl;
     LogIO os(LogOrigin("tMSSummary", "main()"));
 
     if (argc < 2) {
@@ -68,7 +68,7 @@ int main(int argc, const char* argv[])
       mss.listHistory(os);
     }
   } catch (const std::exception& x) {
-    cout << x.what() << endl;
+    cout << x.what() << std::endl;
   } 
   
   return 0;

--- a/ms/MSSel/MSAntennaIndex.cc
+++ b/ms/MSSel/MSAntennaIndex.cc
@@ -102,7 +102,7 @@ Vector<Int> MSAntennaIndex::matchAntennaRegexOrPattern(const String& pattern,
   } else {
     reg=reg.fromPattern(patt);
   }
-  //  cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << endl;
+  //  cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << std::endl;
   IPosition sh(msAntennaCols_p.name().getColumn().shape());
   LogicalArray maskArray(sh,False);
   IPosition i=sh;
@@ -112,7 +112,7 @@ Vector<Int> MSAntennaIndex::matchAntennaRegexOrPattern(const String& pattern,
       Int ret=(msAntennaCols_p.name().getColumn()(i).matches(reg,pos));
       if (ret <= 0)
 	ret = (msAntennaCols_p.station().getColumn()(i).matches(reg,pos));
-      //      cerr << i << " " << ret << endl;
+      //      cerr << i << " " << ret << std::endl;
       maskArray(i) = ( (ret>0) != negate );
       //		       && !msAntennaCols_p.flagRow().getColumn()(i));
     }
@@ -207,7 +207,7 @@ Vector<Int> MSAntennaIndex::matchStationRegexOrPattern(const String& pattern,
   } else {
     reg=reg.fromPattern(patt);
   }
-  //  cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << endl;
+  //  cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << std::endl;
   IPosition sh(msAntennaCols_p.station().getColumn().shape());
   LogicalArray maskArray(sh,False);
   IPosition i=sh;
@@ -217,7 +217,7 @@ Vector<Int> MSAntennaIndex::matchStationRegexOrPattern(const String& pattern,
       Int ret=(msAntennaCols_p.station().getColumn()(i).matches(reg,pos));
       // if (ret <= 0)
       // 	ret = (msAntennaCols_p.station().getColumn()(i).matches(reg,pos));
-      //      cerr << i << " " << ret << endl;
+      //      cerr << i << " " << ret << std::endl;
       maskArray(i) = ( (ret>0) != negate );
       //		       && !msAntennaCols_p.flagRow().getColumn()(i));
     }

--- a/ms/MSSel/MSAntennaIndex.cc
+++ b/ms/MSSel/MSAntennaIndex.cc
@@ -65,7 +65,7 @@ MSAntennaIndex::MSAntennaIndex(const MSAntenna& antenna)
     IDs = set_intersection(sourceId,antennaIds_p);
     if (IDs.nelements() == 0)
       {
-    	ostringstream mesg;
+    	std::ostringstream mesg;
         mesg << "No match found for the antenna specificion [ID(s): " << sourceId << "]";
         // Use the error handler if defined, otherwise throw.
         if (MSAntennaParse::thisMSAErrorHandler) {

--- a/ms/MSSel/MSAntennaParse.cc
+++ b/ms/MSSel/MSAntennaParse.cc
@@ -87,7 +87,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	TableExprNode noAutoCorr = (column1AsTEN_p != column2AsTEN_p);
 	condition = noAutoCorr && condition;
       }
-    //    if (negate) cerr << "Generating a negation condition" << endl;
+    //    if (negate) cerr << "Generating a negation condition" << std::endl;
     if (negate) condition = !condition;
     if(node_p.isNull()) node_p = condition;
     else

--- a/ms/MSSel/MSArrayGram.ll
+++ b/ms/MSSel/MSArrayGram.ll
@@ -35,7 +35,7 @@
 
 #undef YY_DECL
 #define YY_DECL int MSArrayGramlex (YYSTYPE* lvalp)
-static string                qstr;
+static std::string                qstr;
 #include <casacore/ms/MSSel/MSSelectionTools.h>
 %}
 

--- a/ms/MSSel/MSArrayParse.cc
+++ b/ms/MSSel/MSArrayParse.cc
@@ -62,7 +62,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       {
 	// Enumerated list of IDs can be treated as a [ID0, ID1]
 	// (range inclusive of the bounds).
-	//	cerr << "Selecting enumerated range: " << id0 << " " << id1 << endl;
+	//	cerr << "Selecting enumerated range: " << id0 << " " << id1 << std::endl;
 	selectRangeGEAndLE(id0,id1);
       }
     return parsedIDList_p;

--- a/ms/MSSel/MSArrayParse.cc
+++ b/ms/MSSel/MSArrayParse.cc
@@ -84,7 +84,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 					     (ms()->col(colName) < n1));
     if ((n0 < 0) || (n1 < 0) || (n1 <= n0))
       {
-	ostringstream os;
+	std::ostringstream os;
 	os << "Array Expression: Malformed range bounds " 
 	   << n0 << " (lower bound) and " 
 	   << n1 << " (upper bound)";
@@ -105,7 +105,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 					     (ms()->col(colName) <= n1));
     if ((n0 < 0) || (n1 < 0) || (n1 <= n0))
       {
-	ostringstream os;
+	std::ostringstream os;
 	os << "Array Expression: Malformed range bounds " 
 	   << n0 << " (lower bound) and " 
 	   << n1 << " (upper bound)";

--- a/ms/MSSel/MSCorrParse.cc
+++ b/ms/MSSel/MSCorrParse.cc
@@ -62,7 +62,7 @@ const TableExprNode *MSCorrParse::selectCorrType(const String& corrType)
   
   MeasurementSet selms= Table(ms()->tableName(), Table::Update);
   if(!selms.isWritable()) {
-    cout << "Table is not writable " << endl;
+    cout << "Table is not writable " << std::endl;
     return NULL;
   } 
 
@@ -104,7 +104,7 @@ const TableExprNode *MSCorrParse::selectCorrType(const String& corrType)
     }
   }
   if(!corrTypeExist) {
-    cout << " corrtype " << corrType << " does not exist" << endl;
+    cout << " corrtype " << corrType << " does not exist" << std::endl;
     return NULL;
   }
 

--- a/ms/MSSel/MSFeedIndex.cc
+++ b/ms/MSSel/MSFeedIndex.cc
@@ -186,7 +186,7 @@ Vector<Int> MSFeedIndex::matchFeedId(const Vector<Int>& sourceId)
     Vector<Int> IDs = set_intersection(sourceId, feedIds);
     if (IDs.nelements() == 0)
       {
-        ostringstream mesg;
+        std::ostringstream mesg;
         mesg << "No match found for requested feeds [ID(s): " << sourceId << "]";
         // Use the error handler if defined, otherwise throw.
         if (MSFeedParse::thisMSFErrorHandler) {

--- a/ms/MSSel/MSFieldGram.ll
+++ b/ms/MSSel/MSFieldGram.ll
@@ -35,7 +35,7 @@
 
 #undef YY_DECL
 #define YY_DECL int MSFieldGramlex (YYSTYPE* lvalp)
-static string                qstr;
+static std::string                qstr;
 #include <casacore/ms/MSSel/MSSelectionTools.h>
 %}
 

--- a/ms/MSSel/MSFieldIndex.cc
+++ b/ms/MSSel/MSFieldIndex.cc
@@ -90,7 +90,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	Mesg << "Field Expression: Invalid regular expression \"" << pattern << "\"";
 	throw(MSSelectionFieldParseError(Mesg.str().c_str()));
       }
-    //    cerr << "Pattern = " << strippedPattern << "  Regex = " << reg.regexp() << endl;
+    //    cerr << "Pattern = " << strippedPattern << "  Regex = " << reg.regexp() << std::endl;
     Vector<String> names=msFieldCols_p.name().getColumn();
     Vector<Bool> flagRow=msFieldCols_p.flagRow().getColumn();
     IPosition sh(names.shape());
@@ -128,7 +128,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (regex) reg=pattern;
     else       reg=reg.fromPattern(pattern);
     
-    //    cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << endl;
+    //    cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << std::endl;
     Vector<Bool> flagRow=msFieldCols_p.flagRow().getColumn();
     Vector<String> codes=msFieldCols_p.code().getColumn();
     IPosition sh(codes.shape());

--- a/ms/MSSel/MSFieldIndex.cc
+++ b/ms/MSSel/MSFieldIndex.cc
@@ -86,7 +86,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     catch (...) // Since I (SB) don't know the type of exception Regex throws, catch them all!
       {
-	ostringstream Mesg;
+	std::ostringstream Mesg;
 	Mesg << "Field Expression: Invalid regular expression \"" << pattern << "\"";
 	throw(MSSelectionFieldParseError(Mesg.str().c_str()));
       }
@@ -356,7 +356,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     for (uInt i=0;i<ids.nelements();i++)
       if ((ids[i] < 0) || (ids[i] > (Int)fieldIds_p.nelements()-1))
 	{
-	  ostringstream intAsName;
+	  std::ostringstream intAsName;
 	  outOfRangeIdList.push_back(ids[i]);
 	  //	  throw(MSSelectionFieldParseError(Mesg.str()));
 	  //	  logIO << Mesg.str() << LogIO::WARN << LogIO::POST;
@@ -374,7 +374,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     LogIO logIO;
     if (outOfRangeIdList.size()) 
       {
-	ostringstream Mesg;
+	std::ostringstream Mesg;
 	Mesg << "Field Expression: Found out-of-range index(s) in the list (";
 	for (uInt i=0;i<outOfRangeIdList.size(); i++) Mesg << outOfRangeIdList[i] << " " ;
 	Mesg << ")" << " [TIP: Double-quoted strings forces name matching]";
@@ -382,7 +382,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     if (intAsNameIdList.size())
       {
-	ostringstream Mesg;
+	std::ostringstream Mesg;
 	Mesg << "Field Expression: Successfully parsed \"";
 	for (uInt i=0;i<intAsNameIdList.size(); i++) Mesg << intAsNameIdList[i] << " " ;
 	Mesg << "\" as name(s) and failed for the rest (please ensure this is what you intended).";

--- a/ms/MSSel/MSObservationGram.ll
+++ b/ms/MSSel/MSObservationGram.ll
@@ -35,7 +35,7 @@
 
 #undef YY_DECL
 #define YY_DECL int MSObservationGramlex (YYSTYPE* lvalp)
-static string                qstr;
+static std::string                qstr;
 #include <casacore/ms/MSSel/MSSelectionTools.h>
 %}
 

--- a/ms/MSSel/MSObservationParse.cc
+++ b/ms/MSSel/MSObservationParse.cc
@@ -75,7 +75,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       {
   	// Enumerated list of IDs can be treated as a [ID0, ID1]
   	// (range inclusive of the bounds).
-  	//	cerr << "Selecting enumerated range: " << id0 << " " << id1 << endl;
+  	//	cerr << "Selecting enumerated range: " << id0 << " " << id1 << std::endl;
   	selectRangeGEAndLE(id0,id1);
       }
     return parsedIDList_p;
@@ -139,7 +139,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     if (scanids.size() > 0)
       {
-	//	cerr << "Selecting disjoint list: " << scanids << endl;
+	//	cerr << "Selecting disjoint list: " << scanids << std::endl;
 	//TableExprNode condition = TableExprNode(ms()->col(colName).in(scanids));
 	TableExprNode condition = TableExprNode(columnAsTEN_p.in(scanids));
 	appendToIDList(scanids);

--- a/ms/MSSel/MSObservationParse.cc
+++ b/ms/MSSel/MSObservationParse.cc
@@ -99,7 +99,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 					     (columnAsTEN_p < n1));
     if ((n0 < 0) || (n1 < 0) || (n1 <= n0))
       {
-	ostringstream os;
+	std::ostringstream os;
 	os << "ObservationID Expression: Malformed range bounds " << n0 << " (lower bound) and " << n1 << " (upper bound)";
 	throw(MSSelectionObservationParseError(os.str()));
       }
@@ -121,7 +121,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
      					     (columnAsTEN_p <= n1));
     if ((n0 < 0) || (n1 < 0) || (n1 <= n0))
       {
-	ostringstream os;
+	std::ostringstream os;
 	os << "ObservationID Expression: Malformed range bounds " << n0 << " (lower bound) and " << n1 << " (upper bound)";
 	throw(MSSelectionObservationParseError(os.str()));
       }

--- a/ms/MSSel/MSPolnParse.cc
+++ b/ms/MSSel/MSPolnParse.cc
@@ -135,10 +135,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    validPolIDs[n]=polnIDs[p];
 	    validPolIndices.resize((n=validPolIndices.nelements())+1,True);
 	    validPolIndices[n]=polnIndices[p];
-	    //	    cout << "Found DDID for PolID " << polnIDs[p] << endl;
+	    //	    cout << "Found DDID for PolID " << polnIDs[p] << std::endl;
 	  }
 	// else
-	//   cout << "Not found DDID for PolID " << polnIDs[p] << endl;
+	//   cout << "Not found DDID for PolID " << polnIDs[p] << std::endl;
       }
     polnIDs.resize(0); polnIDs=validPolIDs;
     polnIndices.resize(0); polnIndices=validPolIndices;
@@ -157,9 +157,9 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Vector<Int> validPolIDs;//, validPolIndices;
     MSDataDescIndex msDDNdx(ms()->dataDescription());
     MSPolarizationIndex msPolNdx(ms()->polarization());
-    //    cout << "SpwIDs = " << spwIDs << endl;
+    //    cout << "SpwIDs = " << spwIDs << std::endl;
     polnIDs = getPolnIDsV2(polnExpr, polTypes);
-    //    cout << "PolIDs = " << polnIDs << " polTypes = " << polTypes << endl;
+    //    cout << "PolIDs = " << polnIDs << " polTypes = " << polTypes << std::endl;
     //   if (polnIDs.nelements() == 0)
    if (polTypes.nelements() == 0)
       {
@@ -171,7 +171,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       {
 	Vector<Int> tt;
 	tt = getPolnIndices(polnIDs[p],polTypes);
-	//	cout << "Poln indices for " << polnIDs[p] << " = " << tt << endl;
+	//	cout << "Poln indices for " << polnIDs[p] << " = " << tt << std::endl;
 	polnIndices.resize(0);
         polnIndices=tt;
 	thisDDList.resize(0);
@@ -188,7 +188,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		setIDLists((Int)polnIDs[p],0,polnIndices);
 		polMap_p[polnIDs[p]].resize(0);
 		polMap_p[polnIDs[p]]=polnIndices;
-		//		cout << "DDIDs for SPW = " << spwIDs[s] << " = " << tmp[0] << endl;
+		//		cout << "DDIDs for SPW = " << spwIDs[s] << " = " << tmp[0] << std::endl;
 	      }
 	  }
 	if (thisDDList.nelements() > 0) 
@@ -201,7 +201,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    // validPolIndices[n]=polnIndices[p];
 	  }
 	// else
-	//   cout << "Not found DDID for PolID " << polnIDs[p] << endl;
+	//   cout << "Not found DDID for PolID " << polnIDs[p] << std::endl;
       }
     if (ddIDs.nelements() == 0)
       {
@@ -324,7 +324,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     //  indices which will then be used for in-row selection.
     //
     polIDList=matchPolIDsToPolTableRow(idList,polMap_p, polIndices);
-    //    cout << "IDList=" << idList << " " << polIDList << " " << polIndices << endl;
+    //    cout << "IDList=" << idList << " " << polIDList << " " << polIndices << std::endl;
     return polIDList;
   }
   //  
@@ -428,13 +428,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	    // polnIDs=getPolnIDs(polnExpr, polIndices);
 	    // MSDataDescIndex msDDNdx(ms()->dataDescription());
 	    // MSPolarizationIndex msPolNdx(ms()->polarization());
-	    // cout << "PolIDs = " << polnIDs << endl;
+	    // cout << "PolIDs = " << polnIDs << std::endl;
 	    
 	    //	    tddIDList=getMapToDDIDs(msDDNdx, msPolNdx, spwIDs, polnIDs, polIndices);
-	    //	    cout << "PolExpr = " << polnExpr << endl;
+	    //	    cout << "PolExpr = " << polnExpr << std::endl;
 	    tddIDList=getMapToDDIDsV2(polnExpr, spwIDs, polnIDs, polIndices);
-	    //	    cout << "DDIDs = " << tddIDList << endl;
-	    //	    cout << "-----------------------------------" << endl;
+	    //	    cout << "DDIDs = " << tddIDList << std::endl;
+	    //	    cout << "-----------------------------------" << std::endl;
 	    tt=set_union(tddIDList, ddIDList_p);
 	    ddIDList_p.resize(0);
 	    ddIDList_p = tt;

--- a/ms/MSSel/MSPolnParse.cc
+++ b/ms/MSSel/MSPolnParse.cc
@@ -108,7 +108,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     Vector<Int> validPolIDs, validPolIndices;
     if (polnIDs.nelements() == 0)
       {
-	ostringstream mesg;
+	std::ostringstream mesg;
 	mesg << "No match for polarization ID(s) ";
 	throw(MSSelectionPolnParseError(String(mesg.str())));
       }
@@ -163,7 +163,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     //   if (polnIDs.nelements() == 0)
    if (polTypes.nelements() == 0)
       {
-	ostringstream mesg;
+	std::ostringstream mesg;
 	mesg << "No match for polarization ID(s) ";
 	throw(MSSelectionPolnParseError(String(mesg.str())));
       }
@@ -205,7 +205,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     if (ddIDs.nelements() == 0)
       {
-	ostringstream mesg;
+	std::ostringstream mesg;
 	mesg << "No match for polarization ID(s) ";
 	//	strpMSPolnGram = polnExpr.c_str();
 	throw(MSSelectionPolnParseError(String(mesg.str())));

--- a/ms/MSSel/MSSSpwErrorHandler.cc
+++ b/ms/MSSel/MSSSpwErrorHandler.cc
@@ -39,7 +39,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	if (tokenList.size() > 0)
 	  for (uInt i=0;i<tokenList.size();i++) Mesg << tokenList[i] << " ";
 	else
-	  for (uInt i=1;i<messageList.size(); i++) Mesg << endl << messageList[i];
+	  for (uInt i=1;i<messageList.size(); i++) Mesg << std::endl << messageList[i];
       }
     String casaMesg(Mesg.str());
     return casaMesg;

--- a/ms/MSSel/MSSSpwErrorHandler.cc
+++ b/ms/MSSel/MSSSpwErrorHandler.cc
@@ -32,7 +32,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   String MSSSpwErrorHandler::constructMessage()
   {
-    ostringstream Mesg;
+    std::ostringstream Mesg;
     if (messageList.size() > 0)
       {
 	Mesg << messageList[0];

--- a/ms/MSSel/MSScanGram.ll
+++ b/ms/MSSel/MSScanGram.ll
@@ -35,7 +35,7 @@
 
 #undef YY_DECL
 #define YY_DECL int MSScanGramlex (YYSTYPE* lvalp)
-static string                qstr;
+static std::string                qstr;
 #include <casacore/ms/MSSel/MSSelectionTools.h>
 %}
 

--- a/ms/MSSel/MSScanParse.cc
+++ b/ms/MSSel/MSScanParse.cc
@@ -106,7 +106,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
      					     (columnAsTEN_p < n1));
     if ((n0 < 0) || (n1 < 0) || (n1 <= n0))
       {
-	ostringstream os;
+	std::ostringstream os;
 	os << "Scan Expression: Malformed range bounds " << n0 << " (lower bound) and " << n1 << " (upper bound)";
 	throw(MSSelectionScanParseError(os.str()));
       }
@@ -126,7 +126,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 					     (columnAsTEN_p <= n1));
     if ((n0 < 0) || (n1 < 0) || (n1 <= n0))
       {
-	ostringstream os;
+	std::ostringstream os;
 	os << "Scan Expression: Malformed range bounds " << n0 << " (lower bound) and " << n1 << " (upper bound)";
 	throw(MSSelectionScanParseError(os.str()));
       }

--- a/ms/MSSel/MSScanParse.cc
+++ b/ms/MSSel/MSScanParse.cc
@@ -59,7 +59,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       {
 	// Enumerated list of IDs can be treated as a [ID0, ID1]
 	// (range inclusive of the bounds).
-	//	cerr << "Selecting enumerated range: " << id0 << " " << id1 << endl;
+	//	cerr << "Selecting enumerated range: " << id0 << " " << id1 << std::endl;
 	selectRangeGEAndLE(id0,id1);
       }
     return parsedIDList_p;
@@ -144,7 +144,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     if (scanids.size() > 0)
       {
-	//	cerr << "Selecting disjoint list: " << scanids << endl;
+	//	cerr << "Selecting disjoint list: " << scanids << std::endl;
 	TableExprNode condition = TableExprNode(columnAsTEN_p.in(scanids));
 	appendToIDList(scanids);
 	addCondition(node_p,condition);

--- a/ms/MSSel/MSSelectableTable.h
+++ b/ms/MSSel/MSSelectableTable.h
@@ -175,7 +175,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 // 		    uvdistStr,taqlStr,polnStr,scanStr,arrayStr,
 // 		    stateObsModeStr,observationStr);
 // if (msSelection.getSelectedMS(selectedMS))
-//   cerr << "Got the selected MS!" << endl;
+//   cerr << "Got the selected MS!" << std::endl;
 // else
 //   cerr << "The set of expressions resulted into null-selection";
 // </srcblock>

--- a/ms/MSSel/MSSelection.cc
+++ b/ms/MSSel/MSSelection.cc
@@ -1432,13 +1432,13 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Debug print statements
     
     //   cout << "MSSel::fromSI, at start, selectionItem.nfields=" << selectionItem.nfields()
-    //        << endl;
+    //        << std::endl;
     //   for (uInt fld=0; fld<selectionItem.nfields(); fld++) {
     //     cout << "MSSel::fromGR, fld= " << fld << ", name= "
     // 	 << selectionItem.name(fld) << ", type= "
-    // 	 << selectionItem.type(fld) << endl;
+    // 	 << selectionItem.type(fld) << std::endl;
     //   }
-    //   cout << "------------------------------------------------------" << endl;
+    //   cout << "------------------------------------------------------" << std::endl;
     
     exprOrder_p = Vector<Int>(MAX_EXPR, Int(NO_EXPR));
     
@@ -1447,31 +1447,31 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Antenna expression
     if (definedAndSet(selectionItem,"antenna")) {
       setAntennaExpr(selectionItem.asString("antenna"));
-      //    cout << antennaExpr_p << ", antenna" << endl;
+      //    cout << antennaExpr_p << ", antenna" << std::endl;
     }
 
     // Feed expression
     if (definedAndSet(selectionItem,"feed")) {
       setFieldExpr(selectionItem.asString("feed"));
-      //    cout << feedExpr_p << ", feed" << endl;
+      //    cout << feedExpr_p << ", feed" << std::endl;
     }
 
     // Field expression
     if (definedAndSet(selectionItem,"field")) {
       setFieldExpr(selectionItem.asString("field"));
-      //    cout << fieldExpr_p << ", field" << endl;
+      //    cout << fieldExpr_p << ", field" << std::endl;
     }
     
     // SPW expression
     if (definedAndSet(selectionItem,"spw")) {
       setSpwExpr(selectionItem.asString("spw"));
-      //    cout << spwExpr_p << ", spw" << endl;
+      //    cout << spwExpr_p << ", spw" << std::endl;
     }
     
     // Scan expression
     if (definedAndSet(selectionItem,"scan")) {
       setScanExpr(selectionItem.asString("scan"));
-      //    cout << scanExpr_p << ", scan" << endl;
+      //    cout << scanExpr_p << ", scan" << std::endl;
     }
     
     // Observation expression
@@ -1487,18 +1487,18 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     // Time expression
     if (definedAndSet(selectionItem,"time")) {
       setTimeExpr(selectionItem.asString("time"));
-      //    cout << timeExpr_p << ", time" << endl;
+      //    cout << timeExpr_p << ", time" << std::endl;
     }
     
     // UV Distribution expression
     if (definedAndSet(selectionItem,"uvdist")) {
       setUvDistExpr(selectionItem.asString("uvdist"));
-      //    cout << uvDistExpr_p << ", uvdist" << endl;
+      //    cout << uvDistExpr_p << ", uvdist" << std::endl;
     }
     // Poln expression
     if (definedAndSet(selectionItem,"poln")) {
       setUvDistExpr(selectionItem.asString("poln"));
-      //    cout << polnExpr_p << ", poln" << endl;
+      //    cout << polnExpr_p << ", poln" << std::endl;
     }
     
     clearErrorHandlers();

--- a/ms/MSSel/MSSelectionError.cc
+++ b/ms/MSSel/MSSelectionError.cc
@@ -52,7 +52,7 @@ void MSSelectionError::changeMessage(String& mesg)
 //
 String constructMessage(const Int pos, const String& command)
 {
-  ostringstream newMesg;
+  std::ostringstream newMesg;
   newMesg << endl << "(near char. " << pos << " in string \"" << command << "\")";
   //
   // Make a few guess about user errors and help them out 

--- a/ms/MSSel/MSSelectionError.cc
+++ b/ms/MSSel/MSSelectionError.cc
@@ -53,13 +53,13 @@ void MSSelectionError::changeMessage(String& mesg)
 String constructMessage(const Int pos, const String& command)
 {
   std::ostringstream newMesg;
-  newMesg << endl << "(near char. " << pos << " in string \"" << command << "\")";
+  newMesg << std::endl << "(near char. " << pos << " in string \"" << command << "\")";
   //
   // Make a few guess about user errors and help them out 
   // (did someone say I don't do user support? ;-))
   //
   if ((pos > 0) && (pos < (Int)command.length()) && (command[pos-1] == '-'))
-    newMesg << endl << "[TIP: Did you know we use \"~\" as the range operator (for a good reason)?]";
+    newMesg << std::endl << "[TIP: Did you know we use \"~\" as the range operator (for a good reason)?]";
   return String(newMesg.str().c_str());
 }
 //

--- a/ms/MSSel/MSSelectionErrorHandler.cc
+++ b/ms/MSSel/MSSelectionErrorHandler.cc
@@ -62,7 +62,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
   String MSSelectionErrorHandler::constructMessage()
   {
-    ostringstream Mesg;
+    std::ostringstream Mesg;
     if (messageList.size() > 0)
       {
 	Mesg << messageList[0];

--- a/ms/MSSel/MSSelectionErrorHandler.cc
+++ b/ms/MSSel/MSSelectionErrorHandler.cc
@@ -69,7 +69,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	if (tokenList.size() > 0)
 	  for (uInt i=0;i<tokenList.size();i++) Mesg << tokenList[i] << " ";
 	else
-	  for (uInt i=1;i<messageList.size(); i++) Mesg << endl << messageList[i];
+	  for (uInt i=1;i<messageList.size(); i++) Mesg << std::endl << messageList[i];
       }
     String casaMesg(Mesg.str());
     return casaMesg;

--- a/ms/MSSel/MSSelectionTools.cc
+++ b/ms/MSSel/MSSelectionTools.cc
@@ -353,7 +353,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     std::stringstream ss(s);
     std::string item;
-    vector<string> tmp;
+    std::vector<std::string> tmp;
     while(std::getline(ss, item, delim))   tmp.push_back(item);
 
     elems.resize(tmp.size());

--- a/ms/MSSel/MSSelector.cc
+++ b/ms/MSSel/MSSelector.cc
@@ -231,7 +231,7 @@ Bool MSSelector::initSelection(const Vector<Int>& dataDescId, Bool reset)
 		}
 
 		if (polVaries) {
-			os<< LogIO::WARN << "Polarization type varies with row - "<<endl<<
+			os<< LogIO::WARN << "Polarization type varies with row - "<<std::endl<<
 					"do not use selectpolarization or results will be incorrect "
 					"Assuming (falsely) the following polarizations are present:"
 					<< LogIO::POST;
@@ -1455,7 +1455,7 @@ Bool MSSelector::putData(const Record& items)
 			}
 			if (polIndex_p.nelements()>0) {
 				os << LogIO::SEVERE << "Polarization selection must be 1,2 or "
-						<< "all correlations,"<<endl<<
+						<< "all correlations,"<<std::endl<<
 						"in correct order (ie MeasurementSet order), when writing data"
 						<< LogIO::POST;
 				return False;

--- a/ms/MSSel/MSSpwGram.ll
+++ b/ms/MSSel/MSSpwGram.ll
@@ -35,7 +35,7 @@
 
 #undef YY_DECL
 #define YY_DECL int MSSpwGramlex (YYSTYPE* lvalp)
-static string                qstr;
+static std::string                qstr;
 %}
 
 WHITE     [ \t\n]*

--- a/ms/MSSel/MSSpwIndex.cc
+++ b/ms/MSSel/MSSpwIndex.cc
@@ -60,7 +60,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (regex) reg=pattern;
     else       reg=reg.fromPattern(pattern);
     
-    //  cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << endl;
+    //  cerr << "Pattern = " << pattern << "  Regex = " << reg.regexp() << std::endl;
     IPosition sh(msSpwSubTable_p.name().getColumn().shape());
     LogicalArray maskArray(sh,False);
     IPosition i=sh;
@@ -243,7 +243,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	Int nChan=chanFreqList.nelements();
 	refFreq = (chanFreqList(nChan-1)+chanFreqList(0))/2.0;;
 
-	//cout << chanFreqList[0] << " " << chanFreqList[nChan-1] << " " << f0 << " " << f1 << " " << f3 << " " << maxChanWidth << endl;
+	//cout << chanFreqList[0] << " " << chanFreqList[nChan-1] << " " << f0 << " " << f1 << " " << f3 << " " << maxChanWidth << std::endl;
 
 	switch (mode)
 	  {
@@ -542,14 +542,14 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		  //
 		  //Float start=freqList(j),stop=freqList(j+1),step=freqList(j+2);
 		  //
- 		  // cerr << "Start = " << start << " Stop = " << stop << " Step = " << step << endl;
+ 		  // cerr << "Start = " << start << " Stop = " << stop << " Step = " << step << std::endl;
  		  // MRadialVelocity vstart(Quantity(start, "km/s"), MRadialVelocity::LSRK);
  		  // MDoppler mdoppler(vstart.getValue().get(), MDoppler::RADIO);
  		  // MSDopplerUtil msdoppler(*ms_p);
  		  // msdoppler.dopplerInfo(restFreq ,spw(i), fieldid);
 		  
  		  // cout << MFrequency::fromDoppler(mdoppler, 
- 		  // 				  restFreq).getValue().getValue() << endl;
+ 		  // 				  restFreq).getValue().getValue() << std::endl;
 		}
 	    }
       }

--- a/ms/MSSel/MSSpwIndex.cc
+++ b/ms/MSSel/MSSpwIndex.cc
@@ -122,7 +122,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     if (IDs.nelements() != sourceId.nelements())
       {
 	vector<int> tt = IDs.tovector();
-	ostringstream Mesg, tok;
+	std::ostringstream Mesg, tok;
 	Mesg << "Spw Expression: No match found for ";
 	for (uInt i=0;i<sourceId.nelements();i++)
 	  {
@@ -297,7 +297,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     if (IDs.nelements()==0)
       {
-	ostringstream msg;
+	std::ostringstream msg;
 	String rangeStr(" frequency range ");
 	if (f0==f1) rangeStr=" frequency ";
 	msg << "No matching SPW found for" << rangeStr << f0;
@@ -408,7 +408,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     ArrayColumn<Double> chanFreq(msSpwSubTable_p.chanFreq());
 
     Bool someMatchFailed=False;
-    ostringstream Mesg;
+    std::ostringstream Mesg;
 
     if (nFList > 0)
       {
@@ -442,7 +442,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 		    {
 		      if (stop >= numChans(spw(i)))
 			{
-			  //			  ostringstream Mesg;
+			  //			  std::ostringstream Mesg;
 			  Mesg << "Channel " << stop << " out of range for SPW "
 			       << spw(i) << " (valid range 0~" << numChans(spw(i))-1 << ")."
 			       << " Limiting it to be within the available range.";
@@ -578,7 +578,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	//       << LogIO::WARN << LogIO::POST;
 	;
       } else {
-        ostringstream m;
+        std::ostringstream m;
         log_l << "Found no matching SPW(s) " << spw << LogIO::WARN << LogIO::POST;
         //	  log_l << m.str() << LogIO::WARN << LogIO::POST;
       }

--- a/ms/MSSel/MSSpwParse.cc
+++ b/ms/MSSel/MSSpwParse.cc
@@ -108,7 +108,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	Found = False;
 	for(Int i=0;i<nDDIDRows;i++)
 	  {
-	    //	    cerr << "DDID->SPWID: " << i << " " <<  mapDDID2SpwID(i) << endl;
+	    //	    cerr << "DDID->SPWID: " << i << " " <<  mapDDID2SpwID(i) << std::endl;
 	  if ((SpwIds(n) == mapDDID2SpwID(i)) && 
 	      (!msDataDescSubTable.flagRow()(i)) && 
 	      (!msSpwSubTable.flagRow()(SpwIds(n)))
@@ -149,7 +149,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
     if (addTen) addCondition(*node_p, condition);
 
-    //    cerr << "DDID = " << ddidList << endl;
+    //    cerr << "DDID = " << ddidList << std::endl;
 
     return node_p;
   }

--- a/ms/MSSel/MSSpwParse.cc
+++ b/ms/MSSel/MSSpwParse.cc
@@ -213,7 +213,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	  }
 	if (!Found)
 	  {
-	    ostringstream Mesg;
+	    std::ostringstream Mesg;
 	    Mesg << "No Spw ID found";
 	    throw(MSSelectionSpwError(Mesg.str()));
 	  }
@@ -306,7 +306,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
     if (tten->isNull())
       {
-	ostringstream Mesg;
+	std::ostringstream Mesg;
 	Mesg << "No Spw ID(s) matched specifications ";
 	throw(MSSelectionSpwError(Mesg.str()));
       }

--- a/ms/MSSel/MSStateGram.ll
+++ b/ms/MSSel/MSStateGram.ll
@@ -35,7 +35,7 @@
 
 #undef YY_DECL
 #define YY_DECL int MSStateGramlex (YYSTYPE* lvalp)
-static string                qstrState;
+static std::string                qstrState;
 #include <casacore/ms/MSSel/MSSelectionTools.h>
 %}
 

--- a/ms/MSSel/MSStateIndex.cc
+++ b/ms/MSSel/MSStateIndex.cc
@@ -89,7 +89,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	Mesg << "State Expression: Invalid regular expression \"" << pattern << "\"";
 	throw(MSSelectionStateParseError(Mesg.str().c_str()));
       }
-    //cerr << "Pattern = " << strippedPattern << "  Regex = " << reg.regexp() << endl;
+    //cerr << "Pattern = " << strippedPattern << "  Regex = " << reg.regexp() << std::endl;
     IPosition sh(msStateCols_p.obsMode().getColumn().shape());
     LogicalArray maskArray(sh,False);
     IPosition i=sh;

--- a/ms/MSSel/MSStateIndex.cc
+++ b/ms/MSSel/MSStateIndex.cc
@@ -85,7 +85,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
       }
     catch (...) // Since I (SB) don't know the type of exception Regex throws, catch them all!
       {
-	ostringstream Mesg;
+	std::ostringstream Mesg;
 	Mesg << "State Expression: Invalid regular expression \"" << pattern << "\"";
 	throw(MSSelectionStateParseError(Mesg.str().c_str()));
       }

--- a/ms/MSSel/MSTimeParse.cc
+++ b/ms/MSSel/MSTimeParse.cc
@@ -389,21 +389,21 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
   {
     if (tf.year < 1858) // This is not precise (should be < Wed Nov 17 00:00:00 1858)
       {                                       
-	ostringstream mesg;
+	std::ostringstream mesg;
 	mesg << "MSTime Selection error: Year = " << tf.year << " out of range";
 	//	throw(MSSelectionTimeError(mesg.str()));
 	throw(AipsError(mesg.str()));
       }
     if ((tf.month <= 0) || (tf.month > 12)) 
       {
-	ostringstream mesg;
+	std::ostringstream mesg;
 	mesg << "MSTime Selection error: Month = " << tf.month << " out of range";
 	//	throw(MSSelectionTimeError(mesg.str()));
 	throw(AipsError(mesg.str()));
       }
     if ((tf.day <= 0) || (tf.day > 31)) 
       {
-	ostringstream mesg;
+	std::ostringstream mesg;
 	mesg << "MSTime Selection error: Day = " << tf.day << " out of range";
 	//	throw(MSSelectionTimeError(mesg.str()));
 	throw(AipsError(mesg.str()));

--- a/ms/MSSel/MSTimeParse.cc
+++ b/ms/MSSel/MSTimeParse.cc
@@ -167,7 +167,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
     firstRowTime = mainColumn_p->timeQuant()(firstLogicalRow);
 
-    //    cout << firstRowTime.string(MVTime::DMY,7) << endl;
+    //    cout << firstRowTime.string(MVTime::DMY,7) << std::endl;
 
     Time t0(firstRowTime.getTime());
 
@@ -380,7 +380,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 	if (tf.sec == -1)      tf.sec=0;
 	if (tf.fsec == -1)     tf.fsec = 0;
       }
-    //    cout << tf.year << " " << tf.month << " " << tf.day << " " << endl;
+    //    cout << tf.year << " " << tf.month << " " << tf.day << " " << std::endl;
   }
   //
   //-------------------------------------------------------------------

--- a/ms/MSSel/test/tMSAntennaGram.cc
+++ b/ms/MSSel/test/tMSAntennaGram.cc
@@ -62,43 +62,43 @@ int main(int argc, const char* argv[])
 {
   try {
     if(argc < 3) {
-      cout << "Please input ms file and selection string on command line " << endl;
+      cout << "Please input ms file and selection string on command line " << std::endl;
       return 3;
     } 
     const String msName = argv[1];
-    cout << "ms file is  " << msName << endl;
+    cout << "ms file is  " << msName << std::endl;
     MeasurementSet ms(msName);
     MSSelection mss;
     mss.setAntennaExpr(String(argv[2]));
     TableExprNode node = mss.toTableExprNode(&ms);
 
     MeasurementSet* mssel = 0;
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     Vector<Int> selectedAnt1, selectedAnt2;
     Matrix<Int> selectedBaselines;
     node = msAntennaGramParseCommand(&ms, argv[2],
                                      selectedAnt1, selectedAnt2,
                                      selectedBaselines);
     if(node.isNull()) {
-      cout << "NULL node " << endl;
+      cout << "NULL node " << std::endl;
       return 0;
     }
-    cout << "TableExprNode has rows = " << node.nrow() << endl;
+    cout << "TableExprNode has rows = " << node.nrow() << std::endl;
     Table tablesel(ms.tableName(), Table::Update);
     mssel = new MeasurementSet(tablesel(node, node.nrow() ));
     mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::New);
     mssel->flush();
     if(mssel->nrow()==0) {
-      cout << "Check your input, No data selected" << endl;
+      cout << "Check your input, No data selected" << std::endl;
     }
     else {
-      cout << "selected table has rows " << mssel->nrow() << endl;
-      cout << "selected ant1 = " << selectedAnt1 << endl
-           << "selected ant2 = " << selectedAnt2 << endl;
+      cout << "selected table has rows " << mssel->nrow() << std::endl;
+      cout << "selected ant1 = " << selectedAnt1 << std::endl
+           << "selected ant2 = " << selectedAnt2 << std::endl;
     }
     delete mssel;
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MSSel/test/tMSAntennaGram2.cc
+++ b/ms/MSSel/test/tMSAntennaGram2.cc
@@ -63,45 +63,45 @@ int main(int argc, const char* argv[])
   try 
     {
       if(argc < 3)  {
-	cout << "Please input ms file and selection string on command line " << endl;
+	cout << "Please input ms file and selection string on command line " << std::endl;
         return 3;
       }
       const String msName = argv[1];
-      cout << "ms file is  " << msName << endl;
+      cout << "ms file is  " << msName << std::endl;
       MeasurementSet ms(msName);
       MSSelection mss;
       for(Int i=2;i<argc;i++)
 	{
-	  cout << "Parsing expression: " << argv[i] << endl;
+	  cout << "Parsing expression: " << argv[i] << std::endl;
 	  mss.setAntennaExpr(String(argv[i]));
 	}
       TableExprNode node = mss.toTableExprNode(&ms);
       
       MeasurementSet* mssel = 0;
-      cout << "Original table has rows " << ms.nrow() << endl;
+      cout << "Original table has rows " << ms.nrow() << std::endl;
       if(node.isNull()) 
 	{
-	  cout << "NULL node " << endl;
+	  cout << "NULL node " << std::endl;
 	  return 0;
 	}
-      cout << "TableExprNode has rows = " << node.nrow() << endl;
+      cout << "TableExprNode has rows = " << node.nrow() << std::endl;
       Table tablesel(ms.tableName(), Table::Update);
       mssel = new MeasurementSet(tablesel(node, node.nrow() ));
       mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::New);
       mssel->flush();
       if(mssel->nrow()==0) 
-        cout << "Check your input, No data selected" << endl;
+        cout << "Check your input, No data selected" << std::endl;
       else 
 	{
-	  cout << "selected table has rows " << mssel->nrow() << endl;
-	  cout << "selected ant1 = " << mss.getAntenna1List() << endl
-	       << "selected ant2 = " << mss.getAntenna2List() << endl;
+	  cout << "selected table has rows " << mssel->nrow() << std::endl;
+	  cout << "selected ant1 = " << mss.getAntenna1List() << std::endl
+	       << "selected ant2 = " << mss.getAntenna2List() << std::endl;
 	}
       delete mssel;
     } 
   catch (std::exception& x) 
     {
-      cout << "ERROR: " << x.what() << endl;
+      cout << "ERROR: " << x.what() << std::endl;
       return 1;
     } 
   return 0;

--- a/ms/MSSel/test/tMSAntennaGram3.cc
+++ b/ms/MSSel/test/tMSAntennaGram3.cc
@@ -74,15 +74,15 @@ void makeMS()
 
 void doSel (const MeasurementSet& ms, const String& command, bool showBL=False)
 {
-  cout << command << endl;
+  cout << command << std::endl;
   Vector<Int> selectedAnts1;
   Vector<Int> selectedAnts2;
   Matrix<Int> selectedBaselines;
   msAntennaGramParseCommand (&ms, command,
                              selectedAnts1, selectedAnts2, selectedBaselines);
-  cout << "  " << selectedAnts1 << ' ' << selectedAnts2 << endl;
+  cout << "  " << selectedAnts1 << ' ' << selectedAnts2 << std::endl;
   if (showBL) {
-    cout << "  " << selectedBaselines << endl;
+    cout << "  " << selectedBaselines << std::endl;
   }
 }
 
@@ -123,7 +123,7 @@ int main()
     makeMS();
     selMS();
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MSSel/test/tMSCorrGram.cc
+++ b/ms/MSSel/test/tMSCorrGram.cc
@@ -61,20 +61,20 @@ int main(int argc, const char* argv[])
 {
   try {
     if(argc<3) {
-      cout << " please input ms file and selection string on command line " << endl;
+      cout << " please input ms file and selection string on command line " << std::endl;
       return 0;
     }
     const String msName = argv[1];
     MeasurementSet ms(msName);
     MeasurementSet * mssel;
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     if(msCorrGramParseCommand(&ms, argv[2])==0) {
       const TableExprNode *node = msCorrGramParseNode();
       if(node->isNull()) {
-	cout << "NULL node " << endl;
+	cout << "NULL node " << std::endl;
 	return 0;
       }
-      cout << "TableExprNode has rows = " << node->nrow() << endl;
+      cout << "TableExprNode has rows = " << node->nrow() << std::endl;
       Table tablesel(ms.tableName(), Table::Update);
       mssel = new MeasurementSet(tablesel(*node, node->nrow() ));
 
@@ -82,18 +82,18 @@ int main(int argc, const char* argv[])
       if(mssel->isColumnWritable("SELECTED_DATA"))
 	mssel->flush();
       if(mssel->nrow()==0) {
-        cout << "Check your input, No data selected" << endl;
+        cout << "Check your input, No data selected" << std::endl;
       }
       else {
-        cout << "selected table has rows " << mssel->nrow() << endl;
+        cout << "selected table has rows " << mssel->nrow() << std::endl;
       }
       delete mssel;
     }
     else {
-      cout << "failed to parse expression" << endl;
+      cout << "failed to parse expression" << std::endl;
     }
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MSSel/test/tMSFeedGram.cc
+++ b/ms/MSSel/test/tMSFeedGram.cc
@@ -62,25 +62,25 @@ int main(int argc, const char* argv[])
 {
   try {
     if(argc < 3) {
-      cout << "Please input ms file and selection string on command line " << endl;
+      cout << "Please input ms file and selection string on command line " << std::endl;
       return 3;
     } 
     const String msName = argv[1];
-    cout << "ms file is  " << msName << endl;
+    cout << "ms file is  " << msName << std::endl;
     MeasurementSet ms(msName);
     MSSelection mss;
     mss.setFeedExpr(String(argv[2]));
-    cout << "feed selection is " << String(argv[2]) << endl;
+    cout << "feed selection is " << String(argv[2]) << std::endl;
     TableExprNode node = mss.toTableExprNode(&ms);
 
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     Vector<Int> selectedFeed1, selectedFeed2;
     Matrix<Int> selectedFeedPairs;
     node = msFeedGramParseCommand(&ms, argv[2],
                                      selectedFeed1, selectedFeed2,
                                      selectedFeedPairs);
     if(node.isNull()) {
-      cout << "NULL node " << endl;
+      cout << "NULL node " << std::endl;
       return 0;
     }
     Table tablesel(ms.tableName(), Table::Update);
@@ -88,16 +88,16 @@ int main(int argc, const char* argv[])
     mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::New);
     mssel->flush();
     if(mssel->nrow()==0) {
-      cout << "Check your input, No data selected" << endl;
+      cout << "Check your input, No data selected" << std::endl;
     }
     else {
-      cout << "Selected table has nrows " << mssel->nrow() << endl;
-      cout << "Selected feed1 = " << selectedFeed1 << endl
-           << "Selected feed2 = " << selectedFeed2 << endl;
+      cout << "Selected table has nrows " << mssel->nrow() << std::endl;
+      cout << "Selected feed1 = " << selectedFeed1 << std::endl
+           << "Selected feed2 = " << selectedFeed2 << std::endl;
     }
     delete mssel;
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MSSel/test/tMSFieldGram.cc
+++ b/ms/MSSel/test/tMSFieldGram.cc
@@ -62,39 +62,39 @@ int main(int argc, const char* argv[])
     {
       if(argc < 3) 
       {
-	cout << "Please input selection string on command line " << endl;
+	cout << "Please input selection string on command line " << std::endl;
 	return 0;
       } 
     
     const String msName = argv[1];
     MeasurementSet ms(msName);
     MeasurementSet * mssel;
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     Vector<Int> selectedIDs;
     TableExprNode colAsTen=ms.col(MS::columnName(MS::FIELD_ID));
     const TableExprNode node = msFieldGramParseCommand(ms.field(), colAsTen, argv[2],selectedIDs);
     if(node.isNull()) 
       {
-	cout << "NULL node " << endl;
+	cout << "NULL node " << std::endl;
 	return 0;
       }
-    cout << "TableExprNode has rows = " << node.nrow() << endl;
+    cout << "TableExprNode has rows = " << node.nrow() << std::endl;
     Table tablesel(ms.tableName(), Table::Update);
     mssel = new MeasurementSet(tablesel(node, node.nrow() ));
     mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::Scratch);
     mssel->flush();
     if(mssel->nrow()==0)
-      cout << "Check your input, No data selected" << endl;
+      cout << "Check your input, No data selected" << std::endl;
     else 
       {
-	cout << "selected table has rows " << mssel->nrow() << endl;
-	cout << "Field IDs selected = " << selectedIDs << endl;
+	cout << "selected table has rows " << mssel->nrow() << std::endl;
+	cout << "Field IDs selected = " << selectedIDs << std::endl;
       }
     delete mssel;
   }
   catch (std::exception& x) 
     {
-      cout << "ERROR: " << x.what() << endl;
+      cout << "ERROR: " << x.what() << std::endl;
       return 1;
     } 
   return 0;

--- a/ms/MSSel/test/tMSScanGram.cc
+++ b/ms/MSSel/test/tMSScanGram.cc
@@ -60,37 +60,37 @@
 int main(int argc, const char* argv[])
 {
   if (argc != 2) {
-    cout << "Usage: "<< argv[0] << " MS_filename" << endl;
+    cout << "Usage: "<< argv[0] << " MS_filename" << std::endl;
     return 0;
   }
   try {
-    cout << "before ms constructor called " << endl;
+    cout << "before ms constructor called " << std::endl;
     const String msName = argv[1];
     MeasurementSet ms(msName);
     MeasurementSet * mssel;
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     Vector<Int> selectedIds;
     const TableExprNode node = msScanGramParseCommand(&ms, "1", selectedIds);
     if (!node.isNull()) {
-      cout << "TableExprNode has rows = " << node.nrow() << endl;
+      cout << "TableExprNode has rows = " << node.nrow() << std::endl;
       Table tablesel(ms.tableName(), Table::Update);
       mssel = new MeasurementSet(tablesel(node, node.nrow() ));
-      cout << "After mssel constructor called " << endl;
+      cout << "After mssel constructor called " << std::endl;
       mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::Scratch);
       mssel->flush();
       if(mssel->nrow()==0) {
-	cout << "Check your input, No data selected" << endl;
+	cout << "Check your input, No data selected" << std::endl;
       }
       else {
-	cout << "selected table has rows " << mssel->nrow() << endl;
+	cout << "selected table has rows " << mssel->nrow() << std::endl;
       }
       delete mssel;
     }
     else {
-      cout << "ERROR: failed to parse expression " << endl;
+      cout << "ERROR: failed to parse expression " << std::endl;
     }
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MSSel/test/tMSSelection.cc
+++ b/ms/MSSel/test/tMSSelection.cc
@@ -90,10 +90,10 @@ void showTableCache()
 
   Int n=lockedTables.nelements();
   if(n > 0)
-    cout << endl << "####WARNING!!!!: The Table Cache has the following " << n << " entries:"  << endl;
+    cout << std::endl << "####WARNING!!!!: The Table Cache has the following " << n << " entries:"  << std::endl;
   
   for (Int i=0; i<n; ++i) 
-    cout << "    " << i << ": \"" <<  lockedTables(i) << "\"" << endl;
+    cout << "    " << i << ": \"" <<  lockedTables(i) << "\"" << std::endl;
 }
 //
 //-------------------------------------------------------------------------
@@ -106,60 +106,60 @@ void printBaselineList(Matrix<Int> list,ostream& os)
     {
       for(Int i=0;i<shp(0);i++)
 	os << list(i,j) << " ";
-      os << endl << "\t            " ;
+      os << std::endl << "\t            " ;
     }
-  os << endl;
+  os << std::endl;
 }
 //
 //-------------------------------------------------------------------------
 //
 void printInfo(MSSelection& msSelection, Int& nRows)
 {
-  cout << "BE: Baseline Expr=" << msSelection.getExpr(MSSelection::ANTENNA_EXPR) << endl;
-  cout << "\tBE: Ant1         = " << msSelection.getAntenna1List() << endl;
-  cout << "\tBE: Ant2         = " << msSelection.getAntenna2List() << endl;
+  cout << "BE: Baseline Expr=" << msSelection.getExpr(MSSelection::ANTENNA_EXPR) << std::endl;
+  cout << "\tBE: Ant1         = " << msSelection.getAntenna1List() << std::endl;
+  cout << "\tBE: Ant2         = " << msSelection.getAntenna2List() << std::endl;
   printBaselineList(msSelection.getBaselineList(),cout);
-  //  cout << "Baselines    = " << msSelection.getBaselineList() << endl;
+  //  cout << "Baselines    = " << msSelection.getBaselineList() << std::endl;
 
-  cout << "FE: Field Expr=" << msSelection.getExpr(MSSelection::FIELD_EXPR) << endl;
-  cout << "\tFE: Field        = " << msSelection.getFieldList()    << endl;
+  cout << "FE: Field Expr=" << msSelection.getExpr(MSSelection::FIELD_EXPR) << std::endl;
+  cout << "\tFE: Field        = " << msSelection.getFieldList()    << std::endl;
 
-  cout << "SE: SPW Expr=" << msSelection.getExpr(MSSelection::SPW_EXPR) << endl;
-  cout << "\tSE: SPW          = " << msSelection.getSpwList()      << endl;
-  cout << "\tSE: Chan         = " << msSelection.getChanList(NULL,1,True)     << endl;
-  cout << "\tSE: Freq         = " << msSelection.getChanFreqList(NULL,True)     << endl;
+  cout << "SE: SPW Expr=" << msSelection.getExpr(MSSelection::SPW_EXPR) << std::endl;
+  cout << "\tSE: SPW          = " << msSelection.getSpwList()      << std::endl;
+  cout << "\tSE: Chan         = " << msSelection.getChanList(NULL,1,True)     << std::endl;
+  cout << "\tSE: Freq         = " << msSelection.getChanFreqList(NULL,True)     << std::endl;
 
-  cout << "ScE: Scan Expr=" << msSelection.getExpr(MSSelection::SCAN_EXPR) << endl;
-  cout << "\tScE: tScan         = " << msSelection.getScanList()     << endl;
+  cout << "ScE: Scan Expr=" << msSelection.getExpr(MSSelection::SCAN_EXPR) << std::endl;
+  cout << "\tScE: tScan         = " << msSelection.getScanList()     << std::endl;
   
-  cout << "StE: STATE Expr=" << msSelection.getExpr(MSSelection::STATE_EXPR) << endl;
-  cout << "\tStE: StateObsMode = " << msSelection.getStateObsModeList()     << endl;
+  cout << "StE: STATE Expr=" << msSelection.getExpr(MSSelection::STATE_EXPR) << std::endl;
+  cout << "\tStE: StateObsMode = " << msSelection.getStateObsModeList()     << std::endl;
 
-  cout << "AE: Array Expr=" << msSelection.getExpr(MSSelection::ARRAY_EXPR) << endl;
-  cout << "\tAE: Array        = " << msSelection.getSubArrayList() << endl;
+  cout << "AE: Array Expr=" << msSelection.getExpr(MSSelection::ARRAY_EXPR) << std::endl;
+  cout << "\tAE: Array        = " << msSelection.getSubArrayList() << std::endl;
 
-  cout << "TE: Time Expr=" << msSelection.getExpr(MSSelection::TIME_EXPR) << endl;
-  cout << "\tTE: Time         = " << msSelection.getTimeList()     << endl;
+  cout << "TE: Time Expr=" << msSelection.getExpr(MSSelection::TIME_EXPR) << std::endl;
+  cout << "\tTE: Time         = " << msSelection.getTimeList()     << std::endl;
 
-  cout << "UVE: UVRange Expr=" << msSelection.getExpr(MSSelection::UVDIST_EXPR) << endl;
-  cout << "\tUVE: UVRange      = " << msSelection.getUVList()       << endl;
-  cout << "\tUVE: UV in meters = " << msSelection.getUVUnitsList()  << endl;
+  cout << "UVE: UVRange Expr=" << msSelection.getExpr(MSSelection::UVDIST_EXPR) << std::endl;
+  cout << "\tUVE: UVRange      = " << msSelection.getUVList()       << std::endl;
+  cout << "\tUVE: UV in meters = " << msSelection.getUVUnitsList()  << std::endl;
 
-  cout << "OE: Observation Expr=" << msSelection.getExpr(MSSelection::OBSERVATION_EXPR) << endl;
-  cout << "\tOE: ObservationIDList    = " << msSelection.getObservationList() << endl;
+  cout << "OE: Observation Expr=" << msSelection.getExpr(MSSelection::OBSERVATION_EXPR) << std::endl;
+  cout << "\tOE: ObservationIDList    = " << msSelection.getObservationList() << std::endl;
 
-  cout << "PE: Poln Expr=" << msSelection.getExpr(MSSelection::POLN_EXPR) << endl;
-  cout << "\tPE: PolMap       = " << msSelection.getPolMap()       << endl;
-  cout << "\tPE: CorrMap      = " << msSelection.getCorrMap( )     << endl;
+  cout << "PE: Poln Expr=" << msSelection.getExpr(MSSelection::POLN_EXPR) << std::endl;
+  cout << "\tPE: PolMap       = " << msSelection.getPolMap()       << std::endl;
+  cout << "\tPE: CorrMap      = " << msSelection.getCorrMap( )     << std::endl;
 
-  cout << endl << "===========================================================" << endl;
-  cout << "DDIDs(Poln)  = " << msSelection.getDDIDList()     << endl;
-  cout << "DDIDs(SPW)   = " << msSelection.getSPWDDIDList()     << endl;
-  cout << "StateList    = " << msSelection.getStateObsModeList() << endl;
+  cout << std::endl << "===========================================================" << std::endl;
+  cout << "DDIDs(Poln)  = " << msSelection.getDDIDList()     << std::endl;
+  cout << "DDIDs(SPW)   = " << msSelection.getSPWDDIDList()     << std::endl;
+  cout << "StateList    = " << msSelection.getStateObsModeList() << std::endl;
 
-  if (nRows >= 0) cout << "Number of selected rows: " << nRows << endl;
+  if (nRows >= 0) cout << "Number of selected rows: " << nRows << std::endl;
 
-  if (nRows > 0) cout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
+  if (nRows > 0) cout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 }
 //
 //-------------------------------------------------------------------------
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
     			  uvdistStr,taqlStr,polnStr,scanStr,arrayStr,
     			  stateObsModeStr,observationStr);
     	// TableExprNode ten=msSelection.toTableExprNode(&msInterface);
-    	// cerr << "TEN rows = " << ten.nrow() << endl;
+    	// cerr << "TEN rows = " << ten.nrow() << std::endl;
 
 	Int nRows=0;
 	try
@@ -245,9 +245,9 @@ int main(int argc, char **argv)
     	  {
     	    cout << "###Informational:  Nothing selected.  ";
     	    if (OutMSBuf != "")
-    	      cout << "New MS not written." << endl;
+    	      cout << "New MS not written." << std::endl;
     	    else
-    	      cout << endl;
+    	      cout << std::endl;
     	  }
     	else
 	  {
@@ -260,8 +260,8 @@ int main(int argc, char **argv)
       }
     catch (MSSelectionError& x)
       {
-    	cout << "###MSSelectionError: " << x.what() << endl;
-	cout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
+    	cout << "###MSSelectionError: " << x.what() << std::endl;
+	cout << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
       }
     //
     // Catch any exception thrown by AIPS++ libs.  Do your cleanup here
@@ -272,11 +272,11 @@ int main(int argc, char **argv)
     //
     catch (AipsError& x)
       {
-    	cout << "###AipsError: " << x.what() << endl;
+    	cout << "###AipsError: " << x.what() << std::endl;
       }
     catch (std::exception& x)
       {
-    	cout << "###std::exception: " << x.what() << endl;
+    	cout << "###std::exception: " << x.what() << std::endl;
       }
   }
   //

--- a/ms/MSSel/test/tMSSpwGram.cc
+++ b/ms/MSSel/test/tMSSpwGram.cc
@@ -61,7 +61,7 @@ int main(int argc, const char* argv[])
 {
   try {
     if(argc<3) {
-      cout << " please input ms file and selection string on command line " << endl;
+      cout << " please input ms file and selection string on command line " << std::endl;
       return 0;
     }
     const String msName = argv[1];
@@ -69,32 +69,32 @@ int main(int argc, const char* argv[])
     MeasurementSet * mssel;
     Vector<Int> selectedIDs;
     Matrix<Int> selectedChans;
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     if(msSpwGramParseCommand(&ms, argv[2], selectedIDs, selectedChans)==0) {
       const TableExprNode *node = msSpwGramParseNode();
       if(node->isNull()) {
-	cout << "NULL node " << endl;
+	cout << "NULL node " << std::endl;
 	return 0;
       }
-      cout << "TableExprNode has rows = " << node->nrow() << endl;
+      cout << "TableExprNode has rows = " << node->nrow() << std::endl;
       Table tablesel(ms.tableName(), Table::Update);
       mssel = new MeasurementSet(tablesel(*node, node->nrow() ));
       mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::Scratch);
       mssel->flush();
       if(mssel->nrow()==0) {
-        cout << "Check your input, No data selected" << endl;
+        cout << "Check your input, No data selected" << std::endl;
       }
       else {
-        cout << "selected table has rows " << mssel->nrow() << endl;
-	cout << "Selected IDs = " << selectedIDs << endl;
+        cout << "selected table has rows " << mssel->nrow() << std::endl;
+	cout << "Selected IDs = " << selectedIDs << std::endl;
       }
       delete mssel;
     }
     else {
-      cout << "failed to parse expression" << endl;
+      cout << "failed to parse expression" << std::endl;
     }
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MSSel/test/tMSTimeGram.cc
+++ b/ms/MSSel/test/tMSTimeGram.cc
@@ -73,26 +73,26 @@ int main(int argc, const char* argv[])
       const String msName = argv[1];
       MeasurementSet ms(msName);
       MeasurementSet * mssel;
-      cout << "Original table has rows " << ms.nrow() << endl;
+      cout << "Original table has rows " << ms.nrow() << std::endl;
       MSSelection mss;
       mss.setTimeExpr(String(argv[2]));
       TableExprNode node=mss.toTableExprNode(&ms);
 
-      cout << "TableExprNode has rows = " << node.nrow() << endl;
+      cout << "TableExprNode has rows = " << node.nrow() << std::endl;
       Table tablesel(ms.tableName(), Table::Update);
       mssel = new MeasurementSet(tablesel(node, node.nrow() ));
-      cout << "After mssel constructor called " << endl;
+      cout << "After mssel constructor called " << std::endl;
       mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::Scratch);
       mssel->flush();
       if(mssel->nrow()==0) 
-	cout << "Check your input, No data selected" << endl;
+	cout << "Check your input, No data selected" << std::endl;
       else 
-	cout << "selected table has rows " << mssel->nrow() << endl;
+	cout << "selected table has rows " << mssel->nrow() << std::endl;
       delete mssel;
     } 
   catch (std::exception& x) 
     {
-      cout << "ERROR: " << x.what() << endl;
+      cout << "ERROR: " << x.what() << std::endl;
       return 1;
     } 
   return 0;

--- a/ms/MSSel/test/tMSUvDistGram.cc
+++ b/ms/MSSel/test/tMSUvDistGram.cc
@@ -61,38 +61,38 @@ int main(int argc, const char* argv[])
 {
   try {
     if(argc<3){
-      cout << "Please input MS file and selection string on command line " << endl;
+      cout << "Please input MS file and selection string on command line " << std::endl;
       return 0;
     }
     const String msName = argv[1];
     MeasurementSet ms(msName);
     MeasurementSet * mssel;
-    cout << "Select from " << msName << endl;
-    cout << "Original table has rows " << ms.nrow() << endl;
+    cout << "Select from " << msName << std::endl;
+    cout << "Original table has rows " << ms.nrow() << std::endl;
     if(msUvDistGramParseCommand(&ms, argv[2])==0) {
       const TableExprNode *node = msUvDistGramParseNode();
       if(node->isNull()) {
-	cout << "NULL node " << endl;
+	cout << "NULL node " << std::endl;
 	return 0;
       }
-      cout << "TableExprNode has rows = " << node->nrow() << endl;
+      cout << "TableExprNode has rows = " << node->nrow() << std::endl;
       Table tablesel(ms.tableName(), Table::Update);
       mssel = new MeasurementSet(tablesel(*node, node->nrow() ));
       mssel->rename(ms.tableName()+"/SELECTED_TABLE", Table::Scratch);
       mssel->flush();
       if(mssel->nrow()==0) {
-        cout << "Check your input, No data selected" << endl;
+        cout << "Check your input, No data selected" << std::endl;
       }
       else {
-        cout << "selected table has rows " << mssel->nrow() << endl;
+        cout << "selected table has rows " << mssel->nrow() << std::endl;
       }
       delete mssel;
     }
     else {
-      cout << "failed to parse expression" << endl;
+      cout << "failed to parse expression" << std::endl;
     }
   } catch (std::exception& x) {
-    cout << "ERROR: " << x.what() << endl;
+    cout << "ERROR: " << x.what() << std::endl;
     return 1;
   } 
   return 0;

--- a/ms/MeasurementSets.h
+++ b/ms/MeasurementSets.h
@@ -239,16 +239,16 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //      // Create the RO column access objects for main table and subtables
 //      MSColumns msc(ms);
 //      // show data from row 5
-//      cout << msc.data()(5) << endl;
+//      cout << msc.data()(5) << std::endl;
 //      // show phase center for row 3 in field table
 //      Vector<double> phaseCtr=msc.field().phaseCenter()(3);
-//      cout << phaseCtr<<endl;
+//      cout << phaseCtr<<std::endl;
 //      // now create a Measure for the phaseCenter
 //      MDirection phaseCenterMeasure =
 //         MS::directionMeasure(msc.field().phaseCenter());
 //      // put the value from row 3 in the Measure and print it
 //      phaseCenterMeasure.set(MVPosition(phaseCtr));
-//      cout <<"phase center:"<< phaseCenterMeasure<<endl;
+//      cout <<"phase center:"<< phaseCenterMeasure<<std::endl;
 //
 // </srcblock>
 //

--- a/ms/MeasurementSets/MSField.cc
+++ b/ms/MeasurementSets/MSField.cc
@@ -216,7 +216,7 @@ Bool MSField::addEphemeris(const uInt id, const String& inputEphemTableName,
     }
     if(Table::isReadable(inputEphemTableName)){
       Directory inputDir(inputEphemTableName);
-      stringstream ss;
+      std::stringstream ss;
       ss << "/EPHEM" << id << "_" << comment << ".tab";
       String destTableName = Path(this->tableName()).absoluteName() + String(ss.str());
       removeEphemeris(id); // remove preexisting ephemerides with the same id
@@ -231,7 +231,7 @@ Bool MSField::removeEphemeris(const uInt id){
 
   Bool rval=True;
   Directory fieldDir(Path(this->tableName()).absoluteName());
-  stringstream ss;
+  std::stringstream ss;
   ss << "EPHEM" << id << "_*.tab";
   Regex ephemTableRegex (Regex::fromPattern(ss.str()));
   Vector<String> candidates = fieldDir.find(ephemTableRegex, True, False); // followSymLinks=True, recursive=False

--- a/ms/MeasurementSets/MSFieldColumns.cc
+++ b/ms/MeasurementSets/MSFieldColumns.cc
@@ -421,7 +421,7 @@ void MSFieldColumns::updateMeasComets()
   Vector<Int> ephId = ephemerisId_p.getColumn();
   for(size_t i=0; i<ephId.size(); i++){
     Int theEphId = ephId(i);
-    //cout << "updateMeasComet: processing row " << i << ", found eph id " << theEphId << endl;
+    //cout << "updateMeasComet: processing row " << i << ", found eph id " << theEphId << std::endl;
     if(theEphId>=0 
        && ephIdToMeasComet_p.find(theEphId) == ephIdToMeasComet_p.end()){
       // the id is not yet in use, need to create a new MeasComet object
@@ -446,7 +446,7 @@ void MSFieldColumns::updateMeasComets()
       measCometsV_p(nMeasCom) = mC;
       // remember the connection ephId to the measCometsV_p index
       ephIdToMeasComet_p.insert(std::make_pair(theEphId, nMeasCom)); 
-      //cout << "Found and successfully opened ephemeris table " << ephemTablePath << endl;
+      //cout << "Found and successfully opened ephemeris table " << ephemTablePath << std::endl;
     }
   }
 } 

--- a/ms/MeasurementSets/MSFieldColumns.cc
+++ b/ms/MeasurementSets/MSFieldColumns.cc
@@ -201,7 +201,7 @@ MRadialVelocity MSFieldColumns::radVelMeas(rownr_t row, Double interTime) const
       MVRadialVelocity mvradvel;
     
       if(!measCometsV_p(index)->getRadVel(mvradvel, interMJD)){
-	stringstream ss;
+	std::stringstream ss;
 	ss << "MSFieldColumns::radVelMeas(...) - No valid ephemeris entry for MJD " 
 	   << setprecision(11) << interMJD << " for field " << row;
 	throw(AipsError(ss.str()));
@@ -240,7 +240,7 @@ Quantity MSFieldColumns::rho(rownr_t row, Double interTime) const
     
       MVPosition mvpos;
       if(!measCometsV_p(index)->get(mvpos, interMJD)){
-	stringstream ss;
+	std::stringstream ss;
 	ss << "MSFieldColumns::rho(...) - No valid ephemeris entry for MJD " 
 	   << setprecision(11) << interMJD << " for field " << row;
 	throw(AipsError(ss.str()));
@@ -428,7 +428,7 @@ void MSFieldColumns::updateMeasComets()
       
       // find the table belonging to this id
       Directory fieldDir(measCometsPath_p);
-      stringstream ss;
+      std::stringstream ss;
       ss << theEphId;
       Regex ephemTableRegex (Regex::fromPattern("EPHEM"+ss.str()+"_*\\.tab"));
       Vector<String> candidates = fieldDir.find(ephemTableRegex, True, False); // followSymLinks=True, recursive=False
@@ -468,7 +468,7 @@ MDirection MSFieldColumns::extractDirMeas(const MDirection& offsetDir,
     
     MVPosition xmvpos;
     if(!measCometsV_p(index)->get(xmvpos, interMJD)){
-      stringstream ss;
+      std::stringstream ss;
       ss << "MSFieldColumns::extractDirMeas(...) - No valid ephemeris entry for MJD " 
 	 << setprecision(11) << interMJD << " in ephemeris " << measCometsV_p(index)->getTablePath();
       throw(AipsError(ss.str()));

--- a/ms/MeasurementSets/MSIter.cc
+++ b/ms/MeasurementSets/MSIter.cc
@@ -388,7 +388,7 @@ void MSIter::construct(const Block<Int>& sortColumns,
 
     if (!useIn && !useSorted) {
       // we have to resort the input; enclose in >>> <<< to avoid pollution of test .out file
-      if (aips_debug) cout << ">>>"<<endl<<"MSIter::construct - resorting table"<<endl<<"<<<"<<endl;
+      if (aips_debug) cout << ">>>"<<std::endl<<"MSIter::construct - resorting table"<<std::endl<<"<<<"<<std::endl;
       sorted = bms_p[i].sort(columns, Sort::Ascending, Sort::QuickSort);
     }
 
@@ -1003,9 +1003,9 @@ void  MSIter::getSpwInFreqRange(Block<Vector<Int> >& spw,
     spw[k]=spwIn.convertToSpwIndex(freqlist, numSpec);
     Vector<Int> retchanlist=
       spwIn.convertToChannelIndex(spw[k], freqlist, numSpec);
-    cout << "retchanlist " << retchanlist << endl;
+    cout << "retchanlist " << retchanlist << std::endl;
     if((retchanlist.nelements()%3) != 0){
-      cout << "Error in getting channel out " << endl;
+      cout << "Error in getting channel out " << std::endl;
     }
     else{
       start[k].resize(spw[k].nelements());

--- a/ms/MeasurementSets/MSIter.h
+++ b/ms/MeasurementSets/MSIter.h
@@ -105,11 +105,11 @@ private:
 // MSIter msIter(ms,sort,timeInteval);
 // for (msIter.origin(); msIter.more(); msIter++) {
 // // print out some of the iteration state
-//    cout << msIter.fieldId() << endl;
-//    cout << msIter.fieldName() << endl;
-//    cout << msIter.dataDescriptionId() << endl;
-//    cout << msIter.frequency0() << endl;
-//    cout << msIter.table().nrow() << endl;
+//    cout << msIter.fieldId() << std::endl;
+//    cout << msIter.fieldName() << std::endl;
+//    cout << msIter.dataDescriptionId() << std::endl;
+//    cout << msIter.frequency0() << std::endl;
+//    cout << msIter.table().nrow() << std::endl;
 //    process(msIter.table()); // process the data in the current iteration
 // }
 // // Output shows only 1 row at a time because the table is sorted on TIME
@@ -132,11 +132,11 @@ private:
 // MSIter msIter(ms,sort,timeInteval);
 // for (msIter.origin(); msIter.more(); msIter++) {
 // // print out some of the iteration state
-//    cout << msIter.fieldId() << endl;
-//    cout << msIter.fieldName() << endl;
-//    cout << msIter.dataDescriptionId() << endl;
-//    cout << msIter.frequency0() << endl;
-//    cout << msIter.table().nrow() << endl;
+//    cout << msIter.fieldId() << std::endl;
+//    cout << msIter.fieldName() << std::endl;
+//    cout << msIter.dataDescriptionId() << std::endl;
+//    cout << msIter.frequency0() << std::endl;
+//    cout << msIter.table().nrow() << std::endl;
 //    process(msIter.table()); // process the data in the current iteration
 // // Now the output shows 7 rows at a time, all with identical ANTENNA1
 // // and ANTENNA2 values and TIME values within a 3000s interval.

--- a/ms/MeasurementSets/MSRange.cc
+++ b/ms/MeasurementSets/MSRange.cc
@@ -469,7 +469,7 @@ Record MSRange::range(const Vector<Int>& keys,
 
   if (shapeChangesWarning) {
     os << LogIO::WARN << "Not all requested items were returned because "
-       <<"the input contains "<< endl 
+       <<"the input contains "<< std::endl 
        <<"multiple data descriptions with varying data shape"<<LogIO::POST;
   }
   return out;

--- a/ms/MeasurementSets/MSRange.h
+++ b/ms/MeasurementSets/MSRange.h
@@ -70,7 +70,7 @@ class MSSelector;
 // items(1)="time";
 // items(2)="data_desc_id";
 // // get the range of values for the items specified
-// cout << myRange.range(items)<<endl;
+// cout << myRange.range(items)<<std::endl;
 // // sample output: range=[field_id=[0,1,2],time=[4.5e9, 4.51e9],
 // //   data_desc_id=[0,1,2]];
 // // Now preselect on data_desc_id
@@ -79,7 +79,7 @@ class MSSelector;
 // mss.selectinit(0,dd); // select data desc ids 1 and 2
 // MSRange r2(mss);
 // items(2)="amplitude";
-// cout<< r2.range(items)<<endl;
+// cout<< r2.range(items)<<std::endl;
 // // sample output: [field_id=[0,1,2],time=[4.5e9, 4.51e9],
 // //   amplitude=[0.00132,1.543]]
 // </srcblock></example>

--- a/ms/MeasurementSets/MSSpWindowColumns.cc
+++ b/ms/MeasurementSets/MSSpWindowColumns.cc
@@ -338,10 +338,10 @@ matchRefFreqCnvtrd(rownr_t row, MFrequency refFreq, const Bool isRefFreq, const 
   MFrequency rowFreq;
   if( isRefFreq ) { 
      rowFreq = refFrequencyMeas()(row);
-	  //cout<< "[MSSpWindowColumns::matchRefFreqCnvtr()] match reference frequency. "<< endl;
+	  //cout<< "[MSSpWindowColumns::matchRefFreqCnvtr()] match reference frequency. "<< std::endl;
   }else{
      rowFreq = Vector<MFrequency>(chanFreqMeas()(row))(0);
-	  //cout<< "[MSSpWindowColumns::matchRefFreqCnvtr()] match first channel frequency. " << endl;
+	  //cout<< "[MSSpWindowColumns::matchRefFreqCnvtr()] match first channel frequency. " << std::endl;
   }
   //const MFrequency refFreqCtrd;
   const MFrequency::Types refType = MFrequency::castType(refFreq.getRef().getType());

--- a/ms/MeasurementSets/MSTableImpl.cc
+++ b/ms/MeasurementSets/MSTableImpl.cc
@@ -279,7 +279,7 @@ void MSTableImpl::addColumnToDesc(TableDesc &td, const String& colName,
 	}	    
     } else {
       cerr << "MSTableImpl::addColumnToDesc - Invalid data type: "
-	   << colDType <<", "<<colName<<endl;
+	   << colDType <<", "<<colName<<std::endl;
       //	throw(AipsError ("MSTableImpl::addColumnToDesc(...) - "
       //			 "Invalid default data type for specified column"));
     }
@@ -321,7 +321,7 @@ void MSTableImpl::addKeyToDesc(TableDesc& td, const String& keyName,
 //#	    keywordStandardComment(key);
 	break; 
     default:
-      cerr << "Data type: "<< keyDType << ", "<< keyName<< "not handled"<<endl;
+      cerr << "Data type: "<< keyDType << ", "<< keyName<< "not handled"<<std::endl;
       //	throw(AipsError ("MSTableImpl::addKeyToDesc(...) - "
       //			 "Data type not handled"));
     }  
@@ -455,7 +455,7 @@ Bool MSTableImpl::validate(const TableDesc& tabDesc,
 	isSuperset(requiredTD.columnDescSet(), eqDTypes);
 #if defined(AIPS_DEBUG)
     if (!temp) {
-	cerr << "MSTableImpl::validate - tabDesc not superset of requiredTD"<<endl;
+	cerr << "MSTableImpl::validate - tabDesc not superset of requiredTD"<<std::endl;
     }
 #endif
     // check all of the UNIT and MEASINFO-Type values against 
@@ -473,7 +473,7 @@ Bool MSTableImpl::validate(const TableDesc& tabDesc,
 #if defined(AIPS_DEBUG)
 	  if (!detail) {
 	    cerr <<"MSTableImpl::validate - column "<<colNames(colnr) <<
-	      " doesn't have QuantumUnits"<<endl;
+	      " doesn't have QuantumUnits"<<std::endl;
 	  }
 #endif
 	  if (detail) detail = allEQ(keySet.asArrayString("QuantumUnits"), 
@@ -481,12 +481,12 @@ Bool MSTableImpl::validate(const TableDesc& tabDesc,
 #if defined(AIPS_DEBUG)
 //*** testing
 //	  cerr << "Column "<<colNames(colnr)<<" has QuantumUnits "<<
-//	    keySet.asArrayString("QuantumUnits")<<endl;
+//	    keySet.asArrayString("QuantumUnits")<<std::endl;
 //*** testing
 	    if (!detail) {
 	      cerr <<"MSTableImpl::validate - column "<<colNames(colnr) <<
 		" has invalid QuantumUnits: "<< 
-		keySet.asArrayString("QuantumUnits")<<endl;
+		keySet.asArrayString("QuantumUnits")<<std::endl;
 	    }
 #endif
 	    // check Measure type if defined
@@ -495,7 +495,7 @@ Bool MSTableImpl::validate(const TableDesc& tabDesc,
 #if defined(AIPS_DEBUG)
 	      if (!detail) {
 		cerr <<"MSTableImpl::validate - column "<<colNames(colnr) <<
-		  " doesn't have MEASINFO"<<endl;
+		  " doesn't have MEASINFO"<<std::endl;
 	      }
 #endif
 	      if (detail) {
@@ -506,7 +506,7 @@ Bool MSTableImpl::validate(const TableDesc& tabDesc,
 		if (!detail) {
 		  cerr << "MSTableImpl::validate - column "<<colNames(colnr)
 		       << " has invalid MEASURE TYPE: "
-		       << keySet.asRecord("MEASINFO").asString("type") << endl;
+		       << keySet.asRecord("MEASINFO").asString("type") << std::endl;
 		}
 #endif
 	    }

--- a/ms/MeasurementSets/MSTileLayout.h
+++ b/ms/MeasurementSets/MSTileLayout.h
@@ -63,7 +63,7 @@ class String;
 // IPosition tileShape = MSTileLayout::tileShape(dataShape,
 //                                               MSTileLayout::FastMosaic,
 //                                               "ATCA");
-// cout << "tileShape = "<< tileShape << endl;
+// cout << "tileShape = "<< tileShape << std::endl;
 // // Output is: 
 // tileShape = (4,11,15)
 // </srcblock>

--- a/ms/MeasurementSets/MeasurementSet.cc
+++ b/ms/MeasurementSets/MeasurementSet.cc
@@ -57,7 +57,7 @@
 
 #define MrsDebugLog(level,message) \
         { if ((level) <= mrsDebugLevel_p) { \
-            LogIO logIo (LogOrigin ("MS")); logIo << (message) << endl; logIo.post();\
+            LogIO logIo (LogOrigin ("MS")); logIo << (message) << std::endl; logIo.post();\
           }\
         }
 
@@ -1007,7 +1007,7 @@ Bool MeasurementSet::validateMeasureRefs()
 	if (refFld<0 || tableDesc()[i].keywordSet().asRecord(fld).
 	    asString(refFld) == "") {
 	  cerr << "Missing Measure reference for column "<<tableDesc()[i].name()
-	       << endl;
+	       << std::endl;
 	  ok = False;
 	}
       }
@@ -1028,7 +1028,7 @@ Bool MeasurementSet::validateMeasureRefs()
 	      asString(refFld) == "") {
 	    cerr << "Missing Measure reference for column "
 		 <<tab.tableDesc()[i].name()<<" in subtable "<<tab.tableName() 
-		 << endl;
+		 << std::endl;
 	    ok = False;
 	  }
 	}
@@ -1107,7 +1107,7 @@ Record MeasurementSet::msseltoindex(const String& spw, const String& field,
   else allDDIDList = set_intersection(ddIDList, spwDDIDList);
 
 
-  //  cerr << ddIDList << endl << spwDDIDList << endl << allDDIDList << endl;
+  //  cerr << ddIDList << std::endl << spwDDIDList << std::endl << allDDIDList << std::endl;
 
   retval.define("spw", spwlist);
   retval.define("field", fieldlist);

--- a/ms/MeasurementSets/test/tMSColumns.cc
+++ b/ms/MeasurementSets/test/tMSColumns.cc
@@ -186,7 +186,7 @@ int main() {
     }
     return 0;  
   } catch (std::exception& x) {
-    cerr << x.what() <<endl;
+    cerr << x.what() <<std::endl;
     return 1;
   } 
 }

--- a/ms/MeasurementSets/test/tMSDataDescBuffer.cc
+++ b/ms/MeasurementSets/test/tMSDataDescBuffer.cc
@@ -90,11 +90,11 @@ int main() {
     }
   }
   catch (std::exception& x) {
-    cerr << x.what() << endl;
-    cout << "FAIL" << endl;
+    cerr << x.what() << std::endl;
+    cout << "FAIL" << std::endl;
     return 1;
   }
-  cout << "OK" << endl;
+  cout << "OK" << std::endl;
 }
 
 // Local Variables: 

--- a/ms/MeasurementSets/test/tMSFieldBuffer.cc
+++ b/ms/MeasurementSets/test/tMSFieldBuffer.cc
@@ -215,8 +215,8 @@ int main() {
 //     }
 //   }
 //   catch (std::exception x) {
-//     cerr << x.what() << endl;
-//     cout << "FAIL" << endl;
+//     cerr << x.what() << std::endl;
+//     cout << "FAIL" << std::endl;
 //     return 1;
 //   }
 //   try {
@@ -225,11 +225,11 @@ int main() {
 //     ms.markForDelete();
 //   }
 //   catch (std::exception x) {
-//     cerr << x.what() << endl;
-//     cout << "FAIL" << endl;
+//     cerr << x.what() << std::endl;
+//     cout << "FAIL" << std::endl;
 //     return 1;
 //   }
-//   cout << "OK" << endl;
+//   cout << "OK" << std::endl;
   return 3;   //untested
 }
 

--- a/ms/MeasurementSets/test/tMSFieldEphem.cc
+++ b/ms/MeasurementSets/test/tMSFieldEphem.cc
@@ -162,7 +162,7 @@ int main() {
 	Table x; Table* y=0;
 	MeasIERS::findTab(x, y, " ", " ", "VTOP");
 	tablePathName = Path(x.tableName()).absoluteName();
-        // cout << "Found " << tablePathName  << endl;
+        // cout << "Found " << tablePathName  << std::endl;
       }
 
       AlwaysAssertExit( ms.field().addEphemeris(0, tablePathName, "Venus") );
@@ -172,7 +172,7 @@ int main() {
 	Table x2; Table* y2=0;
 	MeasIERS::findTab(x2, y2, " ", " ", "VGEO");
 	tablePathName2 = Path(x2.tableName()).absoluteName();
-        // cout << "Found " << tablePathName2 << endl;
+        // cout << "Found " << tablePathName2 << std::endl;
       }
       // add using non-absolute path
      {
@@ -210,7 +210,7 @@ int main() {
 	Int row = 0;
 	Double mjds = 50802.75*86400.;
 	MDirection dDir = msfc.delayDirMeas(row, mjds);
-	// cout << "position for row " << row << ", MJD " << mjds/86400. << ": " << dDir.getAngle(Unit("deg")) << endl;
+	// cout << "position for row " << row << ", MJD " << mjds/86400. << ": " << dDir.getAngle(Unit("deg")) << std::endl;
 	MDirection rDir = msfc.referenceDirMeas(row, mjds);
 	MDirection eDir = msfc.ephemerisDirMeas(row, mjds);
 	MVDirection expDir(rDir.getAngle());
@@ -229,13 +229,13 @@ int main() {
 	Int row = 1;
 	Double mjds = 50802.75*86400.;
 	MDirection dDir = msfc.delayDirMeas(row, mjds);
-	// cout << "delaydir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << dDir.getAngle(Unit("deg")) << endl;
+	// cout << "delaydir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << dDir.getAngle(Unit("deg")) << std::endl;
 	MDirection pDir = msfc.phaseDirMeas(row, mjds);
-	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << endl;
+	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << std::endl;
 	MDirection rDir = msfc.referenceDirMeas(row, mjds);
-	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << endl;
+	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << std::endl;
 	MDirection eDir = msfc.ephemerisDirMeas(row, mjds);
-	// cout << "ephemerisdir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << eDir.getAngle(Unit("deg")) << endl;
+	// cout << "ephemerisdir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << eDir.getAngle(Unit("deg")) << std::endl;
 
 	MDirection expected(Quantity(-54.3855, "deg"), Quantity(-19.8873, "deg"), MDirection::APP);
 	MVDirection expDir(expected.getAngle());
@@ -263,13 +263,13 @@ int main() {
 	Int row = 2;
 	Double mjds = 50802.75*86400.;
 	MDirection dDir = msfc.delayDirMeas(row, mjds);
-	// cout << "delaydir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << dDir.getAngle(Unit("deg")) << endl;
+	// cout << "delaydir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << dDir.getAngle(Unit("deg")) << std::endl;
 	MDirection pDir = msfc.phaseDirMeas(row, mjds);
-	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << endl;
+	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << std::endl;
 	MDirection rDir = msfc.referenceDirMeas(row, mjds);
-	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << endl;
+	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << std::endl;
 	MDirection eDir = msfc.ephemerisDirMeas(row, mjds);
-	// cout << "ephemerisdir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << eDir.getAngle(Unit("deg")) << endl;
+	// cout << "ephemerisdir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << eDir.getAngle(Unit("deg")) << std::endl;
 
 	MVDirection original(Quantity(305.6145129, "deg"),
 			     Quantity(-19.8873316, "deg"));
@@ -283,7 +283,7 @@ int main() {
 	MVDirection expDir(expected.getAngle());
 	MVDirection unalteredExpDir(unalteredExpected.getAngle());
 
-	// cout << "separation " << expDir.separation(MVDirection(dDir.getAngle()), "deg") << endl;
+	// cout << "separation " << expDir.separation(MVDirection(dDir.getAngle()), "deg") << std::endl;
 
 	AlwaysAssertExit(expDir.separation(MVDirection(dDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
 	AlwaysAssertExit(dDir.getRef().getType()==expected.getRef().getType());
@@ -291,7 +291,7 @@ int main() {
 	AlwaysAssertExit(pDir.getRef().getType()==expected.getRef().getType());
 	AlwaysAssertExit(expDir.separation(MVDirection(rDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
 
-	// cout << "types " << rDir.getRef() << " " << expected.getRef() << endl;
+	// cout << "types " << rDir.getRef() << " " << expected.getRef() << std::endl;
 
 	AlwaysAssertExit(rDir.getRef().getType()  == expected.getRef().getType() );
 	AlwaysAssertExit(unalteredExpDir.separation(MVDirection(eDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
@@ -310,11 +310,11 @@ int main() {
 	Int row = 3;
 	Double mjds = 50802.75*86400.;
 	MDirection dDir = msfc.delayDirMeas(row, mjds);
-	// cout << "delaydir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << dDir.getAngle(Unit("deg")) << endl;
+	// cout << "delaydir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << dDir.getAngle(Unit("deg")) << std::endl;
 	MDirection pDir = msfc.phaseDirMeas(row, mjds);
-	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << endl;
+	// cout << "phasedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << pDir.getAngle(Unit("deg")) << std::endl;
 	MDirection rDir = msfc.referenceDirMeas(row, mjds);
-	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << endl;
+	// cout << "referencedir for row " << row << ", MJD-50802. " << mjds/86400.-50802. << ": " << rDir.getAngle(Unit("deg")) << std::endl;
 
 	MVDirection original(Quantity(305.6095079, "deg"),
 			     Quantity(-19.88256944, "deg"));
@@ -322,7 +322,7 @@ int main() {
 	MDirection expected(original, MDirection::APP);
 	MVDirection expDir(expected.getAngle());
 
-	// cout << "separation " << expDir.separation(MVDirection(dDir.getAngle()), "deg") << endl;
+	// cout << "separation " << expDir.separation(MVDirection(dDir.getAngle()), "deg") << std::endl;
 
 	AlwaysAssertExit(expDir.separation(MVDirection(dDir.getAngle()))<Quantity(1/3600., "deg").getValue("rad"));
 	AlwaysAssertExit(dDir.getRef().getType()==expected.getRef().getType());
@@ -338,7 +338,7 @@ int main() {
 	try{
 	  MDirection xDir = msfc.delayDirMeas(row, 12345.); // time outside validity range
 	} catch (std::exception& x) {
-	  //cout <<  x.what() <<endl;
+	  //cout <<  x.what() <<std::endl;
 	  didThrow = True;
 	}
 	AlwaysAssertExit(didThrow);
@@ -347,7 +347,7 @@ int main() {
 	try{
 	  MRadialVelocity xmradvel = msfc.radVelMeas(row, 12345.); // time outside validity range
 	} catch (std::exception& x) {
-	  //cout <<  x.what() <<endl;
+	  //cout <<  x.what() <<std::endl;
 	  didThrow = True;
 	}
 	AlwaysAssertExit(didThrow);
@@ -356,7 +356,7 @@ int main() {
 	try{
 	  MRadialVelocity xrho = msfc.rho(row, 12345.); // time outside validity range
 	} catch (std::exception& x) {
-	  //cout <<  x.what() <<endl;
+	  //cout <<  x.what() <<std::endl;
 	  didThrow = True;
 	}
 	AlwaysAssertExit(didThrow);
@@ -364,11 +364,11 @@ int main() {
 	// Finally test radial velocity and rho access
 
 	MRadialVelocity mradvel = msfc.radVelMeas(row, mjds);
-	// cout << "mradvel " << mradvel.get("AU/d") << endl;
+	// cout << "mradvel " << mradvel.get("AU/d") << std::endl;
 	AlwaysAssertExit((mradvel.get("AU/d")-Quantity(-0.0057244046, "AU/d")).getValue("km/s")<0.01);
 
 	Quantity rho =  msfc.rho(row, mjds);
-	// cout << "rho " << rho.get("AU") << endl;
+	// cout << "rho " << rho.get("AU") << std::endl;
 	AlwaysAssertExit((rho.get("AU") - Quantity(0.35214584, "AU")).getValue("km")<10.);
 
       }      
@@ -382,7 +382,7 @@ int main() {
     }
     return 0;  
   } catch (std::exception& x) {
-    cerr << x.what() <<endl;
+    cerr << x.what() <<std::endl;
     return 1;
   } 
 }

--- a/ms/MeasurementSets/test/tMSIter.cc
+++ b/ms/MeasurementSets/test/tMSIter.cc
@@ -960,19 +960,19 @@ int main (int argc, char* argv[])
     double msinterval = 60.;
     double binwidth = 120.;
     if (argc > 1) {
-      istringstream iss(argv[1]);
+      std::istringstream iss(argv[1]);
       iss >> nAnt;
     }
     if (argc > 2) {
-      istringstream iss(argv[2]);
+      std::istringstream iss(argv[2]);
       iss >> nTime;
     }
     if (argc > 3) {
-      istringstream iss(argv[3]);
+      std::istringstream iss(argv[3]);
       iss >> msinterval;
     }
     if (argc > 4) {
-      istringstream iss(argv[4]);
+      std::istringstream iss(argv[4]);
       iss >> binwidth;
     }
     createMS(nAnt, nTime, msinterval);

--- a/ms/MeasurementSets/test/tMSIter.cc
+++ b/ms/MeasurementSets/test/tMSIter.cc
@@ -141,7 +141,7 @@ void iterMS (double binwidth)
          << " time="
          << ScalarColumn<double>(msIter.table(), "TIME").getColumn() - 1e9
          << " keyCh=" << msIter.keyChange()
-         << endl;
+         << std::endl;
   }
 }
 
@@ -158,7 +158,7 @@ void iterMSMemory (double binwidth)
          << " a2=" << ScalarColumn<Int>(msIter.table(), "ANTENNA2")(0)
          << " time="
          << ScalarColumn<double>(msIter.table(), "TIME").getColumn() - 1e9
-         << endl;
+         << std::endl;
   }
 }
 
@@ -178,9 +178,9 @@ void iter2MS (double binwidth)
          << " time="
          << ScalarColumn<double>(msIter.table(), "TIME").getColumn() - 1e9
          << " keyCh=" << msIter.keyChange()
-         << endl;
+         << std::endl;
     if (++i == 4) {
-      cout << "=====" << endl;
+      cout << "=====" << std::endl;
       MSIter msIter1 = msIter;
       for (msIter1.origin(); msIter1.more(); ++msIter1) {
         cout << "nrow=" << msIter1.table().nrow()
@@ -189,12 +189,12 @@ void iter2MS (double binwidth)
              << " time="
              << ScalarColumn<double>(msIter1.table(), "TIME").getColumn() - 1e9
              << " keyCh=" << msIter1.keyChange()
-             << endl;
+             << std::endl;
       }
-      cout << "=====" << endl;
+      cout << "=====" << std::endl;
     }
   }
-  cout << "=====" << endl;
+  cout << "=====" << std::endl;
 }
 
 void iter2MSMemory (double binwidth)
@@ -213,7 +213,7 @@ void iter2MSMemory (double binwidth)
          << " a2=" << ScalarColumn<Int>(it->table(), "ANTENNA2")(0)
          << " time="
          << ScalarColumn<double>(it->table(), "TIME").getColumn() - 1e9
-         << endl;
+         << std::endl;
     if (++i % 2 == 1) {
       msIter1 = msIter;
       it = &msIter1;
@@ -236,7 +236,7 @@ void iterMSGenericSortFuncAlwaysTrue ()
   MSIter msIter(ms, sortCols);
   size_t niter = 0;
   for (msIter.origin(); msIter.more(); msIter++) {
-    cout << "nrow=" << msIter.table().nrow()<<endl;
+    cout << "nrow=" << msIter.table().nrow()<<std::endl;
     niter++;
   }
   AlwaysAssertExit(niter == 1);
@@ -281,7 +281,7 @@ void iterMSGenericSortFuncAntennaGrouping ()
   size_t nAnt01 = 0;
   size_t nAnt2 = 0;
   for (msIter.origin(); msIter.more(); msIter++) {
-    cout << "nrow=" << msIter.table().nrow()<<endl;
+    cout << "nrow=" << msIter.table().nrow()<<std::endl;
     Int antenna =  ScalarColumn<Int>(msIter.table(), "ANTENNA1")(0);
     if(antenna == 0 || antenna == 1)
       nAnt01 += msIter.table().nrow();
@@ -411,8 +411,8 @@ void iterMSCachedDDFeedInfo ()
   // There will be as many iterations as DDIDs. 
   // This is done both for the traditional constructor as for the 
   // constructor with the generic sorting definition.
-  cout << "Iteration with DDID sorting" << endl;
-  cout << "===========================" << endl;
+  cout << "Iteration with DDID sorting" << std::endl;
+  cout << "===========================" << std::endl;
   for(int useGenericSortCons = 0 ; useGenericSortCons < 2 ; useGenericSortCons++)
   {
     std::unique_ptr<MSIter> msIter;
@@ -460,11 +460,11 @@ void iterMSCachedDDFeedInfo ()
     // It is expected that in each iteration a new DDId is retrieved
     for (msIter->origin(); msIter->more(); (*msIter)++) 
     {
-      cout << "nrow=" << msIter->table().nrow()<<endl;
+      cout << "nrow=" << msIter->table().nrow()<<std::endl;
       cout << "ddid = " << msIter->dataDescriptionId() << 
               " spwid = " << msIter->spectralWindowId() <<
-              " polid = " << msIter->polarizationId() << endl;
-      cout << "freqs = " << msIter->frequency() << " freq0 " << msIter->frequency0() << endl;
+              " polid = " << msIter->polarizationId() << std::endl;
+      cout << "freqs = " << msIter->frequency() << " freq0 " << msIter->frequency0() << std::endl;
 
       // Check that the DD related metadata is what we expect
       AlwaysAssertExit(msIter->dataDescriptionId() == expectedDDId);
@@ -520,8 +520,8 @@ void iterMSCachedDDFeedInfo ()
   // Antenna1 has been choosen as the other one.
   // This is done both for the traditional constructor as for the
   // constructor with the generic sorting definition.
-  cout << "Iteration with ANTENNA1 and DDID sorting" << endl;
-  cout << "========================================" << endl;
+  cout << "Iteration with ANTENNA1 and DDID sorting" << std::endl;
+  cout << "========================================" << std::endl;
   for(int useGenericSortCons = 0 ; useGenericSortCons < 2 ; useGenericSortCons++)
   {
     std::unique_ptr<MSIter> msIter;
@@ -576,11 +576,11 @@ void iterMSCachedDDFeedInfo ()
     int antena1Idx = 0;
     for (msIter->origin(); msIter->more(); (*msIter)++)
     {
-      cout << "nrow=" << msIter->table().nrow()<<endl;
+      cout << "nrow=" << msIter->table().nrow()<<std::endl;
       cout << "ddid = " << msIter->dataDescriptionId() <<
               " spwid = " << msIter->spectralWindowId() <<
-              " polid = " << msIter->polarizationId() << endl;
-      cout << "freqs = " << msIter->frequency() << " freq0 " << msIter->frequency0() << endl;
+              " polid = " << msIter->polarizationId() << std::endl;
+      cout << "freqs = " << msIter->frequency() << " freq0 " << msIter->frequency0() << std::endl;
 
       // Check that the DD related metadata is what we expect
       AlwaysAssertExit(msIter->dataDescriptionId() == expectedDDId);
@@ -651,8 +651,8 @@ void iterMSCachedDDFeedInfo ()
   // all baselines and all DDIds are present
   // This is done both for the traditional constructor as for the 
   // constructor with the generic sorting definition.
-  cout << "Iteration with TIME sorting" << endl;
-  cout << "===========================" << endl;
+  cout << "Iteration with TIME sorting" << std::endl;
+  cout << "===========================" << std::endl;
   for(int useGenericSortCons = 0 ; useGenericSortCons < 2 ; useGenericSortCons++)
   {
     std::unique_ptr<MSIter> msIter;
@@ -705,11 +705,11 @@ void iterMSCachedDDFeedInfo ()
       {
         if(rowsToSkip == 0)
         {
-          cout << "nrow=" << msIter->table().nrow()<<endl;
+          cout << "nrow=" << msIter->table().nrow()<<std::endl;
           cout << "ddid = " << msIter->dataDescriptionId() <<
                   " spwid = " << msIter->spectralWindowId() <<
-                  " polid = " << msIter->polarizationId() << endl;
-          cout << "freqs = " << msIter->frequency() << " freq0 " << msIter->frequency0() << endl;
+                  " polid = " << msIter->polarizationId() << std::endl;
+          cout << "freqs = " << msIter->frequency() << " freq0 " << msIter->frequency0() << std::endl;
           // Check that the DD related metadata is what we expect
           // For DDId, SPWId, polID: since there is no unique ID in this iteration
           // the first one (0) is returned
@@ -756,7 +756,7 @@ void iterMSCachedDDFeedInfo ()
         }
         else
         {
-          cout << " Skipping row" << endl;
+          cout << " Skipping row" << std::endl;
           rowsToSkip--;
         }
       }
@@ -781,8 +781,8 @@ void iterMSCachedFieldInfo ()
   // There will be as many iterations as FIELD_IDs.
   // This is done both for the traditional constructor as for the
   // constructor with the generic sorting definition.
-  cout << "Iteration with FIELD sorting" << endl;
-  cout << "===========================" << endl;
+  cout << "Iteration with FIELD sorting" << std::endl;
+  cout << "===========================" << std::endl;
   for(int useGenericSortCons = 0 ; useGenericSortCons < 2 ; useGenericSortCons++)
   {
     std::unique_ptr<MSIter> msIter;
@@ -809,8 +809,8 @@ void iterMSCachedFieldInfo ()
     // It is expected that in each iteration a new FIELD_ID is retrieved
     for (msIter->origin(); msIter->more(); (*msIter)++)
     {
-      cout << "nrow=" << msIter->table().nrow()<<endl;
-      cout << "fieldid = " << msIter->fieldId() << endl;
+      cout << "nrow=" << msIter->table().nrow()<<std::endl;
+      cout << "fieldid = " << msIter->fieldId() << std::endl;
 
       // Check that the FIELD related metadata is what we expect
       AlwaysAssertExit(msIter->fieldId() == expectedFieldId);
@@ -830,8 +830,8 @@ void iterMSCachedFieldInfo ()
   // Antenna1 has been choosen as the other one.
   // This is done both for the traditional constructor as for the
   // constructor with the generic sorting definition.
-  cout << "Iteration with ANTENNA1 and FIELD sorting" << endl;
-  cout << "========================================" << endl;
+  cout << "Iteration with ANTENNA1 and FIELD sorting" << std::endl;
+  cout << "========================================" << std::endl;
   for(int useGenericSortCons = 0 ; useGenericSortCons < 2 ; useGenericSortCons++)
   {
     std::unique_ptr<MSIter> msIter;
@@ -863,8 +863,8 @@ void iterMSCachedFieldInfo ()
     int antena1Idx = 0;
     for (msIter->origin(); msIter->more(); (*msIter)++)
     {
-      cout << "nrow=" << msIter->table().nrow()<<endl;
-      cout << "fieldid = " << msIter->fieldId() << endl;
+      cout << "nrow=" << msIter->table().nrow()<<std::endl;
+      cout << "fieldid = " << msIter->fieldId() << std::endl;
 
       // Check that the DD related metadata is what we expect
       AlwaysAssertExit(msIter->fieldId() == expectedFieldId);
@@ -893,8 +893,8 @@ void iterMSCachedFieldInfo ()
   // all baselines and all FIELD_IDs are present
   // This is done both for the traditional constructor as for the
   // constructor with the generic sorting definition.
-  cout << "Iteration with TIME sorting" << endl;
-  cout << "===========================" << endl;
+  cout << "Iteration with TIME sorting" << std::endl;
+  cout << "===========================" << std::endl;
   for(int useGenericSortCons = 0 ; useGenericSortCons < 2 ; useGenericSortCons++)
   {
     std::unique_ptr<MSIter> msIter;
@@ -930,8 +930,8 @@ void iterMSCachedFieldInfo ()
       {
         if(rowsToSkip == 0)
         {
-          cout << "nrow=" << msIter->table().nrow()<<endl;
-          cout << "fieldid = " << msIter->fieldId() << endl;
+          cout << "nrow=" << msIter->table().nrow()<<std::endl;
+          cout << "fieldid = " << msIter->fieldId() << std::endl;
           // Check that the FIELD related metadata is what we expect
           // For FIELD_ID: since there is no unique ID in this iteration
           // the first one (0) is returned
@@ -944,7 +944,7 @@ void iterMSCachedFieldInfo ()
         }
         else
         {
-          cout << " Skipping row" << endl;
+          cout << " Skipping row" << std::endl;
           rowsToSkip--;
         }
       }
@@ -977,22 +977,22 @@ int main (int argc, char* argv[])
     }
     createMS(nAnt, nTime, msinterval);
     iterMS(binwidth);
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iterMSMemory(binwidth);
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iter2MS(binwidth);
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iter2MSMemory(binwidth);
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iterMSGenericSortFuncAlwaysTrue();
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iterMSGenericSortFuncAntennaGrouping();
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iterMSCachedDDFeedInfo();
-    cout << "########" << endl;
+    cout << "########" << std::endl;
     iterMSCachedFieldInfo();
   } catch (std::exception& x) {
-    cerr << "Unexpected exception: " << x.what() << endl;
+    cerr << "Unexpected exception: " << x.what() << std::endl;
     return 1;
   }
   return 0;

--- a/ms/MeasurementSets/test/tMSMainBuffer.cc
+++ b/ms/MeasurementSets/test/tMSMainBuffer.cc
@@ -346,8 +346,8 @@ int main() {
 //     }
 //   }
 //   catch (std::exception x) {
-//     cerr << x.what() << endl;
-//     cout << "FAIL" << endl;
+//     cerr << x.what() << std::endl;
+//     cout << "FAIL" << std::endl;
 //     return 1;
 //   } 
 //   try {
@@ -358,11 +358,11 @@ int main() {
 //     ms.markForDelete();
 //   }
 //   catch (std::exception x) {
-//     cerr << x.what() << endl;
-//     cout << "FAIL" << endl;
+//     cerr << x.what() << std::endl;
+//     cout << "FAIL" << std::endl;
 //     return 1;
 //   }
-//   cout << "OK" << endl;
+//   cout << "OK" << std::endl;
   return 3;  //untested
 }
 // Local Variables: 

--- a/ms/MeasurementSets/test/tMSPolBuffer.cc
+++ b/ms/MeasurementSets/test/tMSPolBuffer.cc
@@ -160,8 +160,8 @@ int main() {
 //     }
 //   }
 //   catch (std::exception x) {
-//     cerr << x.what() << endl;
-//     cout << "FAIL" << endl;
+//     cerr << x.what() << std::endl;
+//     cout << "FAIL" << std::endl;
 //     return 1;
 //   }
 //   try {
@@ -170,11 +170,11 @@ int main() {
 //     ms.markForDelete();
 //   }
 //   catch (std::exception x) {
-//     cerr << x.what() << endl;
-//     cout << "FAIL" << endl;
+//     cerr << x.what() << std::endl;
+//     cout << "FAIL" << std::endl;
 //     return 1;
 //   }
-//   cout << "OK" << endl;
+//   cout << "OK" << std::endl;
   return 3;   //untested
 }
 

--- a/ms/MeasurementSets/test/tMeasurementSet.cc
+++ b/ms/MeasurementSets/test/tMeasurementSet.cc
@@ -58,9 +58,9 @@ uInt tColumnStatics()
 	String pdname = MS::columnName(pdcol);
 	MS::PredefinedColumns pdtype = MS::columnType(pdname);
 	if (pdtype != pdcol) {
-	    cerr << "Inconsistency found for column : " << pdname << endl;
+	    cerr << "Inconsistency found for column : " << pdname << std::endl;
 	    cerr << "  Type : " << Int(pdtype) << " should be : " 
-		 << Int(pdcol) <<endl;
+		 << Int(pdcol) <<std::endl;
 	    errCount++;
 	}
 
@@ -68,7 +68,7 @@ uInt tColumnStatics()
 	pdtype = MS::columnType("NotAPredefinedColumn");
 	if (pdtype != MS::UNDEFINED_COLUMN) {
 	    cerr << "columnType returned a valid PredefinedColumn for \"NotAPredefinedColumn\""
-		<< Int(pdtype) << endl;
+		<< Int(pdtype) << std::endl;
 	    errCount++;
 	}
 
@@ -98,9 +98,9 @@ uInt tKeywordStatics()
 	MS::PredefinedKeywords pdtype = MS::keywordType(pdname);
 	// this MUST be valid and it must have the same value as pdkey
 	if (pdtype != pdkey) {
-	    cerr << "Inconsistency found for keyword : " << pdname << endl;
+	    cerr << "Inconsistency found for keyword : " << pdname << std::endl;
 	    cerr << "  Type : " << Int(pdtype) << " should be : " 
-		 << Int(pdkey) << endl;
+		 << Int(pdkey) << std::endl;
 	    errCount++;
 	}
 
@@ -200,22 +200,22 @@ uInt tNonStatic(const String& sdmsName)
 
     // verify that it is valid
     if (! ms.validate()) {
-	cerr << "self validation failed" <<endl;
+	cerr << "self validation failed" <<std::endl;
 	errCount++;
     }
     if (! MS::validate(ms.tableDesc())) {
-	cerr << "validation of tableDesc fails" << endl;
+	cerr << "validation of tableDesc fails" << std::endl;
 	errCount++;
     }
     if (! MS::validate(ms.keywordSet())) {
-	cerr << "validation of keywordSet fails" << endl;
+	cerr << "validation of keywordSet fails" << std::endl;
 	errCount++;
     }
 
     // they are all writable at this point
     if (!ms.isColumnWritable(MS::TIME)) {
 	cerr << "TIME column should be writable but isColumnWritable() returned False" 
-	     << endl;
+	     << std::endl;
 	errCount++;
     }
 
@@ -224,32 +224,32 @@ uInt tNonStatic(const String& sdmsName)
 
     // TIME is a scalar column, DATA is an array column
     if (!ms.isScalar(MS::TIME)) {
-	cerr << "TIME column is scalar but isScalar() returned False" << endl;
+	cerr << "TIME column is scalar but isScalar() returned False" << std::endl;
 	errCount++;
     }
     if (ms.isArray(MS::TIME)) {
-	cerr << "TIME column is scalar but isArray() returned True" << endl;
+	cerr << "TIME column is scalar but isArray() returned True" << std::endl;
 	errCount++;
     }
     if (ms.isScalar(MS::DATA)) {
-	cerr << "DATA column is array but isScalar() returned True" << endl;
+	cerr << "DATA column is array but isScalar() returned True" << std::endl;
 	errCount++;
     }
     if (!ms.isArray(MS::DATA)) {
-	cerr << "DATA column is array but isArray() returned False" << endl;
+	cerr << "DATA column is array but isArray() returned False" << std::endl;
 	errCount++;
     }
 
     // TIME has units of seconds
     // test via string
     if (ms.unit(MS::columnName(MS::TIME)) != "s") {
-	cerr << "MS::unit(const String&) failed to return s for TIME" << endl;
+	cerr << "MS::unit(const String&) failed to return s for TIME" << std::endl;
 	errCount++;
     }
     if (ms.unit(MS::TIME) != "s") {
-	cerr << "MS::unit(MS::TIME) failed to return s" << endl;
+	cerr << "MS::unit(MS::TIME) failed to return s" << std::endl;
 //*** testing
-	cerr << ms.unit(MS::TIME) <<endl;
+	cerr << ms.unit(MS::TIME) <<std::endl;
 //*** testing
 
 	errCount++;
@@ -265,7 +265,7 @@ uInt tNonStatic(const String& sdmsName)
 
     //    String parentName = ms.tableName();
     //    String subName = ms.keywordSet().asTable("ANTENNA").tableName();
-    //    cout << "Parent: "<<parentName<<", sub:"<<subName<<endl;
+    //    cout << "Parent: "<<parentName<<", sub:"<<subName<<std::endl;
     ms.flush();
 
     // ok, use operator to convert ms to sms
@@ -273,12 +273,12 @@ uInt tNonStatic(const String& sdmsName)
 
     // a couple of simple tests
     if (ms.nrow() != sms.nrow()) {
-	cerr << "operator= failed, number of rows is not correct" << endl;
+	cerr << "operator= failed, number of rows is not correct" << std::endl;
 	errCount++;
     }
 
     if (!ms.validate()) {
-	cerr << "operator= failed, validate returns False" << endl;
+	cerr << "operator= failed, validate returns False" << std::endl;
 	errCount++;
     }
 
@@ -486,14 +486,14 @@ uInt tReferenceCopy(const String& msName, const String& refMSName)
 	    // if so, it had better be TIME
 	    if (colNames(i) != MS::columnName(MS::TIME)) {
 //		cerr << "reference copy table column : " << colNames(i) 
-//		     << " is writable.  Only MS::TIME should be writable." << endl;
+//		     << " is writable.  Only MS::TIME should be writable." << std::endl;
 //		errCount++;
 	    }
 	} else {
 	    // it had better NOT be TIME
 	    if (colNames(i) == MS::columnName(MS::TIME)) {
 //		cerr << "reference copy table column : " << colNames(i)
-//		     << " is NOT writable.  It should be!" << endl;
+//		     << " is NOT writable.  It should be!" << std::endl;
 //		errCount++;
 	    }
 	}
@@ -513,7 +513,7 @@ uInt tNullMS(const String& msName)
     // Test construction and destruction of null MS.
     MeasurementSet ms;
     if (! ms.isNull()) {
-      cout << "tNullMS: MS should be null" << endl;
+      cout << "tNullMS: MS should be null" << std::endl;
       errCount++;
     }
   }
@@ -522,7 +522,7 @@ uInt tNullMS(const String& msName)
     // Test copy construction of null MS.
     MeasurementSet mscopy (nullMS);
     if (! mscopy.isNull()) {
-      cout << "tNullMS: MS copy should be null" << endl;
+      cout << "tNullMS: MS copy should be null" << std::endl;
       errCount++;
     }
   }
@@ -531,7 +531,7 @@ uInt tNullMS(const String& msName)
     MeasurementSet ms;
     ms = nullMS;
     if (! ms.isNull()) {
-      cout << "tNullMS: assign to null MS should be null" << endl;
+      cout << "tNullMS: assign to null MS should be null" << std::endl;
       errCount++;
     }
   }
@@ -540,7 +540,7 @@ uInt tNullMS(const String& msName)
     MeasurementSet ms(msName);
     ms = nullMS;
     if (! ms.isNull()) {
-      cout << "tNullMS: assign to non-null MS should be null" << endl;
+      cout << "tNullMS: assign to non-null MS should be null" << std::endl;
       errCount++;
     }
   }
@@ -550,7 +550,7 @@ uInt tNullMS(const String& msName)
     MeasurementSet ms(msName);
     nms = ms;
     if (nms.isNull()) {
-      cout << "tNullMS: assign to null MS should be non-null" << endl;
+      cout << "tNullMS: assign to null MS should be non-null" << std::endl;
       errCount++;
     }
   }
@@ -579,7 +579,7 @@ uInt tSetupNewTabError()
     } 
     if (!thrown) {
 	cerr << "MeasurementSet(SetupNewTable &, uInt) " 
-	    << "should have thrown an exception" << endl;
+	    << "should have thrown an exception" << std::endl;
 	errCount++;
     }
 
@@ -600,7 +600,7 @@ uInt tDestructorError(const String& sdmsName)
     } 
 
     if (!thrown) {
-	cerr << "~MeasurementSet() should have thrown an exception" << endl;
+	cerr << "~MeasurementSet() should have thrown an exception" << std::endl;
 	errCount++;
     }
   
@@ -610,9 +610,9 @@ uInt tDestructorError(const String& sdmsName)
 void checkErrors(uInt newErrors)
 {
     if (newErrors > 0) {
-	cout << newErrors << " errors!" << endl;
+	cout << newErrors << " errors!" << std::endl;
     } else {
-	cout << "ok." << endl;
+	cout << "ok." << std::endl;
     }
 }
 
@@ -660,7 +660,7 @@ int main() {
     checkErrors(newErrors);
     errCount += newErrors;
     
-    cout << "\nTest exceptions" << endl;
+    cout << "\nTest exceptions" << std::endl;
     cout << "in Constructors ... ";
     newErrors = tSetupNewTabError();
     checkErrors(newErrors);
@@ -678,14 +678,14 @@ int main() {
     ms.markForDelete();
 
     if (errCount > 0) {
-	cout << "tMeasurementSet ends with " << errCount << " errors." << endl;
+	cout << "tMeasurementSet ends with " << errCount << " errors." << std::endl;
     } else {
-	cout << "tMeasurementSet ends successfully" << endl;
+	cout << "tMeasurementSet ends successfully" << std::endl;
     }
 
     return errCount;
   } catch (std::exception& x) {
-      cerr << x.what() << endl;
+      cerr << x.what() << std::endl;
   } 
   return 1;
 }

--- a/ms/MeasurementSets/test/tStokesConverter.cc
+++ b/ms/MeasurementSets/test/tStokesConverter.cc
@@ -68,7 +68,7 @@ int main()
 	  !nearAbs(dataout(5),Complex(0.231824,0.0),1.e-6)||
 	  !nearAbs(dataout(6),Complex(0.67082,0.0),1.e-6)) {
 	err++;
-	cerr << "dataout="<<dataout<<endl;
+	cerr << "dataout="<<dataout<<std::endl;
       }
 
       Vector<Bool> flagout, flagin(4);
@@ -78,13 +78,13 @@ int main()
       if (flagout(0) || !flagout(1) || !flagout(2) || flagout(3) ||
 	  !flagout(4) || !flagout(5) || !flagout(6)) {
 	err++;
-	cerr << "flagout="<<flagout<<endl;
+	cerr << "flagout="<<flagout<<std::endl;
       }
 
       sc.invert(flagin, flagout);
       if (!flagin(0) || !flagin(1) || !flagin(2) || !flagin(3)) {
 	err++;
-	cerr << "flagin="<<flagin<< endl;
+	cerr << "flagin="<<flagin<< std::endl;
       }
     }
 
@@ -108,9 +108,9 @@ int main()
 	    data.column(k)=dataout;
 	  } else {
 	    if (!allNearAbs(data.column(k),dataout,1.e-6)) {
-	      cerr<< "Error for i="<<i<<", k="<<k<<endl;
-	      cerr<< "dataout="<<dataout<<endl;
-	      cerr<< "data.column(k)="<<data.column(k)<<endl;
+	      cerr<< "Error for i="<<i<<", k="<<k<<std::endl;
+	      cerr<< "dataout="<<dataout<<std::endl;
+	      cerr<< "data.column(k)="<<data.column(k)<<std::endl;
 	      err++;
 	    }
 	  }
@@ -118,10 +118,10 @@ int main()
       }
     }
   } catch (std::exception& x) {
-    cout << "Exception: "<< x.what() <<endl;
+    cout << "Exception: "<< x.what() <<std::endl;
   } 
-  if (err==0) cout<<"OK"<<endl;
-  else cout << err << " errors encountered"<<endl;
+  if (err==0) cout<<"OK"<<std::endl;
+  else cout << err << " errors encountered"<<std::endl;
   return err;
 }
 

--- a/ms/apps/msselect.cc
+++ b/ms/apps/msselect.cc
@@ -63,7 +63,7 @@ void select (const String& msin, const String& out, const String& baseline,
     cout << "Created RefTable " << out;
   }
   cout << " containing " << mssel.nrow() << " rows (out of "
-       << ms.nrow() << ')' << endl;
+       << ms.nrow() << ')' << std::endl;
 }
 
 // Copy (or symlink) directories that are not a subtable.
@@ -85,7 +85,7 @@ void copyOtherDirs (const String& msName, const String& outName, bool deep)
         if (deep) {
           Directory sdir(iter.file());
           sdir.copyRecursive (outName + '/' + bname);
-          cout << "Copied subdirectory " << bname << endl;
+          cout << "Copied subdirectory " << bname << std::endl;
         } else {
           // Resolve a possible symlink created by another msselect.
           // Do it only one deep.
@@ -98,7 +98,7 @@ void copyOtherDirs (const String& msName, const String& outName, bool deep)
           // Create a symlink to the directory.
           SymLink slink(outName + '/' + bname);
           slink.create (newName.absoluteName(), False);
-          cout << "Created symlink to subdirectory " << bname << endl;
+          cout << "Created symlink to subdirectory " << bname << std::endl;
         }
       }
     }
@@ -153,7 +153,7 @@ int main (int argc, char* argv[])
     select (msin, out, baseline, deep);
     copyOtherDirs (msin, out, deep);
   } catch (std::exception& x) {
-    cerr << "Error: " << x.what() << endl;
+    cerr << "Error: " << x.what() << std::endl;
     return 1;
   }
   return 0;

--- a/ms/apps/readms.cc
+++ b/ms/apps/readms.cc
@@ -73,10 +73,10 @@ Vector<String> mySortCols;
 
 void showHelp()
 {
-  cout << "The program reads one or more MeasurementSets" << endl;
-  cout << "Run as:" << endl;
-  cout << "      readms parm=value parm=value ..." << endl;
-  cout << "Use   readms -h   to see the possible parameters." << endl;
+  cout << "The program reads one or more MeasurementSets" << std::endl;
+  cout << "Run as:" << std::endl;
+  cout << "      readms parm=value parm=value ..." << std::endl;
+  cout << "Use   readms -h   to see the possible parameters." << std::endl;
 }
 
 
@@ -201,30 +201,30 @@ String makeMSName (int seqnr, const String& msName)
 void showParmsHDF5 (const IPosition& tileShape, uInt tileSize, uInt nspw,
                     const Record& attr)
 {
-  cout << " nms       = " << myNPart << "    " << myMsName << endl;
-  cout << " nthread   = " << OMP::maxThreads() << endl;
+  cout << " nms       = " << myNPart << "    " << myMsName << std::endl;
+  cout << " nthread   = " << OMP::maxThreads() << std::endl;
   cout << " nant      = " << attr.asInt("NAntenna")
-       << "   (" << attr.asInt("NBaseline") << " baselines)" << endl;
-  cout << " nspw      = " << nspw << endl;
+       << "   (" << attr.asInt("NBaseline") << " baselines)" << std::endl;
+  cout << " nspw      = " << nspw << std::endl;
   cout << " nfield    = " << attr.asInt("NField");
   int ntimefield = attr.asInt("NTimeField");
   if (ntimefield > 0) {
     cout << "   (" << ntimefield << "times per field)";
   }
-  cout << endl;
-  cout << " nchan     = " << myNChan << endl;
-  cout << " startchan = " << myStartChan << endl;
+  cout << std::endl;
+  cout << " nchan     = " << myNChan << std::endl;
+  cout << " startchan = " << myStartChan << std::endl;
   if (myChanSize > 0) {
-    cout << " chansize  = " << myChanSize << endl;
+    cout << " chansize  = " << myChanSize << std::endl;
   }
-  cout << " npol      = " << myNPol << endl;
-  cout << " rowwise             = " << myReadRowWise << endl;
-  cout << " readdata            = " << myReadData << endl;
-  cout << " readfloatdata       = " << myReadFloatData << endl;
-  cout << " readflag            = " << myReadFlag << endl;
-  cout << " readweightspectrum  = " << myReadWeightSpectrum << endl;
+  cout << " npol      = " << myNPol << std::endl;
+  cout << " rowwise             = " << myReadRowWise << std::endl;
+  cout << " readdata            = " << myReadData << std::endl;
+  cout << " readfloatdata       = " << myReadFloatData << std::endl;
+  cout << " readflag            = " << myReadFlag << std::endl;
+  cout << " readweightspectrum  = " << myReadWeightSpectrum << std::endl;
   cout << " data tileshape      = " << tileShape
-       << "   (tilesize = " << tileSize << " bytes)" << endl;
+       << "   (tilesize = " << tileSize << " bytes)" << std::endl;
 }
 
 void showParms()
@@ -249,8 +249,8 @@ void showParms()
   if (parts.size() > 1) {
     cout << "   (MultiMS with " << parts.size() << " MSs)";
   }
-  cout << endl;
-  cout << " nthread   = " << OMP::maxThreads() << endl;
+  cout << std::endl;
+  cout << " nthread   = " << OMP::maxThreads() << std::endl;
 
   // Since all parts are the same, only use the first one to determine sizes.
   MeasurementSet ms(parts[0]);
@@ -269,34 +269,34 @@ void showParms()
     ntimefield = iterfld.table().nrow() / tab1.nrow();
   }
   cout << " nant      = " << nant
-       << "   (" << nbl << " baselines)" << endl;
+       << "   (" << nbl << " baselines)" << std::endl;
   cout << " nspw      = " << ms.spectralWindow().nrow()
-       << "   (" << nspw << " per ms)" << endl;
+       << "   (" << nspw << " per ms)" << std::endl;
   cout << " nfield    = " << ms.field().nrow();
   if (ntimefield > 0) {
     cout << "   (" << ntimefield << "times per field)";
   }
-  cout << endl;
-  cout << " ntime     = " << ntime << endl;
+  cout << std::endl;
+  cout << " ntime     = " << ntime << std::endl;
   IPosition dataShape;
   if (ms.tableDesc().isColumn("DATA")) {
     dataShape = ArrayColumn<Complex>(ms, "DATA").shape(0);
   } else {
     dataShape = ArrayColumn<Float>(ms, "FLOAT_DATA").shape(0);
   }
-  cout << " nchan     = " << dataShape[1] << endl;
-  cout << " startchan = " << myStartChan << endl;
-  cout << " chansize  = " << myChanSize << endl;
-  cout << " npol      = " << dataShape[0] << endl;
-  cout << " rowwise             = " << myReadRowWise << endl;
-  cout << " readdata            = " << myReadData << endl;
-  cout << " readfloatdata       = " << myReadFloatData << endl;
-  cout << " readflag            = " << myReadFlag << endl;
-  cout << " readweightspectrum  = " << myReadWeightSpectrum << endl;
+  cout << " nchan     = " << dataShape[1] << std::endl;
+  cout << " startchan = " << myStartChan << std::endl;
+  cout << " chansize  = " << myChanSize << std::endl;
+  cout << " npol      = " << dataShape[0] << std::endl;
+  cout << " rowwise             = " << myReadRowWise << std::endl;
+  cout << " readdata            = " << myReadData << std::endl;
+  cout << " readfloatdata       = " << myReadFloatData << std::endl;
+  cout << " readflag            = " << myReadFlag << std::endl;
+  cout << " readweightspectrum  = " << myReadWeightSpectrum << std::endl;
   try {
     ROTiledStManAccessor acc(ms, ms.tableDesc().isColumn("DATA") ? "DATA" : "FLOAT_DATA", True);
     cout << " data tileshape      = " << acc.tileShape(0)
-         << "   (tilesize = " << acc.bucketSize(0) << " bytes)" << endl;
+         << "   (tilesize = " << acc.bucketSize(0) << " bytes)" << std::endl;
   } catch (const AipsError&) {
   }
   const StorageOption& opt = ms.storageOption();
@@ -304,18 +304,18 @@ void showParms()
       opt.option() == StorageOption::MultiHDF5) {
     cout << " multi"
          << (opt.option() == StorageOption::MultiFile ? "file" : "hdf5");
-    cout << "    (blocksize = " << opt.blockSize() << " bytes)" << endl;
+    cout << "    (blocksize = " << opt.blockSize() << " bytes)" << std::endl;
   }
   if (! myBaselines.empty()) {
-    cout << "baseline selection   = " << myBaselines << endl;
+    cout << "baseline selection   = " << myBaselines << std::endl;
   }
   if (! mySelection.empty()) {
-    cout << "TaQL selection       = " << mySelection << endl;
+    cout << "TaQL selection       = " << mySelection << std::endl;
   }
-  cout << " iteration1 columns  = " << myIterCols1 << endl;
-  cout << " iteration2 columns  = " << myIterCols2 << endl;
+  cout << " iteration1 columns  = " << myIterCols1 << std::endl;
+  cout << " iteration2 columns  = " << myIterCols2 << std::endl;
   if (mySortCols.size() > 0) {
-    cout << " sort columns        = " << mySortCols << endl;
+    cout << " sort columns        = " << mySortCols << std::endl;
   }
   ///possibly show ntimes, etc. of selection subset
 }
@@ -788,7 +788,7 @@ std::vector<Int64> doHDF5 (int seqnr, const String& name)
         myNChan = shape[1];
       }
       showParmsHDF5 (tileShape, tileSize, groupNames.size(), attr);
-      cout << "HDF5 cache size = " << cacheSize << endl;
+      cout << "HDF5 cache size = " << cacheSize << std::endl;
     }
     // Determine nr of rows to read per time step.
     int ntoread = attr.asInt("NBaseline");
@@ -882,13 +882,13 @@ void doAll()
     }
   }
   if (myNPart == 1) {
-    cout << "Read 1 MS part" << endl;
+    cout << "Read 1 MS part" << std::endl;
   } else {
     cout << "Read " << myNPart << " MS parts in "
-         << nthread << " threads" << endl;
+         << nthread << " threads" << std::endl;
   }
   cout << "For each part " << selNrow << " rows out of " << nrow
-       << " have been read" << endl;
+       << " have been read" << std::endl;
 }
 
 int main (int argc, char* argv[])

--- a/ms/apps/writems.cc
+++ b/ms/apps/writems.cc
@@ -1426,7 +1426,7 @@ void MSCreateHDF5::createMS (const String& msName, int ntimeField,
     IPosition tileShape1(1, nrbasel);
     uInt freqPerTile = itsDataTileShape[1];
     uInt cacheSize = (itsNFreq[band] + freqPerTile - 1) / freqPerTile;
-    cout << "HDF5 cacheSize = " << cacheSize << endl;
+    cout << "HDF5 cacheSize = " << cacheSize << std::endl;
     if (itsWriteFloatData) {
       spw.floatData = std::make_shared<HDF5DataSet>(*spw.spw, "FLOAT_DATA", shape,
                                                     itsDataTileShape, (float*)0);
@@ -1702,11 +1702,11 @@ IPosition formTileShape (int tileSize, int tileNPol, int tileNFreq,
 
 void showHelp()
 {
-  cout << "The program creates one or more MeasurementSets with a given number of" <<endl;
-  cout << "baselines, times, fields, spectral windows, channels and polarizations." << endl;
-  cout << "Run as:" << endl;
-  cout << "      writems parm=value parm=value ..." << endl;
-  cout << "Use   writems -h   to see the possible parameters." << endl;
+  cout << "The program creates one or more MeasurementSets with a given number of" <<std::endl;
+  cout << "baselines, times, fields, spectral windows, channels and polarizations." << std::endl;
+  cout << "Run as:" << std::endl;
+  cout << "      writems parm=value parm=value ..." << std::endl;
+  cout << "Use   writems -h   to see the possible parameters." << std::endl;
 }
 
 Int64 parmInt (Input& params, const String& name, const Record& vars=Record())
@@ -1973,8 +1973,8 @@ bool readParms (int argc, char* argv[])
 
 void showParms()
 {
-  cout << " nms      = " << myNPart << "   " << myMsName << endl;
-  cout << " nthread  = " << OMP::maxThreads() << endl;
+  cout << " nms      = " << myNPart << "   " << myMsName << std::endl;
+  cout << " nthread  = " << OMP::maxThreads() << std::endl;
   int nant = myAntPos.ncolumn();
   cout << " nant     = " << nant << "   (";
   if (myWriteFloatData) {
@@ -1984,24 +1984,24 @@ void showParms()
   } else {
     cout << nant*(nant-1)/2;
   }
-  cout << " baselines)" << endl;
+  cout << " baselines)" << std::endl;
   cout << " totalspw = " << myTotalNBand
-       << "   (firstspw = " << myFirstBand << ')' << endl;
+       << "   (firstspw = " << myFirstBand << ')' << std::endl;
   cout << " nspw     = " << myNBand
-       << "   (" << myNBand/myNPart << " per ms)" << endl;
+       << "   (" << myNBand/myNPart << " per ms)" << std::endl;
   cout << " nfield   = " << myRa.size();
   if (myNTimeField > 0) {
     cout << "   (" << myNTimeField << "times per field)";
   }
-  cout << endl;
-  cout << " ntime    = " << myNTime << endl;
-  cout << " nchan    = " << myNChan << endl;
-  cout << " npol     = " << myNPol << endl;
-  cout << " rowwise             = " << myWriteRowWise << endl;
-  cout << " writeweightspectrum = " << myWriteWeightSpectrum << endl;
-  cout << " createimagercolumns = " << myCreateImagerColumns << endl;
+  cout << std::endl;
+  cout << " ntime    = " << myNTime << std::endl;
+  cout << " nchan    = " << myNChan << std::endl;
+  cout << " npol     = " << myNPol << std::endl;
+  cout << " rowwise             = " << myWriteRowWise << std::endl;
+  cout << " writeweightspectrum = " << myWriteWeightSpectrum << std::endl;
+  cout << " createimagercolumns = " << myCreateImagerColumns << std::endl;
   if (!myFlagColumn.empty()  &&  myNFlagBits > 0) {
-    cout << " FLAG written as " << myNFlagBits << " bits per flag" << endl;
+    cout << " FLAG written as " << myNFlagBits << " bits per flag" << std::endl;
   }
   IPosition tileShape = formTileShape(myTileSize, myTileSizePol, myTileSizeFreq,
                                       myWriteFloatData, myNPol, myNChan);
@@ -2010,14 +2010,14 @@ void showParms()
     tileSize /= 2;
   }
   cout << " data tileshape      = " << tileShape
-       <<   "  (tilesize = " << tileSize << " bytes)" << endl;
+       <<   "  (tilesize = " << tileSize << " bytes)" << std::endl;
   if (!myWriteHDF5  &&  myUseMultiFile) {
     cout << " multi" << (myUseMultiFile==1 ? "file" : "hdf5");
     int multiBlockSize = myMultiBlockSize;
     if (multiBlockSize <= 0) {
       multiBlockSize = tileSize;
     }
-    cout << "    (blocksize = " << multiBlockSize << " bytes)" << endl;
+    cout << "    (blocksize = " << multiBlockSize << " bytes)" << std::endl;
   }
 }
 
@@ -2088,16 +2088,16 @@ void doAll()
     msnames[i] = doOne (i, myMsName);
   }
   if (myNPart == 1) {
-    cout << "Created 1 MS part" << endl;
+    cout << "Created 1 MS part" << std::endl;
   } else {
     cout << "Created " << myNPart << " MS parts in "
-         << nthread << " threads" << endl;
+         << nthread << " threads" << std::endl;
   }
   // Create the concatenated MS.
   if (!myDoSinglePart  &&  !myWriteHDF5) {
     Table tab = Table(msnames);
     tab.rename (myMsName, Table::New);
-    cout << "Created MultiMS " << myMsName << " containing all parts" << endl;
+    cout << "Created MultiMS " << myMsName << " containing all parts" << std::endl;
   }
 }
 
@@ -2112,7 +2112,7 @@ int main (int argc, char** argv)
       doAll();
     }
   } catch (std::exception& ex) {
-    cerr << "Unexpected exception in " << argv[0] << ": " << ex.what() << endl;
+    cerr << "Unexpected exception in " << argv[0] << ": " << ex.what() << std::endl;
     return 1;
   }
 #ifdef HAVE_MPI

--- a/python/Converters/PycImport.cc
+++ b/python/Converters/PycImport.cc
@@ -43,7 +43,7 @@ namespace casacore { namespace python {
         // because Boost-Python does not do that.
         // (from http://stackoverflow.com/questions/9285384/
         //  how-does-import-work-with-boost-python-from-inside-python-files)
-        string workingDir = Path(".").absoluteName();
+        std::string workingDir = Path(".").absoluteName();
         char path[] = "path";      // warning if "path" is used below
         PyObject* sysPath = PySys_GetObject(path);
 #ifdef IS_PY3K

--- a/tables/DataMan/DataManAccessor.h
+++ b/tables/DataMan/DataManAccessor.h
@@ -108,7 +108,7 @@ public:
       { return itsDataManager->sequenceNr(); } 
 
     // Show IO statistics.
-    void showCacheStatistics (ostream& os) const
+    void showCacheStatistics (std::ostream& os) const
       { itsDataManager->showCacheStatistics (os); }
 
 protected:

--- a/tables/DataMan/DataManInfo.cc
+++ b/tables/DataMan/DataManInfo.cc
@@ -509,7 +509,7 @@ void DataManInfo::setTiledStMan (Record& dminfo, const Vector<String>& columns,
   }
 }
 
-void DataManInfo::showDataManStats (const Table& tab, ostream& os)
+void DataManInfo::showDataManStats (const Table& tab, std::ostream& os)
 {
   Record dmInfo = tab.dataManagerInfo();
   // Loop through all data managers.

--- a/tables/DataMan/DataManInfo.h
+++ b/tables/DataMan/DataManInfo.h
@@ -26,8 +26,8 @@
 #ifndef TABLES_DATAMANINFO_H
 #define TABLES_DATAMANINFO_H
 
+#include <ostream>
 
-//# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/BasicSL/String.h>
@@ -152,7 +152,7 @@ public:
   static void adjustDesc (TableDesc& tabDesc, const Record& dminfo);
 
   // Show the Table IO statistics.
-  static void showDataManStats (const Table&, ostream&);
+  static void showDataManStats (const Table&, std::ostream&);
 
 private:
   // Merge the column info of data manager definitions.

--- a/tables/DataMan/DataManager.cc
+++ b/tables/DataMan/DataManager.cc
@@ -380,12 +380,12 @@ DataManagerCtor DataManager::getCtor (const String& type)
     // data managers can use the same library).
     String libname(type);
     libname.downcase();
-    string::size_type pos = libname.find_first_of (".<");
-    if (pos != string::npos) {
+    std::string::size_type pos = libname.find_first_of (".<");
+    if (pos != std::string::npos) {
         libname = libname.substr (0, pos);
     }
     // Try to load and initialize the dynamic library.
-    DynLib dl(libname, string("libcasa_"), CASACORE_STRINGIFY(SOVERSION),
+    DynLib dl(libname, std::string("libcasa_"), CASACORE_STRINGIFY(SOVERSION),
               "register_"+libname, False);
     if (dl.getHandle()) {
         // See if registered now.

--- a/tables/TaQL/UDFBase.cc
+++ b/tables/TaQL/UDFBase.cc
@@ -220,7 +220,7 @@ namespace casacore {
       iter = theirRegistry.find (libname);
       if (iter == theirRegistry.end()) {
         // Try to load the dynamic library.
-        DynLib dl(libname, string("libcasa_"), CASACORE_STRINGIFY(SOVERSION),
+        DynLib dl(libname, std::string("libcasa_"), CASACORE_STRINGIFY(SOVERSION),
                   "register_"+libname, False);
         if (dl.getHandle()) {
           // Add to map to indicate library has been loaded.


### PR DESCRIPTION
This doesn't change every occurrence of std in header files, it just changes String.h and fixes (using find and replace) non-std usage in parts of the code that failed.