### PR TITLE
Add test for splitName() in TableParseUtil and fix segfault on empty string

### DIFF
--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -554,3 +554,22 @@ DESTINATION include/casacore/tables
 foreach (casa_module Tables AlternateMans DataMan TaQL LogTables)
   add_subdirectory (${casa_module}/test ${EXCL_ALL})
 endforeach (casa_module)
+
+set (unittestfiles
+  TaQL/test/tTableParseUtil.cc
+)
+
+find_package(Boost 1.73 COMPONENTS unit_test_framework)
+if(Boost_FOUND)
+	include_directories(${Boost_INCLUDE_DIR})
+
+	add_executable (tablestests ${unittestfiles})
+	add_pch_support(tablestests)
+  target_link_libraries(tablestests
+    PRIVATE
+      casa_tables
+      Boost::unit_test_framework
+  )
+  add_test (tablestests ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./tablestests)
+	add_dependencies(check tablestests)
+endif(Boost_FOUND)

--- a/tables/TaQL/TableParseUtil.cc
+++ b/tables/TaQL/TableParseUtil.cc
@@ -261,6 +261,12 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
         // Users can use column.subfield by preceeding it with a dot
         // (.a.b always means column.subfield).
         fldNam = stringToVector (columnName, '.');
+        if(fldNam.empty()) {
+          if (checkError) {
+            throw (TableInvExpr ("No name given"));
+          }
+          return False;
+        }
         if (fldNam.size() == 1) {
           stfld = 0;                      // one part simply means column
         } else if (fldNam(0).empty()) {

--- a/tables/TaQL/test/tTableParseUtil.cc
+++ b/tables/TaQL/test/tTableParseUtil.cc
@@ -1,0 +1,132 @@
+#include <casacore/tables/TaQL/TableParseUtil.h>
+
+#define BOOST_TEST_MODULE tables
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+using casacore::String;
+using casacore::Vector;
+using casacore::TableParseUtil::splitName;
+
+BOOST_AUTO_TEST_SUITE(table_parse_util)
+
+BOOST_AUTO_TEST_CASE(split_name)
+{
+  String short_hand;
+  String column_name;
+  casacore::Vector<String> field_names;
+  constexpr bool kCheckError = true;
+  constexpr bool kAllowNoKey = false;
+  bool result;
+
+  result = splitName(short_hand, column_name, field_names, "Abc", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "Abc");
+
+  result = splitName(short_hand, column_name, field_names, "A::B", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "A");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "B");
+
+  result = splitName(short_hand, column_name, field_names, "::A", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "A");
+
+  result = splitName(short_hand, column_name, field_names, "::A", kCheckError, false, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "A");
+
+  result = splitName(short_hand, column_name, field_names, "First::Second", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "First");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "Second");
+
+  result = splitName(short_hand, column_name, field_names, "A::B", kCheckError, false, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "A");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "B");
+
+  result = splitName(short_hand, column_name, field_names, "A::B.c", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "A");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 2);
+  BOOST_CHECK_EQUAL(field_names[0], "B");
+  BOOST_CHECK_EQUAL(field_names[1], "c");
+
+  result = splitName(short_hand, column_name, field_names, "B.c", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 2);
+  BOOST_CHECK_EQUAL(field_names[0], "B");
+  BOOST_CHECK_EQUAL(field_names[1], "c");
+
+  result = splitName(short_hand, column_name, field_names, "A.b::C", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "A");
+  BOOST_CHECK_EQUAL(column_name, "b");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 1);
+  BOOST_CHECK_EQUAL(field_names[0], "C");
+
+  result = splitName(short_hand, column_name, field_names, "A.b::C.D.E", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "A");
+  BOOST_CHECK_EQUAL(column_name, "b");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 3);
+  BOOST_CHECK_EQUAL(field_names[0], "C");
+  BOOST_CHECK_EQUAL(field_names[1], "D");
+  BOOST_CHECK_EQUAL(field_names[2], "E");
+
+  result = splitName(short_hand, column_name, field_names, "::A.Bc", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 2);
+  BOOST_CHECK_EQUAL(field_names[0], "A");
+  BOOST_CHECK_EQUAL(field_names[1], "Bc");
+
+  result = splitName(short_hand, column_name, field_names, "::A.Bc", kCheckError, false, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "");
+  BOOST_CHECK_EQUAL(column_name, "");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 2);
+  BOOST_CHECK_EQUAL(field_names[0], "A");
+  BOOST_CHECK_EQUAL(field_names[1], "Bc");
+
+  result = splitName(short_hand, column_name, field_names, "Shorthand.Column::Field1.Field2.Field3", kCheckError, true, kAllowNoKey);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(short_hand, "Shorthand");
+  BOOST_CHECK_EQUAL(column_name, "Column");
+  BOOST_REQUIRE_EQUAL(field_names.size(), 3);
+  BOOST_CHECK_EQUAL(field_names[0], "Field1");
+  BOOST_CHECK_EQUAL(field_names[1], "Field2");
+  BOOST_CHECK_EQUAL(field_names[2], "Field3");
+
+  BOOST_CHECK_THROW(splitName(short_hand, column_name, field_names, "", kCheckError, true, kAllowNoKey), std::exception);
+  BOOST_CHECK_THROW(splitName(short_hand, column_name, field_names, "", kCheckError, false, kAllowNoKey), std::exception);
+  BOOST_CHECK_THROW(splitName(short_hand, column_name, field_names, "S.C::Field1..Field2", kCheckError, true, kAllowNoKey), std::exception);
+
+  result = splitName(short_hand, column_name, field_names, "B.c", kCheckError, false, kAllowNoKey);
+  BOOST_CHECK(!result);
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
The string changes require modification of this function, but because its behaviour was somewhat difficult to understand I first added a test set.

This uncovered that the function crashes when supplied with an empty string. I'm not sure this could ever occur but better to fix it, which is done in this PR.