### PR TITLE
Fix some small string-transformation issues

### DIFF
--- a/casa/BasicSL/String.cc
+++ b/casa/BasicSL/String.cc
@@ -353,7 +353,10 @@ String::size_type String::index(const Regex &r, int startpos) const {
 std::string RegexSubStr(const std::string& str, const Regex& r, size_t startpos) {
   int mlen;
   size_t first = r.search(str.c_str(), str.length(), mlen, startpos);
-  return str.substr(first, mlen);
+  if(first == std::string::npos)
+    return "";
+  else
+    return str.substr(first, mlen);
 }
 
 SubString String::at(const Regex &r, int startpos) {

--- a/casa/BasicSL/String.h
+++ b/casa/BasicSL/String.h
@@ -98,12 +98,12 @@ inline bool EqualStringsAndNotEmpty(std::string_view str1, std::string_view str2
 // Otherwise it returns false and @p value contains the value read
 // so far.
 template<typename T>
-inline bool StringToValue (const std::string& str, T& value, bool check=true)
+inline bool StringToValue (const std::string& str, T& value, bool throw_on_error=true)
 {
   std::istringstream is(str);
   is >> value;
   if (is.fail()  ||  !is.eof()) {
-    if (check) {
+    if (throw_on_error) {
       if(is.fail()) {
         throw std::runtime_error ("String '" + str + "' failed to parse in StringToValue()");
       } else {
@@ -119,26 +119,26 @@ inline bool StringToValue (const std::string& str, T& value, bool check=true)
 
 // Same as other StringToValue() overload, but returns the parsed value.
 template<typename T>
-inline T StringToValue(const std::string& str)
+inline T StringToValue(const std::string& str, bool throw_on_error = true)
 {
   T value;
-  StringToValue(str, value);
+  StringToValue(str, value, throw_on_error);
   return value;
 }
 
 // Same as StringToValue<int>
-inline int StringToInt(const std::string& str) {
-  return StringToValue<int>(str);
+inline int StringToInt(const std::string& str, bool throw_on_error = false) {
+  return StringToValue<int>(str, throw_on_error);
 }
 
 // Same as StringToValue<float>
-inline float StringToFloat(const std::string& str) {
-  return StringToValue<float>(str);
+inline float StringToFloat(const std::string& str, bool throw_on_error = false) {
+  return StringToValue<float>(str, throw_on_error);
 }
 
 // Same as StringToValue<double>
-inline double StringToDouble(const std::string& str) {
-  return StringToValue<double>(str);
+inline double StringToDouble(const std::string& str, bool throw_on_error = false) {
+  return StringToValue<double>(str, throw_on_error);
 }
 
 template<typename T>
@@ -469,9 +469,9 @@ class String : public std::string {
   // <group>
   template<typename T>
   DEPRECATED("Use StringToValue()")
-  inline bool fromString (T& value, bool chk=true) const
+  inline bool fromString (T& value, bool throw_on_error=true) const
   {
-    return StringToValue(*this, value, chk);
+    return StringToValue(*this, value, throw_on_error);
   }
   template<typename T>
   DEPRECATED("Use StringToValue()")
@@ -511,7 +511,7 @@ class String : public std::string {
   // It uses a shift into an ostringstream, so that operator must be
   // defined for the data type used.
   template<typename T>
-  DEPRECATED("Use ValueToString()")
+  DEPRECATED("Use std::to_string or ValueToString()")
   static String toString(const T& value)
   {
     return ValueToString(value);

--- a/casa/BasicSL/test/tString.cc
+++ b/casa/BasicSL/test/tString.cc
@@ -264,9 +264,14 @@ BOOST_AUTO_TEST_CASE(StringToInt) {
   BOOST_CHECK_EQUAL(StringToInt("-0"), 0);
   BOOST_CHECK_EQUAL(StringToInt("-32768"), -32768);
 
-  BOOST_CHECK_THROW(StringToInt(""), std::runtime_error);
-  BOOST_CHECK_THROW(StringToInt("0?"), std::runtime_error);
-  BOOST_CHECK_THROW(StringToInt("1e12"), std::runtime_error);
+  BOOST_CHECK_THROW(StringToInt("", true), std::runtime_error);
+  BOOST_CHECK_THROW(StringToInt("0?", true), std::runtime_error);
+  BOOST_CHECK_THROW(StringToInt("1e12", true), std::runtime_error);
+
+
+  BOOST_CHECK_NO_THROW(StringToInt("", false));
+  BOOST_CHECK_NO_THROW(StringToInt("0?", false));
+  BOOST_CHECK_NO_THROW(StringToInt("1e12", false));
 }
 
 BOOST_AUTO_TEST_CASE(StringToFloat) {
@@ -276,9 +281,13 @@ BOOST_AUTO_TEST_CASE(StringToFloat) {
   BOOST_CHECK_EQUAL(StringToFloat("-0.0"), -0.0f);
   BOOST_CHECK_CLOSE_FRACTION(StringToFloat("-3.14159265e-4"), -3.14159265e-4f, 1e-6);
 
-  BOOST_CHECK_THROW(StringToFloat(""), std::runtime_error);
-  BOOST_CHECK_THROW(StringToFloat("0?"), std::runtime_error);
-  BOOST_CHECK_THROW(StringToFloat("1e12e"), std::runtime_error);
+  BOOST_CHECK_THROW(StringToFloat("", true), std::runtime_error);
+  BOOST_CHECK_THROW(StringToFloat("0?", true), std::runtime_error);
+  BOOST_CHECK_THROW(StringToFloat("1e12e", true), std::runtime_error);
+
+  BOOST_CHECK_NO_THROW(StringToFloat("", false));
+  BOOST_CHECK_NO_THROW(StringToFloat("0?", false));
+  BOOST_CHECK_NO_THROW(StringToFloat("1e12e", false));
 }
 
 BOOST_AUTO_TEST_CASE(StringToDouble) {
@@ -289,9 +298,13 @@ BOOST_AUTO_TEST_CASE(StringToDouble) {
   BOOST_CHECK_CLOSE_FRACTION(StringToDouble("-3.14159265e-4"), -3.14159265e-4, 1e-8);
   BOOST_CHECK_CLOSE_FRACTION(StringToDouble("1e308"), 1e308, 1e-8);
 
-  BOOST_CHECK_THROW(StringToDouble(""), std::runtime_error);
-  BOOST_CHECK_THROW(StringToDouble("0?"), std::runtime_error);
-  BOOST_CHECK_THROW(StringToDouble("1e12e"), std::runtime_error);
+  BOOST_CHECK_THROW(StringToDouble("", true), std::runtime_error);
+  BOOST_CHECK_THROW(StringToDouble("0?", true), std::runtime_error);
+  BOOST_CHECK_THROW(StringToDouble("1e12e", true), std::runtime_error);
+
+  BOOST_CHECK_NO_THROW(StringToDouble("", false));
+  BOOST_CHECK_NO_THROW(StringToDouble("0?", false));
+  BOOST_CHECK_NO_THROW(StringToDouble("1e12e", false));
 }
 
 BOOST_AUTO_TEST_CASE(SubStringCount) {

--- a/casa/CMakeLists.txt
+++ b/casa/CMakeLists.txt
@@ -711,6 +711,6 @@ if(Boost_FOUND)
       casa_casa
       Boost::unit_test_framework
   )
-  add_test (arraytest ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./unittests)
+  add_test (unittests ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./unittests)
 	add_dependencies(check unittests)
 endif(Boost_FOUND)

--- a/casa/Utilities/Regex.h
+++ b/casa/Utilities/Regex.h
@@ -312,6 +312,7 @@ extern const Regex RXuppercase;      //# = "[A-Z]+"
 extern const Regex RXalphanum;       //# = "[0-9A-Za-z]+"
 extern const Regex RXidentifier;     //# = "[A-Za-z_][A-Za-z0-9_]*"
 
+constexpr std::string_view kIntegerCharacters = "-0123456789";
 
 } //# NAMESPACE CASACORE - END
 


### PR DESCRIPTION
- Makes sure that the in #1493 newly added functions behave as their old counterparts.
- Fix an issue in RegexSubStr() when no matches are found
- Refer to std::to_string in deprecation message of toString()
- Add a kIntegerCharacters constant that can be used to replace regex searches.